### PR TITLE
fix(device-link): detect dead peers promptly

### DIFF
--- a/packages/device-link/README.md
+++ b/packages/device-link/README.md
@@ -21,6 +21,11 @@ required by Go's dependency direction; it does not own account, pairing,
 rendezvous, or Agent behavior. Product bridges must not expose raw
 `QUICEndpoint.Listen` or `Dial`.
 
+Every direct QUIC session uses a 5-second keepalive period and a 15-second
+maximum idle timeout. These defaults apply uniformly to Desktop, mobile, and
+TSH consumers so a peer whose network path disappears is retired promptly
+without product-specific liveness timers.
+
 ## Managed connection lifecycle
 
 The `linkmanager` package owns the reusable lifecycle mechanics that sit above

--- a/packages/device-link/devicelink_test.go
+++ b/packages/device-link/devicelink_test.go
@@ -29,6 +29,16 @@ func TestQUICEndpointCloseClosesOwnedUDPSocket(t *testing.T) {
 	}
 }
 
+func TestDefaultQUICLiveness(t *testing.T) {
+	config := defaultQUICConfig()
+	if config.KeepAlivePeriod != 5*time.Second {
+		t.Fatalf("KeepAlivePeriod = %s, want 5s", config.KeepAlivePeriod)
+	}
+	if config.MaxIdleTimeout != 15*time.Second {
+		t.Fatalf("MaxIdleTimeout = %s, want 15s", config.MaxIdleTimeout)
+	}
+}
+
 func TestGlobalIPv6FromAddr(t *testing.T) {
 	tests := []struct {
 		name string

--- a/packages/device-link/types.go
+++ b/packages/device-link/types.go
@@ -12,8 +12,8 @@ const (
 	ALPN = "tutti-device-link/1"
 
 	defaultHandshakeTimeout = 3 * time.Second
-	defaultKeepAlive        = 20 * time.Second
-	defaultIdleTimeout      = 2 * time.Minute
+	defaultKeepAlive        = 5 * time.Second
+	defaultIdleTimeout      = 15 * time.Second
 )
 
 type CandidateType string


### PR DESCRIPTION
## Summary

- reduce the shared Direct QUIC keepalive period from 20 seconds to 5 seconds
- reduce the shared maximum idle timeout from 2 minutes to 15 seconds
- lock the defaults with a focused test and document their cross-consumer behavior

## Motivation

When one peer changes networks, the other peer can retain an unreachable QUIC session until the two-minute idle timeout expires. Query, control, and activity streams then remain bound to the stale transport and recover only after that timeout. The shorter shared defaults let Desktop, mobile, and TSH retire the dead peer path promptly without product-specific liveness timers.

Relay WebSocket ping behavior is unchanged.

## Testing

- pnpm check:changed
- pnpm check:changed -- --push-ready

## Platform impact

The defaults are platform-neutral and apply uniformly to Windows, macOS, Linux, Android, and iOS consumers.