### PR TITLE
fix(agent): preserve live Cursor message projections

### DIFF
--- a/apps/mobile/src/services/workspaceAgentLiveLane.ts
+++ b/apps/mobile/src/services/workspaceAgentLiveLane.ts
@@ -260,7 +260,11 @@ export class WorkspaceAgentLiveLane {
 
   private applyEvent(event: AgentActivityLiveEvent): void {
     const result = this.coordinator.ingestEvent(event);
-    if (result.optimisticMessage || result.inlineApplied) {
+    if (
+      result.optimisticMessage ||
+      result.inlineApplied ||
+      result.inlinePreviewed
+    ) {
       this.options.onActivityChanged();
     }
     if (result.accepted && event.eventType !== "message_delta") {

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -1425,7 +1425,22 @@ that overlay over the latest canonical message base, applies continuous inline
 messages, owns Session deletion tombstones, admits only explicit
 `session_restored` events through those tombstones, and schedules authoritative
 reconciliation after a restore, gap, discontinuity, recovered connection,
-invalid payload, or unanchored append. The Tutti desktop receives local deltas
+invalid payload, or unanchored append. Inline canonical messages and ordinary
+incremental reads merge into that base by stable message identity; their
+omissions are not deletions because either source may be partial or may race a
+precommit delta. Matching nonterminal canonical content may advance a confirmed
+text or tool-output prefix in place, while only a terminal canonical snapshot
+clears the matching optimistic row. Scope-wide omission becomes authoritative
+only for an effective-history replacement, which preserves nonterminal
+optimistic rows belonging to Turns that remain active and removes them after
+those Turns settle or leave effective history. When an otherwise valid inline
+message follows a version gap, the coordinator leaves the Engine's durable
+message cursor unchanged and requests reconciliation, but projects the message
+for an already cached Session through a separate canonical-preview lane. This
+keeps a tool anchor visible and available to later tool-output deltas without
+allowing a missing mutable version to be skipped. Continuous or authoritative
+canonical confirmation removes the preview; an effective-history read retains
+it only while its Turn remains active. The Tutti desktop receives local deltas
 through the business-event WebSocket; shared-device hosts receive the same live
 subset through the framed Go protocol. UI consumers never retain transport
 epoch/sequence state or distinguish local from shared activity sources.

--- a/packages/agent/activity-core/README.md
+++ b/packages/agent/activity-core/README.md
@@ -273,8 +273,21 @@ Each host creates one
 `createAgentActivityWorkspaceEventCoordinator` per workspace and passes
 transport deliveries into it. The coordinator validates and cleans
 `message_delta`, owns its optimistic projection over canonical
-`sessionMessagesById`, and clears that projection after authoritative message
-reads or Session removal. The generated `AgentActivityUpdatedEvent` input also
+`sessionMessagesById`, and merges inline or incrementally read canonical
+messages by stable message identity. Partial canonical batches and ordinary
+message reads do not make omission authoritative: an active optimistic row
+remains available as an `append_text` anchor, while matching nonterminal
+canonical content may advance its confirmed prefix in place. A terminal
+canonical snapshot clears the matching optimistic row. Only an
+effective-history replacement, explicit Session removal, or rebind may use
+omission to clear the projection; effective-history replacement still
+preserves nonterminal rows for Turns that remain active. A structurally valid
+inline message that follows a version gap is not written to the Engine or used
+to advance its durable cursor. For an already cached Session, the coordinator
+instead keeps it in a separate canonical preview so tool anchors and status
+remain visible while the required message reconcile runs. Later live deltas
+may attach to that preview by `messageId`; a continuous or authoritative read
+confirms or removes it. The generated `AgentActivityUpdatedEvent` input also
 accepts:
 
 - `turn_update`: atomically updates the canonical Turn and the cached Session's

--- a/packages/agent/activity-core/src/activityEventObservation.test.ts
+++ b/packages/agent/activity-core/src/activityEventObservation.test.ts
@@ -46,9 +46,11 @@ test("message updates apply inline only for a cached Session with continuity", (
   });
 
   assert.equal(cached.canApplyInlineMessages, true);
+  assert.equal(cached.canPreviewInlineMessages, true);
   assert.equal(cached.intent.inlineApplied, true);
   assert.equal(cached.intent.hasInlineMessages, true);
   assert.equal(uncached.canApplyInlineMessages, true);
+  assert.equal(uncached.canPreviewInlineMessages, false);
   assert.equal(uncached.intent.inlineApplied, false);
 });
 
@@ -68,6 +70,7 @@ test("message updates fail closed when any advertised message is malformed", () 
     [2]
   );
   assert.equal(observation.canApplyInlineMessages, false);
+  assert.equal(observation.canPreviewInlineMessages, false);
   assert.equal(observation.intent.inlineApplied, false);
 });
 
@@ -87,6 +90,7 @@ test("message updates fail closed on envelope, message, or cursor disagreement",
       hasCachedSession: true
     });
     assert.equal(observation.canApplyInlineMessages, false);
+    assert.equal(observation.canPreviewInlineMessages, false);
     assert.equal(observation.intent.inlineApplied, false);
   }
 });
@@ -102,6 +106,20 @@ test("message updates fail closed when acceptedCount disagrees with the payload"
   });
 
   assert.equal(observation.canApplyInlineMessages, false);
+  assert.equal(observation.canPreviewInlineMessages, false);
+  assert.equal(observation.intent.inlineApplied, false);
+});
+
+test("message version gaps remain eligible for cached-Session preview", () => {
+  const observation = analyzeAgentActivityEventObservation({
+    cachedMessages: [message(1)],
+    event: messageUpdateEvent([eventMessage(3)]),
+    hasCachedSession: true
+  });
+
+  assert.equal(observation.inlineContinuity.continuous, false);
+  assert.equal(observation.canApplyInlineMessages, false);
+  assert.equal(observation.canPreviewInlineMessages, true);
   assert.equal(observation.intent.inlineApplied, false);
 });
 

--- a/packages/agent/activity-core/src/activityEventObservation.ts
+++ b/packages/agent/activity-core/src/activityEventObservation.ts
@@ -19,6 +19,7 @@ export interface InlineMessageVersionContinuity {
 
 export interface AgentActivityEventObservation {
   canApplyInlineMessages: boolean;
+  canPreviewInlineMessages: boolean;
   inlineContinuity: InlineMessageVersionContinuity;
   inlineMessages: readonly AgentActivityMessage[];
   intent: SessionActivityObservedIntent;
@@ -50,8 +51,13 @@ export function analyzeAgentActivityEventObservation(input: {
     inlineMessages.length > 0 &&
     inlinePayloadConsistent &&
     inlineContinuity.continuous;
+  const canPreviewInlineMessages =
+    input.hasCachedSession &&
+    inlineMessages.length > 0 &&
+    inlinePayloadConsistent;
   return {
     canApplyInlineMessages,
+    canPreviewInlineMessages,
     inlineContinuity,
     inlineMessages,
     intent: {

--- a/packages/agent/activity-core/src/optimisticMessageOverlay.test.ts
+++ b/packages/agent/activity-core/src/optimisticMessageOverlay.test.ts
@@ -102,13 +102,13 @@ test("requires an anchor before append and requests reconcile", () => {
   );
 });
 
-test("authoritative reconcile clears a stale nonterminal projection before the next delta", () => {
+test("canonical merge advances a confirmed nonterminal projection before the next delta", () => {
   const overlay = createAgentActivityOptimisticMessageOverlay();
   const initial = canonical({
     version: 1,
     payload: { text: "Hel", content: "Hel" }
   });
-  overlay.reconcile(scope, [initial]);
+  overlay.mergeCanonical(scope, [initial]);
   overlay.apply(delta({ operation: "append_text", text: "lo" }));
   assert.equal(overlay.project(scope, [initial])[0]?.payload.text, "Hello");
 
@@ -116,7 +116,7 @@ test("authoritative reconcile clears a stale nonterminal projection before the n
     version: 2,
     payload: { text: "Hello world", content: "Hello world" }
   });
-  overlay.reconcile(scope, [advanced]);
+  overlay.mergeCanonical(scope, [advanced]);
   assert.equal(
     overlay.project(scope, [advanced])[0]?.payload.text,
     "Hello world"
@@ -135,7 +135,7 @@ test("explicit Session reset drops all state and requires a new authoritative an
     version: 1,
     payload: { text: "cloud", content: "cloud" }
   });
-  overlay.reconcile(scope, [base]);
+  overlay.mergeCanonical(scope, [base]);
   overlay.apply(delta({ operation: "append_text", text: " live" }));
   assert.equal(overlay.project(scope, [base])[0]?.payload.text, "cloud live");
 
@@ -150,7 +150,7 @@ test("explicit Session reset drops all state and requires a new authoritative an
     }
   );
 
-  overlay.reconcile(scope, [base]);
+  overlay.mergeCanonical(scope, [base]);
   assert.equal(
     overlay.apply(delta({ operation: "append_text", text: " recovered" }))
       .applied,
@@ -168,7 +168,7 @@ test("keeps an explicitly terminal optimistic projection until canonical becomes
     version: 1,
     payload: { text: "canonical", content: "canonical" }
   });
-  overlay.reconcile(scope, [initial]);
+  overlay.mergeCanonical(scope, [initial]);
   overlay.apply(
     delta({ operation: "append_text", text: " live final" }, "completed")
   );
@@ -178,7 +178,7 @@ test("keeps an explicitly terminal optimistic projection until canonical becomes
     status: "streaming",
     payload: { text: "canonical partial", content: "canonical partial" }
   });
-  overlay.reconcile(scope, [cloudNonterminal]);
+  overlay.mergeCanonical(scope, [cloudNonterminal]);
   const optimisticTerminal = overlay.project(scope, [cloudNonterminal])[0];
   assert.equal(optimisticTerminal?.status, "completed");
   assert.equal(optimisticTerminal?.payload.text, "canonical live final");
@@ -189,7 +189,7 @@ test("keeps an explicitly terminal optimistic projection until canonical becomes
     completedAtUnixMs: 30,
     payload: { text: "canonical final", content: "canonical final" }
   });
-  overlay.reconcile(scope, [cloudTerminal]);
+  overlay.mergeCanonical(scope, [cloudTerminal]);
   const canonicalTerminal = overlay.project(scope, [cloudTerminal]);
   assert.equal(canonicalTerminal.length, 1);
   assert.equal(canonicalTerminal[0]?.version, 3);
@@ -206,7 +206,7 @@ test("authoritative history removes a terminal optimistic row from a retracted T
       content: "old answer"
     }
   });
-  overlay.reconcile(scope, [initial]);
+  overlay.mergeCanonical(scope, [initial]);
   overlay.apply(
     delta({ operation: "set", value: "old final answer" }, "completed")
   );
@@ -226,7 +226,7 @@ test("authoritative history preserves terminal optimistic rows whose stable iden
       content: "answer"
     }
   });
-  overlay.reconcile(scope, [initial]);
+  overlay.mergeCanonical(scope, [initial]);
   overlay.apply(
     delta({ operation: "set", value: "final answer" }, "completed")
   );
@@ -260,7 +260,7 @@ test("rejects a nonterminal delta after canonical terminal truth", () => {
     completedAtUnixMs: 30,
     payload: { text: "final", content: "final" }
   });
-  overlay.reconcile(scope, [terminal]);
+  overlay.mergeCanonical(scope, [terminal]);
 
   assert.deepEqual(
     overlay.apply(delta({ operation: "append_text", text: " late" })),
@@ -280,7 +280,7 @@ test("allows a terminal set to correct an earlier terminal projection", () => {
     completedAtUnixMs: 30,
     payload: { text: "first final", content: "first final" }
   });
-  overlay.reconcile(scope, [terminal]);
+  overlay.mergeCanonical(scope, [terminal]);
 
   assert.deepEqual(
     overlay.apply(
@@ -304,7 +304,7 @@ test("normalizes missing canonical workspace identity without duplicate messages
     version: 1,
     payload: { text: "Hel", content: "Hel" }
   });
-  overlay.reconcile(scope, [withoutWorkspace]);
+  overlay.mergeCanonical(scope, [withoutWorkspace]);
   assert.equal(
     overlay.apply(delta({ operation: "append_text", text: "lo" })).applied,
     true
@@ -314,14 +314,14 @@ test("normalizes missing canonical workspace identity without duplicate messages
   assert.equal(appended[0]?.workspaceId, scope.workspaceId);
   assert.equal(appended[0]?.payload.text, "Hello");
 
-  overlay.reconcile(scope, [withoutWorkspace]);
+  overlay.mergeCanonical(scope, [withoutWorkspace]);
   overlay.apply(delta({ operation: "set", value: "replacement" }));
   const replaced = overlay.project(scope, [withoutWorkspace]);
   assert.equal(replaced.length, 1);
   assert.equal(replaced[0]?.payload.text, "replacement");
 });
 
-test("reconcile and reset affect only their exact workspace and Session scope", () => {
+test("canonical merge and reset affect only their exact workspace and Session scope", () => {
   const overlay = createAgentActivityOptimisticMessageOverlay();
   const firstScope = sessionScope("session-1");
   const secondScope = sessionScope("session-2");
@@ -334,8 +334,8 @@ test("reconcile and reset affect only their exact workspace and Session scope", 
     messageId: "message-1",
     payload: { text: "second", content: "second" }
   });
-  overlay.reconcile(firstScope, [first]);
-  overlay.reconcile(secondScope, [second]);
+  overlay.mergeCanonical(firstScope, [first]);
+  overlay.mergeCanonical(secondScope, [second]);
   overlay.apply(
     delta(
       { operation: "append_text", text: " optimistic" },
@@ -351,8 +351,11 @@ test("reconcile and reset affect only their exact workspace and Session scope", 
     )
   );
 
-  overlay.reconcile(firstScope, [first]);
-  assert.equal(overlay.project(firstScope, [first])[0]?.payload.text, "first");
+  overlay.mergeCanonical(firstScope, [first]);
+  assert.equal(
+    overlay.project(firstScope, [first])[0]?.payload.text,
+    "first optimistic"
+  );
   assert.equal(
     overlay.project(secondScope, [second])[0]?.payload.text,
     "second optimistic"
@@ -365,12 +368,207 @@ test("reconcile and reset affect only their exact workspace and Session scope", 
   );
 });
 
+test("partial canonical confirmation preserves an unrelated optimistic append anchor", () => {
+  const overlay = createAgentActivityOptimisticMessageOverlay();
+  overlay.apply(delta({ operation: "set", value: "正在" }));
+  const unrelated = canonical({
+    messageId: "message-2",
+    version: 1,
+    payload: { text: "其他消息", content: "其他消息" }
+  });
+
+  overlay.mergeCanonical(scope, [unrelated]);
+
+  assert.deepEqual(
+    overlay.apply(delta({ operation: "append_text", text: "检查" })),
+    { applied: true, needsReconcile: false }
+  );
+  const projected = overlay.project(scope, [unrelated]);
+  assert.equal(
+    projected.find((message) => message.messageId === "message-1")?.payload
+      .text,
+    "正在检查"
+  );
+  assert.equal(
+    projected.find((message) => message.messageId === "message-2")?.payload
+      .text,
+    "其他消息"
+  );
+});
+
+test("ordinary canonical omission preserves an optimistic append anchor", () => {
+  const overlay = createAgentActivityOptimisticMessageOverlay();
+  overlay.apply(delta({ operation: "set", value: "正在" }));
+
+  overlay.mergeCanonical(scope, []);
+
+  assert.deepEqual(
+    overlay.apply(delta({ operation: "append_text", text: "检查" })),
+    { applied: true, needsReconcile: false }
+  );
+  assert.equal(overlay.project(scope, [])[0]?.payload.text, "正在检查");
+});
+
+test("projects a gapped canonical tool preview as a stable output anchor", () => {
+  const overlay = createAgentActivityOptimisticMessageOverlay();
+  const toolPreview = canonical({
+    messageId: "tool-1",
+    version: 3,
+    kind: "tool_call",
+    status: "running",
+    payload: { toolName: "Read", title: "Read" }
+  });
+  overlay.previewCanonical(scope, [toolPreview]);
+
+  assert.equal(overlay.project(scope, [])[0]?.messageId, "tool-1");
+  const output = delta(undefined);
+  output.data.messageId = "tool-1";
+  output.data.kind = "tool_call";
+  output.data.toolOutput = {
+    operation: "append_text",
+    text: "first output",
+    offsetBytes: 0
+  };
+  assert.deepEqual(overlay.apply(output), {
+    applied: true,
+    needsReconcile: false
+  });
+  assert.deepEqual(overlay.project(scope, [])[0]?.payload.output, {
+    text: "first output"
+  });
+});
+
+test("keeps a newer tool preview across an older ordinary canonical read", () => {
+  const overlay = createAgentActivityOptimisticMessageOverlay();
+  const preview = canonical({
+    messageId: "tool-1",
+    version: 3,
+    kind: "tool_call",
+    status: "running",
+    payload: { toolName: "Read", title: "new preview" }
+  });
+  overlay.previewCanonical(scope, [preview]);
+
+  overlay.mergeCanonical(scope, [
+    canonical({
+      messageId: "tool-1",
+      version: 2,
+      kind: "tool_call",
+      status: "running",
+      payload: { toolName: "Read", title: "old canonical" }
+    })
+  ]);
+
+  assert.equal(overlay.project(scope, [])[0]?.version, 3);
+  assert.equal(overlay.project(scope, [])[0]?.payload.title, "new preview");
+});
+
+test("authoritative history preserves a tool preview only while its Turn is active", () => {
+  const overlay = createAgentActivityOptimisticMessageOverlay();
+  const preview = canonical({
+    messageId: "tool-1",
+    version: 3,
+    kind: "tool_call",
+    status: "running",
+    payload: { toolName: "Read", title: "Read" }
+  });
+  overlay.previewCanonical(scope, [preview]);
+
+  overlay.reconcileAuthoritativeHistory(
+    scope,
+    [],
+    [effectiveTurn({ phase: "running" })]
+  );
+  assert.equal(overlay.project(scope, []).length, 1);
+
+  overlay.reconcileAuthoritativeHistory(scope, [], [effectiveTurn()]);
+  assert.deepEqual(overlay.project(scope, []), []);
+});
+
+test("terminal canonical confirmation replaces a tool preview without duplication", () => {
+  const overlay = createAgentActivityOptimisticMessageOverlay();
+  const running = canonical({
+    messageId: "tool-1",
+    version: 3,
+    kind: "tool_call",
+    status: "running",
+    payload: { toolName: "Read", title: "Read" }
+  });
+  const completed = canonical({
+    messageId: "tool-1",
+    version: 4,
+    kind: "tool_call",
+    status: "completed",
+    completedAtUnixMs: 30,
+    payload: { toolName: "Read", title: "Read", output: { text: "done" } }
+  });
+  overlay.previewCanonical(scope, [running]);
+
+  overlay.mergeCanonical(scope, [completed]);
+
+  const projected = overlay.project(scope, [completed]);
+  assert.equal(projected.length, 1);
+  assert.equal(projected[0]?.status, "completed");
+  assert.deepEqual(projected[0]?.payload.output, { text: "done" });
+});
+
+test("a canceled gapped tool preview updates in place before authoritative confirmation", () => {
+  const overlay = createAgentActivityOptimisticMessageOverlay();
+  overlay.previewCanonical(scope, [
+    canonical({
+      messageId: "tool-1",
+      version: 3,
+      kind: "tool_call",
+      status: "running",
+      payload: { toolName: "Read", title: "Read" }
+    })
+  ]);
+
+  overlay.previewCanonical(scope, [
+    canonical({
+      messageId: "tool-1",
+      version: 4,
+      kind: "tool_call",
+      status: "canceled",
+      completedAtUnixMs: 30,
+      payload: { toolName: "Read", title: "Read" }
+    })
+  ]);
+
+  const projected = overlay.project(scope, []);
+  assert.equal(projected.length, 1);
+  assert.equal(projected[0]?.messageId, "tool-1");
+  assert.equal(projected[0]?.status, "canceled");
+});
+
+test("authoritative history preserves a nonterminal projection for an active Turn", () => {
+  const overlay = createAgentActivityOptimisticMessageOverlay();
+  overlay.apply(delta({ operation: "set", value: "正在检查" }));
+
+  overlay.reconcileAuthoritativeHistory(
+    scope,
+    [],
+    [effectiveTurn({ phase: "running" })]
+  );
+
+  assert.equal(overlay.project(scope, [])[0]?.payload.text, "正在检查");
+});
+
+test("authoritative history clears a nonterminal projection after its Turn settles", () => {
+  const overlay = createAgentActivityOptimisticMessageOverlay();
+  overlay.apply(delta({ operation: "set", value: "正在检查" }));
+
+  overlay.reconcileAuthoritativeHistory(scope, [], [effectiveTurn()]);
+
+  assert.deepEqual(overlay.project(scope, []), []);
+});
+
 test("applies payload set and unset atomically", () => {
   const overlay = createAgentActivityOptimisticMessageOverlay();
   const base = canonical({
     payload: { text: "base", private: true, preserved: "yes" }
   });
-  overlay.reconcile(scope, [base]);
+  overlay.mergeCanonical(scope, [base]);
   const event = delta(undefined);
   event.data.payloadSet = { phase: "running" };
   event.data.payloadUnset = ["private"];
@@ -393,7 +591,7 @@ test("appends normalized tool output with UTF-8 byte offsets", () => {
       output: { text: "你", exitCode: null }
     }
   });
-  overlay.reconcile(scope, [toolBase]);
+  overlay.mergeCanonical(scope, [toolBase]);
   const event = delta(undefined);
   event.data.messageId = "tool-1";
   event.data.kind = "tool_call";
@@ -420,7 +618,7 @@ test("rejects duplicate or out-of-order tool output without corrupting the overl
     status: "streaming",
     payload: { output: { text: "abc" } }
   });
-  overlay.reconcile(scope, [toolBase]);
+  overlay.mergeCanonical(scope, [toolBase]);
   const event = delta(undefined);
   event.data.messageId = "tool-1";
   event.data.kind = "tool_call";

--- a/packages/agent/activity-core/src/optimisticMessageOverlay.ts
+++ b/packages/agent/activity-core/src/optimisticMessageOverlay.ts
@@ -31,14 +31,27 @@ export interface AgentActivityOptimisticMessageScope {
 export interface AgentActivityOptimisticMessageOverlay {
   apply(event: AgentActivityLiveEvent): AgentActivityOptimisticApplyResult;
   /**
-   * Replaces the authoritative base for one Session after a successful read.
+   * Projects validated canonical messages that cannot advance the durable
+   * cursor because their versions follow a gap.
    *
-   * Ordinary optimistic projections are discarded because the read is now the
-   * best known truth. An explicitly terminal optimistic projection remains
-   * visible over a nonterminal canonical message until canonical truth also
-   * reaches a terminal state.
+   * Preview rows remain separate from the canonical cache, but provide stable
+   * anchors for later live deltas until a continuous or authoritative read
+   * confirms them.
    */
-  reconcile(
+  previewCanonical(
+    scope: AgentActivityOptimisticMessageScope,
+    canonicalMessages: readonly AgentActivityMessage[]
+  ): void;
+  /**
+   * Merges canonical confirmations for one Session without treating omission
+   * as deletion.
+   *
+   * Realtime inline updates and ordinary incremental reads are partial by
+   * construction, and may also race a message_delta that was published before
+   * its durable commit. They may confirm a terminal message with the same
+   * stable identity, but must not clear unrelated or newer optimistic rows.
+   */
+  mergeCanonical(
     scope: AgentActivityOptimisticMessageScope,
     canonicalMessages: readonly AgentActivityMessage[]
   ): void;
@@ -46,9 +59,10 @@ export interface AgentActivityOptimisticMessageOverlay {
    * Replaces one Session from an authoritative effective-history snapshot.
    *
    * Unlike an ordinary read, omission is meaningful after history replacement:
-   * a terminal optimistic row is removed when neither its Turn nor stable
-   * client-submit identity remains in effective history. Turnless controls stay
-   * projected until another explicit lifecycle boundary removes the Session.
+   * a nonterminal row remains only while its Turn is active, and a terminal
+   * optimistic row is removed when neither its Turn nor stable client-submit
+   * identity remains in effective history. Turnless controls stay projected
+   * until another explicit lifecycle boundary removes the Session.
    */
   reconcileAuthoritativeHistory(
     scope: AgentActivityOptimisticMessageScope,
@@ -58,8 +72,8 @@ export interface AgentActivityOptimisticMessageOverlay {
   /**
    * Drops all cached state for one Session when the host removes or rebinds
    * that Session. A stream discontinuity should instead complete an
-   * authoritative read and call reconcile so a confirmed optimistic terminal
-   * projection remains visible until canonical terminal truth arrives.
+   * authoritative read and merge its canonical confirmations so an optimistic
+   * projection remains visible until matching canonical truth arrives.
    */
   reset(scope: AgentActivityOptimisticMessageScope): void;
   project(
@@ -82,6 +96,7 @@ interface ProjectionCacheEntry {
 
 export function createAgentActivityOptimisticMessageOverlay(): AgentActivityOptimisticMessageOverlay {
   const optimistic = new Map<string, OptimisticEntry>();
+  const previews = new Map<string, AgentActivityMessage>();
   const canonical = new Map<string, AgentActivityMessage>();
   const projectionCache = new Map<string, ProjectionCacheEntry>();
   const scopeRevisions = new Map<string, number>();
@@ -102,6 +117,24 @@ export function createAgentActivityOptimisticMessageOverlay(): AgentActivityOpti
     return { normalized, prefix };
   }
 
+  function mergeCanonicalBase(
+    scope: AgentActivityOptimisticMessageScope,
+    messages: readonly AgentActivityMessage[]
+  ): AgentActivityMessage[] {
+    const normalized = normalizeCanonicalMessages(scope, messages);
+    const merged: AgentActivityMessage[] = [];
+    for (const message of normalized) {
+      const key = messageKey(message);
+      const existing = canonical.get(key);
+      const next = existing
+        ? mergeAgentActivityMessages([existing], [message])[0]!
+        : cloneMessage(message);
+      canonical.set(key, next);
+      merged.push(next);
+    }
+    return merged;
+  }
+
   return {
     apply(event) {
       if (event.eventType !== "message_delta") {
@@ -114,19 +147,38 @@ export function createAgentActivityOptimisticMessageOverlay(): AgentActivityOpti
       return result;
     },
 
-    reconcile(scope, messages) {
-      const { prefix } = replaceCanonicalBase(scope, messages);
-      for (const [key, entry] of optimistic) {
-        if (!key.startsWith(prefix)) {
+    previewCanonical(scope, messages) {
+      const normalized = normalizeCanonicalMessages(scope, messages);
+      for (const message of normalized) {
+        const key = messageKey(message);
+        const existing = previews.get(key);
+        const next = existing
+          ? mergeAgentActivityMessages([existing], [message])[0]!
+          : cloneMessage(message);
+        previews.set(key, next);
+        if (isTerminalMessage(next)) {
+          optimistic.delete(key);
+        }
+      }
+      markScopeChanged(scope);
+    },
+
+    mergeCanonical(scope, messages) {
+      const normalized = mergeCanonicalBase(scope, messages);
+      for (const message of normalized) {
+        const key = messageKey(message);
+        const preview = previews.get(key);
+        if (preview !== undefined && message.version >= preview.version) {
+          previews.delete(key);
+        }
+        const entry = optimistic.get(key);
+        if (entry === undefined) continue;
+        if (isTerminalMessage(message)) {
+          optimistic.delete(key);
           continue;
         }
-        const canonicalMessage = canonical.get(key);
-        if (
-          !entry.explicitlyTerminal ||
-          (canonicalMessage !== undefined &&
-            isTerminalMessage(canonicalMessage))
-        ) {
-          optimistic.delete(key);
+        if (!entry.explicitlyTerminal) {
+          advanceOptimisticContentFromCanonical(message, entry.message);
         }
       }
       markScopeChanged(scope);
@@ -135,6 +187,7 @@ export function createAgentActivityOptimisticMessageOverlay(): AgentActivityOpti
     reconcileAuthoritativeHistory(scope, messages, effectiveTurns) {
       const { normalized, prefix } = replaceCanonicalBase(scope, messages);
       const effectiveTurnIds = new Set<string>();
+      const activeTurnIds = new Set<string>();
       for (const turn of effectiveTurns) {
         if (turn.agentSessionId !== scope.agentSessionId) {
           throw new Error(
@@ -142,25 +195,49 @@ export function createAgentActivityOptimisticMessageOverlay(): AgentActivityOpti
           );
         }
         const turnId = turn.turnId.trim();
-        if (turnId) effectiveTurnIds.add(turnId);
+        if (turnId) {
+          effectiveTurnIds.add(turnId);
+          if (turn.phase !== "settled") activeTurnIds.add(turnId);
+        }
       }
       const effectiveClientSubmitIds = new Set(
         normalized
           .map(clientSubmitId)
           .filter((value): value is string => value !== null)
       );
+      for (const [key, preview] of previews) {
+        if (!key.startsWith(prefix)) continue;
+        const canonicalMessage = canonical.get(key);
+        if (
+          canonicalMessage !== undefined &&
+          canonicalMessage.version >= preview.version
+        ) {
+          previews.delete(key);
+          continue;
+        }
+        const turnId = preview.turnId?.trim() ?? "";
+        if (!activeTurnIds.has(turnId)) {
+          previews.delete(key);
+        }
+      }
       for (const [key, entry] of optimistic) {
         if (!key.startsWith(prefix)) continue;
         const canonicalMessage = canonical.get(key);
         if (
-          !entry.explicitlyTerminal ||
-          (canonicalMessage !== undefined &&
-            isTerminalMessage(canonicalMessage))
+          canonicalMessage !== undefined &&
+          isTerminalMessage(canonicalMessage)
         ) {
           optimistic.delete(key);
           continue;
         }
         const turnId = entry.message.turnId?.trim() ?? "";
+        if (!entry.explicitlyTerminal && activeTurnIds.has(turnId)) {
+          continue;
+        }
+        if (!entry.explicitlyTerminal) {
+          optimistic.delete(key);
+          continue;
+        }
         if (!turnId) continue;
         const submitId = clientSubmitId(entry.message);
         if (
@@ -176,6 +253,7 @@ export function createAgentActivityOptimisticMessageOverlay(): AgentActivityOpti
     reset(scope) {
       const prefix = scopePrefix(scope);
       deleteScopeEntries(optimistic, prefix);
+      deleteScopeEntries(previews, prefix);
       deleteScopeEntries(canonical, prefix);
       markScopeChanged(scope);
     },
@@ -194,6 +272,16 @@ export function createAgentActivityOptimisticMessageOverlay(): AgentActivityOpti
       const byKey = new Map<string, AgentActivityMessage>();
       for (const message of normalized) {
         byKey.set(messageKey(message), cloneMessage(message));
+      }
+      for (const [key, preview] of previews) {
+        if (!key.startsWith(prefix)) continue;
+        const existing = byKey.get(key);
+        byKey.set(
+          key,
+          existing
+            ? mergeAgentActivityMessages([existing], [preview])[0]!
+            : cloneMessage(preview)
+        );
       }
       for (const [key, entry] of optimistic) {
         if (!key.startsWith(prefix)) {
@@ -241,7 +329,10 @@ export function createAgentActivityOptimisticMessageOverlay(): AgentActivityOpti
     }
     const key = liveMessageKey(event);
     const existing =
-      optimistic.get(key)?.message ?? canonical.get(key) ?? undefined;
+      optimistic.get(key)?.message ??
+      previews.get(key) ??
+      canonical.get(key) ??
+      undefined;
     if (
       existing &&
       isTerminalMessage(existing) &&
@@ -359,6 +450,45 @@ export function createAgentActivityOptimisticMessageOverlay(): AgentActivityOpti
     });
     return { applied: true, needsReconcile: false };
   }
+}
+
+function advanceOptimisticContentFromCanonical(
+  canonical: AgentActivityMessage,
+  optimistic: AgentActivityMessage
+): void {
+  const optimisticText = messageText(optimistic);
+  const canonicalText = messageText(canonical);
+  if (
+    optimisticText !== null &&
+    canonicalText !== null &&
+    canonicalText.startsWith(optimisticText)
+  ) {
+    optimistic.payload.text = canonicalText;
+    optimistic.payload.content = canonicalText;
+  }
+  const optimisticToolOutput = toolOutputText(optimistic);
+  const canonicalToolOutput = toolOutputText(canonical);
+  if (
+    optimisticToolOutput !== null &&
+    canonicalToolOutput !== null &&
+    canonicalToolOutput.startsWith(optimisticToolOutput)
+  ) {
+    const output = recordValue(optimistic.payload.output) ?? {};
+    output.text = canonicalToolOutput;
+    optimistic.payload.output = output;
+  }
+}
+
+function messageText(message: AgentActivityMessage): string | null {
+  if (typeof message.payload.text === "string") return message.payload.text;
+  return typeof message.payload.content === "string"
+    ? message.payload.content
+    : null;
+}
+
+function toolOutputText(message: AgentActivityMessage): string | null {
+  const output = recordValue(message.payload.output);
+  return typeof output?.text === "string" ? output.text : null;
 }
 
 function recordValue(value: unknown): Record<string, unknown> | null {

--- a/packages/agent/activity-core/src/workspaceEventCoordinator.test.ts
+++ b/packages/agent/activity-core/src/workspaceEventCoordinator.test.ts
@@ -11,6 +11,7 @@ import { createTestEngineCommandPort } from "./engine/testEngineCommandPort.ts";
 import type { EngineExternalCommand } from "./engine/types.ts";
 import { normalizeAgentActivitySession } from "./sessionNormalization.ts";
 import type {
+  AgentActivityUpdatedEvent,
   AgentActivityTurn,
   AgentActivityTurnUpdatedEvent
 } from "./types.ts";
@@ -322,6 +323,271 @@ test("projects message deltas and clears them on authoritative deletion", () => 
   harness.coordinator.dispose();
   harness.engine.dispose();
 });
+
+test("keeps a reasoning append anchor across an unrelated inline canonical update", () => {
+  const harness = createHarness();
+  harness.engine.dispatch({
+    session: session(turn("running", 1), 1),
+    type: "session/upserted"
+  });
+  harness.engine.dispatch({
+    messages: [message("session-1", "message-1", "canonical")],
+    type: "message/snapshotReceived",
+    workspaceId: "workspace-1"
+  });
+
+  harness.coordinator.ingestEvent({
+    workspaceId: "workspace-1",
+    agentSessionId: "session-1",
+    eventType: "message_delta",
+    data: {
+      workspaceId: "workspace-1",
+      agentSessionId: "session-1",
+      messageId: "reasoning-live",
+      turnId: "turn-1",
+      role: "assistant",
+      kind: "reasoning",
+      occurredAtUnixMs: 2,
+      content: { operation: "set", value: "正在" }
+    }
+  });
+
+  const inline = harness.coordinator.ingestEvent({
+    workspaceId: "workspace-1",
+    agentSessionId: "session-1",
+    eventType: "message_update",
+    data: {
+      workspaceId: "workspace-1",
+      agentSessionId: "session-1",
+      eventType: "message_update",
+      latestVersion: 2,
+      acceptedCount: 1,
+      messages: [
+        {
+          agentSessionId: "session-1",
+          kind: "text",
+          messageId: "message-2",
+          occurredAtUnixMs: 3,
+          payload: { text: "其他消息" },
+          role: "assistant",
+          sequence: 2,
+          turnId: "turn-1",
+          version: 2
+        }
+      ]
+    }
+  });
+  assert.equal(inline.inlineApplied, true);
+
+  const appended = harness.coordinator.ingestEvent({
+    workspaceId: "workspace-1",
+    agentSessionId: "session-1",
+    eventType: "message_delta",
+    data: {
+      workspaceId: "workspace-1",
+      agentSessionId: "session-1",
+      messageId: "reasoning-live",
+      turnId: "turn-1",
+      role: "assistant",
+      kind: "reasoning",
+      occurredAtUnixMs: 4,
+      content: { operation: "append_text", text: "检查" }
+    }
+  });
+
+  assert.equal(appended.accepted, true);
+  assert.equal(appended.reason, "applied");
+  const projected = harness.coordinator.project(harness.readCanonicalSnapshot())
+    .sessionMessagesById["session-1"];
+  assert.equal(
+    projected?.find((item) => item.messageId === "reasoning-live")?.payload
+      .text,
+    "正在检查"
+  );
+  assert.equal(
+    projected?.find((item) => item.messageId === "message-2")?.payload.text,
+    "其他消息"
+  );
+  harness.coordinator.dispose();
+  harness.engine.dispose();
+});
+
+test("previews a gapped tool update without advancing the durable cursor", () => {
+  const harness = createHarness();
+  harness.engine.dispatch({
+    session: session(turn("running", 1), 1),
+    type: "session/upserted"
+  });
+  harness.engine.dispatch({
+    messages: [message("session-1", "message-1", "canonical")],
+    type: "message/snapshotReceived",
+    workspaceId: "workspace-1"
+  });
+
+  const previewed = harness.coordinator.ingestEvent({
+    workspaceId: "workspace-1",
+    agentSessionId: "session-1",
+    eventType: "message_update",
+    data: {
+      workspaceId: "workspace-1",
+      agentSessionId: "session-1",
+      eventType: "message_update",
+      latestVersion: 3,
+      acceptedCount: 1,
+      messages: [
+        {
+          agentSessionId: "session-1",
+          kind: "tool_call",
+          messageId: "tool-1",
+          occurredAtUnixMs: 3,
+          payload: { toolName: "Read", title: "Read" },
+          role: "assistant",
+          sequence: 3,
+          status: "running",
+          turnId: "turn-1",
+          version: 3
+        }
+      ]
+    }
+  });
+
+  assert.equal(previewed.inlineApplied, false);
+  assert.equal(previewed.inlinePreviewed, true);
+  assert.deepEqual(previewed.inlineGap, {
+    cachedVersion: 1,
+    firstUnseenVersion: 3,
+    latestIncomingVersion: 3
+  });
+  assert.equal(
+    harness
+      .readCanonicalSnapshot()
+      .sessionMessagesById["session-1"]?.some(
+        (item) => item.messageId === "tool-1"
+      ),
+    false
+  );
+  assert.equal(
+    harness.coordinator
+      .project(harness.readCanonicalSnapshot())
+      .sessionMessagesById["session-1"]?.find(
+        (item) => item.messageId === "tool-1"
+      )?.status,
+    "running"
+  );
+  assert.ok(
+    harness.commands.some(
+      (command) =>
+        command.type === "session/reconcile" &&
+        command.agentSessionId === "session-1" &&
+        command.scope === "messages"
+    )
+  );
+
+  const output = harness.coordinator.ingestEvent({
+    workspaceId: "workspace-1",
+    agentSessionId: "session-1",
+    eventType: "message_delta",
+    data: {
+      workspaceId: "workspace-1",
+      agentSessionId: "session-1",
+      messageId: "tool-1",
+      turnId: "turn-1",
+      role: "assistant",
+      kind: "tool_call",
+      occurredAtUnixMs: 4,
+      toolOutput: {
+        operation: "append_text",
+        text: "output",
+        offsetBytes: 0
+      }
+    }
+  });
+  assert.equal(output.accepted, true);
+  assert.deepEqual(
+    harness.coordinator
+      .project(harness.readCanonicalSnapshot())
+      .sessionMessagesById["session-1"]?.find(
+        (item) => item.messageId === "tool-1"
+      )?.payload.output,
+    { text: "output" }
+  );
+
+  const completed = {
+    workspaceId: "workspace-1",
+    agentSessionId: "session-1",
+    messageId: "tool-1",
+    version: 4,
+    sequence: 3,
+    turnId: "turn-1",
+    role: "assistant" as const,
+    kind: "tool_call",
+    status: "completed",
+    payload: {
+      toolName: "Read",
+      title: "Read",
+      output: { text: "output" }
+    },
+    occurredAtUnixMs: 5,
+    completedAtUnixMs: 5
+  };
+  harness.coordinator.reconcileAuthoritativeHistory(
+    "session-1",
+    [completed],
+    [turn("settled", 5)]
+  );
+  const finalTools = harness.coordinator
+    .project({
+      ...harness.readCanonicalSnapshot(),
+      sessionMessagesById: { "session-1": [completed] }
+    })
+    .sessionMessagesById["session-1"]?.filter(
+      (item) => item.messageId === "tool-1"
+    );
+  assert.equal(finalTools?.length, 1);
+  assert.equal(finalTools?.[0]?.status, "completed");
+  harness.coordinator.dispose();
+  harness.engine.dispose();
+});
+
+for (const terminalStatus of ["completed", "canceled"] as const) {
+  test(`keeps one visible tool row when a gapped preview becomes ${terminalStatus}`, () => {
+    const harness = createHarness();
+    harness.engine.dispatch({
+      session: session(turn("running", 1), 1),
+      type: "session/upserted"
+    });
+    harness.engine.dispatch({
+      messages: [message("session-1", "message-1", "canonical")],
+      type: "message/snapshotReceived",
+      workspaceId: "workspace-1"
+    });
+
+    harness.coordinator.ingestEvent(toolUpdateEvent(3, "running"));
+    const terminal = harness.coordinator.ingestEvent(
+      toolUpdateEvent(4, terminalStatus)
+    );
+
+    assert.equal(terminal.inlineApplied, false);
+    assert.equal(terminal.inlinePreviewed, true);
+    const projected = harness.coordinator
+      .project(harness.readCanonicalSnapshot())
+      .sessionMessagesById["session-1"]?.filter(
+        (item) => item.messageId === "tool-1"
+      );
+    assert.equal(projected?.length, 1);
+    assert.equal(projected?.[0]?.status, terminalStatus);
+    assert.equal(
+      harness
+        .readCanonicalSnapshot()
+        .sessionMessagesById["session-1"]?.some(
+          (item) => item.messageId === "tool-1"
+        ),
+      false
+    );
+    harness.coordinator.dispose();
+    harness.engine.dispose();
+  });
+}
 
 test("an explicit restore event clears only its tombstone and requests authoritative hydration", () => {
   const harness = createHarness();
@@ -847,6 +1113,40 @@ function message(agentSessionId: string, messageId: string, text: string) {
     kind: "text",
     payload: { text },
     occurredAtUnixMs: 1
+  };
+}
+
+function toolUpdateEvent(
+  version: number,
+  status: "running" | "completed" | "canceled"
+): Extract<AgentActivityUpdatedEvent, { eventType: "message_update" }> {
+  const terminal = status !== "running";
+  return {
+    workspaceId: "workspace-1",
+    agentSessionId: "session-1",
+    eventType: "message_update",
+    data: {
+      workspaceId: "workspace-1",
+      agentSessionId: "session-1",
+      eventType: "message_update",
+      latestVersion: version,
+      acceptedCount: 1,
+      messages: [
+        {
+          agentSessionId: "session-1",
+          kind: "tool_call",
+          messageId: "tool-1",
+          occurredAtUnixMs: version,
+          ...(terminal ? { completedAtUnixMs: version } : {}),
+          payload: { toolName: "Read", title: "Read" },
+          role: "assistant",
+          sequence: 3,
+          status,
+          turnId: "turn-1",
+          version
+        }
+      ]
+    }
   };
 }
 

--- a/packages/agent/activity-core/src/workspaceEventCoordinator.ts
+++ b/packages/agent/activity-core/src/workspaceEventCoordinator.ts
@@ -26,6 +26,7 @@ export interface AgentActivityWorkspaceEventResult {
   accepted: boolean;
   eventType: AgentActivityUpdatedEvent["eventType"];
   inlineApplied: boolean;
+  inlinePreviewed: boolean;
   inlineGap: {
     cachedVersion: number;
     firstUnseenVersion: number | null;
@@ -435,18 +436,28 @@ export function createAgentActivityWorkspaceEventCoordinator({
           },
           { batch: true }
         );
-        overlay.reconcile(
+        overlay.mergeCanonical(
           { agentSessionId, workspaceId: normalizedWorkspaceId },
-          [...cachedMessages, ...observation.inlineMessages]
+          observation.inlineMessages
         );
+        markChanged();
+      } else if (observation.canPreviewInlineMessages) {
+        overlay.previewCanonical(
+          { agentSessionId, workspaceId: normalizedWorkspaceId },
+          observation.inlineMessages
+        );
+        overlaySessionIds.add(agentSessionId);
         markChanged();
       }
       engine.dispatch(observation.intent);
       return {
         ...eventResult(eventType, true, "applied"),
         inlineApplied: observation.canApplyInlineMessages,
+        inlinePreviewed:
+          !observation.canApplyInlineMessages &&
+          observation.canPreviewInlineMessages,
         inlineGap:
-          observation.inlineMessages.length > 0 &&
+          observation.canPreviewInlineMessages &&
           !observation.canApplyInlineMessages
             ? {
                 cachedVersion: observation.inlineContinuity.cachedVersion,
@@ -499,7 +510,7 @@ export function createAgentActivityWorkspaceEventCoordinator({
       if (disposed) return;
       const normalizedSessionId = agentSessionId.trim();
       if (!normalizedSessionId) return;
-      overlay.reconcile(
+      overlay.mergeCanonical(
         {
           agentSessionId: normalizedSessionId,
           workspaceId: normalizedWorkspaceId
@@ -547,6 +558,7 @@ function eventResult(
     accepted,
     eventType,
     inlineApplied: false,
+    inlinePreviewed: false,
     inlineGap: null,
     inlineMessages: [],
     optimisticMessage: null,


### PR DESCRIPTION
## Summary

修复 Tutti 使用 Cursor 时执行中消息投影不稳定的问题：同一思考块曾因无关的部分 canonical 更新丢失追加锚点，工具消息则可能因消息版本缺口被拒绝实时投影，直到 turn 结束或主动停止后的权威历史同步才重新出现。

- 将普通 inline/incremental canonical 更新改为按稳定 `messageId` 合并；批次遗漏不再被解释为删除，从而保留活动 Turn 中思考消息的 `append_text` 锚点
- 为已缓存 Session 的结构合法、但存在版本缺口的消息增加独立 canonical preview lane；工具行可立即显示并承接后续 tool-output delta，同时不推进 Engine 的 durable message cursor
- 在 continuous/authoritative canonical 确认、Turn 结束或历史移除时清理 preview/optimistic 状态，按 `messageId` 原位完成或取消，避免补回和重复
- Mobile live lane 在 inline preview 变化时触发刷新；Desktop 继续通过 workspace coordinator 订阅投影变化
- 补充思考连续追加、版本缺口工具预览、正常完成、主动取消、旧快照竞争和权威历史替换的回归测试
- 更新 activity-core README 与 agent activity 架构文档，固化 partial merge、preview 和 authoritative cleanup 边界

## Verification

- `pnpm check:changed -- --push-ready --base upstream/main`（14/14 通过）
- `go test ./packages/agent/daemon/runtime -run 'TestStandardACPNormalizerSegmentsAssistantAndThinkingAroundToolCalls|TestStandardACPToolCallLifecycleReusesStableEventID|TestCursorGlobAndGrepToolCallsPreserveIdentityAndInput'`
- Cursor 实机冒烟：正常完成与执行中主动停止路径；思考在执行中持续合并，工具消息持续可见，结束时无补回、消失或重复

## Reviewer handoff

建议后续贡献者重点复核：

1. `previewCanonical` 不得推进 durable cursor，版本缺口仍必须触发消息 reconcile
2. 普通部分更新的 omission 不具有删除语义；只有 effective-history replacement、Session reset/removal 等权威边界可以清理缺失项
3. completed/canceled canonical 必须按稳定 `messageId` 替换 preview，不能形成重复工具行
4. Desktop 与 Mobile 两个消费端都能在 preview 变化时刷新当前投影

当前 Session Replay 尚不支持 `local:cursor`；本 PR 的 Cursor E2E 证据来自实机冒烟，自动化覆盖集中在共享 activity-core 事件链路。后续如需无订阅环境的确定性 Cursor UI 回放，应作为独立测试基础设施任务增加 Cursor Replay 支持。

## Checklist

- [x] 本 PR 不修改 Session/Turn/Goal/runtime-operation 生命周期语义，无需 Agent Host conformance 场景
- [x] 变更聚焦于 Cursor 实时消息投影稳定性
- [x] 已更新行为和数据流文档
- [x] 未修改 README/CONTRIBUTING 多语言源文件
- [x] 已运行变更面对应的 push-ready 检查与 Cursor 实机冒烟
- [x] 提交包含 DCO `Signed-off-by`
