### PR TITLE
fix(agent-gui): reconcile stale CCS model history

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2172,6 +2172,20 @@ as ordinary prompts.
 The host capability remains explicit so unsupported hosts can fail closed, but
 Tutti Desktop always supplies `sessionInputHistoryEnabled: true`; historical
 `lab.agentInputHistory` preference values do not hide or disable the feature.
+
+Composer model recents and favorites are separate browser-local menu chrome.
+The Composer presentation projects the exact Agent Target identity together
+with narrow provider-native catalog testimony, and one focused controller owns
+storage reads, writes, cross-window refresh, and reconciliation. An unresolved
+active-Session target disables history instead of reading or writing a shared
+fallback bucket. Only an authoritative, settled native catalog may retire a
+recent model; loading, empty catalogs, requested-origin entries, and
+selected-model-only echoes remain unverifiable. Favorites preserve explicit
+user intent even when a model is currently unavailable. The legacy shared
+`default` bucket migrates lazily to the first exact target: recents pass through
+current authoritative testimony before migration, while favorites migrate
+without availability filtering.
+
 Bare Up/Down recalls older/newer structured drafts only from an empty composer
 or an unchanged recalled entry, and only when the collapsed caret is at a
 whole-document boundary. Palette handling and IME composition take precedence,

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2185,6 +2185,10 @@ user intent even when a model is currently unavailable. The legacy shared
 `default` bucket migrates lazily to the first exact target: recents pass through
 current authoritative testimony before migration, while favorites migrate
 without availability filtering.
+Quick Composer projects the same history identity and testimony from its exact
+selected target and host-owned options capability. Host-level option loading
+keeps that testimony unsettled, so a retained last-good catalog cannot retire
+history while the embedding host is refreshing or changing targets.
 
 Bare Up/Down recalls older/newer structured drafts only from an empty composer
 or an unchanged recalled entry, and only when the collapsed caret is at a

--- a/packages/agent/gui/AgentGUIQuickComposer.spec.tsx
+++ b/packages/agent/gui/AgentGUIQuickComposer.spec.tsx
@@ -3,10 +3,11 @@ import type { AgentActivityComposerOptions } from "@tutti-os/agent-activity-core
 import { createI18nRuntime } from "@tutti-os/ui-i18n-runtime";
 import { createRichTextMentionService } from "@tutti-os/ui-rich-text/service";
 import type { RichTextTriggerProvider } from "@tutti-os/ui-rich-text/types";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentGUIQuickComposer } from "./AgentGUIQuickComposer";
 import type { AgentGUIQuickComposerAgentTarget } from "./AgentGUIQuickComposer";
 import { agentGuiI18nResources } from "./i18n/index";
+import { projectQuickComposerSettings } from "./quickComposerSettings";
 
 const agentTargets = [
   {
@@ -49,6 +50,10 @@ const composerOptions = {
   skills: [],
   speeds: []
 } satisfies AgentActivityComposerOptions;
+
+beforeEach(() => {
+  globalThis.localStorage.clear();
+});
 
 describe("AgentGUIQuickComposer", () => {
   it("fails closed when the controlled Agent target is missing or disabled", () => {
@@ -159,6 +164,102 @@ describe("AgentGUIQuickComposer", () => {
     );
 
     expect(onSettingsChange).toHaveBeenCalledWith({ model: "gpt-5.5" });
+    expect(
+      globalThis.localStorage.getItem(
+        "agent-gui:composer-model-recents:agent:codex"
+      )
+    ).toBe('["gpt-5.5"]');
+    expect(
+      globalThis.localStorage.getItem(
+        "agent-gui:composer-model-recents:default"
+      )
+    ).toBeNull();
+  });
+
+  it("migrates legacy model history into the exact selected target", async () => {
+    globalThis.localStorage.setItem(
+      "agent-gui:composer-model-recents:default",
+      '["obsolete-model","gpt-5.5"]'
+    );
+    globalThis.localStorage.setItem(
+      "agent-gui:composer-model-favorites:default",
+      '["gpt-5.5"]'
+    );
+    const { container } = render(
+      <AgentGUIQuickComposer
+        agentTargets={agentTargets}
+        capabilitiesByAgentTargetId={capabilitiesByAgentTargetId}
+        composerSettings={{
+          loading: false,
+          onChange: vi.fn(),
+          options: composerOptions,
+          value: { model: "gpt-5.6-sol", reasoningEffort: "high" }
+        }}
+        content={[{ text: "Inspect this", type: "text" }]}
+        selectedAgentTargetId="agent:codex"
+        workspaceId="workspace:test"
+        onAgentTargetChange={vi.fn()}
+        onContentChange={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    );
+
+    fireEvent.pointerDown(
+      container.querySelector<HTMLButtonElement>(
+        '[data-agent-model-reasoning-trigger="true"]'
+      )!,
+      { button: 0, ctrlKey: false }
+    );
+
+    await waitFor(() => {
+      expect(
+        globalThis.localStorage.getItem(
+          "agent-gui:composer-model-recents:agent:codex"
+        )
+      ).toBe('["gpt-5.5"]');
+      expect(
+        globalThis.localStorage.getItem(
+          "agent-gui:composer-model-favorites:agent:codex"
+        )
+      ).toBe('["gpt-5.5"]');
+    });
+    expect(
+      globalThis.localStorage.getItem(
+        "agent-gui:composer-model-recents:default"
+      )
+    ).toBeNull();
+    expect(
+      globalThis.localStorage.getItem(
+        "agent-gui:composer-model-favorites:default"
+      )
+    ).toBeNull();
+    expect(
+      document.querySelector(
+        '[data-agent-model-value="gpt-5.5"] [data-agent-model-favorite-toggle="true"]'
+      )
+    ).toHaveAttribute("data-favorited", "true");
+  });
+
+  it("marks retained catalog testimony unsettled while the host is loading", () => {
+    const projected = projectQuickComposerSettings({
+      agentTargetId: "agent:codex",
+      loading: true,
+      options: composerOptions,
+      projectLocked: false,
+      provider: "codex",
+      selectedProjectPath: null,
+      settings: {}
+    });
+
+    expect(projected.modelChoiceHistory).toEqual({
+      targetId: "agent:codex",
+      catalog: {
+        authoritative: true,
+        effectiveModel: "gpt-5.6-sol",
+        loading: true,
+        models: [{ value: "gpt-5.6-sol" }, { value: "gpt-5.5" }]
+      }
+    });
   });
 
   it("keeps prompt entry and references available while options load", () => {

--- a/packages/agent/gui/AgentGUIQuickComposer.tsx
+++ b/packages/agent/gui/AgentGUIQuickComposer.tsx
@@ -160,6 +160,7 @@ function AgentGUIQuickComposerInner({
     agentTargets.find(
       (target) => target.agentTargetId === selectedAgentTargetId
     ) ?? null;
+  const resolvedAgentTargetId = selectedAgentTarget?.agentTargetId ?? null;
   const selectedTargetCapabilities = selectedAgentTarget
     ? (capabilitiesByAgentTargetId[selectedAgentTarget.agentTargetId] ?? null)
     : null;
@@ -211,6 +212,7 @@ function AgentGUIQuickComposerInner({
   const composerSettings = useMemo<AgentGUIComposerSettingsVM>(
     () =>
       projectQuickComposerSettings({
+        agentTargetId: resolvedAgentTargetId,
         loading: composerOptionsLoading,
         options: composerOptions,
         projectLocked: disabled,
@@ -223,6 +225,7 @@ function AgentGUIQuickComposerInner({
       composerOptionsLoading,
       disabled,
       provider,
+      resolvedAgentTargetId,
       selectedProjectPath,
       settings
     ]

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerModelReasoningDropdown.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerModelReasoningDropdown.tsx
@@ -106,7 +106,11 @@ export function AgentModelReasoningDropdown({
         : modelHistoryTargetId,
     catalog: projectedModelHistory?.catalog ?? null
   });
-  const { favoriteModelIds, recentModelIds } = modelHistory;
+  const {
+    enabled: modelHistoryEnabled,
+    favoriteModelIds,
+    recentModelIds
+  } = modelHistory;
   const handleMenuOpenChange = (open: boolean): void => {
     if (open) {
       // Pick up writes from other windows and clear the previous filter.
@@ -151,6 +155,9 @@ export function AgentModelReasoningDropdown({
   const handleToggleFavoriteModel = (value: string): void => {
     modelHistory.toggleFavoriteModel(value);
   };
+  const toggleFavoriteModel = modelHistoryEnabled
+    ? handleToggleFavoriteModel
+    : undefined;
   const favoriteValueSet = new Set(menu.model.favoriteValues);
   const modelDescriptionPresentation = menu.model.optionDescriptionInline
     ? ("inline" as const)
@@ -344,7 +351,7 @@ export function AgentModelReasoningDropdown({
                   descriptionPresentation={modelDescriptionPresentation}
                   tooltipsEnabled
                   favoriteValues={favoriteValueSet}
-                  onToggleFavorite={handleToggleFavoriteModel}
+                  onToggleFavorite={toggleFavoriteModel}
                   onSelect={applyModelSelection}
                 />
               </>
@@ -363,7 +370,7 @@ export function AgentModelReasoningDropdown({
                   descriptionPresentation={modelDescriptionPresentation}
                   tooltipsEnabled
                   favoriteValues={favoriteValueSet}
-                  onToggleFavorite={handleToggleFavoriteModel}
+                  onToggleFavorite={toggleFavoriteModel}
                   onSelect={applyModelSelection}
                 />
               </>
@@ -387,7 +394,7 @@ export function AgentModelReasoningDropdown({
                     descriptionPresentation={modelDescriptionPresentation}
                     tooltipsEnabled
                     favoriteValues={favoriteValueSet}
-                    onToggleFavorite={handleToggleFavoriteModel}
+                    onToggleFavorite={toggleFavoriteModel}
                     onSelect={applyModelSelection}
                   />
                 </Fragment>
@@ -399,7 +406,7 @@ export function AgentModelReasoningDropdown({
                 descriptionPresentation={modelDescriptionPresentation}
                 tooltipsEnabled
                 favoriteValues={favoriteValueSet}
-                onToggleFavorite={handleToggleFavoriteModel}
+                onToggleFavorite={toggleFavoriteModel}
                 onSelect={applyModelSelection}
               />
             )}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerModelReasoningDropdown.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerModelReasoningDropdown.tsx
@@ -1,7 +1,6 @@
 import {
   Fragment,
   cloneElement,
-  useCallback,
   useState,
   type HTMLAttributes,
   type ReactElement
@@ -32,14 +31,7 @@ import {
   type AgentComposerSettingsMenuLabels,
   type ComposerMenuOption
 } from "./model/composerSettingsMenuModel";
-import {
-  composerModelFavoritesStorageKey,
-  composerModelRecentsStorageKey,
-  parseComposerModelIdList,
-  recordRecentComposerModel,
-  serializeComposerModelIdList,
-  toggleFavoriteComposerModel
-} from "./model/composerModelChoiceHistory";
+import { useComposerModelChoiceHistory } from "./controller/useComposerModelChoiceHistory";
 import { translate } from "../../i18n/index";
 import styles from "./AgentGUINode.styles";
 
@@ -84,7 +76,7 @@ export function AgentModelReasoningDropdown({
   composerSettings,
   disabled = false,
   labels,
-  modelHistoryTargetId = null,
+  modelHistoryTargetId,
   onRetryComposerOptions,
   onSettingsChange
 }: {
@@ -92,8 +84,8 @@ export function AgentModelReasoningDropdown({
   disabled?: boolean;
   labels: AgentComposerSettingsMenuLabels;
   /**
-   * Stable per-target key for the recents/favorites localStorage chrome
-   * state; omit to fall back to one shared "default" bucket.
+   * Optional test/embedding override. Omission uses the controller-projected
+   * exact target; explicit null disables model history.
    */
   modelHistoryTargetId?: string | null;
   onRetryComposerOptions?: () => void;
@@ -106,41 +98,19 @@ export function AgentModelReasoningDropdown({
   "use memo";
   const [menuOpen, setMenuOpen] = useState(false);
   const [modelSearchQuery, setModelSearchQuery] = useState("");
-  const [favoriteModelIds, setFavoriteModelIds] = useState<readonly string[]>(
-    () =>
-      parseComposerModelIdList(
-        readComposerLocalStorage(
-          composerModelFavoritesStorageKey(modelHistoryTargetId)
-        )
-      )
-  );
-  const [recentModelIds, setRecentModelIds] = useState<readonly string[]>(() =>
-    parseComposerModelIdList(
-      readComposerLocalStorage(
-        composerModelRecentsStorageKey(modelHistoryTargetId)
-      )
-    )
-  );
-  const reloadModelHistory = useCallback(() => {
-    setFavoriteModelIds(
-      parseComposerModelIdList(
-        readComposerLocalStorage(
-          composerModelFavoritesStorageKey(modelHistoryTargetId)
-        )
-      )
-    );
-    setRecentModelIds(
-      parseComposerModelIdList(
-        readComposerLocalStorage(
-          composerModelRecentsStorageKey(modelHistoryTargetId)
-        )
-      )
-    );
-  }, [modelHistoryTargetId]);
+  const projectedModelHistory = composerSettings.modelChoiceHistory;
+  const modelHistory = useComposerModelChoiceHistory({
+    targetId:
+      modelHistoryTargetId === undefined
+        ? (projectedModelHistory?.targetId ?? null)
+        : modelHistoryTargetId,
+    catalog: projectedModelHistory?.catalog ?? null
+  });
+  const { favoriteModelIds, recentModelIds } = modelHistory;
   const handleMenuOpenChange = (open: boolean): void => {
     if (open) {
       // Pick up writes from other windows and clear the previous filter.
-      reloadModelHistory();
+      modelHistory.refreshFromStorage();
       setModelSearchQuery("");
     }
     setMenuOpen(open);
@@ -175,24 +145,11 @@ export function AgentModelReasoningDropdown({
     setMenuOpen(false);
   };
   const applyModelSelection = (value: string): void => {
-    const nextRecentIds = recordRecentComposerModel(recentModelIds, value);
-    setRecentModelIds(nextRecentIds);
-    writeComposerLocalStorage(
-      composerModelRecentsStorageKey(modelHistoryTargetId),
-      serializeComposerModelIdList(nextRecentIds)
-    );
+    modelHistory.recordRecentModel(value);
     applySettingsChange({ model: value });
   };
   const handleToggleFavoriteModel = (value: string): void => {
-    const nextFavoriteIds = toggleFavoriteComposerModel(
-      favoriteModelIds,
-      value
-    );
-    setFavoriteModelIds(nextFavoriteIds);
-    writeComposerLocalStorage(
-      composerModelFavoritesStorageKey(modelHistoryTargetId),
-      serializeComposerModelIdList(nextFavoriteIds)
-    );
+    modelHistory.toggleFavoriteModel(value);
   };
   const favoriteValueSet = new Set(menu.model.favoriteValues);
   const modelDescriptionPresentation = menu.model.optionDescriptionInline
@@ -530,29 +487,6 @@ export function AgentModelReasoningDropdown({
       </DropdownMenuContent>
     </DropdownMenu>
   );
-}
-
-function readComposerLocalStorage(key: string): string | null {
-  try {
-    if (typeof window === "undefined" || !window.localStorage) {
-      return null;
-    }
-    return window.localStorage.getItem(key);
-  } catch {
-    return null;
-  }
-}
-
-function writeComposerLocalStorage(key: string, value: string): void {
-  try {
-    if (typeof window === "undefined" || !window.localStorage) {
-      return;
-    }
-    window.localStorage.setItem(key, value);
-  } catch {
-    // Chrome-state persistence is best-effort; never break the menu.
-    return;
-  }
 }
 
 // Renders a list of pick-to-apply menu items. Pointer activation applies

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
@@ -30,9 +30,11 @@ describe("AgentModelReasoningDropdown", () => {
     const onSettingsChange = vi.fn();
     render(
       <AgentModelReasoningDropdown
-        composerSettings={composerModelSettings()}
+        composerSettings={{
+          ...composerModelSettings(),
+          modelChoiceHistory: { targetId: "target-1", catalog: null }
+        }}
         labels={modelSettingsLabels}
-        modelHistoryTargetId="target-1"
         onSettingsChange={onSettingsChange}
       />
     );
@@ -65,6 +67,11 @@ describe("AgentModelReasoningDropdown", () => {
         "agent-gui:composer-model-favorites:target-1"
       )
     ).toBe('["gpt-5.4"]');
+    expect(
+      globalThis.localStorage.getItem(
+        "agent-gui:composer-model-favorites:default"
+      )
+    ).toBeNull();
     expect(screen.getByText("Model selection")).toBeInTheDocument();
   });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
@@ -108,6 +108,29 @@ describe("AgentModelReasoningDropdown", () => {
     expect(screen.getByText("Model selection")).toBeInTheDocument();
   });
 
+  it("hides favorite controls when model history has no exact target", async () => {
+    render(
+      <AgentModelReasoningDropdown
+        composerSettings={{
+          ...composerModelSettings(),
+          modelChoiceHistory: { targetId: null, catalog: null }
+        }}
+        labels={modelSettingsLabels}
+        onSettingsChange={vi.fn()}
+      />
+    );
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Model / Reasoning" }),
+      { button: 0, ctrlKey: false, pointerType: "mouse" }
+    );
+
+    expect(await screen.findByText("Model selection")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Add to favorites" })
+    ).not.toBeInTheDocument();
+  });
+
   it("retries composer options from the compact error state", async () => {
     const onRetryComposerOptions = vi.fn();
     render(

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentModelReasoningDropdown.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentModelReasoningDropdown.tsx
@@ -67,7 +67,11 @@ export function AgentModelReasoningDropdown({
         : modelHistoryTargetId,
     catalog: projectedModelHistory?.catalog ?? null
   });
-  const { favoriteModelIds, recentModelIds } = modelHistory;
+  const {
+    enabled: modelHistoryEnabled,
+    favoriteModelIds,
+    recentModelIds
+  } = modelHistory;
   const handleMenuOpenChange = (open: boolean): void => {
     if (open) {
       // Pick up writes from other windows and clear the previous filter.
@@ -103,6 +107,9 @@ export function AgentModelReasoningDropdown({
   const handleToggleFavoriteModel = (value: string): void => {
     modelHistory.toggleFavoriteModel(value);
   };
+  const toggleFavoriteModel = modelHistoryEnabled
+    ? handleToggleFavoriteModel
+    : undefined;
   const favoriteValueSet = new Set(menu.model.favoriteValues);
   const modelDescriptionPresentation = menu.model.optionDescriptionInline
     ? ("inline" as const)
@@ -230,7 +237,7 @@ export function AgentModelReasoningDropdown({
                   descriptionPresentation={modelDescriptionPresentation}
                   tooltipsEnabled
                   favoriteValues={favoriteValueSet}
-                  onToggleFavorite={handleToggleFavoriteModel}
+                  onToggleFavorite={toggleFavoriteModel}
                   onSelect={applyModelSelection}
                 />
               </>
@@ -249,7 +256,7 @@ export function AgentModelReasoningDropdown({
                   descriptionPresentation={modelDescriptionPresentation}
                   tooltipsEnabled
                   favoriteValues={favoriteValueSet}
-                  onToggleFavorite={handleToggleFavoriteModel}
+                  onToggleFavorite={toggleFavoriteModel}
                   onSelect={applyModelSelection}
                 />
               </>
@@ -273,7 +280,7 @@ export function AgentModelReasoningDropdown({
                     descriptionPresentation={modelDescriptionPresentation}
                     tooltipsEnabled
                     favoriteValues={favoriteValueSet}
-                    onToggleFavorite={handleToggleFavoriteModel}
+                    onToggleFavorite={toggleFavoriteModel}
                     onSelect={applyModelSelection}
                   />
                 </Fragment>
@@ -285,7 +292,7 @@ export function AgentModelReasoningDropdown({
                 descriptionPresentation={modelDescriptionPresentation}
                 tooltipsEnabled
                 favoriteValues={favoriteValueSet}
-                onToggleFavorite={handleToggleFavoriteModel}
+                onToggleFavorite={toggleFavoriteModel}
                 onSelect={applyModelSelection}
               />
             )}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentModelReasoningDropdown.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentModelReasoningDropdown.tsx
@@ -5,7 +5,6 @@ import { CheckIcon, ChevronDown, Star, ZapIcon } from "lucide-react";
 import {
   Fragment,
   cloneElement,
-  useMemo,
   useState,
   type HTMLAttributes,
   type ReactElement
@@ -34,28 +33,21 @@ import {
   buildComposerModelMenuModel,
   type ComposerMenuOption
 } from "./model/composerSettingsMenuModel";
-import {
-  composerModelFavoritesStorageKey,
-  composerModelRecentsStorageKey,
-  parseComposerModelIdList,
-  recordRecentComposerModel,
-  serializeComposerModelIdList,
-  toggleFavoriteComposerModel
-} from "./model/composerModelChoiceHistory";
+import { useComposerModelChoiceHistory } from "./controller/useComposerModelChoiceHistory";
 
 export function AgentModelReasoningDropdown({
   composerSettings,
   disabled = false,
   labels,
-  modelHistoryTargetId = null,
+  modelHistoryTargetId,
   onSettingsChange
 }: {
   composerSettings: AgentGUIComposerSettingsVM;
   disabled?: boolean;
   labels: AgentComposerSettingsMenuLabels;
   /**
-   * Stable per-target key for the recents/favorites localStorage chrome
-   * state; omit to fall back to one shared "default" bucket.
+   * Optional test/embedding override. Omission uses the controller-projected
+   * exact target; explicit null disables model history.
    */
   modelHistoryTargetId?: string | null;
   onSettingsChange: (patch: {
@@ -67,31 +59,19 @@ export function AgentModelReasoningDropdown({
   "use memo";
   const [menuOpen, setMenuOpen] = useState(false);
   const [modelSearchQuery, setModelSearchQuery] = useState("");
-  // localStorage is not reactive, so history re-derives only when the
-  // target changes or a local write/menu-open bumps the refresh counter.
-  const [historyRefresh, setHistoryRefresh] = useState(0);
-  const favoriteModelIds = useMemo(
-    () =>
-      parseComposerModelIdList(
-        readComposerLocalStorage(
-          composerModelFavoritesStorageKey(modelHistoryTargetId)
-        )
-      ),
-    [modelHistoryTargetId, historyRefresh]
-  );
-  const recentModelIds = useMemo(
-    () =>
-      parseComposerModelIdList(
-        readComposerLocalStorage(
-          composerModelRecentsStorageKey(modelHistoryTargetId)
-        )
-      ),
-    [modelHistoryTargetId, historyRefresh]
-  );
+  const projectedModelHistory = composerSettings.modelChoiceHistory;
+  const modelHistory = useComposerModelChoiceHistory({
+    targetId:
+      modelHistoryTargetId === undefined
+        ? (projectedModelHistory?.targetId ?? null)
+        : modelHistoryTargetId,
+    catalog: projectedModelHistory?.catalog ?? null
+  });
+  const { favoriteModelIds, recentModelIds } = modelHistory;
   const handleMenuOpenChange = (open: boolean): void => {
     if (open) {
       // Pick up writes from other windows and clear the previous filter.
-      setHistoryRefresh((value) => value + 1);
+      modelHistory.refreshFromStorage();
       setModelSearchQuery("");
     }
     setMenuOpen(open);
@@ -117,24 +97,11 @@ export function AgentModelReasoningDropdown({
     setMenuOpen(false);
   };
   const applyModelSelection = (value: string): void => {
-    const nextRecentIds = recordRecentComposerModel(recentModelIds, value);
-    setHistoryRefresh((refresh) => refresh + 1);
-    writeComposerLocalStorage(
-      composerModelRecentsStorageKey(modelHistoryTargetId),
-      serializeComposerModelIdList(nextRecentIds)
-    );
+    modelHistory.recordRecentModel(value);
     applySettingsChange({ model: value });
   };
   const handleToggleFavoriteModel = (value: string): void => {
-    const nextFavoriteIds = toggleFavoriteComposerModel(
-      favoriteModelIds,
-      value
-    );
-    setHistoryRefresh((refresh) => refresh + 1);
-    writeComposerLocalStorage(
-      composerModelFavoritesStorageKey(modelHistoryTargetId),
-      serializeComposerModelIdList(nextFavoriteIds)
-    );
+    modelHistory.toggleFavoriteModel(value);
   };
   const favoriteValueSet = new Set(menu.model.favoriteValues);
   const modelDescriptionPresentation = menu.model.optionDescriptionInline
@@ -406,29 +373,6 @@ export function AgentModelReasoningDropdown({
       </DropdownMenuContent>
     </DropdownMenu>
   );
-}
-
-function readComposerLocalStorage(key: string): string | null {
-  try {
-    if (typeof window === "undefined" || !window.localStorage) {
-      return null;
-    }
-    return window.localStorage.getItem(key);
-  } catch {
-    return null;
-  }
-}
-
-function writeComposerLocalStorage(key: string, value: string): void {
-  try {
-    if (typeof window === "undefined" || !window.localStorage) {
-      return;
-    }
-    window.localStorage.setItem(key, value);
-  } catch {
-    // Chrome-state persistence is best-effort; never break the menu.
-    return;
-  }
 }
 
 // Renders a list of pick-to-apply menu items. Pointer activation applies

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerPresentation.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerPresentation.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { AgentActivityComposerOptions } from "@tutti-os/agent-activity-core";
 import type { AgentGUINodeData } from "../../../types";
 import {
+  composerModelChoiceHistoryTargetId,
   composerTargetDataForConversation,
   effectiveComposerSettingsFromOptions,
   enforceComposerModelBindingForHomeDefaults,
@@ -24,6 +25,27 @@ describe("composer target presentation", () => {
       lastActiveAgentSessionId: null
     }
   };
+
+  it("fails model history closed for unresolved active targets", () => {
+    expect(
+      composerModelChoiceHistoryTargetId({
+        activeConversationId: null,
+        target: { agentTargetId: null, targetId: "local:codex" }
+      })
+    ).toBe("local:codex");
+    expect(
+      composerModelChoiceHistoryTargetId({
+        activeConversationId: "session-1",
+        target: { agentTargetId: null, targetId: "local:codex" }
+      })
+    ).toBeNull();
+    expect(
+      composerModelChoiceHistoryTargetId({
+        activeConversationId: "session-1",
+        target: { agentTargetId: "agent:ccs", targetId: "legacy:ccs" }
+      })
+    ).toBe("agent:ccs");
+  });
 
   it("keeps the submitted target until the host node projection catches up", () => {
     const staleNodeData: AgentGUINodeData = {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerPresentation.ts
@@ -52,6 +52,24 @@ export function composerTargetDataFromNodeData(
   };
 }
 
+/**
+ * Resolve the device-local model-history owner without guessing an active
+ * Session's identity. Home may use its stable target fallback, while an active
+ * Session without a canonical Agent Target fails closed.
+ */
+export function composerModelChoiceHistoryTargetId(input: {
+  activeConversationId: string | null;
+  target: Pick<AgentGUIComposerTargetData, "agentTargetId" | "targetId">;
+}): string | null {
+  const agentTargetId = normalizeOptionalText(input.target.agentTargetId);
+  if (agentTargetId) {
+    return agentTargetId;
+  }
+  return input.activeConversationId === null
+    ? normalizeOptionalText(input.target.targetId)
+    : null;
+}
+
 export function composerTargetDataForConversation(input: {
   activeConversationId: string | null;
   activeSessionTarget: AgentGUIActiveSessionTarget | null;
@@ -235,6 +253,17 @@ export type ComposerNativeModelVerdict =
   | "rejected"
   | "unverifiable";
 
+export interface ComposerNativeModelOptionsTestimony {
+  models: readonly {
+    value: string;
+    requested?: boolean;
+  }[];
+  modelOptionsLoading?: boolean;
+  effectiveSettings?: {
+    model?: string | null;
+  } | null;
+}
+
 /**
  * Verdict of a bare model id against the provider-native options list. Only
  * settled catalog entries are testimony:
@@ -253,7 +282,7 @@ export type ComposerNativeModelVerdict =
  */
 export function verifyComposerModelAgainstNativeOptions(
   model: string,
-  options: AgentActivityComposerOptions | null
+  options: ComposerNativeModelOptionsTestimony | null
 ): ComposerNativeModelVerdict {
   if (options === null || options.modelOptionsLoading === true) {
     return "unverifiable";

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.stableHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.stableHelpers.ts
@@ -366,6 +366,35 @@ export function areComposerSettingOptionListsEqual(
   );
 }
 
+function areComposerModelChoiceHistoriesEqual(
+  left: AgentGUIComposerSettingsVM["modelChoiceHistory"],
+  right: AgentGUIComposerSettingsVM["modelChoiceHistory"]
+): boolean {
+  if (!left || !right) {
+    return left === right;
+  }
+  if (left.targetId !== right.targetId) {
+    return false;
+  }
+  const leftCatalog = left.catalog;
+  const rightCatalog = right.catalog;
+  if (!leftCatalog || !rightCatalog) {
+    return leftCatalog === rightCatalog;
+  }
+  return (
+    leftCatalog.authoritative === rightCatalog.authoritative &&
+    leftCatalog.loading === rightCatalog.loading &&
+    leftCatalog.effectiveModel === rightCatalog.effectiveModel &&
+    leftCatalog.models.length === rightCatalog.models.length &&
+    leftCatalog.models.every(
+      (model, index) =>
+        model.value === rightCatalog.models[index]!.value &&
+        Boolean(model.requested) ===
+          Boolean(rightCatalog.models[index]!.requested)
+    )
+  );
+}
+
 export function useStableComposerSettings(
   settings: AgentSessionComposerSettings
 ): AgentSessionComposerSettings;
@@ -473,6 +502,10 @@ export function areComposerSettingsVMsEqual(
       (right.composerOptionsLoadStatus ?? null) &&
     !!left.isCapabilityOptionsLoading === !!right.isCapabilityOptionsLoading &&
     !!left.isModelOptionsLoading === !!right.isModelOptionsLoading &&
+    areComposerModelChoiceHistoriesEqual(
+      left.modelChoiceHistory,
+      right.modelChoiceHistory
+    ) &&
     left.modelUnavailable === right.modelUnavailable &&
     left.reasoningUnavailable === right.reasoningUnavailable &&
     left.speedUnavailable === right.speedUnavailable &&
@@ -562,6 +595,12 @@ export function stabilizeComposerSettingsVM(
   )
     ? previous.permissionConfig
     : next.permissionConfig;
+  const modelChoiceHistory = areComposerModelChoiceHistoriesEqual(
+    previous.modelChoiceHistory,
+    next.modelChoiceHistory
+  )
+    ? previous.modelChoiceHistory
+    : next.modelChoiceHistory;
   const availableModels = areComposerSettingOptionListsEqual(
     previous.availableModels,
     next.availableModels
@@ -591,6 +630,7 @@ export function stabilizeComposerSettingsVM(
     ...next,
     sessionSettings,
     draftSettings,
+    modelChoiceHistory,
     permissionConfig,
     availableModels,
     availableReasoningEfforts,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerPresentation.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerPresentation.spec.tsx
@@ -35,6 +35,7 @@ describe("useAgentGUIComposerPresentation", () => {
         composerOptionsLoading: false,
         composerSupport: composerSettingsSupportFromOptions(null, null),
         composerTargetProvider: "opencode",
+        composerTargetData: target,
         data,
         defaultReasoningEffort: null,
         draftSettingsBySessionId: {},
@@ -127,6 +128,7 @@ describe("useAgentGUIComposerPresentation", () => {
           composerOptionsLoading: false,
           composerTargetProvider: "opencode",
           codexSaverModeEntryEnabled: entryEnabled,
+          composerTargetData: target,
           data,
           defaultReasoningEffort: null,
           draftSettingsBySessionId: drafts,
@@ -157,6 +159,14 @@ describe("useAgentGUIComposerPresentation", () => {
     });
     expect(result.current.stableComposerSettings).toMatchObject({
       selectedModelValue: "opencode/new-model",
+      modelChoiceHistory: {
+        targetId: "local:opencode",
+        catalog: {
+          authoritative: false,
+          effectiveModel: "opencode/old-model",
+          loading: false
+        }
+      },
       selectedPermissionModeValue: "full-access",
       selectedReasoningEffortValue: "high",
       selectedSpeedValue: "fast"
@@ -296,6 +306,7 @@ describe("useAgentGUIComposerPresentation", () => {
           composerSupport: composerSettingsSupportFromOptions(options, null),
           composerOptionsLoading: false,
           composerTargetProvider: "opencode",
+          composerTargetData: target,
           data,
           defaultReasoningEffort: "high",
           draftSettingsBySessionId,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerPresentation.ts
@@ -29,6 +29,7 @@ import {
   speedSelectionFromComposerOptions
 } from "./agentGuiController.composerHelpers";
 import {
+  composerModelChoiceHistoryTargetId,
   enforceComposerModelBindingForHomeDefaults,
   isForegroundModelOptionsLoading,
   resolveComposerSettingsPresentation,
@@ -57,6 +58,7 @@ interface UseAgentGUIComposerPresentationInput {
   defaultReasoningEffort: AgentSessionReasoningEffort | null;
   draftSettingsBySessionId: Record<string, AgentSessionComposerSettings>;
   providerComposerOptions: AgentActivityComposerOptions | null;
+  composerTargetData: AgentGUIComposerTargetData;
   selectedComposerTargetData: AgentGUIComposerTargetData;
   selectedProjectPath: string | null;
   shouldApplyPreparedProjectSelection: boolean;
@@ -257,6 +259,28 @@ export function useAgentGUIComposerPresentation(
         selection: activeSessionModelSelection,
         supportsModel: input.composerSupport.model
       }),
+      modelChoiceHistory: {
+        targetId: composerModelChoiceHistoryTargetId({
+          activeConversationId: input.activeConversationId,
+          target: input.composerTargetData
+        }),
+        catalog: input.providerComposerOptions
+          ? {
+              authoritative:
+                input.providerComposerOptions.behavior
+                  .modelOptionsAuthoritative === true,
+              loading:
+                input.providerComposerOptions.modelOptionsLoading === true,
+              effectiveModel: normalizeOptionalText(
+                input.providerComposerOptions.effectiveSettings?.model
+              ),
+              models: input.providerComposerOptions.models.map((option) => ({
+                value: option.value,
+                ...(option.requested === true ? { requested: true } : {})
+              }))
+            }
+          : null
+      },
       modelUnavailable:
         input.activeConversationId !== null &&
         sessionSettings === null &&
@@ -344,6 +368,7 @@ export function useAgentGUIComposerPresentation(
     input.composerSupport,
     input.composerOptionsLoadStatus,
     input.composerOptionsLoading,
+    input.composerTargetData,
     input.composerTargetProvider,
     input.providerComposerOptions,
     input.selectedComposerTargetData.agentTargetId,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useComposerModelChoiceHistory.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useComposerModelChoiceHistory.spec.tsx
@@ -151,6 +151,7 @@ describe("useComposerModelChoiceHistory", () => {
       result.current.recordRecentModel("new-model");
       result.current.toggleFavoriteModel("new-model");
     });
+    expect(result.current.enabled).toBe(false);
     expect(result.current.recentModelIds).toEqual([]);
     expect(globalThis.localStorage.getItem(`${RECENTS_PREFIX}default`)).toBe(
       '["legacy-model"]'
@@ -160,6 +161,7 @@ describe("useComposerModelChoiceHistory", () => {
     ).toBeNull();
 
     rerender({ targetId: "agent:first" });
+    expect(result.current.enabled).toBe(true);
     act(() => result.current.recordRecentModel("first-model"));
     expect(
       globalThis.localStorage.getItem(`${RECENTS_PREFIX}agent:first`)

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useComposerModelChoiceHistory.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useComposerModelChoiceHistory.spec.tsx
@@ -1,0 +1,204 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { AgentGUIComposerModelChoiceHistoryVM } from "../model/agentGuiNodeTypes";
+import { useComposerModelChoiceHistory } from "./useComposerModelChoiceHistory";
+
+const RECENTS_PREFIX = "agent-gui:composer-model-recents:";
+const FAVORITES_PREFIX = "agent-gui:composer-model-favorites:";
+
+beforeEach(() => {
+  globalThis.localStorage.clear();
+});
+
+describe("useComposerModelChoiceHistory", () => {
+  it("reconciles recents against an authoritative target catalog", async () => {
+    globalThis.localStorage.setItem(
+      `${RECENTS_PREFIX}agent:ccs`,
+      '["old-model","valid-model"]'
+    );
+    globalThis.localStorage.setItem(
+      `${FAVORITES_PREFIX}agent:ccs`,
+      '["old-model"]'
+    );
+
+    const { result } = renderHook(() =>
+      useComposerModelChoiceHistory(
+        history("agent:ccs", catalog(["valid-model", "other-model"]))
+      )
+    );
+
+    await waitFor(() => {
+      expect(result.current.recentModelIds).toEqual(["valid-model"]);
+    });
+    act(() => result.current.refreshFromStorage());
+    expect(globalThis.localStorage.getItem(`${RECENTS_PREFIX}agent:ccs`)).toBe(
+      '["valid-model"]'
+    );
+    expect(
+      globalThis.localStorage.getItem(`${FAVORITES_PREFIX}agent:ccs`)
+    ).toBe('["old-model"]');
+  });
+
+  it("removes an empty recents key after every remembered model is rejected", async () => {
+    globalThis.localStorage.setItem(
+      `${RECENTS_PREFIX}agent:ccs`,
+      '["old-model"]'
+    );
+
+    const { result } = renderHook(() =>
+      useComposerModelChoiceHistory(
+        history("agent:ccs", catalog(["valid-model", "other-model"]))
+      )
+    );
+
+    act(() => result.current.refreshFromStorage());
+
+    await waitFor(() => {
+      expect(
+        globalThis.localStorage.getItem(`${RECENTS_PREFIX}agent:ccs`)
+      ).toBeNull();
+    });
+  });
+
+  it.each([
+    ["non-authoritative", catalog(["valid-model"], { authoritative: false })],
+    ["loading", catalog(["valid-model"], { loading: true })],
+    ["empty", catalog([])],
+    [
+      "requested-only",
+      catalog([], {
+        models: [{ value: "old-model", requested: true }]
+      })
+    ],
+    [
+      "selected-only echo",
+      catalog([], {
+        effectiveModel: "old-model",
+        models: [{ value: "old-model" }]
+      })
+    ]
+  ])("preserves recents while the catalog is %s", async (_label, testimony) => {
+    globalThis.localStorage.setItem(
+      `${RECENTS_PREFIX}agent:ccs`,
+      '["old-model"]'
+    );
+
+    const { result } = renderHook(() =>
+      useComposerModelChoiceHistory(history("agent:ccs", testimony))
+    );
+
+    await waitFor(() => {
+      expect(result.current.recentModelIds).toEqual(["old-model"]);
+    });
+    act(() => result.current.refreshFromStorage());
+    expect(globalThis.localStorage.getItem(`${RECENTS_PREFIX}agent:ccs`)).toBe(
+      '["old-model"]'
+    );
+  });
+
+  it("lazily migrates the legacy shared bucket through current catalog testimony", async () => {
+    globalThis.localStorage.setItem(
+      `${RECENTS_PREFIX}default`,
+      '["old-model","valid-model"]'
+    );
+    globalThis.localStorage.setItem(
+      `${FAVORITES_PREFIX}default`,
+      '["favorite-model"]'
+    );
+    globalThis.localStorage.setItem(
+      `${RECENTS_PREFIX}agent:ccs`,
+      '["target-model"]'
+    );
+
+    const { result } = renderHook(() =>
+      useComposerModelChoiceHistory(
+        history(
+          "agent:ccs",
+          catalog(["target-model", "valid-model", "other-model"])
+        )
+      )
+    );
+
+    act(() => result.current.refreshFromStorage());
+
+    await waitFor(() => {
+      expect(result.current.recentModelIds).toEqual([
+        "target-model",
+        "valid-model"
+      ]);
+      expect(result.current.favoriteModelIds).toEqual(["favorite-model"]);
+    });
+    expect(
+      globalThis.localStorage.getItem(`${RECENTS_PREFIX}default`)
+    ).toBeNull();
+    expect(
+      globalThis.localStorage.getItem(`${FAVORITES_PREFIX}default`)
+    ).toBeNull();
+  });
+
+  it("fails closed without target identity and keeps targets isolated", () => {
+    globalThis.localStorage.setItem(
+      `${RECENTS_PREFIX}default`,
+      '["legacy-model"]'
+    );
+    const { result, rerender } = renderHook(
+      ({ targetId }: { targetId: string | null }) =>
+        useComposerModelChoiceHistory(history(targetId, null)),
+      { initialProps: { targetId: null as string | null } }
+    );
+
+    act(() => {
+      result.current.recordRecentModel("new-model");
+      result.current.toggleFavoriteModel("new-model");
+    });
+    expect(result.current.recentModelIds).toEqual([]);
+    expect(globalThis.localStorage.getItem(`${RECENTS_PREFIX}default`)).toBe(
+      '["legacy-model"]'
+    );
+    expect(
+      globalThis.localStorage.getItem(`${FAVORITES_PREFIX}default`)
+    ).toBeNull();
+
+    rerender({ targetId: "agent:first" });
+    act(() => result.current.recordRecentModel("first-model"));
+    expect(
+      globalThis.localStorage.getItem(`${RECENTS_PREFIX}agent:first`)
+    ).toBe('["first-model"]');
+    rerender({ targetId: "agent:second" });
+    expect(result.current.recentModelIds).toEqual([]);
+  });
+
+  it("refreshes from another window when the menu opens", () => {
+    const { result } = renderHook(() =>
+      useComposerModelChoiceHistory(history("agent:ccs", null))
+    );
+    const key = `${RECENTS_PREFIX}agent:ccs`;
+    globalThis.localStorage.setItem(key, '["external-model"]');
+
+    act(() => result.current.refreshFromStorage());
+
+    expect(result.current.recentModelIds).toEqual(["external-model"]);
+  });
+});
+
+function history(
+  targetId: string | null,
+  testimony: AgentGUIComposerModelChoiceHistoryVM["catalog"]
+): AgentGUIComposerModelChoiceHistoryVM {
+  return { targetId, catalog: testimony };
+}
+
+function catalog(
+  modelIds: readonly string[],
+  overrides: Partial<
+    NonNullable<AgentGUIComposerModelChoiceHistoryVM["catalog"]>
+  > = {}
+): NonNullable<AgentGUIComposerModelChoiceHistoryVM["catalog"]> {
+  return {
+    authoritative: true,
+    effectiveModel: null,
+    loading: false,
+    models: modelIds.map((value) => ({ value })),
+    ...overrides
+  };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useComposerModelChoiceHistory.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useComposerModelChoiceHistory.ts
@@ -1,0 +1,299 @@
+import { useCallback, useMemo, useReducer } from "react";
+import type { AgentGUIComposerModelChoiceHistoryVM } from "../model/agentGuiNodeTypes";
+import {
+  MAX_RECENT_COMPOSER_MODELS,
+  composerModelFavoritesStorageKey,
+  composerModelRecentsStorageKey,
+  normalizeComposerModelHistoryTargetId,
+  parseComposerModelIdList,
+  reconcileRecentComposerModels,
+  recordRecentComposerModel,
+  sanitizeComposerModelIdList,
+  serializeComposerModelIdList,
+  toggleFavoriteComposerModel,
+  type ComposerModelHistoryVerdict
+} from "../model/composerModelChoiceHistory";
+import { verifyComposerModelAgainstNativeOptions } from "./agentGuiController.composerPresentation";
+
+const EMPTY_MODEL_IDS: readonly string[] = [];
+const LEGACY_MODEL_HISTORY_TARGET_ID = "default";
+
+export interface ComposerModelChoiceHistoryController {
+  favoriteModelIds: readonly string[];
+  recentModelIds: readonly string[];
+  recordRecentModel: (modelId: string) => void;
+  refreshFromStorage: () => void;
+  toggleFavoriteModel: (modelId: string) => void;
+}
+
+/**
+ * Owns browser-local model menu history. The exact Agent Target scopes all
+ * reads and writes; unresolved identity disables history rather than falling
+ * back to the legacy shared bucket.
+ */
+export function useComposerModelChoiceHistory(
+  input: AgentGUIComposerModelChoiceHistoryVM | null | undefined
+): ComposerModelChoiceHistoryController {
+  const targetId = normalizeComposerModelHistoryTargetId(input?.targetId);
+  const catalog = input?.catalog ?? null;
+  const [revision, bumpRevision] = useReducer((value: number) => value + 1, 0);
+  const favoriteModelIds = useMemo(
+    () =>
+      targetId
+        ? readModelIds(composerModelFavoritesStorageKey(targetId))
+        : EMPTY_MODEL_IDS,
+    [revision, targetId]
+  );
+  const storedRecentModelIds = useMemo(
+    () =>
+      targetId
+        ? readModelIds(composerModelRecentsStorageKey(targetId))
+        : EMPTY_MODEL_IDS,
+    [revision, targetId]
+  );
+  const recentModelIds = useMemo(
+    () => reconcileForCatalog(storedRecentModelIds, catalog),
+    [catalog, storedRecentModelIds]
+  );
+
+  const refreshFromStorage = useCallback((): void => {
+    if (targetId) {
+      const storage = browserLocalStorage();
+      if (storage) {
+        migrateLegacyFavorites(storage, targetId);
+        migrateLegacyRecents(storage, targetId, catalog);
+        reconcileStoredRecents(storage, targetId, catalog);
+      }
+    }
+    bumpRevision();
+  }, [catalog, targetId]);
+
+  const recordRecentModel = useCallback(
+    (modelId: string): void => {
+      if (!targetId) {
+        return;
+      }
+      const current = reconcileForCatalog(
+        readModelIds(composerModelRecentsStorageKey(targetId)),
+        catalog
+      );
+      writeModelIds(
+        composerModelRecentsStorageKey(targetId),
+        recordRecentComposerModel(current, modelId)
+      );
+      refreshFromStorage();
+    },
+    [catalog, refreshFromStorage, targetId]
+  );
+  const toggleFavoriteModel = useCallback(
+    (modelId: string): void => {
+      if (!targetId) {
+        return;
+      }
+      const key = composerModelFavoritesStorageKey(targetId);
+      writeModelIds(
+        key,
+        toggleFavoriteComposerModel(readModelIds(key), modelId)
+      );
+      refreshFromStorage();
+    },
+    [refreshFromStorage, targetId]
+  );
+
+  return {
+    favoriteModelIds,
+    recentModelIds,
+    recordRecentModel,
+    refreshFromStorage,
+    toggleFavoriteModel
+  };
+}
+
+function verdictForCatalog(
+  catalog: AgentGUIComposerModelChoiceHistoryVM["catalog"],
+  modelId: string
+): ComposerModelHistoryVerdict {
+  if (!catalog?.authoritative) {
+    return "unverifiable";
+  }
+  return verifyComposerModelAgainstNativeOptions(modelId, {
+    models: catalog.models,
+    modelOptionsLoading: catalog.loading,
+    effectiveSettings: { model: catalog.effectiveModel }
+  });
+}
+
+function reconcileForCatalog(
+  recentModelIds: readonly string[],
+  catalog: AgentGUIComposerModelChoiceHistoryVM["catalog"]
+): readonly string[] {
+  return reconcileRecentComposerModels(recentModelIds, (modelId) =>
+    verdictForCatalog(catalog, modelId)
+  );
+}
+
+function migrateLegacyFavorites(storage: Storage, targetId: string): boolean {
+  if (targetId === LEGACY_MODEL_HISTORY_TARGET_ID) {
+    return false;
+  }
+  const legacyKey = composerModelFavoritesStorageKey(
+    LEGACY_MODEL_HISTORY_TARGET_ID
+  );
+  const legacyRaw = safeStorageRead(storage, legacyKey);
+  if (legacyRaw === null) {
+    return false;
+  }
+  const targetKey = composerModelFavoritesStorageKey(targetId);
+  writeModelIdsToStorage(
+    storage,
+    targetKey,
+    mergeModelIds(
+      readModelIdsFromStorage(storage, targetKey),
+      parseComposerModelIdList(legacyRaw)
+    )
+  );
+  safeStorageRemove(storage, legacyKey);
+  return true;
+}
+
+function migrateLegacyRecents(
+  storage: Storage,
+  targetId: string,
+  catalog: AgentGUIComposerModelChoiceHistoryVM["catalog"]
+): boolean {
+  if (targetId === LEGACY_MODEL_HISTORY_TARGET_ID) {
+    return false;
+  }
+  const legacyKey = composerModelRecentsStorageKey(
+    LEGACY_MODEL_HISTORY_TARGET_ID
+  );
+  const legacyRaw = safeStorageRead(storage, legacyKey);
+  if (legacyRaw === null) {
+    return false;
+  }
+  const legacyIds = parseComposerModelIdList(legacyRaw);
+  if (!catalog?.authoritative) {
+    return false;
+  }
+  const verdicts = legacyIds.map((modelId) =>
+    verdictForCatalog(catalog, modelId)
+  );
+  if (verdicts.some((verdict) => verdict === "unverifiable")) {
+    return false;
+  }
+  const targetKey = composerModelRecentsStorageKey(targetId);
+  const migratedIds = legacyIds.filter(
+    (_modelId, index) => verdicts[index] !== "rejected"
+  );
+  writeModelIdsToStorage(
+    storage,
+    targetKey,
+    mergeModelIds(
+      readModelIdsFromStorage(storage, targetKey),
+      migratedIds
+    ).slice(0, MAX_RECENT_COMPOSER_MODELS)
+  );
+  safeStorageRemove(storage, legacyKey);
+  return true;
+}
+
+function reconcileStoredRecents(
+  storage: Storage,
+  targetId: string,
+  catalog: AgentGUIComposerModelChoiceHistoryVM["catalog"]
+): boolean {
+  if (!catalog?.authoritative) {
+    return false;
+  }
+  const key = composerModelRecentsStorageKey(targetId);
+  const raw = safeStorageRead(storage, key);
+  if (raw === null) {
+    return false;
+  }
+  const current = parseComposerModelIdList(raw);
+  const next = reconcileForCatalog(current, catalog);
+  if (sameModelIds(current, next) && next.length > 0) {
+    return false;
+  }
+  writeModelIdsToStorage(storage, key, next);
+  return true;
+}
+
+function mergeModelIds(
+  primary: readonly string[],
+  secondary: readonly string[]
+): readonly string[] {
+  return sanitizeComposerModelIdList([...primary, ...secondary]);
+}
+
+function sameModelIds(
+  left: readonly string[],
+  right: readonly string[]
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((modelId, index) => modelId === right[index])
+  );
+}
+
+function browserLocalStorage(): Storage | null {
+  try {
+    return typeof window === "undefined" ? null : window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function readModelIds(key: string): readonly string[] {
+  const storage = browserLocalStorage();
+  return storage ? readModelIdsFromStorage(storage, key) : EMPTY_MODEL_IDS;
+}
+
+function readModelIdsFromStorage(
+  storage: Storage,
+  key: string
+): readonly string[] {
+  return parseComposerModelIdList(safeStorageRead(storage, key));
+}
+
+function writeModelIds(key: string, modelIds: readonly string[]): void {
+  const storage = browserLocalStorage();
+  if (storage) {
+    writeModelIdsToStorage(storage, key, modelIds);
+  }
+}
+
+function writeModelIdsToStorage(
+  storage: Storage,
+  key: string,
+  modelIds: readonly string[]
+): void {
+  const sanitized = sanitizeComposerModelIdList(modelIds);
+  if (sanitized.length === 0) {
+    safeStorageRemove(storage, key);
+    return;
+  }
+  try {
+    storage.setItem(key, serializeComposerModelIdList(sanitized));
+  } catch {
+    // Browser-local chrome persistence is best-effort.
+    return;
+  }
+}
+
+function safeStorageRead(storage: Storage, key: string): string | null {
+  try {
+    return storage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeStorageRemove(storage: Storage, key: string): void {
+  try {
+    storage.removeItem(key);
+  } catch {
+    // Browser-local chrome persistence is best-effort.
+    return;
+  }
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useComposerModelChoiceHistory.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useComposerModelChoiceHistory.ts
@@ -19,6 +19,7 @@ const EMPTY_MODEL_IDS: readonly string[] = [];
 const LEGACY_MODEL_HISTORY_TARGET_ID = "default";
 
 export interface ComposerModelChoiceHistoryController {
+  enabled: boolean;
   favoriteModelIds: readonly string[];
   recentModelIds: readonly string[];
   recordRecentModel: (modelId: string) => void;
@@ -101,6 +102,7 @@ export function useComposerModelChoiceHistory(
   );
 
   return {
+    enabled: targetId !== null,
     favoriteModelIds,
     recentModelIds,
     recordRecentModel,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
@@ -108,6 +108,27 @@ export interface AgentGUIComposerSettingOption {
   effect?: "new_session" | "next_call";
 }
 
+export interface AgentGUIComposerModelCatalogTestimonyVM {
+  /** Only an authoritative catalog may retire a remembered recent model. */
+  authoritative: boolean;
+  /** Provider-native model discovery is still in flight. */
+  loading: boolean;
+  /** Effective selected model used to recognize selected-only bootstrap echoes. */
+  effectiveModel: string | null;
+  /** Narrow catalog provenance needed by local recent-model reconciliation. */
+  models: readonly {
+    value: string;
+    requested?: boolean;
+  }[];
+}
+
+export interface AgentGUIComposerModelChoiceHistoryVM {
+  /** Exact Agent Target identity; null fails closed and disables persistence. */
+  targetId: string | null;
+  /** Null until the composer has any provider-native catalog testimony. */
+  catalog: AgentGUIComposerModelCatalogTestimonyVM | null;
+}
+
 export interface AgentGUIProviderSkillOption {
   name: string;
   trigger: string;
@@ -318,6 +339,8 @@ export interface AgentGUIComposerSettingsVM {
   /** Initial slash command and capability catalog request is in flight. */
   isCapabilityOptionsLoading?: boolean;
   isModelOptionsLoading?: boolean;
+  /** Device-local model recents/favorites identity and catalog testimony. */
+  modelChoiceHistory?: AgentGUIComposerModelChoiceHistoryVM;
   modelUnavailable: boolean;
   reasoningUnavailable: boolean;
   speedUnavailable: boolean;

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/composerModelChoiceHistory.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/composerModelChoiceHistory.spec.ts
@@ -4,9 +4,11 @@ import {
   composerModelFavoritesStorageKey,
   composerModelRecentsStorageKey,
   parseComposerModelIdList,
+  reconcileRecentComposerModels,
   recordRecentComposerModel,
   serializeComposerModelIdList,
-  toggleFavoriteComposerModel
+  toggleFavoriteComposerModel,
+  type ComposerModelHistoryVerdict
 } from "./composerModelChoiceHistory";
 
 describe("composerModelChoiceHistory", () => {
@@ -67,5 +69,19 @@ describe("composerModelChoiceHistory", () => {
     ]);
     expect(toggleFavoriteComposerModel(withFavorite, "m1")).toEqual([]);
     expect(toggleFavoriteComposerModel(withFavorite, " ")).toEqual(["m1"]);
+  });
+
+  it("removes only positively rejected recent models", () => {
+    const verdicts = new Map<string, ComposerModelHistoryVerdict>([
+      ["old", "rejected"],
+      ["valid", "verified"],
+      ["unknown", "unverifiable"]
+    ]);
+    expect(
+      reconcileRecentComposerModels(
+        ["old", "valid", "unknown"],
+        (modelId) => verdicts.get(modelId) ?? "unverifiable"
+      )
+    ).toEqual(["valid", "unknown"]);
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/composerModelChoiceHistory.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/composerModelChoiceHistory.ts
@@ -12,6 +12,11 @@ const COMPOSER_MODEL_FAVORITES_STORAGE_PREFIX =
 
 export const MAX_RECENT_COMPOSER_MODELS = 5;
 
+export type ComposerModelHistoryVerdict =
+  | "verified"
+  | "rejected"
+  | "unverifiable";
+
 export function composerModelRecentsStorageKey(
   agentTargetId: string | null | undefined
 ): string {
@@ -79,6 +84,25 @@ export function recordRecentComposerModel(
     0,
     MAX_RECENT_COMPOSER_MODELS
   );
+}
+
+/**
+ * Remove only models that the current catalog positively rejects. An
+ * unverifiable window must preserve history until stronger testimony arrives.
+ */
+export function reconcileRecentComposerModels(
+  currentRecentIds: readonly string[],
+  verdictForModel: (modelId: string) => ComposerModelHistoryVerdict
+): readonly string[] {
+  return sanitizeComposerModelIdList(currentRecentIds).filter(
+    (modelId) => verdictForModel(modelId) !== "rejected"
+  );
+}
+
+export function normalizeComposerModelHistoryTargetId(
+  agentTargetId: string | null | undefined
+): string | null {
+  return agentTargetId?.trim() || null;
 }
 
 export function toggleFavoriteComposerModel(

--- a/packages/agent/gui/quickComposerSettings.ts
+++ b/packages/agent/gui/quickComposerSettings.ts
@@ -50,6 +50,7 @@ export function pickQuickComposerSettings(
 }
 
 export interface QuickComposerSettingsProjectionInput {
+  agentTargetId: string | null;
   loading: boolean;
   options: AgentActivityComposerOptions | null;
   projectLocked: boolean;
@@ -131,6 +132,24 @@ export function projectQuickComposerSettings(
     isModelOptionsLoading:
       input.loading || input.options?.modelOptionsLoading === true,
     isSettingsLoading: input.loading,
+    modelChoiceHistory: {
+      targetId: input.agentTargetId,
+      catalog: input.options
+        ? {
+            authoritative:
+              input.options.behavior.modelOptionsAuthoritative === true,
+            loading:
+              input.loading || input.options.modelOptionsLoading === true,
+            effectiveModel: normalizeOptionalText(
+              input.options.effectiveSettings?.model
+            ),
+            models: input.options.models.map((option) => ({
+              value: option.value,
+              ...(option.requested === true ? { requested: true } : {})
+            }))
+          }
+        : null
+    },
     modelPlan: input.options?.modelPlan ?? null,
     modelUnavailable: false,
     permissionConfig,


### PR DESCRIPTION
## Summary

- Scope composer model recents and favorites by the exact Agent Target instead of a shared fallback bucket.
- Reconcile persisted recent models when an authoritative provider-native catalog arrives, while preserving history during loading, empty, requested-only, or selected-only testimony.
- Preserve explicit favorites, lazily migrate legacy `default` history, and centralize browser-local storage ownership in a focused controller.
- Restore the same exact-target history projection in the public Quick Composer used by Desktop Capture, and hide favorite controls whenever target identity is unresolved.
- Document the AgentGUI ownership and authority rules and add regression coverage for stale CCS catalogs, target isolation, migration, Quick Composer, and fail-closed behavior.

## Root cause

Composer model history was persisted in browser localStorage but was not reconciled after a CCS connection changed its model catalog. Some production paths also omitted the exact Agent Target id and fell back to a shared `default` key. The menu could temporarily hide unavailable entries, but the stale ids remained persisted and resurfaced after reconnects or subsequent renders.

The initial fix also exposed a consumer gap: Quick Composer projected the shared settings VM without `modelChoiceHistory`. Once missing target identity correctly failed closed, Desktop Capture stopped recording or displaying recents and rendered favorite controls whose writes were disabled.

## User impact

After a CCS connection configuration changes, positively invalid recent models disappear from the menu once the authoritative catalog settles; persisted cleanup occurs on the next history refresh. Loading, temporary, or echoed catalogs cannot delete history accidentally.

Quick Composer and Desktop Capture now record recents and favorites under the exact selected Agent Target, migrate valid legacy history through current catalog testimony, and preserve history while host-level options are loading. Surfaces with unresolved target identity keep history disabled and do not render a dead favorite control.

The fix lives in the shared `@tutti-os/agent-gui` composer path:

- Tutti Desktop receives the fix directly, including its Desktop Capture window.
- TSH and other AgentGUI hosts receive the same behavior after upgrading to a package release containing this commit.
- No required Host API migration is introduced; the projected history field is optional and unresolved target identity fails closed.

## Validation

- `pnpm check:changed` — 11 lanes passed
- `pnpm --filter @tutti-os/agent-gui test` — 319 files / 2818 tests passed
- `pnpm --filter @tutti-os/agent-gui typecheck` — passed
- `pnpm --filter @tutti-os/agent-gui build` — JS and DTS package build passed

## Review matrix

| Lane | Trigger | Result | Evidence | Affected consumers |
| --- | --- | --- | --- | --- |
| Architecture | Composer projection, controller, and persistence ownership changed | Pass | Exact Target projection; authoritative-only reconciliation; Quick Composer projects host-owned testimony; architecture doc updated | Desktop AgentGUI, Quick Composer/Desktop Capture, standalone windows, TSH and other AgentGUI hosts |
| Performance | Browser-local history/cache path changed | Pass | No new effects or subscriptions; event-bound storage writes; recents capped at 5; degradation check passed | All DOM AgentGUI hosts |
| Consumers | Shared package projection shape and public Quick Composer behavior changed | Pass | Quick Composer regression tests, public JS/DTS build, full AgentGUI suite, and fail-closed control coverage passed; no Host API migration | Tutti Desktop directly; TSH and external AgentGUI hosts on package upgrade |
