### PR TITLE
fix(session-replay): preserve workspace activity offsets

### DIFF
--- a/docs/architecture/agent-session-replay.md
+++ b/docs/architecture/agent-session-replay.md
@@ -161,6 +161,17 @@ SQLite database containing one transient Replay Surface per Cassette. It is runt
 composition, not another durable product Workspace and not a multi-root
 Cassette.
 
+Replay Workspace aligns every cassette's Activity clock to the earliest first
+Activity timestamp in the batch. This preserves the wall-clock offset between
+cassettes that were recorded concurrently. Realtime playback therefore keeps
+cross-Session ordering scenarios deterministic; fast-forward may intentionally
+skip elapsed waits while retaining each cassette's Activity order.
+
+Scenario screenshot settling remains limited to stable checkpoints by default.
+A scenario may opt into immediate `turn.working` settling with
+`settleForWorkingScreenshot: true` when it performs bounded DOM assertions for
+a transient cross-Session state; tool-start checkpoints remain excluded.
+
 After a Replay Workspace creates its Replay Surfaces, Desktop applies the
 Workbench balanced layout to exactly those AgentGUI Nodes. A single Surface
 receives the Workbench safe-area frame without locking the layout. A batch with

--- a/packages/agent/session-replay-runner/src/index.test.mjs
+++ b/packages/agent/session-replay-runner/src/index.test.mjs
@@ -236,6 +236,30 @@ test("provider cursor math and activity clock", async () => {
     waits.reduce((total, duration) => total + duration, 0),
     80
   );
+
+  playback = {
+    paused: false,
+    playbackElapsedMs: 0,
+    speed: 1,
+    timingMode: "realtime"
+  };
+  const sharedOriginWaits = [];
+  const sharedOriginClock = createReplayActivityClock({
+    originOccurredAtUnixMs: 900,
+    playbackState: async () => playback,
+    wait: async (durationMs) => {
+      sharedOriginWaits.push(durationMs);
+      playback = {
+        ...playback,
+        playbackElapsedMs: playback.playbackElapsedMs + durationMs
+      };
+    }
+  });
+  await sharedOriginClock.waitUntil(1_000);
+  assert.equal(
+    sharedOriginWaits.reduce((total, duration) => total + duration, 0),
+    100
+  );
 });
 
 test("submit idle gate and managed failure routing", () => {

--- a/packages/agent/session-replay-runner/src/playback-controller.mjs
+++ b/packages/agent/session-replay-runner/src/playback-controller.mjs
@@ -444,6 +444,7 @@ export function createReplayPlaybackController(input) {
   };
 
   const activityClock = createReplayActivityClock({
+    originOccurredAtUnixMs: input.activityClockOriginUnixMs,
     playbackState: async () => {
       await applyControl();
       return readTransportPlayback();

--- a/packages/agent/session-replay-runner/src/playback-helpers.mjs
+++ b/packages/agent/session-replay-runner/src/playback-helpers.mjs
@@ -54,7 +54,17 @@ export function providerConnectionsReached(checkpoint, state) {
 export function createReplayActivityClock(input) {
   const wait = input.wait ?? defaultDelay;
   const pollIntervalMs = input.pollIntervalMs ?? 50;
-  let originOccurredAtUnixMs = null;
+  const configuredOriginOccurredAtUnixMs = input.originOccurredAtUnixMs ?? null;
+  if (
+    configuredOriginOccurredAtUnixMs !== null &&
+    (!Number.isSafeInteger(configuredOriginOccurredAtUnixMs) ||
+      configuredOriginOccurredAtUnixMs <= 0)
+  ) {
+    throw new Error(
+      `replay activity clock origin is invalid: ${configuredOriginOccurredAtUnixMs}`
+    );
+  }
+  let originOccurredAtUnixMs = configuredOriginOccurredAtUnixMs;
   let originPlaybackElapsedMs = null;
   let lastTargetOccurredAtUnixMs = null;
   let skippedElapsedMs = 0;
@@ -74,12 +84,16 @@ export function createReplayActivityClock(input) {
       }
       if (originOccurredAtUnixMs === null) {
         originOccurredAtUnixMs = occurredAtUnixMs;
-        lastTargetOccurredAtUnixMs = occurredAtUnixMs;
-        const playback = await synchronize();
-        originPlaybackElapsedMs = playback.playbackElapsedMs;
-        return;
       }
       lastTargetOccurredAtUnixMs = occurredAtUnixMs;
+      if (occurredAtUnixMs < originOccurredAtUnixMs) {
+        throw new Error(`replay activity time is invalid: ${occurredAtUnixMs}`);
+      }
+      if (originPlaybackElapsedMs === null) {
+        const playback = await synchronize();
+        originPlaybackElapsedMs = playback.playbackElapsedMs;
+        if (configuredOriginOccurredAtUnixMs === null) return;
+      }
       const targetElapsedMs = occurredAtUnixMs - originOccurredAtUnixMs;
       while (true) {
         const playback = await synchronize();

--- a/packages/agent/session-replay-runner/src/replay-stimuli.mjs
+++ b/packages/agent/session-replay-runner/src/replay-stimuli.mjs
@@ -85,6 +85,7 @@ export async function replayStimuli(
         })
     : undefined;
   const playback = createReplayPlaybackController({
+    activityClockOriginUnixMs: input.activityClockOriginUnixMs,
     baseURL,
     checkpoints: input.checkpoints,
     controlPath: input.controlPath,

--- a/tools/scripts/run-agent-session-replay.mjs
+++ b/tools/scripts/run-agent-session-replay.mjs
@@ -709,6 +709,9 @@ async function runReplayWorkspaceOrchestration(
       )
     ])
   );
+  const activityClockOriginUnixMs = replayWorkspaceActivityClockOrigin(
+    bootstrap.cassettes
+  );
   const catalogLaunch = await reconcileEventStreamCatalogForLaunch({
     daemonPath: bootstrap.runtime.daemonPath,
     managed: Boolean(options.managed),
@@ -805,6 +808,7 @@ async function runReplayWorkspaceOrchestration(
           cassette.action,
           options.timeoutMs,
           {
+            activityClockOriginUnixMs,
             checkpoints: cassette.checkpoints,
             controlPath,
             initialTargetCheckpoint:
@@ -950,6 +954,17 @@ async function runReplayWorkspaceOrchestration(
     client?.close();
     await stopProcessTree(desktop);
   }
+}
+
+export function replayWorkspaceActivityClockOrigin(cassettes) {
+  const firstActivityTimes = cassettes.flatMap((cassette) => {
+    const occurredAtUnixMs =
+      cassette.action?.activityEvents?.[0]?.occurredAtUnixMs;
+    return Number.isSafeInteger(occurredAtUnixMs) && occurredAtUnixMs > 0
+      ? [occurredAtUnixMs]
+      : [];
+  });
+  return firstActivityTimes.length > 0 ? Math.min(...firstActivityTimes) : null;
 }
 
 export function createReplayWorkspaceSurfaceReadyQueue(activate) {
@@ -3233,7 +3248,13 @@ export async function maybeSettleForScreenshot(
   if (
     checkpoint &&
     !checkpointNeedsScreenshotSettle(checkpoint) &&
-    !checkpointAllowsOptionalScreenshotSettle(checkpoint)
+    !checkpointAllowsOptionalScreenshotSettle(checkpoint) &&
+    !(
+      scenario.settleForWorkingScreenshot === true &&
+      [checkpoint.kind, ...(checkpoint.tags ?? [])].some(
+        (token) => String(token) === "turn.working"
+      )
+    )
   ) {
     return;
   }

--- a/tools/scripts/run-agent-session-replay.test.mjs
+++ b/tools/scripts/run-agent-session-replay.test.mjs
@@ -65,6 +65,7 @@ import {
   replayTurnIdentityPlan,
   replayWorkspaceTransportRegistrations,
   readReplayTotalDurationMs,
+  replayWorkspaceActivityClockOrigin,
   replayWorkspaceInitialTargetCheckpoint,
   managedReplayFailure,
   loadRecordScenario,
@@ -335,6 +336,27 @@ test("maybeSettleForScreenshot pins and clears settle agent session id", async (
       expression.includes("delete globalThis.__tuttiSettleAgentSessionId")
     )
   );
+});
+
+test("working checkpoint settle is scenario opt-in", async () => {
+  const client = {
+    async send() {
+      return { result: { value: true } };
+    }
+  };
+  let settles = 0;
+  const scenario = {
+    async settleForScreenshot() {
+      settles += 1;
+    }
+  };
+  const checkpoint = { kind: "turn.working", tags: ["turn.working"] };
+
+  await maybeSettleForScreenshot(scenario, client, 1_000, checkpoint);
+  scenario.settleForWorkingScreenshot = true;
+  await maybeSettleForScreenshot(scenario, client, 1_000, checkpoint);
+
+  assert.equal(settles, 1);
 });
 
 test("replayObservedTurnId prefers Protocol v2 turnId after settle", () => {
@@ -2708,6 +2730,20 @@ test("manual Replay Workspace starts at its first inspectable checkpoint", () =>
       },
       "automatic"
     ),
+    null
+  );
+});
+
+test("Replay Workspace shares the earliest recorded Activity clock origin", () => {
+  assert.equal(
+    replayWorkspaceActivityClockOrigin([
+      { action: { activityEvents: [{ occurredAtUnixMs: 2_000 }] } },
+      { action: { activityEvents: [{ occurredAtUnixMs: 1_000 }] } }
+    ]),
+    1_000
+  );
+  assert.equal(
+    replayWorkspaceActivityClockOrigin([{ action: { activityEvents: [] } }]),
     null
   );
 });


### PR DESCRIPTION
## Summary

- align every cassette in a Replay Workspace to the earliest recorded Activity timestamp
- preserve real cross-cassette offsets during realtime playback
- allow bounded scenario settling at `turn.working` for transient cross-session assertions

## Why

Concurrent session recordings previously replayed each cassette from its own zero point. That erased the real wall-clock offset between sessions, so a replay case could not reliably reproduce conversation-rail ordering based on the latest turn start time.

## Verification

- `pnpm check:changed -- --push-ready` (11 lanes passed)
- session replay runner focused tests: 18 passed
- replay script focused tests: 88 passed
- the same freshly recorded two-session cassette set passed three consecutive headless replays
- removing the existing conversation-rail sort from the product made the same replay fail at the target `turn.working` checkpoint

## Platform impact

The change only passes numeric timestamps through the platform-neutral replay runner. It does not alter paths, process spawning, shell selection, signals, or filesystem behavior on Windows.
