### PR TITLE
fix(agent-gui): converge terminal turn presentation

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -936,7 +936,12 @@ the associated state report wins canonical ordering. Desktop and Mobile Live
 consume the same event variant. The workspace Engine uses its occurrence time
 to reject reordering and prevents an older `running` observation from
 overriding a settled Turn. A disconnect clears the ephemeral observation,
-while canonical Turn state remains authoritative once it exists.
+while canonical Turn state remains authoritative once it exists. AgentGUI
+consumes the Engine's fenced Session display status after the canonical
+Session exists; it must not recompute Composer busy state from the raw runtime
+activity flag, because that would let an older `running` observation outlive a
+completed or failed latest Turn. Raw runtime activity may bridge presentation
+only before that canonical Session projection exists.
 
 ### 4.1 Read/write rules
 

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -918,7 +918,9 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   Creating a Session with an initial Goal starts the processing indicator, then
   stops it as soon as the canonical Session appears. The provider continues
   working without an indicator. When the first assistant message and canonical
-  Turn arrive, the indicator starts again until the Turn settles.
+  Turn arrive, the indicator starts again until the Turn settles. The inverse
+  symptom is a completed or failed Turn whose rail status has settled while the
+  Composer action still spins.
 - Quick checks:
   Compare the Claude SDK `session_state_changed` lifecycle log, activity stream
   connection, Engine runtime activity, canonical Session, and canonical latest
@@ -931,17 +933,23 @@ catalog revision mismatch`, fully restart `dev:desktop`; renderer HMR cannot
   Claude emits an exact session-level `running` observation before the first
   provider Turn identity, but the daemon previously logged and discarded it.
   Goal-only creation correctly has `initialTurnExpected = false`, so neither a
-  pending prompt nor a canonical Turn can bridge that interval.
+  pending prompt nor a canonical Turn can bridge that interval. For the inverse
+  symptom, AgentGUI bypassed the Engine's occurrence-time fence and read the
+  stale raw `running` flag directly after a canonical Turn had settled.
 - Fix:
   Normalize the SDK observation to provider-neutral `running`/`idle` runtime
   activity, publish it as an ephemeral activity-stream event, and let the
-  workspace Engine drive AgentGUI and rail busy projection. Clear ephemeral
+  workspace Engine drive AgentGUI and rail busy projection. Once a canonical
+  Session exists, AgentGUI must consume the Engine's fenced display status;
+  use raw runtime activity only before that projection exists. Clear ephemeral
   runtime activity on disconnect. Keep Goal turnless and do not invent
   lifecycle state, provider-specific timers, or synthetic Turn IDs.
 - Validation:
   Cover SDK projection without Turn identity, post-commit event publication,
   activity-stream ingestion before canonical Session hydration, AgentGUI busy
-  projection, `idle`, and disconnect cleanup.
+  projection, `idle`, disconnect cleanup, and both completed and failed Turns
+  remaining settled when an older raw runtime observation still says
+  `running`.
 - References:
   [claude_sdk_events.go](../../../packages/agent/daemon/runtime/claude_sdk_events.go)
   [workspaceEventCoordinator.ts](../../../packages/agent/activity-core/src/workspaceEventCoordinator.ts)
@@ -976,15 +984,16 @@ catalog revision mismatch`, fully restart `dev:desktop`; renderer HMR cannot
   current.
 - Fix:
   Reconcile terminal `AgentActivityTurn.error` in the shared transcript
-  projection by exact `turnId`, but only when that Turn already exists in the
-  hydrated transcript projection. Reuse a structured visible error, upgrade a
+  projection by exact `turnId`. Reuse a structured visible error, upgrade a
   matching plain assistant failure, or add one view-only row with a stable
-  `(agentSessionId, turnId)` identity. If the owning Turn is outside the message
-  window, skip it until an older page supplies an anchor. Do not manufacture an
-  empty transcript Turn, restore session `lastError`, let session-operation
-  selectors fall back to Turn errors, reinterpret a successful attach as
-  activation failure, persist a duplicate message, or add component-local
-  failure state.
+  `(agentSessionId, turnId)` identity. Normally the owning Turn must already
+  exist in the hydrated transcript projection. The exact latest failed Turn is
+  the narrow exception: if it emitted no transcript item, create its view-only
+  error row so the current failure reason remains visible. Historical Turns
+  outside the message window still wait for an older page to supply an anchor.
+  Do not restore session `lastError`, let session-operation selectors fall back
+  to Turn errors, reinterpret a successful attach as activation failure,
+  persist a duplicate message, or add component-local failure state.
 - Validation:
   Cover a failed Turn with no provider error message, a matching plain failure,
   and an existing structured visible error. The first must render one fallback
@@ -992,8 +1001,9 @@ catalog revision mismatch`, fully restart `dev:desktop`; renderer HMR cannot
   a full canonical Turn list and a newest-page-only transcript window, an older
   failed or interrupted Turn must not create a row or change Turn order. After
   prepending the older page, its error must appear exactly once on the owning
-  Turn. Also cover a failed Turn with zero hydrated transcript items and a
-  newer active Turn whose processing ownership remains current.
+  Turn. Also cover the exact latest failed Turn with zero hydrated transcript
+  items producing one error row, plus an older failed Turn with a newer active
+  Turn whose processing ownership remains current.
 - References:
   [workspaceAgentTurnErrorProjection.ts](../../../packages/agent/gui/shared/workspaceAgentTurnErrorProjection.ts)
   [workspaceAgentTurnErrorProjection.spec.ts](../../../packages/agent/gui/shared/workspaceAgentTurnErrorProjection.spec.ts)

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.spec.tsx
@@ -217,10 +217,12 @@ describe("useAgentGUISessionPresentation", () => {
     input.activePendingActivation = null;
     input.activeEngineLatestTurn = null;
     input.activeEngineRuntimeActivity = "running";
+    input.activityDisplayStatus = "working";
     rendered.rerender();
     expect(rendered.result.current.activeConversationBusy).toBe(true);
 
     input.activeEngineRuntimeActivity = "idle";
+    input.activityDisplayStatus = "idle";
     rendered.rerender();
     expect(rendered.result.current.activeConversationBusy).toBe(false);
 
@@ -371,6 +373,7 @@ describe("useAgentGUISessionPresentation", () => {
       updatedAtUnixMs: 5
     };
     input.activeEngineRuntimeActivity = "running";
+    input.activityDisplayStatus = "working";
     rendered.rerender();
     expect(rendered.result.current.activeConversationBusy).toBe(true);
 
@@ -381,7 +384,16 @@ describe("useAgentGUISessionPresentation", () => {
       settledAtUnixMs: 6,
       updatedAtUnixMs: 6
     };
-    input.activeEngineRuntimeActivity = "idle";
+    input.activityDisplayStatus = "completed";
+    rendered.rerender();
+    expect(rendered.result.current.activeConversationBusy).toBe(false);
+
+    input.activeEngineLatestTurn = {
+      ...input.activeEngineLatestTurn,
+      error: { message: "Runtime host unavailable" },
+      outcome: "failed"
+    };
+    input.activityDisplayStatus = "failed";
     rendered.rerender();
     expect(rendered.result.current.activeConversationBusy).toBe(false);
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts
@@ -315,10 +315,11 @@ export function useAgentGUISessionPresentation(
   );
   const activeConversationBusy =
     activeHasPendingSubmittedTurn ||
-    input.activeEngineRuntimeActivity === "running" ||
     (input.activeEngineSession
-      ? input.activeEngineAvailability === "blocked"
-      : agentActivityDisplayStatusBusy(input.activityDisplayStatus) ||
+      ? agentActivityDisplayStatusBusy(input.activityDisplayStatus) ||
+        input.activeEngineAvailability === "blocked"
+      : input.activeEngineRuntimeActivity === "running" ||
+        agentActivityDisplayStatusBusy(input.activityDisplayStatus) ||
         conversationBusyStatus(input.activeConversation?.status ?? null) ||
         activeSubmitBlocked);
   const activeSessionResumable =

--- a/packages/agent/gui/shared/workspaceAgentTimelineCanonical.ts
+++ b/packages/agent/gui/shared/workspaceAgentTimelineCanonical.ts
@@ -226,6 +226,7 @@ export function buildCanonicalWorkspaceAgentDetailView({
 
   enrichProjectedTurnsWithCanonicalErrors({
     turns,
+    latestTurnId: session.latestTurn?.turnId ?? null,
     sessionTurns:
       sessionTurns.length > 0
         ? sessionTurns

--- a/packages/agent/gui/shared/workspaceAgentTurnErrorProjection.spec.ts
+++ b/packages/agent/gui/shared/workspaceAgentTurnErrorProjection.spec.ts
@@ -315,17 +315,42 @@ describe("canonical Turn error projection", () => {
     ).toBe("Turn failed");
   });
 
-  it("does not synthesize a failed Turn when no transcript item has been hydrated", () => {
+  it("projects the latest failed Turn when no transcript item has been hydrated", () => {
     const failed = failedTurn();
-    const detail = buildCanonicalWorkspaceAgentDetailView({
+    const input = {
       activity: activity(),
       session: session({ latestTurn: failed }),
       sessionTurns: [failed],
       workspaceRoot: "/workspace/demo",
       timelineItems: []
-    });
+    };
+    const detail = buildCanonicalWorkspaceAgentDetailView(input);
+    const conversation = projectWorkspaceAgentTimelineToConversationVM(input);
 
-    expect(detail.turns).toEqual([]);
+    expect(detail.turns).toEqual([
+      expect.objectContaining({
+        id: "turn-1",
+        agentMessages: [
+          expect.objectContaining({
+            id: "turn-error:session-1:turn-1",
+            body: "Turn failed",
+            visibleError: expect.objectContaining({ detail: "Turn failed" })
+          })
+        ]
+      })
+    ]);
+    expect(
+      conversation.rows.some(
+        (row) =>
+          row.kind === "message" &&
+          row.speaker === "assistant" &&
+          row.messages.some(
+            (message) =>
+              message.id === "turn-error:session-1:turn-1" &&
+              message.visibleError?.detail === "Turn failed"
+          )
+      )
+    ).toBe(true);
   });
 
   it("keeps the current running Turn last when an older failed Turn is outside the window", () => {
@@ -372,6 +397,7 @@ describe("canonical Turn error projection", () => {
 
       enrichProjectedTurnsWithCanonicalErrors({
         turns,
+        latestTurnId: "turn-2",
         sessionTurns: [
           failedTurn({
             outcome,

--- a/packages/agent/gui/shared/workspaceAgentTurnErrorProjection.ts
+++ b/packages/agent/gui/shared/workspaceAgentTurnErrorProjection.ts
@@ -5,19 +5,24 @@ import type {
 } from "./workspaceAgentSessionDetailViewModel";
 
 /**
- * Enriches Turns that the hydrated transcript has already projected.
+ * Enriches Turns that the hydrated transcript has already projected, plus an
+ * errored latest Turn that has not emitted any transcript item yet.
  *
  * `sessionTurns` can describe the full session while `turns` contains only the
- * current message window. Canonical lifecycle metadata therefore must not
- * create transcript membership or alter transcript order.
+ * current message window. Historical canonical lifecycle metadata therefore
+ * must not create transcript membership or alter transcript order. The exact
+ * latest Turn is the one exception because its canonical error is the current
+ * conversation result rather than paginated history.
  */
 export function enrichProjectedTurnsWithCanonicalErrors({
   turns,
+  latestTurnId,
   sessionTurns,
   provider,
   agentSessionId
 }: {
-  turns: ReadonlyMap<string, WorkspaceAgentSessionDetailTurn>;
+  turns: Map<string, WorkspaceAgentSessionDetailTurn>;
+  latestTurnId: string | null;
   sessionTurns: readonly AgentActivityTurn[];
   provider: string;
   agentSessionId: string;
@@ -34,7 +39,11 @@ export function enrichProjectedTurnsWithCanonicalErrors({
       continue;
     }
 
-    const turn = turns.get(canonicalTurn.turnId);
+    const turn =
+      turns.get(canonicalTurn.turnId) ??
+      (canonicalTurn.turnId === latestTurnId
+        ? createProjectedTurn(turns, canonicalTurn.turnId)
+        : null);
     if (!turn) {
       continue;
     }
@@ -79,6 +88,24 @@ export function enrichProjectedTurnsWithCanonicalErrors({
     turn.agentMessages.push(message);
     turn.agentItems.push({ kind: "message", message });
   }
+}
+
+function createProjectedTurn(
+  turns: Map<string, WorkspaceAgentSessionDetailTurn>,
+  turnId: string
+): WorkspaceAgentSessionDetailTurn {
+  const turn: WorkspaceAgentSessionDetailTurn = {
+    id: turnId,
+    userMessage: null,
+    userMessages: [],
+    agentMessages: [],
+    toolCalls: [],
+    toolCallCount: 0,
+    hasFailedToolCall: false,
+    agentItems: []
+  };
+  turns.set(turnId, turn);
+  return turn;
 }
 
 function visibleErrorFromCanonicalTurn(


### PR DESCRIPTION
## Summary
- derive canonical Session busy presentation from the Engine's fenced display status so stale runtime `running` observations cannot outlive completed or failed Turns
- project the exact latest canonical Turn error even when the provider emitted no transcript row, while preserving historical transcript pagination
- add regression coverage and update AgentGUI architecture and troubleshooting guidance

## Tests
- `pnpm check:changed -- --push-ready` (12 lanes passed via pre-push)

## Notes
- no public API or lifecycle ownership changes
- no end-to-end test run
