### PR TITLE
fix(agent): project Codex turn workspace cwd

### DIFF
--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -4858,21 +4858,32 @@ agent target`, although the current model picker does not offer that model.
 - Symptom:
   Codex initializes and `thread/start` succeeds, but the first `turn/start`
   fails with JSON-RPC `-32600` and `AbsolutePathBuf deserialized without a base
-path`. Tutti then reports that the provider Turn was not durably accepted.
+path`. On a managed POSIX runtime, another form accepts the Turn but every
+  tool command, including `pwd`, fails with
+  `Failed to create unified exec process: No such file or directory (os error 2)`
+  even though provider-process CWD preflight succeeded.
 - Root cause:
   Tutti sent the POSIX-only `/sandbox-tmp` writable root as though it were a
   portable absolute host path. Codex's Windows `AbsolutePathBuf` parser rejects
   it even when the request also carries `cwd`; the per-turn working-directory
   override does not make a POSIX-rooted string into a Windows absolute path.
-  Tutti also omitted the Session `cwd` from the Turn override. A request-shape
-  mock accepted both omissions and did not exercise the real Rust parser.
+  Tutti also once omitted the Session `cwd` from the Turn override. Supplying
+  that field from the raw persisted Session value introduced the inverse POSIX
+  failure: a stored `/workspace/<room-id>` mount path escaped the managed
+  Agent's logical `/workspace` view even though `thread/start` and the provider
+  process had already projected it. Request-shape mocks accepted these invalid
+  combinations without exercising the real process or Rust parser boundary.
 - Fix:
-  Send the canonical non-empty Session `cwd` on every Codex `turn/start` and
-  omit the POSIX `/sandbox-tmp` projection on Windows. Keep the projection on
-  POSIX hosts where it represents the logical `/tmp` write target.
+  Send the non-empty provider-visible Session `cwd` on every Codex
+  `turn/start`. Apply the same room-mount-to-logical-workspace projection used
+  by `thread/start` and provider launch while preserving native Windows paths.
+  Omit the POSIX `/sandbox-tmp` projection on Windows, and keep it on POSIX
+  hosts where it represents the logical `/tmp` write target.
 - Validation:
-  Assert the emitted `turn/start.cwd`, cover Windows and POSIX sandbox policy
-  construction, and run the Windows contract test against a real pinned
-  `codex.exe app-server`. The contract test submits the historical payload both
-  without and with `cwd` as negative controls, then verifies that the production
-  payload crosses the same parser without an `AbsolutePathBuf` error.
+  Cover a stored room mount root and child path, an already-logical workspace
+  path, and a native Windows path in the emitted `turn/start.cwd`. Cover Windows
+  and POSIX sandbox policy construction, and run the Windows contract test
+  against a real pinned `codex.exe app-server`. The contract test submits the
+  historical payload both without and with `cwd` as negative controls, then
+  verifies that the production payload crosses the same parser without an
+  `AbsolutePathBuf` error.

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_execution_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_execution_test.go
@@ -28,8 +28,8 @@ func TestCodexAppServerAdapterExecStreamsTurn(t *testing.T) {
 	if asString(turnStart["threadId"]) != "codex-thread-1" {
 		t.Fatalf("turn/start threadId = %q", turnStart["threadId"])
 	}
-	if asString(turnStart["cwd"]) != session.CWD {
-		t.Fatalf("turn/start cwd = %q, want %q", turnStart["cwd"], session.CWD)
+	if asString(turnStart["cwd"]) != "/workspace" {
+		t.Fatalf("turn/start cwd = %q, want provider workspace root", turnStart["cwd"])
 	}
 	input, _ := turnStart["input"].([]any)
 	if len(input) != 1 || asString(payloadObject(input[0])["text"]) != "inspect the repo" {
@@ -135,6 +135,40 @@ func TestCodexAppServerTurnStartKeepsLargePromptInInputOnly(t *testing.T) {
 	input, ok := params["input"].([]map[string]any)
 	if !ok || len(input) != 1 || asString(input[0]["text"]) != longPrompt {
 		t.Fatalf("turn/start input did not preserve the full prompt")
+	}
+}
+
+func TestCodexAppServerTurnStartProjectsProviderWorkspaceCWD(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		roomID string
+		cwd    string
+		want   string
+	}{
+		{name: "room mount root", roomID: "room-1", cwd: "/workspace/room-1", want: "/workspace"},
+		{name: "room mount child", roomID: "room-1", cwd: "/workspace/room-1/src", want: "/workspace/src"},
+		{name: "logical workspace child", roomID: "room-1", cwd: "/workspace/src", want: "/workspace/src"},
+		{name: "native Windows path", roomID: "room-1", cwd: `C:\Users\alice\repo`, want: `C:\Users\alice\repo`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			params := appServerTurnStartParams(
+				Session{RoomID: test.roomID, CWD: test.cwd},
+				"codex-thread-1",
+				nil,
+				nil,
+				nil,
+				"",
+				"",
+				false,
+			)
+			if got := asString(params["cwd"]); got != test.want {
+				t.Fatalf("turn/start cwd = %q, want %q", got, test.want)
+			}
+		})
 	}
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_event_params.go
+++ b/packages/agent/daemon/runtime/codex_appserver_event_params.go
@@ -65,9 +65,11 @@ func appServerTurnStartParams(
 		"threadId": threadID,
 		"input":    userInput,
 	}
-	if cwd := strings.TrimSpace(session.CWD); cwd != "" {
-		// Keep the turn's working directory explicit even when it matches the
-		// thread cwd so provider state cannot drift across resumed turns.
+	if cwd := projectCodexWorkspaceCWD(strings.TrimSpace(session.CWD), session.RoomID); cwd != "" {
+		// Keep the provider-visible working directory explicit even when it
+		// matches the thread cwd so provider state cannot drift across resumed
+		// turns. A persisted room-scoped mount path must use the same logical
+		// workspace projection as thread/start and the provider process.
 		params["cwd"] = cwd
 	}
 	if collaborationMode := appServerCollaborationMode(settings, planModeMask, defaultModeMask, defaultModel, tuttiModeHostContext); collaborationMode != nil {


### PR DESCRIPTION
## Summary

- project persisted room-scoped Codex working directories into the provider-visible workspace namespace on every `turn/start`
- preserve native Windows paths while matching the CWD already used by `thread/start` and provider launch
- add regression coverage for workspace roots, nested paths, already-logical paths, and Windows paths
- document the POSIX `Failed to create unified exec process` symptom alongside the Windows path-parser failure

## Verification

- `go test ./runtime -run 'TestCodexAppServer(AdapterExecStreamsTurn|TurnStartProjectsProviderWorkspaceCWD|SandboxPolicyKeepsHostPathSemantics)$' -count=1`
- `pnpm check:changed`
- `pnpm check:changed -- --push-ready`
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -c ./runtime`

## Checklist

- [x] This does not change Host-owned agent lifecycle semantics; it fixes provider-transport CWD projection.
- [x] I kept the change focused on one concern.
- [x] I updated the matching troubleshooting documentation.
- [x] README/CONTRIBUTING translations are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commit is signed off with DCO.
