### PR TITLE
fix(agent): preserve video input capability

### DIFF
--- a/packages/agent/activity-core/src/composerOptions.types.ts
+++ b/packages/agent/activity-core/src/composerOptions.types.ts
@@ -6,6 +6,7 @@ export interface AgentActivityComposerSettingOption {
   label: string;
   description?: string;
   supportsImageInput?: boolean;
+  supportsVideoInput?: boolean;
   /** True when the entry mirrors the requested/current selection, not the provider catalog. */
   requested?: boolean;
 }

--- a/packages/agent/activity-tuttid-adapter/src/composerOptions.test.ts
+++ b/packages/agent/activity-tuttid-adapter/src/composerOptions.test.ts
@@ -38,6 +38,40 @@ test("maps daemon composer options into the canonical activity contract", () => 
   assert.equal(options.effectiveSettings?.model, "gpt-5");
 });
 
+test("maps video input support into the canonical model option", () => {
+  const options = agentActivityComposerOptionsFromTuttidResult("opencode", {
+    behavior: {},
+    capabilityCatalog: [],
+    commands: [],
+    effectiveSettings: { model: "opencode-minimax/MiniMax-M3" },
+    modelConfig: {
+      configurable: true,
+      options: [
+        {
+          id: "opencode-minimax/MiniMax-M3",
+          label: "MiniMax M3",
+          value: "opencode-minimax/MiniMax-M3",
+          supportsVideoInput: true
+        }
+      ]
+    },
+    permissionConfig: { configurable: false, modes: [] },
+    provider: "opencode",
+    reasoningConfig: { configurable: false, options: [] },
+    reasoningOptionsByModel: {},
+    runtimeContext: {},
+    skills: []
+  } as unknown as AgentProviderComposerOptionsResponse);
+
+  assert.deepEqual(options.models, [
+    {
+      label: "MiniMax M3",
+      value: "opencode-minimax/MiniMax-M3",
+      supportsVideoInput: true
+    }
+  ]);
+});
+
 test("keeps fallback slash commands when effects are absent", () => {
   const response = {
     behavior: {

--- a/packages/agent/activity-tuttid-adapter/src/composerOptions.ts
+++ b/packages/agent/activity-tuttid-adapter/src/composerOptions.ts
@@ -296,11 +296,16 @@ function settingOptionsFromRawOptions(
       typeof record.supportsImageInput === "boolean"
         ? record.supportsImageInput
         : undefined;
+    const supportsVideoInput =
+      typeof record.supportsVideoInput === "boolean"
+        ? record.supportsVideoInput
+        : undefined;
     options.push({
       value: optionValue,
       label,
       ...(description ? { description } : {}),
       ...(supportsImageInput !== undefined ? { supportsImageInput } : {}),
+      ...(supportsVideoInput !== undefined ? { supportsVideoInput } : {}),
       // Daemon provenance: the entry mirrors the requested selection (warm
       // catalog append / bootstrap echo) and is not catalog testimony.
       ...(record.requested === true ? { requested: true } : {})

--- a/packages/agent/daemon/modelcatalog/runtime_config_options.go
+++ b/packages/agent/daemon/modelcatalog/runtime_config_options.go
@@ -88,6 +88,7 @@ func NormalizeRuntimeConfigOptionModel(raw json.RawMessage) (ModelOption, bool) 
 		SpeedsAdvertised:           speedsAdvertised,
 		SupportedSpeeds:            speeds,
 		SupportsImageInput:         runtimeConfigImageInputSupport(object),
+		SupportsVideoInput:         runtimeConfigVideoInputSupport(object),
 	}, true
 }
 
@@ -102,6 +103,9 @@ func ProjectRuntimeConfigOptionModel(model ModelOption) map[string]any {
 	}
 	if model.SupportsImageInput != nil {
 		option["supportsImageInput"] = *model.SupportsImageInput
+	}
+	if model.SupportsVideoInput != nil {
+		option["supportsVideoInput"] = *model.SupportsVideoInput
 	}
 	if model.ReasoningEffortsAdvertised {
 		reasoningOptions := make([]map[string]any, 0, len(model.SupportedReasoningEfforts))
@@ -174,4 +178,11 @@ func runtimeConfigImageInputSupport(object map[string]any) *bool {
 		return &supported
 	}
 	return codexImageInputSupport(object)
+}
+
+func runtimeConfigVideoInputSupport(object map[string]any) *bool {
+	if supported, advertised := object["supportsVideoInput"].(bool); advertised {
+		return &supported
+	}
+	return nil
 }

--- a/packages/agent/daemon/modelcatalog/runtime_config_options_test.go
+++ b/packages/agent/daemon/modelcatalog/runtime_config_options_test.go
@@ -9,6 +9,7 @@ func TestRuntimeConfigOptionModelRoundTripPreservesCapabilities(t *testing.T) {
 	t.Parallel()
 
 	imageInput := true
+	videoInput := true
 	model := ModelOption{
 		ID:                         "gpt-5.6-sol",
 		DisplayName:                "GPT-5.6-Sol",
@@ -31,6 +32,7 @@ func TestRuntimeConfigOptionModelRoundTripPreservesCapabilities(t *testing.T) {
 			{Value: "fast", Label: "Fast"},
 		},
 		SupportsImageInput: &imageInput,
+		SupportsVideoInput: &videoInput,
 	}
 
 	projected := ProjectRuntimeConfigOptionModel(model)
@@ -63,6 +65,9 @@ func TestRuntimeConfigOptionModelRoundTripPreservesCapabilities(t *testing.T) {
 	}
 	if got.SupportsImageInput == nil || !*got.SupportsImageInput {
 		t.Fatalf("round-trip image input = %#v, want true", got.SupportsImageInput)
+	}
+	if got.SupportsVideoInput == nil || !*got.SupportsVideoInput {
+		t.Fatalf("round-trip video input = %#v, want true", got.SupportsVideoInput)
 	}
 }
 

--- a/packages/agent/daemon/modelcatalog/selection.go
+++ b/packages/agent/daemon/modelcatalog/selection.go
@@ -86,5 +86,9 @@ func cloneModelOption(model ModelOption) ModelOption {
 		value := *model.SupportsImageInput
 		model.SupportsImageInput = &value
 	}
+	if model.SupportsVideoInput != nil {
+		value := *model.SupportsVideoInput
+		model.SupportsVideoInput = &value
+	}
 	return model
 }

--- a/packages/agent/daemon/modelcatalog/types.go
+++ b/packages/agent/daemon/modelcatalog/types.go
@@ -27,6 +27,7 @@ type ModelOption struct {
 	SpeedsAdvertised           bool
 	SupportedSpeeds            []SpeedOption
 	SupportsImageInput         *bool
+	SupportsVideoInput         *bool
 }
 
 // ModelSelection is the capability projection for the effective model. Field

--- a/packages/agent/daemon/runtime/acp_model_state.go
+++ b/packages/agent/daemon/runtime/acp_model_state.go
@@ -13,6 +13,7 @@ type acpModelInfo struct {
 	ReasoningEffort         json.RawMessage `json:"reasoningEffort"`
 	ReasoningEfforts        json.RawMessage `json:"reasoningEfforts"`
 	SupportsImageInput      json.RawMessage `json:"supportsImageInput"`
+	SupportsVideoInput      json.RawMessage `json:"supportsVideoInput"`
 	Meta                    json.RawMessage `json:"_meta"`
 }
 
@@ -100,6 +101,13 @@ func applyACPModelMetadata(option map[string]any, model acpModelInfo) {
 	}
 	if supportsImage != nil {
 		option["supportsImageInput"] = *supportsImage
+	}
+	supportsVideo := rawJSONBool(model.SupportsVideoInput)
+	if supportsVideo == nil {
+		supportsVideo = rawJSONBool(metadata["supportsVideoInput"])
+	}
+	if supportsVideo != nil {
+		option["supportsVideoInput"] = *supportsVideo
 	}
 }
 

--- a/packages/agent/daemon/runtime/acp_models_test.go
+++ b/packages/agent/daemon/runtime/acp_models_test.go
@@ -46,7 +46,8 @@ func TestApplyACPModelsResultPreservesDynamicModelMetadata(t *testing.T) {
 						{"value":"brief","label":"Brief","description":"Fast"},
 						{"value":"deep","label":"Deep","default":true}
 					],
-					"supportsImageInput":true
+					"supportsImageInput":true,
+					"supportsVideoInput":true
 				},
 				{
 					"modelId":"plain-model",
@@ -54,7 +55,8 @@ func TestApplyACPModelsResultPreservesDynamicModelMetadata(t *testing.T) {
 					"_meta":{
 						"supportsReasoningEffort":false,
 						"reasoningEfforts":[],
-						"supportsImageInput":false
+						"supportsImageInput":false,
+						"supportsVideoInput":false
 					}
 				}
 			],
@@ -66,7 +68,7 @@ func TestApplyACPModelsResultPreservesDynamicModelMetadata(t *testing.T) {
 	if len(options) != 2 {
 		t.Fatalf("model options = %#v, want two", options)
 	}
-	if options[0]["supportsReasoningEffort"] != true || options[0]["reasoningEffort"] != "deep" || options[0]["supportsImageInput"] != true {
+	if options[0]["supportsReasoningEffort"] != true || options[0]["reasoningEffort"] != "deep" || options[0]["supportsImageInput"] != true || options[0]["supportsVideoInput"] != true {
 		t.Fatalf("reasoning model metadata = %#v", options[0])
 	}
 	efforts, ok := options[0]["reasoningEfforts"].([]any)
@@ -77,7 +79,7 @@ func TestApplyACPModelsResultPreservesDynamicModelMetadata(t *testing.T) {
 	if brief["value"] != "brief" || brief["label"] != "Brief" || brief["description"] != "Fast" {
 		t.Fatalf("brief effort = %#v", brief)
 	}
-	if options[1]["supportsReasoningEffort"] != false || options[1]["supportsImageInput"] != false {
+	if options[1]["supportsReasoningEffort"] != false || options[1]["supportsImageInput"] != false || options[1]["supportsVideoInput"] != false {
 		t.Fatalf("plain model metadata = %#v", options[1])
 	}
 	if efforts, ok := options[1]["reasoningEfforts"].([]any); !ok || len(efforts) != 0 {

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -1890,6 +1890,7 @@ export type AgentProviderComposerConfigOptionValue = {
   label: string;
   description?: string;
   supportsImageInput?: boolean;
+  supportsVideoInput?: boolean;
   /**
    * True when the entry mirrors the requested/current selection instead of the provider catalog (warm-catalog append of the requested model, selected-model bootstrap echo). Clients keep such entries selectable but must not treat them as proof the provider can run the model; create validation runs against the raw catalog only.
    */

--- a/services/tuttid/api/daemon_agent_composer_options.go
+++ b/services/tuttid/api/daemon_agent_composer_options.go
@@ -174,6 +174,9 @@ func generatedComposerConfigOption(config agentservice.ComposerConfigOption) tut
 		if option.SupportsImageInput != nil {
 			resultOption.SupportsImageInput = option.SupportsImageInput
 		}
+		if option.SupportsVideoInput != nil {
+			resultOption.SupportsVideoInput = option.SupportsVideoInput
+		}
 		if option.Requested {
 			requested := true
 			resultOption.Requested = &requested

--- a/services/tuttid/api/daemon_agent_composer_options_test.go
+++ b/services/tuttid/api/daemon_agent_composer_options_test.go
@@ -44,6 +44,23 @@ func TestGeneratedComposerConfigOptionKeepsRequestedProvenance(t *testing.T) {
 	}
 }
 
+func TestGeneratedComposerConfigOptionKeepsVideoInputCapability(t *testing.T) {
+	videoInput := true
+	generated := generatedComposerConfigOption(agentservice.ComposerConfigOption{
+		Options: []agentservice.ComposerConfigOptionValue{{
+			ID:                 "opencode-minimax/MiniMax-M3",
+			Label:              "MiniMax M3",
+			Value:              "opencode-minimax/MiniMax-M3",
+			SupportsVideoInput: &videoInput,
+		}},
+	})
+	if len(generated.Options) != 1 ||
+		generated.Options[0].SupportsVideoInput == nil ||
+		!*generated.Options[0].SupportsVideoInput {
+		t.Fatalf("generated option = %#v, want supportsVideoInput=true", generated.Options)
+	}
+}
+
 func TestDaemonAPIGeneratedRoutesGetAgentProviderComposerOptions(t *testing.T) {
 	mux := http.NewServeMux()
 	RegisterRoutes(mux, NewRoutes(DaemonAPI{

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -5112,6 +5112,7 @@ type AgentProviderComposerConfigOptionValue struct {
 	// Requested True when the entry mirrors the requested/current selection instead of the provider catalog (warm-catalog append of the requested model, selected-model bootstrap echo). Clients keep such entries selectable but must not treat them as proof the provider can run the model; create validation runs against the raw catalog only.
 	Requested          *bool  `json:"requested,omitempty"`
 	SupportsImageInput *bool  `json:"supportsImageInput,omitempty"`
+	SupportsVideoInput *bool  `json:"supportsVideoInput,omitempty"`
 	Value              string `json:"value"`
 }
 

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -11461,6 +11461,8 @@ components:
           type: string
         supportsImageInput:
           type: boolean
+        supportsVideoInput:
+          type: boolean
         requested:
           type: boolean
           description: >-

--- a/services/tuttid/service/agent/composer_config_option_values.go
+++ b/services/tuttid/service/agent/composer_config_option_values.go
@@ -35,6 +35,9 @@ func composerConfigOptionValuesToRuntimeModelOptions(options []ComposerConfigOpt
 		if option.SupportsImageInput != nil {
 			entry["supportsImageInput"] = *option.SupportsImageInput
 		}
+		if option.SupportsVideoInput != nil {
+			entry["supportsVideoInput"] = *option.SupportsVideoInput
+		}
 		if option.SupportsReasoningEffort != nil {
 			entry["supportsReasoningEffort"] = *option.SupportsReasoningEffort
 		}

--- a/services/tuttid/service/agent/composer_live_model_discovery.go
+++ b/services/tuttid/service/agent/composer_live_model_discovery.go
@@ -728,6 +728,7 @@ func normalizeLiveComposerModelOptions(options []ComposerConfigOptionValue) []Co
 			Value:                      value,
 			Description:                strings.TrimSpace(option.Description),
 			SupportsImageInput:         option.SupportsImageInput,
+			SupportsVideoInput:         option.SupportsVideoInput,
 			SupportsReasoningEffort:    option.SupportsReasoningEffort,
 			ReasoningEffort:            strings.TrimSpace(option.ReasoningEffort),
 			ReasoningEfforts:           append([]AgentModelReasoningEffortOption(nil), option.ReasoningEfforts...),

--- a/services/tuttid/service/agent/composer_model_options_test.go
+++ b/services/tuttid/service/agent/composer_model_options_test.go
@@ -110,3 +110,13 @@ func TestComposerConfigOptionValuesToRuntimeModelOptionsEmitsRequested(t *testin
 		t.Fatal("requested entry must emit requested=true in runtime context")
 	}
 }
+
+func TestComposerConfigOptionValuesToRuntimeModelOptionsEmitsVideoInput(t *testing.T) {
+	supported := true
+	entries := composerConfigOptionValuesToRuntimeModelOptions([]ComposerConfigOptionValue{{
+		ID: "opencode-minimax/MiniMax-M3", Label: "MiniMax M3", Value: "opencode-minimax/MiniMax-M3", SupportsVideoInput: &supported,
+	}})
+	if len(entries) != 1 || entries[0]["supportsVideoInput"] != true {
+		t.Fatalf("runtime entries = %#v, want supportsVideoInput true", entries)
+	}
+}

--- a/services/tuttid/service/agent/composer_options.go
+++ b/services/tuttid/service/agent/composer_options.go
@@ -50,6 +50,7 @@ type ComposerConfigOptionValue struct {
 	Label                      string
 	Value                      string
 	SupportsImageInput         *bool
+	SupportsVideoInput         *bool
 	SupportsReasoningEffort    *bool
 	ReasoningEffort            string
 	ReasoningEfforts           []AgentModelReasoningEffortOption
@@ -753,6 +754,7 @@ func composerModelConfig(provider string, selected string, options []ComposerCon
 			Value:              value,
 			Description:        strings.TrimSpace(option.Description),
 			SupportsImageInput: option.SupportsImageInput,
+			SupportsVideoInput: option.SupportsVideoInput,
 			Requested:          option.Requested,
 		})
 	}

--- a/services/tuttid/service/agent/composer_runtime_model_options.go
+++ b/services/tuttid/service/agent/composer_runtime_model_options.go
@@ -134,6 +134,7 @@ func composerModelOptionsFromCanonicalCatalog(models []modelcatalog.ModelOption)
 			Value:                      value,
 			Description:                strings.TrimSpace(model.Description),
 			SupportsImageInput:         model.SupportsImageInput,
+			SupportsVideoInput:         model.SupportsVideoInput,
 			SupportsReasoningEffort:    supportsReasoningEffort,
 			ReasoningEffort:            strings.TrimSpace(model.DefaultReasoningEffort),
 			ReasoningEfforts:           append([]AgentModelReasoningEffortOption(nil), model.SupportedReasoningEfforts...),
@@ -166,12 +167,19 @@ func composerConfigOptionValuesFromAny(input any) []ComposerConfigOptionValue {
 		if id == "" {
 			id = value
 		}
-		options = append(options, ComposerConfigOptionValue{
+		option := ComposerConfigOptionValue{
 			ID:          id,
 			Label:       label,
 			Value:       value,
 			Description: strings.TrimSpace(stringFromAny(optionMap["description"])),
-		})
+		}
+		if supported, advertised := optionMap["supportsImageInput"].(bool); advertised {
+			option.SupportsImageInput = &supported
+		}
+		if supported, advertised := optionMap["supportsVideoInput"].(bool); advertised {
+			option.SupportsVideoInput = &supported
+		}
+		options = append(options, option)
 	}
 	return options
 }

--- a/services/tuttid/service/agent/opencode_model_catalog.go
+++ b/services/tuttid/service/agent/opencode_model_catalog.go
@@ -147,10 +147,14 @@ func normalizeVerboseOpenCodeModel(modelID string, metadata map[string]any) Agen
 		return openCodeReasoningEffortOrder(reasoningEfforts[leftIndex].Value) < openCodeReasoningEffortOrder(reasoningEfforts[rightIndex].Value)
 	})
 	var supportsImageInput *bool
+	var supportsVideoInput *bool
 	if capabilities, ok := metadata["capabilities"].(map[string]any); ok {
 		if input, ok := capabilities["input"].(map[string]any); ok {
 			if image, ok := input["image"].(bool); ok {
 				supportsImageInput = &image
+			}
+			if video, ok := input["video"].(bool); ok {
+				supportsVideoInput = &video
 			}
 		}
 	}
@@ -161,6 +165,7 @@ func normalizeVerboseOpenCodeModel(modelID string, metadata map[string]any) Agen
 		ReasoningEffortsAdvertised: variantsAdvertised,
 		SupportedReasoningEfforts:  reasoningEfforts,
 		SupportsImageInput:         supportsImageInput,
+		SupportsVideoInput:         supportsVideoInput,
 	}
 }
 

--- a/services/tuttid/service/agent/opencode_model_catalog_test.go
+++ b/services/tuttid/service/agent/opencode_model_catalog_test.go
@@ -104,6 +104,23 @@ tutti/glm-5
 	}
 }
 
+func TestParseVerboseOpenCodeModelsOutputKeepsMiniMaxInputCapabilities(t *testing.T) {
+	t.Parallel()
+
+	models := parseOpenCodeModelsOutput([]byte(`opencode-minimax/MiniMax-M3
+{"name":"MiniMax M3","capabilities":{"input":{"text":true,"image":true,"video":true}},"variants":{}}
+`))
+
+	if len(models) != 1 {
+		t.Fatalf("len(models) = %d, want 1: %#v", len(models), models)
+	}
+	if models[0].ID != "opencode-minimax/MiniMax-M3" ||
+		models[0].SupportsImageInput == nil || !*models[0].SupportsImageInput ||
+		models[0].SupportsVideoInput == nil || !*models[0].SupportsVideoInput {
+		t.Fatalf("MiniMax M3 input capabilities = %#v", models[0])
+	}
+}
+
 func TestParseVerboseOpenCodeModelsOutputDistinguishesSameModelAcrossProviders(t *testing.T) {
 	t.Parallel()
 

--- a/services/tuttid/service/cli/providers/agentcontext/composer_options.go
+++ b/services/tuttid/service/cli/providers/agentcontext/composer_options.go
@@ -142,6 +142,9 @@ func composerConfigOptionValue(config agentservice.ComposerConfigOption) map[str
 		if option.SupportsImageInput != nil {
 			value["supportsImageInput"] = *option.SupportsImageInput
 		}
+		if option.SupportsVideoInput != nil {
+			value["supportsVideoInput"] = *option.SupportsVideoInput
+		}
 		options = append(options, value)
 	}
 	return map[string]any{


### PR DESCRIPTION
Reason: MiniMax M3 advertises video input, but the model option contract drops that capability.

## Summary

- parse advertised video-input metadata from verbose catalog entries
- preserve video-input support across canonical model options, runtime snapshots, daemon and CLI projections, and the TypeScript activity adapter
- expose the optional capability in the OpenAPI contract and regenerate clients

## Verification

- `go test ./packages/agent/daemon/modelcatalog -run '^TestRuntimeConfigOptionModelRoundTripPreservesCapabilities$' -count=1`
- `go test ./packages/agent/daemon/runtime -run '^TestApplyACPModelsResultPreservesDynamicModelMetadata$' -count=1`
- `go test ./services/tuttid/api -run '^TestGeneratedComposerConfigOptionKeepsVideoInputCapability$' -count=1`
- `pnpm --filter @tutti-os/agent-activity-tuttid-adapter test`
- `pnpm --filter @tutti-os/agent-activity-core typecheck`
- `pnpm --filter @tutti-os/agent-activity-tuttid-adapter typecheck`
- `pnpm check:api-generated`
- `pnpm check:agent-host-boundary`
- focused TypeScript, YAML, Go formatting, and diff checks

## Impact

This is platform-neutral capability metadata and does not change path, process, filesystem, or operating-system behavior. The OpenAPI schema is the durable contract documentation for the new optional field.
