### PR TITLE
fix(agent): harden session and activity projections

### DIFF
--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -108,6 +108,11 @@ implementation. `daemon/hostadapter` is the official daemon-runtime-to-Host
 adapter, `host.SQLiteWorkspaceStore` is the workspace-routed canonical store,
 and `daemon/modelcatalog` owns provider model/reasoning/speed normalization;
 product daemons compose these modules instead of copying their mappings.
+Tool adapters also preserve raw output and exit code while translating a
+tool-specific result into the provider-neutral completed/failed state. The
+generic fallback remains zero-success/nonzero-failure; a documented nonzero
+result such as `git diff --no-index` exit 1 is accepted only by an exact
+command classifier, never by a global exit-code exception or a GUI branch.
 
 Canonical delete is a lossless tombstone transition. The transaction preserves
 each selected root/child Session component, its Turns, Messages, Interactions,
@@ -1123,7 +1128,7 @@ createAgentSessionEngine({
   identity: { workspaceId, origin },
   clock,
   scheduler,
-  commandPort
+  commandPort,
 });
 ```
 
@@ -1169,32 +1174,32 @@ export interface AgentActivityAdapter {
   }): Promise<AgentActivityMessagePage>;
 
   loadComposerOptions(
-    input: AgentActivityLoadComposerOptionsInput
+    input: AgentActivityLoadComposerOptionsInput,
   ): Promise<AgentActivityComposerOptions>;
 
   createSession(
-    input: AgentActivityCreateSessionInput
+    input: AgentActivityCreateSessionInput,
   ): Promise<AgentActivitySession>;
   sendInput(
-    input: AgentActivitySendInput
+    input: AgentActivitySendInput,
   ): Promise<AgentActivitySendInputResult>;
   goalControl(
-    input: AgentActivityGoalControlInput
+    input: AgentActivityGoalControlInput,
   ): Promise<AgentActivityGoalControlResult>;
   submitInteractive(
-    input: AgentActivitySubmitInteractiveInput
+    input: AgentActivitySubmitInteractiveInput,
   ): Promise<AgentActivitySubmitInteractiveResult>;
   deleteSession(
-    input: AgentActivityDeleteSessionInput
+    input: AgentActivityDeleteSessionInput,
   ): Promise<AgentActivityDeleteSessionResult>;
   deleteSessions(
-    input: AgentActivityDeleteSessionsInput
+    input: AgentActivityDeleteSessionsInput,
   ): Promise<AgentActivityDeleteSessionsResult>;
   renameSession(
-    input: AgentActivityRenameSessionInput
+    input: AgentActivityRenameSessionInput,
   ): Promise<AgentActivitySession>;
   setSessionPinned(
-    input: AgentActivitySetSessionPinnedInput
+    input: AgentActivitySetSessionPinnedInput,
   ): Promise<AgentActivitySession>;
 }
 ```

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -222,14 +222,16 @@ entry capability may additionally hide or disable an experimental control; the
 activation boundary must fail closed as well, so a remembered `true` value
 cannot outlive a disabled host entry. Provider support comes from the resolved
 composer descriptor rather than provider-name checks in shared UI code.
-Extension-owned model catalogs can change independently of target-scoped
+Provider and extension model catalogs can change independently of target-scoped
 remembered defaults. On Create, the daemon treats such a default as a fallback
-preference and resolves an obsolete value to the extension runtime's current
-model. Non-explicit model-dependent settings, such as reasoning effort, resolve
-against that effective model rather than remaining bound to the obsolete
-preference. A model or dependent setting explicitly supplied by the caller
-remains strict. If the runtime rejects an explicit model selection, startup
-fails rather than continuing with an undisclosed provider default.
+preference and resolves an obsolete value to the current catalog default from
+the same target. Non-explicit model-dependent settings, such as reasoning
+effort, resolve against that effective model rather than remaining bound to the
+obsolete preference. A strict per-model catalog never forwards an inherited
+value that the target model did not advertise. A model or dependent setting
+explicitly supplied by the caller remains strict. If the runtime rejects an
+explicit model selection, startup fails rather than continuing with an
+undisclosed provider default.
 
 Settings that affect provider preparation are immutable after launch. The
 daemon validates them against current product policy and resolved provider
@@ -582,6 +584,13 @@ delegation call and the canonical child Session/Turn. AgentGUI attaches the
 child lane only through the immutable `parentToolCallId`; it must not parse
 provider-native spawn events, invent a missing parent card, or create a
 presentation-only child lane.
+
+The parent-side child lane projects live activity and the terminal assistant
+result as different fields. Activity is a bounded plain-text progress summary;
+it cannot become the completed result. The terminal result preserves the full
+canonical Markdown and uses the ordinary safe Markdown/link boundary, so a
+character-level progress truncation cannot corrupt a generated-file link or
+drop earlier result context.
 
 User-initiated Fork creates a new root Session rather than a provider-native
 subagent. The child records durable lineage to the source Session and inclusive
@@ -1476,7 +1485,13 @@ command flows. Plural consumer selectors exclude them before Rail and Message
 Center collection projection; a hidden Session must not become a list row just
 because it is resumable or receives later canonical updates.
 
-When runtime sections are enabled, projection unions IDs from the current section, search, and reconciliation, then joins canonical Sessions. Unchanged summaries preserve structural sharing so unrelated engine updates do not rebuild the whole Rail snapshot.
+When runtime sections are enabled, projection unions IDs from the current
+section, search, reconciliation, and every in-progress root Session in the
+exact target scope, then joins canonical Sessions. In-progress Sessions remain
+display overlays until the bounded section query contains them; overlay rows
+do not alter cursors, `hasMore`, or server totals. Unchanged summaries preserve
+structural sharing so unrelated engine updates do not rebuild the whole Rail
+snapshot.
 
 Scroll, section collapse, visible limits, and search query belong to mounted view scope. Non-search state is isolated by `workspaceId + agentTargetId/all`; search creates a temporary navigation scope. `activeConversationId` expresses selection only. Scrolling requires an explicit reveal intent.
 

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -2253,8 +2253,9 @@ inline data URL instead`. Claude or standard ACP may instead receive no
 - Fix:
   Keep page sessions in the workspace engine. Cache only ordered membership ids,
   cursor, `hasMore`, and `totalCount` in the controller query, then join ids to
-  engine entities with a pure model projection. Keep active and pending sessions
-  as display overlays outside pagination. Preserve old scope chrome and metadata
+  engine entities with a pure model projection. Keep active, pending, and all
+  exact-target in-progress root sessions as display overlays outside pagination
+  until canonical membership catches up. Preserve old scope chrome and metadata
   atomically while a provider refetch is pending. Engine snapshots merge
   monotonically; only explicit `session/removed` owns deletion. Keep first-page
   bootstrap as a required narrow repository seam: one requested-section-driven
@@ -4850,11 +4851,13 @@ agent target`, although the current model picker does not offer that model.
   provider-side reconfiguration failure.
 - Fix:
   At Create, distinguish a target-scoped persisted default from a model
-  explicitly supplied by the caller. For an Agent Extension, resolve an
-  obsolete persisted default to the current model reported by that same
-  extension; never use a different provider. Resolve non-explicit per-model
-  reasoning against that effective model while keeping explicit caller values
-  strict. Treat an explicit ACP model selection as identity-bearing: leave an
+  explicitly supplied by the caller. For a provider or Agent Extension,
+  resolve an obsolete persisted default to the current catalog default
+  reported by that same target; never use a different provider. Resolve
+  non-explicit per-model reasoning against that effective model while keeping
+  explicit caller values strict. A strict per-model reasoning catalog must
+  omit an inherited value when it cannot prove that the target model supports
+  it. Treat an explicit ACP model selection as identity-bearing: leave an
   already-selected model unchanged, and if a real model change is rejected,
   abort startup rather than falling back.
 - Validation:

--- a/packages/agent/daemon/runtime/acp_tool_exit_status.go
+++ b/packages/agent/daemon/runtime/acp_tool_exit_status.go
@@ -1,0 +1,88 @@
+package agentruntime
+
+import "strings"
+
+func acpTerminalExitCodeCompleted(update map[string]any, body map[string]any, exitCode int) bool {
+	if exitCode == 0 {
+		return true
+	}
+	return exitCode == 1 && acpIsGitDiffNoIndexCommand(update, body)
+}
+
+func acpIsGitDiffNoIndexCommand(update map[string]any, body map[string]any) bool {
+	input := acpMapFromValue(acpToolCallRawInput(update), "input")
+	found := false
+	for _, candidate := range []any{
+		input["parsed_cmd"],
+		input["parsedCmd"],
+		input["command"],
+		body["parsed_cmd"],
+		body["parsedCmd"],
+		body["command"],
+		update["parsed_cmd"],
+		update["parsedCmd"],
+		update["command"],
+	} {
+		if candidate == nil {
+			continue
+		}
+		found = true
+		if !acpCommandValueIsGitDiffNoIndex(candidate) {
+			return false
+		}
+	}
+	return found
+}
+
+func acpCommandValueIsGitDiffNoIndex(value any) bool {
+	switch typed := value.(type) {
+	case string:
+		if strings.ContainsAny(typed, ";&|\r\n<>`") {
+			return false
+		}
+		return acpCommandTokensAreGitDiffNoIndex(strings.Fields(typed))
+	case []string:
+		return acpCommandTokensAreGitDiffNoIndex(typed)
+	case []any:
+		tokens := make([]string, 0, len(typed))
+		allStrings := true
+		for _, item := range typed {
+			text, ok := item.(string)
+			if !ok {
+				allStrings = false
+				break
+			}
+			tokens = append(tokens, text)
+		}
+		if allStrings && acpCommandTokensAreGitDiffNoIndex(tokens) {
+			return true
+		}
+		if len(typed) == 1 {
+			return acpCommandValueIsGitDiffNoIndex(typed[0])
+		}
+	}
+	return false
+}
+
+func acpCommandTokensAreGitDiffNoIndex(tokens []string) bool {
+	if len(tokens) < 3 {
+		return false
+	}
+	executable := strings.ToLower(strings.Trim(strings.TrimSpace(tokens[0]), "\"'"))
+	executable = strings.ReplaceAll(executable, "\\", "/")
+	if slash := strings.LastIndex(executable, "/"); slash >= 0 {
+		executable = executable[slash+1:]
+	}
+	if executable != "git" && executable != "git.exe" {
+		return false
+	}
+	if strings.ToLower(strings.Trim(strings.TrimSpace(tokens[1]), "\"'")) != "diff" {
+		return false
+	}
+	for _, token := range tokens[2:] {
+		if strings.ToLower(strings.Trim(strings.TrimSpace(token), "\"'")) == "--no-index" {
+			return true
+		}
+	}
+	return false
+}

--- a/packages/agent/daemon/runtime/acp_tool_normalizer.go
+++ b/packages/agent/daemon/runtime/acp_tool_normalizer.go
@@ -723,7 +723,7 @@ func acpResolvedToolCallStatus(update map[string]any, fallback string) string {
 		return status
 	}
 	rawOutput := acpToolCallRawOutput(update)
-	if inferred := acpInferTerminalToolStatus(rawOutput); inferred != "" {
+	if inferred := acpInferTerminalToolStatus(update, rawOutput); inferred != "" {
 		return inferred
 	}
 	if inferred := acpInferImageGenerationTerminalStatus(update, rawOutput); inferred != "" {
@@ -732,7 +732,7 @@ func acpResolvedToolCallStatus(update map[string]any, fallback string) string {
 	return status
 }
 
-func acpInferTerminalToolStatus(rawOutput any) string {
+func acpInferTerminalToolStatus(update map[string]any, rawOutput any) string {
 	body := acpMapFromValue(rawOutput, "output")
 	if len(body) == 0 {
 		return ""
@@ -744,19 +744,19 @@ func acpInferTerminalToolStatus(rawOutput any) string {
 		return status
 	}
 	if exitCode, ok := acpIntFromValue(body["exitCode"]); ok {
-		if exitCode == 0 {
+		if acpTerminalExitCodeCompleted(update, body, exitCode) {
 			return messageStreamStateCompleted
 		}
 		return messageStreamStateFailed
 	}
 	if exitCode, ok := acpIntFromValue(body["exit_code"]); ok {
-		if exitCode == 0 {
+		if acpTerminalExitCodeCompleted(update, body, exitCode) {
 			return messageStreamStateCompleted
 		}
 		return messageStreamStateFailed
 	}
 	if exitCode, ok := acpExitCodeFromText(body["output"]); ok {
-		if exitCode == 0 {
+		if acpTerminalExitCodeCompleted(update, body, exitCode) {
 			return messageStreamStateCompleted
 		}
 		return messageStreamStateFailed

--- a/packages/agent/daemon/runtime/acp_update_normalizer_test.go
+++ b/packages/agent/daemon/runtime/acp_update_normalizer_test.go
@@ -43,3 +43,92 @@ func TestApplyACPUpdateToLiveStateCapturesCurrentModeID(t *testing.T) {
 		t.Fatalf("state.currentMode = %q, want auto", state.currentMode)
 	}
 }
+
+func TestACPInferTerminalToolStatusUnderstandsGitDiffNoIndex(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		update   map[string]any
+		output   map[string]any
+		expected string
+	}{
+		{
+			name: "differences are a completed command result",
+			update: map[string]any{
+				"rawInput": map[string]any{
+					"command": []any{"git", "diff", "--no-index", "old", "new"},
+				},
+			},
+			output:   map[string]any{"exitCode": 1, "stdout": "diff --git a/old b/new"},
+			expected: messageStreamStateCompleted,
+		},
+		{
+			name: "git diff execution errors still fail",
+			update: map[string]any{
+				"rawInput": map[string]any{"command": "git diff --no-index old new"},
+			},
+			output:   map[string]any{"exitCode": 2},
+			expected: messageStreamStateFailed,
+		},
+		{
+			name:     "unknown exit one remains failed",
+			update:   map[string]any{"rawInput": map[string]any{"command": "rg missing"}},
+			output:   map[string]any{"exitCode": 1},
+			expected: messageStreamStateFailed,
+		},
+		{
+			name: "compound shell command remains failed",
+			update: map[string]any{
+				"rawInput": map[string]any{"command": "git diff --no-index old new; exit 1"},
+			},
+			output:   map[string]any{"exitCode": 1},
+			expected: messageStreamStateFailed,
+		},
+		{
+			name: "multiple parsed commands remain failed",
+			update: map[string]any{
+				"rawInput": map[string]any{
+					"parsed_cmd": []any{
+						[]any{"git", "diff", "--no-index", "old", "new"},
+						[]any{"rg", "missing"},
+					},
+				},
+			},
+			output:   map[string]any{"exitCode": 1},
+			expected: messageStreamStateFailed,
+		},
+		{
+			name: "conflicting command representations remain failed",
+			update: map[string]any{
+				"rawInput": map[string]any{
+					"parsed_cmd": []any{
+						[]any{"git", "diff", "--no-index", "old", "new"},
+					},
+					"command": "git diff --no-index old new; exit 1",
+				},
+			},
+			output:   map[string]any{"exitCode": 1},
+			expected: messageStreamStateFailed,
+		},
+		{
+			name: "windows git executable is recognized from parsed command",
+			update: map[string]any{
+				"rawInput": map[string]any{
+					"parsed_cmd": []any{[]any{"C:\\Program Files\\Git\\cmd\\git.exe", "diff", "--no-index", "old", "new"}},
+				},
+			},
+			output:   map[string]any{"exit_code": 1},
+			expected: messageStreamStateCompleted,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := acpInferTerminalToolStatus(test.update, test.output); got != test.expected {
+				t.Fatalf("acpInferTerminalToolStatus() = %q, want %q", got, test.expected)
+			}
+		})
+	}
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
@@ -621,6 +621,7 @@ export class AgentGUIConversationRailQueryController {
   ): void {
     const snapshot = this.selectSnapshot(
       {
+        agentTargetId: this.sectionAgentTargetId,
         queryState: this.queryState,
         runtimeRailFailed: this.queryFailed,
         runtimeSectionsEnabled: this.runtimeSectionsEnabled(),

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentConversationRailQuerySnapshot.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentConversationRailQuerySnapshot.ts
@@ -56,6 +56,7 @@ export function appendConversationSearchPage(
 }
 
 export interface AgentGUIConversationRailQuerySnapshot {
+  agentTargetId: string;
   railSearch: {
     enabled: boolean;
     failed: boolean;
@@ -76,6 +77,7 @@ export interface AgentGUIConversationRailQuerySnapshot {
 
 export function createConversationRailQuerySnapshotSelector(): (
   input: {
+    agentTargetId?: string | null;
     queryState: ConversationRailQueryState;
     runtimeRailFailed: boolean;
     runtimeSectionsEnabled: boolean;
@@ -92,6 +94,7 @@ export function createConversationRailQuerySnapshotSelector(): (
       input.searchState.requestKey === input.searchRequestKey &&
       input.searchState.resolvedQuery === input.searchQuery;
     const next: AgentGUIConversationRailQuerySnapshot = {
+      agentTargetId: input.agentTargetId?.trim() ?? "",
       railSearch: {
         enabled: input.searchEnabled,
         failed: searchResolved && input.searchState.failed,
@@ -123,6 +126,7 @@ function sameSnapshot(
   right: AgentGUIConversationRailQuerySnapshot
 ): boolean {
   return (
+    left.agentTargetId === right.agentTargetId &&
     left.runtimeSectionsEnabled === right.runtimeSectionsEnabled &&
     left.runtimeRailFailed === right.runtimeRailFailed &&
     left.runtimeRailMemberships === right.runtimeRailMemberships &&

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQuerySnapshot.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQuerySnapshot.spec.ts
@@ -121,7 +121,75 @@ describe("createConversationRailQuerySnapshotSelector", () => {
 
     engine.dispose();
   });
+
+  it("projects all running sessions for the exact target even before membership refresh", () => {
+    const engine = createTestAgentSessionEngine();
+    engine.dispatch({
+      sessions: [
+        createRunningSession("running-1", "local:codex"),
+        createRunningSession("running-2", "local:codex"),
+        createRunningSession("other-target", "local:opencode")
+      ],
+      type: "session/snapshotReceived"
+    });
+    const querySnapshot = createConversationRailQuerySnapshotSelector()(
+      {
+        agentTargetId: "local:codex",
+        queryState: {
+          pending: false,
+          reconcilingSessionIds: [],
+          resolvedScopeKey: "codex",
+          sectionPageStates: new Map(),
+          sections: []
+        },
+        runtimeRailFailed: false,
+        runtimeSectionsEnabled: true,
+        searchEnabled: false,
+        searchQuery: "",
+        searchRequestKey: null,
+        searchState: EMPTY_CONVERSATION_SEARCH_QUERY_STATE
+      },
+      undefined
+    );
+
+    const projected = createConversationRailConversationsSelector()({
+      engineState: engine.getSnapshot(),
+      interactionLocked: false,
+      querySnapshot
+    });
+
+    expect(projected.map(({ id }) => id)).toEqual(["running-1", "running-2"]);
+    engine.dispose();
+  });
 });
+
+function createRunningSession(agentSessionId: string, agentTargetId: string) {
+  return normalizeAgentActivitySession({
+    activeTurn: {
+      agentSessionId,
+      error: null,
+      origin: "user_prompt",
+      outcome: null,
+      phase: "running",
+      settledAtUnixMs: null,
+      startedAtUnixMs: 1,
+      turnId: `${agentSessionId}-turn`,
+      updatedAtUnixMs: 2
+    },
+    activeTurnId: `${agentSessionId}-turn`,
+    agentSessionId,
+    agentTargetId,
+    cwd: "/workspace",
+    kind: "root",
+    latestTurnInteractions: [],
+    pendingInteractions: [],
+    provider: agentTargetId.replace("local:", ""),
+    railSectionKey: "conversations",
+    title: agentSessionId,
+    updatedAtUnixMs: 2,
+    workspaceId: "test-workspace"
+  });
+}
 
 function createSession(
   agentSessionId: string,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQuerySnapshot.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQuerySnapshot.ts
@@ -44,6 +44,18 @@ export function createConversationRailConversationsSelector(): (
     for (const sessionId of input.querySnapshot.railSearch.sessionIds) {
       projectionSessionIds.add(sessionId);
     }
+    const scopedAgentTargetId = input.querySnapshot.agentTargetId;
+    for (const item of workspaceSessions) {
+      if (
+        item.session.kind === "root" &&
+        item.activeTurn?.phase !== undefined &&
+        item.activeTurn.phase !== "settled" &&
+        (!scopedAgentTargetId ||
+          item.session.agentTargetId?.trim() === scopedAgentTargetId)
+      ) {
+        projectionSessionIds.add(item.session.agentSessionId);
+      }
+    }
     const rootSessionIdsAwaitingUserAction = new Set([
       ...selectRootAgentSessionIdsWithPendingInteractions(input.engineState),
       ...selectRootAgentSessionIdsAwaitingPlanImplementation(input.engineState)

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { AgentGUIConversationSummary } from "./agentGuiConversationModel";
 import type { ConversationSection } from "../agentGuiNodeViewConversation";
 import {
+  conversationRailActiveOverlayCountsTowardTotal,
   conversationRailSectionActiveConversationId,
   conversationRailSectionHeaderVisibility,
   insertConversationRailSectionOverlay,
@@ -467,6 +468,45 @@ describe("projectConversationRailSectionsWithTransientConversations", () => {
     sectionConversations: "Conversations",
     sectionPinned: "Pinned"
   };
+
+  it("keeps every running canonical session visible while its page is stale", () => {
+    const canonical = section([conversation("older")]);
+    const project = canonical[0]?.project ?? null;
+    const first = {
+      ...conversation("running-1"),
+      project,
+      status: "working" as const,
+      sortTimeUnixMs: 30,
+      updatedAtUnixMs: 30
+    };
+    const second = {
+      ...conversation("running-2"),
+      project,
+      status: "waiting" as const,
+      sortTimeUnixMs: 20,
+      updatedAtUnixMs: 20
+    };
+
+    const projected = projectConversationRailSectionsWithTransientConversations(
+      {
+        conversations: [first, second],
+        labels,
+        reconcilingSessionIds: [],
+        sections: canonical
+      }
+    );
+
+    expect(projected[0]?.items.map((item) => item.id)).toEqual([
+      "running-1",
+      "running-2",
+      "older"
+    ]);
+    expect(projected[0]?.items.map((item) => item.projectionSource)).toEqual([
+      "runtime_overlay",
+      "runtime_overlay",
+      undefined
+    ]);
+  });
 
   it("keeps pending rows out of project sections until exact membership arrives", () => {
     const canonical = section([conversation("canonical")]);
@@ -1103,5 +1143,29 @@ describe("resolveConversationRailActiveConversation", () => {
         conversations: [conversation("other")]
       })
     ).toBe(controllerActive);
+  });
+});
+
+describe("conversationRailActiveOverlayCountsTowardTotal", () => {
+  it("does not count an active canonical entity when its section row is a runtime overlay", () => {
+    const active = conversation("active");
+
+    expect(
+      conversationRailActiveOverlayCountsTowardTotal({
+        activeConversation: active,
+        matchesFilter: true,
+        sectionItems: [{ ...active, projectionSource: "runtime_overlay" }]
+      })
+    ).toBe(false);
+  });
+
+  it("counts an active matching entity that is absent from the section", () => {
+    expect(
+      conversationRailActiveOverlayCountsTowardTotal({
+        activeConversation: conversation("active"),
+        matchesFilter: true,
+        sectionItems: [conversation("older")]
+      })
+    ).toBe(true);
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.ts
@@ -116,7 +116,7 @@ export function canonicalConversationRailSummaries(
   conversations: AgentGUINodeViewModel["rail"]["conversations"]
 ): AgentGUINodeViewModel["rail"]["conversations"] {
   return conversations.filter(
-    (conversation) => conversation.projectionSource !== "pending_activation"
+    (conversation) => conversation.projectionSource === undefined
   );
 }
 
@@ -130,6 +130,8 @@ export function projectConversationRailSectionsWithTransientConversations(input:
   const transientConversations = input.conversations.filter(
     (conversation) =>
       conversation.projectionSource === "pending_activation" ||
+      conversation.status === "working" ||
+      conversation.status === "waiting" ||
       reconcilingSessionIds.has(conversation.id)
   );
   if (transientConversations.length === 0) {
@@ -139,9 +141,13 @@ export function projectConversationRailSectionsWithTransientConversations(input:
     input.sections.flatMap((section) => section.items.map((item) => item.id))
   );
   const transientSections = projectConversationsByExactRailSectionKey({
-    conversations: transientConversations.filter(
-      (conversation) => !loadedIds.has(conversation.id)
-    ),
+    conversations: transientConversations
+      .filter((conversation) => !loadedIds.has(conversation.id))
+      .map((conversation) =>
+        conversation.projectionSource === "pending_activation"
+          ? conversation
+          : { ...conversation, projectionSource: "runtime_overlay" as const }
+      ),
     labels: input.labels,
     sections: input.sections
   });
@@ -210,6 +216,25 @@ export function resolveConversationRailActiveConversation(input: {
     (input.activeConversation?.id === activeConversationId
       ? input.activeConversation
       : null)
+  );
+}
+
+export function conversationRailActiveOverlayCountsTowardTotal(input: {
+  activeConversation: AgentGUINodeViewModel["rail"]["activeConversation"];
+  matchesFilter: boolean;
+  sectionItems: ConversationSection["items"];
+}): boolean {
+  const activeConversation = input.activeConversation;
+  if (
+    !activeConversation ||
+    activeConversation.projectionSource !== undefined ||
+    !input.matchesFilter
+  ) {
+    return false;
+  }
+  return !input.sectionItems.some(
+    (item) =>
+      item.id === activeConversation.id && item.projectionSource !== undefined
   );
 }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRailMembershipRefresh.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRailMembershipRefresh.ts
@@ -4,7 +4,7 @@ export interface ConversationRailMembershipRecord {
   agentTargetId?: string | null;
   id: string;
   pinnedAtUnixMs?: number | null;
-  projectionSource?: "pending_activation";
+  projectionSource?: "pending_activation" | "runtime_overlay";
   railSectionKey?: string | null;
   title: string;
 }
@@ -41,8 +41,7 @@ export function planRuntimeRailMembershipRefresh(input: {
     new Map(
       records
         .filter(
-          (record) =>
-            record.projectionSource !== "pending_activation" && visible(record)
+          (record) => record.projectionSource === undefined && visible(record)
         )
         .map((record) => [record.id, record] as const)
     );

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationTypes.ts
@@ -59,7 +59,7 @@ export interface AgentGUIConversationSummary {
   // presentation layer may use it for the ordinary Rail/detail overlay, but
   // it is excluded before Activity candidates are built.
   isTransient?: boolean;
-  projectionSource?: "pending_activation";
+  projectionSource?: "pending_activation" | "runtime_overlay";
   isImported?: boolean;
   activeTurn?: AgentActivitySession["activeTurn"];
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
@@ -15,6 +15,7 @@ import {
   projectConversationRailSearchSections,
   projectConversationRailSectionsWithActiveConversation,
   projectConversationRailSectionsWithTransientConversations,
+  conversationRailActiveOverlayCountsTowardTotal,
   conversationRailSectionActiveConversationId,
   conversationRailSectionHeaderVisibility,
   isConversationRailProjectPinned,
@@ -615,24 +616,27 @@ export const AgentGUIConversationRailPane = memo(
                     activeOverlayConversation &&
                     section.items.some(
                       (item) =>
-                        item.projectionSource !== "pending_activation" &&
+                        item.projectionSource === undefined &&
                         item.id === activeOverlayConversation.id
                     )
                   );
-                  const activeOverlayCountsTowardTotal = Boolean(
-                    activeOverlayConversation &&
-                    activeOverlayConversation.projectionSource !==
-                      "pending_activation" &&
-                    matchesAgentGUIConversationSummaryFilter(
-                      activeOverlayConversation,
-                      conversationFilter
-                    )
-                  );
+                  const activeOverlayCountsTowardTotal =
+                    conversationRailActiveOverlayCountsTowardTotal({
+                      activeConversation: activeOverlayConversation,
+                      matchesFilter: Boolean(
+                        activeOverlayConversation &&
+                        matchesAgentGUIConversationSummaryFilter(
+                          activeOverlayConversation,
+                          conversationFilter
+                        )
+                      ),
+                      sectionItems: section.items
+                    });
                   const sectionTotalCount = backendSearchActive
                     ? section.items.length + (searchSectionHasMore ? 1 : 0)
                     : (sectionPageState?.totalCount ??
                       section.items.filter(
-                        (item) => item.projectionSource !== "pending_activation"
+                        (item) => item.projectionSource === undefined
                       ).length +
                         (activeOverlayCountsTowardTotal &&
                         !activeOverlayIsCanonical

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailSection.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailSection.tsx
@@ -124,7 +124,7 @@ export const AgentGUIConversationRailSection = memo(
     const projectId = section.project?.id?.trim() ?? "";
     const hasProjectPath = Boolean(projectPath);
     const pageableItems = section.items.filter(
-      (item) => item.projectionSource !== "pending_activation"
+      (item) => item.projectionSource === undefined
     );
     const visibleItemCount = isSectionCollapsed
       ? 0
@@ -132,13 +132,13 @@ export const AgentGUIConversationRailSection = memo(
     const baseItems = isSectionCollapsed
       ? []
       : section.items
-          .filter((item) => item.projectionSource !== "pending_activation")
+          .filter((item) => item.projectionSource === undefined)
           .slice(0, visibleItemCount);
     let visibleItems = isSectionCollapsed
       ? []
       : [
           ...section.items.filter(
-            (item) => item.projectionSource === "pending_activation"
+            (item) => item.projectionSource !== undefined
           ),
           ...baseItems
         ];

--- a/packages/agent/gui/shared/agentConversation/components/AgentSubAgentCards.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentSubAgentCards.spec.tsx
@@ -168,6 +168,33 @@ describe("AgentSubAgentCard", () => {
     expect(screen.queryByText("Starting…")).not.toBeInTheDocument();
   });
 
+  it("renders the complete terminal Markdown and routes its link", async () => {
+    setAgentGuiI18nTestLocale("en");
+    const onLinkClick = vi.fn();
+    render(
+      <AgentSubAgentCard
+        subAgent={subAgent({
+          status: "completed",
+          finalResultMarkdown:
+            "Earlier context remains available in the [report](https://example.com/report.pdf)",
+          latestActivity: "…report.pdf)",
+          terminalAtUnixMs: 2_000
+        })}
+        onLinkClick={onLinkClick}
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Sub-agent Repo smell analyst Completed/
+      })
+    );
+    fireEvent.click(await screen.findByRole("link", { name: "report" }));
+
+    expect(onLinkClick).toHaveBeenCalledWith("https://example.com/report.pdf");
+    expect(screen.queryByText("…report.pdf)")).not.toBeInTheDocument();
+  });
+
   it("shows failed instead of starting when failure detail is absent", async () => {
     setAgentGuiI18nTestLocale("en");
 

--- a/packages/agent/gui/shared/agentConversation/components/AgentSubAgentCards.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentSubAgentCards.tsx
@@ -7,6 +7,7 @@ import type { AgentToolCallVM } from "../contracts/agentToolCallVM";
 import { CollapsibleReveal } from "./CollapsibleReveal";
 import { useAgentConversationNowUnixMs } from "./AgentConversationClock";
 import { formatAgentToolDurationMs } from "./tool-renderers/render-data/agentToolRenderData";
+import { ToolMarkdownBlock } from "./tool-renderers/agentToolContentShared";
 
 // A delegated sub-agent renders as a first-class row aligned with tool rows:
 // header = "Sub-agent · <name> · <elapsed> · <status>" with a chevron, body =
@@ -62,6 +63,7 @@ function subAgentVMEquals(
     left.laneIndex === right.laneIndex &&
     left.laneCount === right.laneCount &&
     left.latestActivity === right.latestActivity &&
+    left.finalResultMarkdown === right.finalResultMarkdown &&
     left.failureDetail === right.failureDetail &&
     left.queued === right.queued &&
     left.startedAtUnixMs === right.startedAtUnixMs &&
@@ -186,7 +188,7 @@ function SubAgentBody({
             {subAgent.task}
           </div>
         ) : null}
-        <SubAgentProgress subAgent={subAgent} />
+        <SubAgentProgress subAgent={subAgent} onLinkClick={onLinkClick} />
         {subAgent.childSessions.length > 0 ? (
           <div className="workspace-agents-status-panel__detail-subagent-children">
             {subAgent.childSessions.map((childSession) => (
@@ -204,16 +206,29 @@ function SubAgentBody({
 }
 
 function SubAgentProgress({
-  subAgent
+  subAgent,
+  onLinkClick
 }: {
   subAgent: AgentTaskSubAgentVM;
+  onLinkClick?: (href: string) => void;
 }): JSX.Element {
   "use memo";
-  // Progress stays a single line - the sub-agent's most recent activity (or
-  // failure detail), not a scrolling log.
+  if (subAgent.status === "completed" && subAgent.finalResultMarkdown?.trim()) {
+    return (
+      <div className="workspace-agents-status-panel__detail-subagent-activity workspace-agents-status-panel__detail-subagent-activity--in-terminal">
+        <ToolMarkdownBlock
+          content={subAgent.finalResultMarkdown}
+          onLinkClick={onLinkClick}
+        />
+      </div>
+    );
+  }
+  // Process activity is only a live progress summary. Terminal cards fall
+  // back to their terminal status rather than presenting a truncated activity
+  // snippet as the final result.
   const text =
     subAgent.failureDetail ??
-    subAgent.latestActivity ??
+    (subAgent.status === "running" ? subAgent.latestActivity : null) ??
     translate(
       subAgent.status === "completed"
         ? "agentHost.agentTool.statusCompleted"

--- a/packages/agent/gui/shared/agentConversation/contracts/agentTaskItemVM.ts
+++ b/packages/agent/gui/shared/agentConversation/contracts/agentTaskItemVM.ts
@@ -32,6 +32,9 @@ export interface AgentTaskSubAgentVM {
   laneCount: number;
   latestActivity: string | null;
   latestActivityKind: AgentTaskSubAgentActivityKind | null;
+  // Canonical terminal assistant result. Unlike latestActivity, this preserves
+  // Markdown and is never truncated into a progress snippet.
+  finalResultMarkdown?: string | null;
   // Chronological recent activity (markers excluded), capped; older entries
   // are summarized by activityOmittedCount.
   activityLog: readonly AgentTaskSubAgentActivityVM[];

--- a/packages/agent/gui/shared/agentConversation/projection/childSessionLanes.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/childSessionLanes.spec.ts
@@ -77,6 +77,53 @@ describe("buildChildSessionLanesByParentToolCallId", () => {
     });
   });
 
+  it("preserves the complete terminal assistant Markdown separately from activity", () => {
+    const child = childSession({
+      id: "child-1",
+      parentSessionId: "root-1",
+      parentToolCallId: "spawn-1",
+      turn: turn("child-1", "settled", "completed")
+    });
+    const markdown =
+      "Complete report with earlier context and [PDF](C:/Reports/final%20report.pdf)";
+    const lanes = buildChildSessionLanesByParentToolCallId({
+      rootSession: rootSession(),
+      rootTimelineItems: [spawnCall("root-1", "spawn-1", "Build report")],
+      childSessions: [child],
+      messagesBySessionId: {
+        "child-1": [message("child-1", markdown, 20)]
+      }
+    });
+
+    expect(lanes.get("spawn-1")?.[0]).toMatchObject({
+      finalResultMarkdown: markdown,
+      status: "completed"
+    });
+  });
+
+  it("keeps the beginning of long progress instead of dropping prior context", () => {
+    const child = childSession({
+      id: "child-1",
+      parentSessionId: "root-1",
+      parentToolCallId: "spawn-1",
+      turn: turn("child-1", "running", null)
+    });
+    const activity = `important-prefix-${"x".repeat(180)}`;
+    const lanes = buildChildSessionLanesByParentToolCallId({
+      rootSession: rootSession(),
+      rootTimelineItems: [spawnCall("root-1", "spawn-1", "Build report")],
+      childSessions: [child],
+      messagesBySessionId: {
+        "child-1": [message("child-1", activity, 20)]
+      }
+    });
+
+    expect(lanes.get("spawn-1")?.[0]?.latestActivity).toMatch(
+      /^important-prefix-/
+    );
+    expect(lanes.get("spawn-1")?.[0]?.finalResultMarkdown).toBeNull();
+  });
+
   it("does not reconstruct legacy owner fields without a child session", () => {
     const legacyItem: WorkspaceAgentActivityTimelineItem = {
       id: 2,

--- a/packages/agent/gui/shared/agentConversation/projection/childSessionLanes.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/childSessionLanes.ts
@@ -149,6 +149,10 @@ function buildChildSessionLane(input: {
   );
   const latestTurn = input.childSession.latestTurn;
   const status = childSessionStatus(input.childSession);
+  const finalResultMarkdown =
+    status === "completed"
+      ? childSessionFinalResultMarkdown(childTimelineItems)
+      : null;
   const terminalAtUnixMs =
     status === "running"
       ? null
@@ -165,6 +169,7 @@ function buildChildSessionLane(input: {
     laneCount: 1,
     latestActivity: latestActivity?.text ?? null,
     latestActivityKind: latestActivity?.kind ?? null,
+    finalResultMarkdown,
     activityLog: activity.entries,
     activityOmittedCount: activity.omittedCount,
     queued: input.childSession.activeTurn?.phase === "submitted",
@@ -195,6 +200,7 @@ function emptyCycleLane(session: AgentActivitySession): AgentTaskSubAgentVM {
     laneCount: 1,
     latestActivity: null,
     latestActivityKind: null,
+    finalResultMarkdown: null,
     activityLog: [],
     activityOmittedCount: 0,
     failureDetail: session.latestTurn?.error?.message?.trim() ?? null,
@@ -323,10 +329,36 @@ function timelineItemText(item: WorkspaceAgentActivityTimelineItem): string {
     .trim();
 }
 
+function childSessionFinalResultMarkdown(
+  timelineItems: readonly WorkspaceAgentActivityTimelineItem[]
+): string | null {
+  for (let index = timelineItems.length - 1; index >= 0; index -= 1) {
+    const item = timelineItems[index];
+    if (!item) continue;
+    const itemType = item.itemType?.trim().toLowerCase() ?? "";
+    const role = item.role?.trim().toLowerCase() ?? "";
+    if (
+      role !== "assistant" ||
+      itemType === "message.assistant_thinking" ||
+      isWorkspaceAgentToolCallItem(item)
+    ) {
+      continue;
+    }
+    const markdown = (
+      stringValue(item.payload?.text) ??
+      stringValue(item.payload?.content) ??
+      stringValue(item.content) ??
+      ""
+    ).trim();
+    if (markdown) return markdown;
+  }
+  return null;
+}
+
 function snippet(text: string): string {
   return text.length <= 140
     ? text
-    : String.fromCodePoint(0x2026) + text.slice(-140);
+    : text.slice(0, 140) + String.fromCodePoint(0x2026);
 }
 
 function assignSiblingLanePositions(lanes: AgentTaskSubAgentVM[]): void {

--- a/services/tuttid/service/agent/service_create.go
+++ b/services/tuttid/service/agent/service_create.go
@@ -111,6 +111,15 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 	requestedModel := value(input.Model)
 	nodeStartedAt := time.Now()
 	planResolution, err := s.resolveCreateSessionModelForPlanOrProvider(ctx, workspaceID, provider, requestedModel, &input)
+	var invalidRememberedModel *InvalidModelError
+	if !modelExplicit && errors.As(err, &invalidRememberedModel) {
+		// Target-scoped defaults are fallback preferences. A provider catalog can
+		// retire a remembered model between launches, so retry resolution without
+		// that preference while keeping explicit caller selections strict.
+		input.Model = nil
+		requestedModel = ""
+		planResolution, err = s.resolveCreateSessionModelForPlanOrProvider(ctx, workspaceID, provider, requestedModel, &input)
+	}
 	if err != nil {
 		s.reportAgentServiceNodeFailure(ctx, input.AgentSessionID, "session_create", "model_validated", provider, nodeStartedAt, err)
 		return createSessionFailureResult(input, err)

--- a/services/tuttid/service/agent/service_create_runtime_test.go
+++ b/services/tuttid/service/agent/service_create_runtime_test.go
@@ -375,6 +375,40 @@ func TestServiceCreateUsesProviderDefaultModelWhenModelOmitted(t *testing.T) {
 	}
 }
 
+func TestServiceCreateRecoversRetiredRememberedModelToProviderDefault(t *testing.T) {
+	runtime := newFakeRuntime()
+	service := newTestService(runtime)
+	service.AgentComposerDefaultsReader = fakeAgentComposerDefaultsReader{
+		agenttargetbiz.IDLocalCodex: {Model: "gpt-5.4"},
+	}
+	service.ModelCatalog = fakeModelCatalog{
+		result: AgentModelCatalogResult{
+			Provider: "codex",
+			Source:   "codex-cli",
+			Models: []AgentModelOption{
+				{ID: "gpt-5.6-sol", DisplayName: "GPT-5.6-Sol", IsDefault: true},
+				{ID: "gpt-5.5", DisplayName: "GPT-5.5"},
+			},
+		},
+	}
+
+	session, err := service.Create(context.Background(), "ws-1", CreateSessionInput{
+		AgentSessionID: "34343434-3434-4434-8434-343434343434",
+		AgentTargetID:  agenttargetbiz.IDLocalCodex,
+		Provider:       "codex",
+		InitialContent: TextPromptContent("hello"),
+	})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if len(runtime.startCalls) != 1 || runtime.startCalls[0].Model != "gpt-5.6-sol" {
+		t.Fatalf("runtime start calls = %#v, want provider default model", runtime.startCalls)
+	}
+	if session.Settings == nil || session.Settings.Model != "gpt-5.6-sol" {
+		t.Fatalf("session settings = %#v, want provider default model", session.Settings)
+	}
+}
+
 func TestServiceCreateClampsLegacyMaxToSelectedModelCapability(t *testing.T) {
 	runtime := newFakeRuntime()
 	service := newTestService(runtime)
@@ -411,6 +445,78 @@ func TestServiceCreateClampsLegacyMaxToSelectedModelCapability(t *testing.T) {
 	}
 	if session.Settings == nil || session.Settings.ReasoningEffort != "xhigh" {
 		t.Fatalf("session settings = %#v, want Spark reasoning xhigh", session.Settings)
+	}
+}
+
+func TestServiceCreateClampsInheritedOpenCodeReasoningToTargetModel(t *testing.T) {
+	runtime := newFakeRuntime()
+	service := newTestService(runtime)
+	service.ModelCatalog = fakeModelCatalog{
+		result: AgentModelCatalogResult{
+			Provider: "opencode",
+			Source:   "opencode-cli",
+			Models: []AgentModelOption{{
+				ID:                         "openai/gpt-5.3-codex-spark",
+				IsDefault:                  true,
+				DefaultReasoningEffort:     "medium",
+				ReasoningEffortsAdvertised: true,
+				SupportedReasoningEfforts: []AgentModelReasoningEffortOption{
+					{Value: "low"},
+					{Value: "medium"},
+					{Value: "high"},
+					{Value: "xhigh"},
+				},
+			}},
+		},
+	}
+
+	session, err := service.Create(context.Background(), "ws-1", CreateSessionInput{
+		AgentSessionID:  "45454545-4545-4545-8545-454545454545",
+		AgentTargetID:   agenttargetbiz.IDLocalOpenCode,
+		Provider:        "opencode",
+		Model:           stringRef("openai/gpt-5.3-codex-spark"),
+		ReasoningEffort: stringRef("none"),
+	})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if len(runtime.startCalls) != 1 || runtime.startCalls[0].ReasoningEffort != "medium" {
+		t.Fatalf("runtime start calls = %#v, want target default reasoning", runtime.startCalls)
+	}
+	if session.Settings == nil || session.Settings.ReasoningEffort != "medium" {
+		t.Fatalf("session settings = %#v, want target default reasoning", session.Settings)
+	}
+}
+
+func TestServiceCreateDropsInheritedOpenCodeReasoningWithoutAdvertisedMetadata(t *testing.T) {
+	runtime := newFakeRuntime()
+	service := newTestService(runtime)
+	service.ModelCatalog = fakeModelCatalog{
+		result: AgentModelCatalogResult{
+			Provider: "opencode",
+			Source:   "opencode-cli",
+			Models: []AgentModelOption{{
+				ID:        "openai/gpt-5.3-codex-spark",
+				IsDefault: true,
+			}},
+		},
+	}
+
+	session, err := service.Create(context.Background(), "ws-1", CreateSessionInput{
+		AgentSessionID:  "46464646-4646-4646-8646-464646464646",
+		AgentTargetID:   agenttargetbiz.IDLocalOpenCode,
+		Provider:        "opencode",
+		Model:           stringRef("openai/gpt-5.3-codex-spark"),
+		ReasoningEffort: stringRef("none"),
+	})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if len(runtime.startCalls) != 1 || runtime.startCalls[0].ReasoningEffort != "" {
+		t.Fatalf("runtime start calls = %#v, want no unadvertised reasoning", runtime.startCalls)
+	}
+	if session.Settings == nil || session.Settings.ReasoningEffort != "" {
+		t.Fatalf("session settings = %#v, want no unadvertised reasoning", session.Settings)
 	}
 }
 

--- a/services/tuttid/service/agent/service_settings.go
+++ b/services/tuttid/service/agent/service_settings.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 )
@@ -30,9 +31,7 @@ func clampReasoningEffortForModelWithCatalog(
 	selected string,
 ) string {
 	selected = strings.TrimSpace(selected)
-	// Only Codex-derived providers currently treat model-advertised reasoning
-	// values as authoritative. OpenCode uses its model catalog for discovery but
-	// keeps the static reasoning vocabulary.
+	profile := composerProfileFor(provider)
 	if !composerProviderUsesModelReasoningCatalog(provider) {
 		return normalizeReasoningEffortForProvider(provider, selected)
 	}
@@ -41,6 +40,11 @@ func clampReasoningEffortForModelWithCatalog(
 	}
 	catalogOptions, ok := composerModelOptionsFromCatalog(ctx, catalog, provider, "", model)
 	if !ok || !catalogOptions.Selection.ReasoningEffortsAdvertised {
+		if profile.ReasoningEffortOptions == providerregistry.ReasoningEffortOptionsStrictModelCatalog {
+			// Strict catalogs intentionally have no provider-wide fallback. Do not
+			// forward an inherited value that the target model never advertised.
+			return ""
+		}
 		return normalizeReasoningEffortForProvider(provider, selected)
 	}
 	return resolveAdvertisedReasoningEffort(


### PR DESCRIPTION
## Summary

- keep every in-progress root session for the exact Agent target visible without changing daemon-owned rail pagination totals
- recover non-explicit remembered models that have left the provider catalog, while keeping explicit invalid selections strict
- clamp inherited reasoning effort against strict model catalogs and fail closed when model reasoning metadata is absent
- separate live child-agent activity snippets from complete terminal Markdown results
- treat exit 1 as success only for an exact, unambiguous `git diff --no-index` command in the ACP adapter

## Validation

- AgentGUI focused Vitest: 4 files, 56 tests passed
- AgentGUI typecheck: passed
- daemon runtime focused Go tests: passed
- tuttid session-create focused Go tests: passed
- changed lint/check lanes: 10/17 passed; failed wrapper lanes were reproduced with native equivalents
- agent activity runtime boundary check with 8 GB Node heap: passed
- incremental golangci-lint for daemon runtime and tuttid agent service: 0 issues
- `git diff --check`: passed
- independent subagent review: Architecture, Performance, and Consumers lanes passed after two review-fix rounds

## Environment limitations

- the repository `rail-scope-reveal` Electron E2E scenario was attempted but stopped before application startup with `spawn sqlite3 ENOENT`
- the full daemon runtime suite includes existing Windows-incompatible process/path tests; affected focused tests pass
- the changed-check WSL wrappers cannot resolve the Windows worktree gitdir/toolchain, and the UI boundary lane reports pre-existing generated theme drift outside this diff

## Related reports

- https://ccn53rwonxso.feishu.cn/record/GBfBreOIQe0opxcIadEcyJDqn2g
- https://ccn53rwonxso.feishu.cn/record/AHvHrlnSeewx4YckPAFccRxfnlh
- https://ccn53rwonxso.feishu.cn/record/XMYlr1k5Le4wDYcoPH4cXVJKn2g
- https://ccn53rwonxso.feishu.cn/record/NCU5rXv3HeQ1GYchCWacTS7Tnmh
- https://ccn53rwonxso.feishu.cn/record/C5bxrFJSae1mYqcuuJQc8pxQnoc
