### PR TITLE
fix(connector): serialize authorization runtime reconciliation

### DIFF
--- a/docs/architecture/connector-market.md
+++ b/docs/architecture/connector-market.md
@@ -355,11 +355,22 @@ work is pending. Each receipt has a terminal resolution, and only unresolved
 receipts for the daemon's current account are polled. Applying an authoritative
 connected Snapshot atomically writes its monotonic Projection and surfaces all
 matching account-and-Connector receipts. The daemon holds the account lifecycle
-fence, awaits Runtime Reconcile, and only then resolves them as
+fence and is the single runtime scheduler for receipt recovery. Host projection
+does not enqueue a second operation. The daemon atomically creates or joins the
+active Reconcile for the same Connector and account scope, awaits it, and only
+then resolves the receipts as
 `account_state_converged`. A same-revision Snapshot still surfaces a receipt created
 after an earlier Snapshot does not cause permanent polling. WebSocket hints and
 the five-minute calibration both fetch Snapshot; runtime reconcile is
 level-triggered and can safely repeat after restart or an interrupted pass.
+The external mutation API continues to use the global Snapshot revision for
+CAS. Internal level-triggered repair reads current durable state inside its
+transaction, so unrelated Connector operations cannot create false revision
+conflicts.
+An existing active Reconcile may have resolved its binding before a newer
+Projection was persisted. Joining it therefore drains older work but is not a
+convergence proof; the daemon ensures and awaits one follow-up Reconcile from
+current durable state before resolving the receipt.
 
 Authorization execution is selected from the exact release frozen into the
 durable operation. `managed_stdio` delegates to the local implementation host;

--- a/packages/connector/daemon/README.md
+++ b/packages/connector/daemon/README.md
@@ -35,8 +35,12 @@ normal uninstall/reconcile concern.
 
 The active account scope also bounds authorization receipt polling. Snapshot
 sync atomically converges the account Projection and surfaces matching private
-receipts, but does not terminalize them. The daemon holds the lifecycle fence,
-awaits Runtime Reconcile, and only then resolves those receipts.
+receipts, but does not terminalize them or enqueue runtime work. The daemon is
+the single scheduler for this recovery path: while holding the lifecycle fence
+it atomically creates or joins one scoped Runtime Reconcile, awaits it, and only
+then resolves those receipts. Joining existing work is not treated as proof of
+current convergence: after that operation completes, the daemon ensures and
+awaits a reconcile created from the latest Projection.
 WebSocket events are only refresh hints; a five-minute level-triggered pass
 reconciles every installed remote authorized Connector so a lost event or an
 interrupted earlier pass cannot leave route state stale.

--- a/packages/connector/daemon/host.go
+++ b/packages/connector/daemon/host.go
@@ -183,30 +183,7 @@ func (host *Host) runAuthorizationReconcileWorker(ctx context.Context) {
 				cancel()
 				continue
 			}
-			intents, err := host.Application.ReconcileAuthorizations(reconcileContext, scope)
-			if err == nil && len(intents) > 0 {
-				// ReconcileAuthorizations persists projection intent and enqueues
-				// runtime operations. Drain a scoped operation for every affected
-				// remote Connector before releasing the lifecycle fence, so logout
-				// or account switching cannot be followed by a late old-account
-				// route publication.
-				connectorKeys := make(map[string]struct{}, len(intents))
-				for _, intent := range intents {
-					connectorKeys[intent.ConnectorKey] = struct{}{}
-				}
-				for connectorKey := range connectorKeys {
-					if reconcileErr := host.reconcileRuntimeForScopeLocked(reconcileContext, scope, connectorKey); reconcileErr != nil {
-						err = errors.Join(err, reconcileErr)
-					}
-				}
-				if err == nil {
-					for _, intent := range intents {
-						if resolveErr := host.repository.ResolveAuthorizationSession(reconcileContext, intent.OperationID, intent.Resolution); resolveErr != nil {
-							err = errors.Join(err, resolveErr)
-						}
-					}
-				}
-			}
+			err := host.reconcileAuthorizationsLocked(reconcileContext, scope)
 			host.bootstrapMu.Unlock()
 			cancel()
 			if err != nil && !errors.Is(err, context.Canceled) {
@@ -214,6 +191,35 @@ func (host *Host) runAuthorizationReconcileWorker(ctx context.Context) {
 			}
 		}
 	}
+}
+
+func (host *Host) reconcileAuthorizationsLocked(ctx context.Context, scope market.OperationScope) error {
+	intents, err := host.Application.ReconcileAuthorizations(ctx, scope)
+	if err != nil || len(intents) == 0 {
+		return err
+	}
+	// ReconcileAuthorizations persists projection intent. Create or join one
+	// scoped runtime operation for every affected Connector before releasing the
+	// lifecycle fence, so logout or account switching cannot be followed by a
+	// late old-account route publication.
+	connectorKeys := make(map[string]struct{}, len(intents))
+	for _, intent := range intents {
+		connectorKeys[intent.ConnectorKey] = struct{}{}
+	}
+	for connectorKey := range connectorKeys {
+		if reconcileErr := host.reconcileRuntimeForScopeLocked(ctx, scope, connectorKey); reconcileErr != nil {
+			err = errors.Join(err, reconcileErr)
+		}
+	}
+	if err != nil {
+		return err
+	}
+	for _, intent := range intents {
+		if resolveErr := host.repository.ResolveAuthorizationSession(ctx, intent.OperationID, intent.Resolution); resolveErr != nil {
+			err = errors.Join(err, resolveErr)
+		}
+	}
+	return err
 }
 
 // Bootstrap restores durable local runtime intent without depending on the
@@ -555,25 +561,36 @@ func (host *Host) ReconcileRuntimeForScope(ctx context.Context, scope market.Ope
 }
 
 func (host *Host) reconcileRuntimeForScopeLocked(ctx context.Context, scope market.OperationScope, connectorKey string) error {
-	connector, err := host.Application.GetConnector(ctx, connectorKey)
-	if errors.Is(err, market.ErrNotFound) || err == nil && connector.Installation.State != market.InstallationStateInstalled {
-		return nil
+	for {
+		connector, err := host.Application.GetConnector(ctx, connectorKey)
+		if errors.Is(err, market.ErrNotFound) || err == nil && connector.Installation.State != market.InstallationStateInstalled {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		result, err := host.Application.EnsureRuntimeReconcile(ctx, scope, connectorKey)
+		if err != nil {
+			return err
+		}
+		operation, waitErr := host.waitForOperationTerminal(ctx, result.Operation.OperationID)
+		if result.Created {
+			if waitErr != nil {
+				return waitErr
+			}
+			if operation.State == market.OperationStateFailed {
+				return fmt.Errorf("connector market runtime reconcile failed: %s", operation.FailureCode)
+			}
+			return nil
+		}
+		if waitErr != nil {
+			return waitErr
+		}
+		// A joined operation may have resolved its runtime binding before the
+		// current authorization projection was persisted. Ensure once more after
+		// it reaches terminal state so success proves convergence of current
+		// desired state rather than merely completion of older work.
 	}
-	if err != nil {
-		return err
-	}
-	snapshot, err := host.Application.Snapshot(ctx)
-	if err != nil {
-		return err
-	}
-	result, err := host.Application.ReconcileRuntime(ctx, market.ConnectorMutation{
-		Mutation:     market.Mutation{ClientRequestID: "daemon-runtime-drift/" + uuid.NewString(), ExpectedRevision: snapshot.Revision},
-		ConnectorKey: connectorKey, AccountID: scope.AccountID,
-	})
-	if err != nil {
-		return err
-	}
-	return host.waitForOperation(ctx, result.Operation.OperationID, "runtime reconcile")
 }
 
 // ObserveAuthorizationForScope commits account authorization and its runtime
@@ -589,18 +606,10 @@ func (host *Host) ObserveAuthorizationForScope(
 	}
 	host.bootstrapMu.Lock()
 	defer host.bootstrapMu.Unlock()
-	snapshot, err := host.Application.Snapshot(ctx)
-	if err != nil {
+	if err := host.Application.ProjectAuthorization(ctx, scope, projection); err != nil {
 		return err
 	}
-	result, err := host.Application.ObserveAuthorization(ctx, market.ConnectorMutation{
-		Mutation:     market.Mutation{ClientRequestID: "daemon-authorization-observation/" + uuid.NewString(), ExpectedRevision: snapshot.Revision},
-		ConnectorKey: projection.ConnectorKey, AccountID: scope.AccountID,
-	}, projection)
-	if err != nil {
-		return err
-	}
-	return host.waitForOperation(ctx, result.Operation.OperationID, "authorization reconcile")
+	return host.reconcileRuntimeForScopeLocked(ctx, scope, projection.ConnectorKey)
 }
 
 func (host *Host) applyCapabilityPublication(ctx context.Context, scope market.OperationScope, enabled bool) error {
@@ -687,23 +696,21 @@ func (host *Host) refreshAndWait(ctx context.Context) error {
 	}
 }
 
-func (host *Host) waitForOperation(ctx context.Context, operationID, label string) error {
+func (host *Host) waitForOperationTerminal(ctx context.Context, operationID string) (market.Operation, error) {
 	ticker := time.NewTicker(25 * time.Millisecond)
 	defer ticker.Stop()
 	for {
 		operation, err := host.Application.GetOperation(ctx, operationID)
 		if err != nil {
-			return err
+			return market.Operation{}, err
 		}
 		switch operation.State {
-		case market.OperationStateCompleted:
-			return nil
-		case market.OperationStateFailed:
-			return fmt.Errorf("connector market %s failed: %s", label, operation.FailureCode)
+		case market.OperationStateCompleted, market.OperationStateFailed:
+			return operation, nil
 		}
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return market.Operation{}, ctx.Err()
 		case <-ticker.C:
 		}
 	}

--- a/packages/connector/daemon/host_test.go
+++ b/packages/connector/daemon/host_test.go
@@ -65,6 +65,23 @@ type runtimeBindingResolverFunc func(context.Context, market.RuntimeBindingReque
 func (resolve runtimeBindingResolverFunc) ResolveRuntimeBinding(ctx context.Context, request market.RuntimeBindingRequest) (market.RuntimeBinding, error) {
 	return resolve(ctx, request)
 }
+
+type connectedAuthorizationObserver struct{}
+
+func (connectedAuthorizationObserver) Begin(context.Context, market.AuthorizationStartRequest) (market.AuthorizationSession, error) {
+	return market.AuthorizationSession{}, errors.New("not implemented")
+}
+
+func (connectedAuthorizationObserver) Disconnect(context.Context, market.AuthorizationDisconnectRequest) error {
+	return errors.New("not implemented")
+}
+
+func (connectedAuthorizationObserver) Observe(_ context.Context, request market.AuthorizationObserveRequest) (market.AuthorizationObservation, error) {
+	return market.AuthorizationObservation{
+		AccountID: request.Scope.AccountID, ConnectorKey: request.Connector.Key,
+		ConnectionID: "connection-1", State: market.AuthorizationObservationConnected,
+	}, nil
+}
 func (delegate *activationGateDelegate) DeactivateRuntime(context.Context, market.RuntimeDeactivationRequest) error {
 	delegate.deactivations++
 	return nil
@@ -331,6 +348,117 @@ func TestBootstrapRestoresInstalledRuntimeWithoutRefreshingCatalog(t *testing.T)
 	if calibrated.Installation.State != market.InstallationStateFailed ||
 		calibrated.Installation.FailureCode != market.InstallationFailureCodePhysicallyAbsent || runtime.reconciles != 5 {
 		t.Fatalf("calibrated connector=%#v reconciles=%d", calibrated, runtime.reconciles)
+	}
+}
+
+func TestAuthorizationRecoverySchedulesOneRuntimeBeforeResolvingReceipt(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	store, err := marketdata.Open(ctx, filepath.Join(t.TempDir(), "tuttid.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	release := hostTestRelease()
+	release.Manifest.AuthorizationKind = "oauth2"
+	release.Manifest.RequiredCapabilities = []string{"tools"}
+	release.Manifest.Implementation.ManagedStdio.Runtime.VersionRange = ">=22.0.0 <23.0.0"
+	release.Manifest.Implementation.ManagedStdio.CLI = &market.ManagedCLIInterface{
+		Entrypoint: "bin/github-cli.mjs", TimeoutMS: 120_000,
+	}
+	release.Manifest.Implementation.ManagedStdio.CredentialBroker = &market.ManagedCredentialBroker{
+		Protocol: market.CredentialBrokerProtocolV1, Entrypoint: "authorization/broker.mjs",
+		TimeoutMS: 30_000, AllowedHosts: []string{"api.example.test"},
+	}
+	connector := market.Connector{
+		Key: release.ConnectorKey, Release: release,
+		Installation: market.Installation{
+			State: market.InstallationStateInstalled, InstalledVersion: release.Version,
+			InstalledReleaseID: release.ReleaseID, InstalledReleaseDigest: release.ReleaseDigest,
+		},
+		Authorization: market.Authorization{State: market.AuthorizationStatePending},
+		Compatibility: market.Compatibility{State: market.CompatibilityStateSupported},
+	}
+	authorizationOperation := market.Operation{
+		OperationID: "authorization-1", ClientRequestID: "authorization-request-1", ConnectorKey: connector.Key,
+		Kind: market.OperationKindStartAuthorization, Scope: market.OperationScope{AccountID: "account-1"},
+		State: market.OperationStateCompleted, Stage: market.OperationStageCompleted,
+		Target: &market.OperationTarget{
+			ConnectorKey: release.ConnectorKey, Version: release.Version, ReleaseID: release.ReleaseID,
+			ReleaseDigest: release.ReleaseDigest, Release: &release,
+		},
+		Execution: market.OperationExecution{AuthorizationSession: &market.AuthorizationSession{
+			OperationID: "authorization-1", ConnectorKey: connector.Key, SessionID: "session-1",
+			State: market.AuthorizationStatePending, Resolution: market.AuthorizationSessionResolutionUnresolved,
+		}},
+		CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
+	}
+	if err := store.Transaction(ctx, func(tx market.Transaction) error {
+		connector.Revision = tx.AdvanceRevision()
+		if err := tx.SaveConnector(connector); err != nil {
+			return err
+		}
+		return tx.SaveOperation(authorizationOperation)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	runtime := &activationGateDelegate{}
+	scope := market.OperationScope{AccountID: "account-1"}
+	scheduler := NewOperationScheduler(ctx)
+	activationGate := newActivationGateHost(runtime)
+	activationGate.setOpen(scope, true)
+	application, err := market.NewApplication(market.ApplicationConfig{
+		Repository: store, CatalogSource: &countingCatalogSource{release: release},
+		ReleaseInstallations: runtime, Host: activationGate,
+		Authorization: connectedAuthorizationObserver{}, AuthorizationProjections: store,
+		RuntimeBindings: runtimeBindingResolverFunc(func(_ context.Context, request market.RuntimeBindingRequest) (market.RuntimeBinding, error) {
+			return market.RuntimeBinding{ConnectionID: "device-" + request.Connector.Key, Enabled: true}, nil
+		}),
+		Compatibility: rejectingCompatibility{}, Scheduler: scheduler,
+		ImplementationRegistry: market.NewImplementationRegistry(nil),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := scheduler.Bind(application); err != nil {
+		t.Fatal(err)
+	}
+	host := &Host{Application: application, scheduler: scheduler, repository: store, activationGate: activationGate}
+
+	host.bootstrapMu.Lock()
+	err = host.reconcileAuthorizationsLocked(ctx, scope)
+	host.bootstrapMu.Unlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.reconciles != 1 {
+		t.Fatalf("runtime reconciles = %d, want 1", runtime.reconciles)
+	}
+	operation, err := store.Operation(ctx, authorizationOperation.OperationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if operation.Execution.AuthorizationSession == nil ||
+		operation.Execution.AuthorizationSession.Resolution != market.AuthorizationSessionResolutionProviderConnected {
+		t.Fatalf("authorization receipt = %#v", operation.Execution.AuthorizationSession)
+	}
+	if err := host.ObserveAuthorizationForScope(ctx, scope, market.AuthorizationProjection{
+		AccountID: scope.AccountID, ConnectorKey: connector.Key,
+		ConnectionID: "connection-2", State: market.AuthorizationStateConnected,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if runtime.reconciles != 2 {
+		t.Fatalf("runtime reconciles after live observation = %d, want 2", runtime.reconciles)
+	}
+	projection, err := store.AuthorizationProjection(ctx, scope.AccountID, connector.Key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if projection.ConnectionID != "connection-2" || projection.State != market.AuthorizationStateConnected {
+		t.Fatalf("live authorization projection = %#v", projection)
 	}
 }
 

--- a/packages/connector/host/README.md
+++ b/packages/connector/host/README.md
@@ -28,3 +28,12 @@ reconcile also carries the bounded `ConnectorSummary` committed by that exact
 route generation. Lifecycle observers consume this receipt projection even
 while Agent publication is fenced; they must not perform a later key-only
 lookup against the mutable published registry.
+
+External Connector mutations retain snapshot-revision CAS semantics.
+Level-triggered daemon repair uses `EnsureRuntimeReconcile` instead: the Host
+atomically creates a reconcile from current durable state or joins the active
+reconcile for the same Connector and account scope. This keeps internal repair
+independent from unrelated Connector revision changes without weakening the
+public mutation contract. A caller that joins older work waits for it and then
+ensures again, because the older operation may already have resolved its
+runtime binding before the caller persisted newer desired state.

--- a/packages/connector/host/application.go
+++ b/packages/connector/host/application.go
@@ -495,7 +495,7 @@ func (application *Application) ReconcileAuthorizations(ctx context.Context, sco
 		if observation.State == AuthorizationObservationFailed {
 			projectionState = AuthorizationStateFailed
 		}
-		if err := application.projectAuthorizationAndScheduleRuntime(ctx, operation.Scope, connector.Key,
+		if _, err := application.projectAuthorization(ctx, operation.Scope, connector.Key,
 			observation.ConnectionID, projectionState, observation.FailureCode); err != nil {
 			reconcileErr = errors.Join(reconcileErr, err)
 			continue

--- a/packages/connector/host/application_scoped_runtime.go
+++ b/packages/connector/host/application_scoped_runtime.go
@@ -12,12 +12,109 @@ import (
 // explicit account scope. It does not mutate installation state.
 func (application *Application) ReconcileRuntime(ctx context.Context, mutation ConnectorMutation) (MutationResult, error) {
 	return application.acceptConnectorOperation(ctx, mutation, OperationKindReconcileRuntime, func(connector Connector) (Connector, error) {
-		if connector.Installation.State != InstallationStateInstalled ||
-			strings.TrimSpace(connector.Installation.InstalledReleaseDigest) == "" {
-			return Connector{}, invalidTransition("runtime", string(connector.Installation.State), string(InstallationStateInstalled))
-		}
-		return connector, nil
+		return validateRuntimeReconcileConnector(connector)
 	})
+}
+
+// EnsureRuntimeReconcile is the level-triggered, host-internal runtime repair
+// command. Unlike ReconcileRuntime, it does not accept an externally observed
+// market revision: it atomically creates a reconcile from current durable
+// state, or joins the active reconcile for the same Connector and account.
+func (application *Application) EnsureRuntimeReconcile(
+	ctx context.Context,
+	scope OperationScope,
+	connectorKey string,
+) (EnsureRuntimeReconcileResult, error) {
+	connectorKey = strings.TrimSpace(connectorKey)
+	scope.AccountID = strings.TrimSpace(scope.AccountID)
+	if connectorKey == "" {
+		return EnsureRuntimeReconcileResult{}, invalidRequest("connectorKey is required")
+	}
+	var result MutationResult
+	created := false
+	err := application.config.Repository.Transaction(ctx, func(tx Transaction) error {
+		active, err := tx.ActiveOperation(connectorKey)
+		if err != nil {
+			return err
+		}
+		if active != nil {
+			if active.Kind != OperationKindReconcileRuntime || active.Scope != scope {
+				return NewDomainError(
+					ErrorCodeOperationInProgress,
+					fmt.Sprintf("operation %s is already in progress", active.OperationID),
+					true,
+					nil,
+				)
+			}
+			connector, err := tx.Connector(connectorKey)
+			if err != nil {
+				return err
+			}
+			result = MutationResult{Connector: &connector, Operation: *active, Revision: tx.Revision()}
+			return nil
+		}
+		connector, err := tx.Connector(connectorKey)
+		if err != nil {
+			return err
+		}
+		connector, err = validateRuntimeReconcileConnector(connector)
+		if err != nil {
+			return err
+		}
+		now := application.config.Now().UTC()
+		operationID, err := application.config.NewID()
+		if err != nil {
+			return NewDomainError(ErrorCodeUnavailable, "connector operation id could not be generated", true, err)
+		}
+		revision := tx.AdvanceRevision()
+		connector.Revision = revision
+		operation := Operation{
+			OperationID:     operationID,
+			ClientRequestID: "ensure-runtime-reconcile/" + operationID,
+			ConnectorKey:    connectorKey,
+			Kind:            OperationKindReconcileRuntime,
+			Scope:           scope,
+			State:           OperationStateAccepted,
+			Stage:           OperationStageAccepted,
+			Target:          operationTarget(OperationKindReconcileRuntime, connector),
+			HostGeneration:  HostGeneration{BootEpoch: application.config.BootEpoch, Generation: revision},
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		}
+		if err := tx.SaveConnector(connector); err != nil {
+			return err
+		}
+		if err := tx.SaveOperation(operation); err != nil {
+			return err
+		}
+		if err := tx.EnqueueConnectorMarketChanged(ChangedEvent{
+			ConnectorKey: connectorKey,
+			OperationID:  operationID,
+			Revision:     revision,
+		}); err != nil {
+			return err
+		}
+		result = MutationResult{Connector: &connector, Operation: operation, Revision: revision}
+		created = true
+		return nil
+	})
+	if err != nil {
+		return EnsureRuntimeReconcileResult{}, err
+	}
+	if created || result.Operation.State == OperationStateAccepted {
+		if err := application.config.Scheduler.Schedule(ctx, result.Operation.OperationID); err != nil {
+			return EnsureRuntimeReconcileResult{}, NewDomainError(ErrorCodeUnavailable, "connector operation could not be scheduled", true, err)
+		}
+	}
+	return EnsureRuntimeReconcileResult{MutationResult: result, Created: created}, nil
+}
+
+func validateRuntimeReconcileConnector(connector Connector) (Connector, error) {
+	if connector.Installation.State != InstallationStateInstalled ||
+		strings.TrimSpace(connector.Installation.InstalledReleaseDigest) == "" {
+		return Connector{}, invalidTransition("runtime", string(connector.Installation.State), string(InstallationStateInstalled))
+	}
+	return connector, nil
 }
 
 func (application *Application) GetAuthorizationProjection(
@@ -44,6 +141,20 @@ func (application *Application) ObserveAuthorization(
 		return MutationResult{}, err
 	}
 	return application.ReconcileRuntime(ctx, mutation)
+}
+
+// ProjectAuthorization persists server-observed account authorization without
+// scheduling runtime work. Daemon hosts pair it with EnsureRuntimeReconcile
+// while holding their account lifecycle fence.
+func (application *Application) ProjectAuthorization(
+	ctx context.Context,
+	scope OperationScope,
+	projection AuthorizationProjection,
+) error {
+	return application.saveAuthorizationProjection(ctx, ConnectorMutation{
+		ConnectorKey: projection.ConnectorKey,
+		AccountID:    scope.AccountID,
+	}, projection)
 }
 
 func (application *Application) saveAuthorizationProjection(
@@ -84,66 +195,11 @@ func (application *Application) projectAuthorizationAndScheduleRuntime(
 	state AuthorizationState,
 	failureCode string,
 ) error {
-	if application.config.AuthorizationProjections == nil || strings.TrimSpace(scope.AccountID) == "" {
-		return nil
-	}
-	connectionID = strings.TrimSpace(connectionID)
-	if state == AuthorizationStateConnected && connectionID == "" {
-		return invalidOperationReceipt("connected authorization did not provide a connection id")
-	}
-	connector, err := application.config.Repository.Connector(ctx, strings.TrimSpace(connectorKey))
-	if err != nil {
+	remote, err := application.projectAuthorization(ctx, scope, connectorKey, connectionID, state, failureCode)
+	if err != nil || application.config.AuthorizationProjections == nil || strings.TrimSpace(scope.AccountID) == "" {
 		return err
 	}
-	release, err := application.installedReleaseEvidence(ctx, connector)
-	if err != nil {
-		return err
-	}
-	if release.Manifest.Implementation.RemoteStreamableHTTP != nil {
-		snapshotStore, ok := application.config.AuthorizationProjections.(AuthorizationSnapshotStore)
-		if !ok || application.config.AuthorizationSnapshots == nil {
-			return NewDomainError(ErrorCodeUnavailable, "remote connector authorization snapshot is unavailable", true, nil)
-		}
-		authoritative, snapshotErr := application.config.AuthorizationSnapshots.AuthorizationSnapshot(ctx, scope.AccountID)
-		if snapshotErr != nil {
-			return fmt.Errorf("refresh remote connector authorization snapshot: %w", snapshotErr)
-		}
-		if _, applyErr := snapshotStore.ApplyAuthorizationSnapshot(ctx, scope.AccountID, authoritative); applyErr != nil {
-			return fmt.Errorf("apply remote connector authorization snapshot: %w", applyErr)
-		}
-		if application.config.AuthorizationReadiness != nil {
-			application.config.AuthorizationReadiness.SetReady(scope.AccountID, true)
-		}
-	} else {
-		mutation := ConnectorMutation{
-			ConnectorKey: strings.TrimSpace(connectorKey),
-			AccountID:    strings.TrimSpace(scope.AccountID),
-		}
-		projection := AuthorizationProjection{
-			AccountID: strings.TrimSpace(scope.AccountID), ConnectorKey: strings.TrimSpace(connectorKey),
-			ConnectionID: connectionID, State: state, FailureCode: strings.TrimSpace(failureCode), UpdatedAt: application.config.Now().UTC(),
-		}
-		// Pending authorization has no runtime effect. Persisting the projection
-		// without scheduling a reconcile also leaves the accepted authorization
-		// operation available for the provider's next continuation step.
-		if state == AuthorizationStatePending {
-			return application.saveAuthorizationProjection(ctx, mutation, projection)
-		}
-		deviceSnapshot, snapshotErr := application.Snapshot(ctx)
-		if snapshotErr != nil {
-			return snapshotErr
-		}
-		requestID, idErr := application.config.NewID()
-		if idErr != nil {
-			return idErr
-		}
-		mutation.Mutation = Mutation{
-			ClientRequestID:  "authorization-projection/" + requestID,
-			ExpectedRevision: deviceSnapshot.Revision,
-		}
-		if _, err := application.ObserveAuthorization(ctx, mutation, projection); err != nil {
-			return err
-		}
+	if state == AuthorizationStatePending {
 		return nil
 	}
 	deviceSnapshot, err := application.Snapshot(ctx)
@@ -154,15 +210,73 @@ func (application *Application) projectAuthorizationAndScheduleRuntime(
 	if err != nil {
 		return err
 	}
+	requestPrefix := "authorization-projection/"
+	if remote {
+		requestPrefix = "authorization-snapshot/"
+	}
 	_, err = application.ReconcileRuntime(ctx, ConnectorMutation{
 		Mutation: Mutation{
-			ClientRequestID:  "authorization-snapshot/" + requestID,
+			ClientRequestID:  requestPrefix + requestID,
 			ExpectedRevision: deviceSnapshot.Revision,
 		},
 		ConnectorKey: strings.TrimSpace(connectorKey),
 		AccountID:    strings.TrimSpace(scope.AccountID),
 	})
 	return err
+}
+
+// projectAuthorization persists authorization truth without creating runtime
+// work. Recovery callers use it before the daemon creates and awaits exactly
+// one reconcile under the account lifecycle fence.
+func (application *Application) projectAuthorization(
+	ctx context.Context,
+	scope OperationScope,
+	connectorKey, connectionID string,
+	state AuthorizationState,
+	failureCode string,
+) (bool, error) {
+	if application.config.AuthorizationProjections == nil || strings.TrimSpace(scope.AccountID) == "" {
+		return false, nil
+	}
+	connectionID = strings.TrimSpace(connectionID)
+	if state == AuthorizationStateConnected && connectionID == "" {
+		return false, invalidOperationReceipt("connected authorization did not provide a connection id")
+	}
+	connector, err := application.config.Repository.Connector(ctx, strings.TrimSpace(connectorKey))
+	if err != nil {
+		return false, err
+	}
+	release, err := application.installedReleaseEvidence(ctx, connector)
+	if err != nil {
+		return false, err
+	}
+	remote := release.Manifest.Implementation.RemoteStreamableHTTP != nil
+	if remote {
+		snapshotStore, ok := application.config.AuthorizationProjections.(AuthorizationSnapshotStore)
+		if !ok || application.config.AuthorizationSnapshots == nil {
+			return false, NewDomainError(ErrorCodeUnavailable, "remote connector authorization snapshot is unavailable", true, nil)
+		}
+		authoritative, snapshotErr := application.config.AuthorizationSnapshots.AuthorizationSnapshot(ctx, scope.AccountID)
+		if snapshotErr != nil {
+			return false, fmt.Errorf("refresh remote connector authorization snapshot: %w", snapshotErr)
+		}
+		if _, applyErr := snapshotStore.ApplyAuthorizationSnapshot(ctx, scope.AccountID, authoritative); applyErr != nil {
+			return false, fmt.Errorf("apply remote connector authorization snapshot: %w", applyErr)
+		}
+		if application.config.AuthorizationReadiness != nil {
+			application.config.AuthorizationReadiness.SetReady(scope.AccountID, true)
+		}
+		return true, nil
+	}
+	mutation := ConnectorMutation{
+		ConnectorKey: strings.TrimSpace(connectorKey),
+		AccountID:    strings.TrimSpace(scope.AccountID),
+	}
+	projection := AuthorizationProjection{
+		AccountID: strings.TrimSpace(scope.AccountID), ConnectorKey: strings.TrimSpace(connectorKey),
+		ConnectionID: connectionID, State: state, FailureCode: strings.TrimSpace(failureCode), UpdatedAt: application.config.Now().UTC(),
+	}
+	return false, application.saveAuthorizationProjection(ctx, mutation, projection)
 }
 
 func (application *Application) ReconcileInstalledRuntimes(ctx context.Context) error {

--- a/packages/connector/host/application_test.go
+++ b/packages/connector/host/application_test.go
@@ -1226,6 +1226,82 @@ func TestApplicationRejectsConcurrentConnectorOperation(t *testing.T) {
 	}
 }
 
+func TestApplicationEnsureRuntimeReconcileCreatesOrJoinsCurrentScope(t *testing.T) {
+	connector := testConnector("github")
+	connector.Installation = Installation{
+		State:                  InstallationStateInstalled,
+		InstalledVersion:       connector.Release.Version,
+		InstalledReleaseID:     connector.Release.ReleaseID,
+		InstalledReleaseDigest: connector.Release.ReleaseDigest,
+	}
+	repository := newMemoryRepository(connector)
+	repository.revision = 7
+	scheduler := &memoryScheduler{}
+	application := newTestApplication(t, repository, scheduler, &memoryInstallRuntime{}, CatalogSnapshot{})
+	scope := OperationScope{AccountID: "account-1"}
+
+	created, err := application.EnsureRuntimeReconcile(context.Background(), scope, connector.Key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	running := repository.operations[created.Operation.OperationID]
+	running.State = OperationStateRunning
+	repository.operations[running.OperationID] = running
+	joined, err := application.EnsureRuntimeReconcile(context.Background(), scope, connector.Key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if joined.Operation.OperationID != created.Operation.OperationID {
+		t.Fatalf("joined operation = %q, want %q", joined.Operation.OperationID, created.Operation.OperationID)
+	}
+	if !created.Created || joined.Created {
+		t.Fatalf("created=%t joined=%t", created.Created, joined.Created)
+	}
+	if repository.revision != 8 || len(repository.operations) != 1 {
+		t.Fatalf("revision=%d operations=%#v", repository.revision, repository.operations)
+	}
+	if len(scheduler.operationIDs) != 1 || scheduler.operationIDs[0] != created.Operation.OperationID {
+		t.Fatalf("scheduled operations = %#v", scheduler.operationIDs)
+	}
+	completed := repository.operations[created.Operation.OperationID]
+	completed.State = OperationStateCompleted
+	completed.Stage = OperationStageCompleted
+	repository.operations[completed.OperationID] = completed
+	followup, err := application.EnsureRuntimeReconcile(context.Background(), scope, connector.Key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !followup.Created || followup.Operation.OperationID == created.Operation.OperationID || repository.revision != 9 {
+		t.Fatalf("followup=%#v revision=%d", followup, repository.revision)
+	}
+}
+
+func TestApplicationEnsureRuntimeReconcileDoesNotJoinDifferentScope(t *testing.T) {
+	connector := testConnector("github")
+	connector.Installation = Installation{
+		State:                  InstallationStateInstalled,
+		InstalledVersion:       connector.Release.Version,
+		InstalledReleaseID:     connector.Release.ReleaseID,
+		InstalledReleaseDigest: connector.Release.ReleaseDigest,
+	}
+	repository := newMemoryRepository(connector)
+	repository.operations["old-account-reconcile"] = Operation{
+		OperationID: "old-account-reconcile", ConnectorKey: connector.Key,
+		Kind: OperationKindReconcileRuntime, Scope: OperationScope{AccountID: "account-old"},
+		State: OperationStateRunning, Stage: OperationStageAccepted,
+	}
+	application := newTestApplication(t, repository, &memoryScheduler{}, &memoryInstallRuntime{}, CatalogSnapshot{})
+
+	_, err := application.EnsureRuntimeReconcile(context.Background(), OperationScope{AccountID: "account-new"}, connector.Key)
+	var domainError *DomainError
+	if !errors.As(err, &domainError) || domainError.Code != ErrorCodeOperationInProgress {
+		t.Fatalf("error = %#v, want operation in progress", err)
+	}
+	if len(repository.operations) != 1 {
+		t.Fatalf("operations = %#v", repository.operations)
+	}
+}
+
 func TestApplicationRefreshRejectsUnknownImplementation(t *testing.T) {
 	repository := newMemoryRepository()
 	scheduler := &memoryScheduler{}
@@ -1393,6 +1469,44 @@ func TestApplicationReconcilesCompletedAuthorizationSession(t *testing.T) {
 	}
 	if updated.Authorization.State != AuthorizationStateConnected || len(repository.events) != 1 {
 		t.Fatalf("connector=%#v events=%#v", updated, repository.events)
+	}
+}
+
+func TestApplicationAuthorizationRecoveryProjectsWithoutSchedulingRuntime(t *testing.T) {
+	connector := testManagedAuthorizedConnector("gmail")
+	connector.Authorization = Authorization{State: AuthorizationStatePending}
+	repository := newMemoryRepository(connector)
+	repository.operations["authorization-1"] = Operation{
+		OperationID: "authorization-1", ConnectorKey: connector.Key,
+		Kind: OperationKindStartAuthorization, Scope: OperationScope{AccountID: "account-1"},
+		State: OperationStateCompleted, Stage: OperationStageCompleted,
+		Target: operationTarget(OperationKindStartAuthorization, connector),
+		Execution: OperationExecution{AuthorizationSession: &AuthorizationSession{
+			OperationID: "authorization-1", ConnectorKey: connector.Key,
+			SessionID: "session-1", State: AuthorizationStatePending,
+			Resolution: AuthorizationSessionResolutionUnresolved,
+		}},
+	}
+	scheduler := &memoryScheduler{}
+	projections := &recordingAuthorizationProjectionStore{}
+	application := newTestApplication(t, repository, scheduler, &memoryInstallRuntime{}, CatalogSnapshot{})
+	application.config.Authorization = observingAuthorizationProvider{observation: AuthorizationObservation{
+		State: AuthorizationObservationConnected, ConnectionID: "connection-1",
+	}}
+	application.config.AuthorizationProjections = projections
+
+	intents, err := application.ReconcileAuthorizations(context.Background(), OperationScope{AccountID: "account-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(intents) != 1 || intents[0].OperationID != "authorization-1" {
+		t.Fatalf("intents = %#v", intents)
+	}
+	if len(scheduler.operationIDs) != 0 {
+		t.Fatalf("recovery scheduled runtime operations = %#v", scheduler.operationIDs)
+	}
+	if projections.projection.State != AuthorizationStateConnected || projections.projection.ConnectionID != "connection-1" {
+		t.Fatalf("projection = %#v", projections.projection)
 	}
 }
 

--- a/packages/connector/host/types.go
+++ b/packages/connector/host/types.go
@@ -532,6 +532,14 @@ type ConnectorMutation struct {
 	AccountID    string `json:"accountId,omitempty"`
 }
 
+// EnsureRuntimeReconcileResult reports whether a level-triggered repair
+// created work from the caller's current desired state or joined older work
+// that must be followed by another ensure after it reaches a terminal state.
+type EnsureRuntimeReconcileResult struct {
+	MutationResult
+	Created bool
+}
+
 // AuthorizationProjection is account-scoped runtime intent. Installation is
 // still device-scoped on Connector; switching accounts changes only this
 // projection and the runtime binding derived from it.


### PR DESCRIPTION
## Summary

授权 receipt 恢复原先存在两个相互竞争的 Runtime Reconcile 调度者：Host 在写入 Authorization Projection 后先创建一次操作，daemon recovery worker 又为同一 Connector 创建第二次操作。第一次操作仍在执行时会触发 `connector_operation_in_progress`，其阶段推进或其他 Connector 更新全局 revision 时则会触发 `connector_market_revision_conflict`，导致 receipt 无法稳定收敛。

本 PR 将 pending authorization recovery 调整为单一调度链路：

- `ReconcileAuthorizations` 只持久化 Projection 并返回待收敛 receipt，不再提前创建 Runtime Operation
- daemon 在 account lifecycle fence 内通过 `EnsureRuntimeReconcile` 原子创建或复用同 Connector、同 Account 的 reconcile，并等待成功后再 resolve receipt
- 如果复用的是可能已读取旧 Projection 的运行中操作，先等待旧操作终态，再创建并等待一个基于当前 Projection 的 follow-up reconcile
- daemon 实时 authorization observation 同样改为 `ProjectAuthorization + Ensure/await`，不再使用内部 Snapshot revision CAS
- 保留外部 UI/API mutation 的全局 revision 语义、两秒 crash-recovery worker，以及现有 Operation/AuthorizationSession 持久化模型；不新增表或通用 Controller
- 补充 Host 与 daemon 回归测试，并更新 Connector 架构和包文档

## Verification

- `go test ./packages/connector/host ./packages/connector/daemon`
- `go test -race -count=1 ./packages/connector/host ./packages/connector/daemon`
- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready`：8 lanes passed

## Fallback Three Questions

- Source: 新 Authorization Projection 写入时，同 Connector 可能已有一个已经读取旧 runtime binding 的 Reconcile 正在执行
- Why can it not be fixed at that source? 已开始的 generation-fenced Runtime Operation 不能安全重写或取消；复用它只能完成旧工作，不能证明新 Projection 已生效
- Removal condition: 当 Runtime Operation 持久化并校验可比较的 Authorization desired generation/fingerprint，且只允许复用相同 desired state 的操作时，可以移除 join 后的 follow-up ensure

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter. (N/A: Connector runtime operations only)
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. (N/A: changed package README files have no language variants)
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
