### PR TITLE
fix(agent-gui): separate submission and execution states

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -295,16 +295,23 @@ command admission check remains in the consumer/controller path.
 
 Submission acknowledgment and execution are separate presentation signals:
 
-- `isSubmitting`, an unconfirmed submit, and an activating live state may drive
-  the Composer spinner immediately because they prove local submission intent
-  or launch progress
-- Conversation `working` status requires canonical activity evidence: a live
-  runtime or a non-settled active Turn; pending activation or submission alone
-  must remain `ready`, both before and after canonical Session confirmation
+- `isSubmitting`, an unconfirmed submit, and a viable initial launch that
+  expects a Turn drive an `isAwaitingTurnStart` Composer spinner immediately
+  because they prove local submission intent or expected launch work
+- a reconnect-only `activating` state belongs to connection chrome and command
+  admission; without submission intent it must not create a sending spinner,
+  `working` status, Stop target, or queue eligibility
+- Conversation `working` status and queue eligibility require canonical
+  execution evidence: the fenced Engine display status or a non-settled active
+  Turn; pending activation or submission alone must remain `ready`, both before
+  and after canonical Session confirmation
 - canonical completed, failed, or canceled activity stops the execution
   indicator even if a lower-level runtime signal has not caught up yet
 - transport recovery chrome, such as connecting or unavailable, takes priority
   over normal working copy
+- Stop is available before Turn identity only when the Engine exposes an exact
+  pending-submit stop target; reconnect and other connection state never invent
+  one
 
 This keeps feedback optimistic for responsiveness while keeping claims about
 Agent work grounded in the canonical Turn/runtime projection.
@@ -930,23 +937,25 @@ queue submission while keeping the editor editable. Draft emptiness, upload
 progress/failure, project existence, and other draft-local conditions may
 disable submission, but must not change editor editability.
 
-Engine submitting and unconfirmed-submit selectors remain busy facts after a
-canonical Session first appears. Session existence or an `available` runtime
-must not create an idle frame before the exact Turn claims the submission. A
-viable new-Session activation with `initialTurnExpected` remains the same busy
-bridge while no canonical latest Turn exists. Goal-only activation deliberately
-does not set `initialTurnExpected`, because Goal Control does not synchronously
-create a Turn. A viable initial Goal `set` whose projected Goal is still active
-remains a busy bridge only while the Goal is optimistic or the host supplies an
-exact pending/applying/unknown `goalSyncState` with a pending operation
-identity. A synced Goal proves only that the Goal mutation converged; it does
-not prove that a future Turn will exist. The first canonical Turn, a synced or
-non-active Goal,
-`failed`/`diverged` synchronization, `pending`/`applying`/`unknown` without an operation identity,
-or a canceled/failed activation releases the bridge; initial Goal `clear` never
+Engine submitting and unconfirmed-submit selectors remain Turn-admission facts
+after a canonical Session first appears. Session existence or an `available`
+runtime must not create an idle frame in the Composer spinner before the exact
+Turn claims the submission, but these facts do not create execution busy,
+Conversation `working`, or queue eligibility. A viable new-Session activation
+with `initialTurnExpected` remains the same Turn-start bridge while no canonical
+latest Turn exists. Goal-only activation deliberately does not set
+`initialTurnExpected`, because Goal Control does not synchronously create a
+Turn. A viable initial Goal `set` whose projected Goal is still active remains a
+Turn-start bridge only while the Goal is optimistic or the host supplies an
+exact pending/applying/unknown `goalSyncState` with a pending operation identity.
+A synced Goal proves only that the Goal mutation converged; it does not prove
+that a future Turn will exist. The first canonical Turn, a synced or non-active
+Goal, `failed`/`diverged` synchronization,
+`pending`/`applying`/`unknown` without an operation identity, or a
+canceled/failed activation releases the bridge; initial Goal `clear` never
 creates it. A host that omits `goalSyncState` cannot prove post-create execution
 and therefore fails closed to the canonical availability projection instead of
-keeping the composer busy indefinitely. When a provider exposes an exact
+keeping the Composer spinner active indefinitely. When a provider exposes an exact
 session-level `running`/`idle` observation before Turn identity, the daemon
 projects that
 typed, non-persistent runtime activity through `agent.activity.updated` after

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -299,8 +299,8 @@ Submission acknowledgment and execution are separate presentation signals:
   the Composer spinner immediately because they prove local submission intent
   or launch progress
 - Conversation `working` status requires canonical activity evidence: a live
-  runtime or a non-settled active Turn; pending submission alone must remain
-  `ready`
+  runtime or a non-settled active Turn; pending activation or submission alone
+  must remain `ready`, both before and after canonical Session confirmation
 - canonical completed, failed, or canceled activity stops the execution
   indicator even if a lower-level runtime signal has not caught up yet
 - transport recovery chrome, such as connecting or unavailable, takes priority

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -291,6 +291,24 @@ the command authority. If the Host omits the reason, the disabled wrapper stays
 out of the tab order and does not create an empty Tooltip. The final semantic
 command admission check remains in the consumer/controller path.
 
+### Submission and execution presentation
+
+Submission acknowledgment and execution are separate presentation signals:
+
+- `isSubmitting`, an unconfirmed submit, and an activating live state may drive
+  the Composer spinner immediately because they prove local submission intent
+  or launch progress
+- Conversation `working` status requires canonical activity evidence: a live
+  runtime or a non-settled active Turn; pending submission alone must remain
+  `ready`
+- canonical completed, failed, or canceled activity stops the execution
+  indicator even if a lower-level runtime signal has not caught up yet
+- transport recovery chrome, such as connecting or unavailable, takes priority
+  over normal working copy
+
+This keeps feedback optimistic for responsiveness while keeping claims about
+Agent work grounded in the canonical Turn/runtime projection.
+
 ### 2.6 On-demand status
 
 AgentGUI owns one provider-neutral `AgentStatusController` for `/status`, Agent

--- a/packages/agent/activity-core/src/engine/pendingIntents.selectors.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.selectors.ts
@@ -199,6 +199,18 @@ export function selectLatestStopTargetSubmitForSession(
   return latest;
 }
 
+/**
+ * Whether an implicit Session stop can target a pending prompt admission.
+ * Consumers use this presentation-safe fact instead of duplicating submit and
+ * canonical Turn correlation rules.
+ */
+export function selectSessionHasPendingSubmitStopTarget(
+  state: AgentSessionEngineStateBase,
+  agentSessionId: string | null | undefined
+): boolean {
+  return selectLatestStopTargetSubmitForSession(state, agentSessionId) !== null;
+}
+
 function stopTargetMayStillProduceUnsettledTurn(
   state: AgentSessionEngineStateBase,
   pending: PendingSubmitIntentRecord

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.test.ts
@@ -171,7 +171,7 @@ test("consumer collections hide presentation-invisible sessions without removing
   );
 });
 
-test("consumer status is derived from canonical entities and engine-owned initial activation", () => {
+test("consumer status is derived from canonical Turn and Interaction entities", () => {
   let state = createInitialAgentSessionEngineState();
   state = rootEngineReducer(state, {
     sessions: [
@@ -227,7 +227,7 @@ test("consumer status is derived from canonical entities and engine-owned initia
   });
 });
 
-test("new activation stays working between session confirmation and first canonical turn", () => {
+test("new activation remains idle until canonical execution appears", () => {
   let state = createInitialAgentSessionEngineState();
   state = rootEngineReducer(state, {
     agentSessionId: "session-1",
@@ -246,6 +246,36 @@ test("new activation stays working between session confirmation and first canoni
     sessions: [
       {
         activeTurnId: null,
+        agentSessionId: "session-1",
+        createdAtUnixMs: 20,
+        cwd: "/workspace",
+        latestTurnInteractions: [],
+        pendingInteractions: [],
+        provider: "codex",
+        title: "test1",
+        workspaceId: "workspace-1"
+      }
+    ],
+    type: "session/snapshotReceived"
+  }).state;
+
+  assert.equal(
+    selectWorkspaceAgentConsumerSession(state, "session-1")?.displayStatus,
+    "idle"
+  );
+
+  state = rootEngineReducer(state, {
+    sessions: [
+      {
+        activeTurn: {
+          agentSessionId: "session-1",
+          origin: "user_prompt",
+          phase: "running",
+          startedAtUnixMs: 20,
+          turnId: "turn-1",
+          updatedAtUnixMs: 20
+        },
+        activeTurnId: "turn-1",
         agentSessionId: "session-1",
         createdAtUnixMs: 20,
         cwd: "/workspace",

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.ts
@@ -506,11 +506,6 @@ export function selectAllWorkspaceAgentConsumerSessions(
       activeTurn,
       displayStatus: displayStatusFromCanonicalState({
         activeTurn,
-        initialActivationTurnPending: initialActivationTurnIsPending(
-          state,
-          session.agentSessionId,
-          latestTurn
-        ),
         latestTurn,
         pendingInteractions,
         runtimeActivity:
@@ -538,11 +533,6 @@ export function selectWorkspaceAgentConsumerSession(
     activeTurn,
     displayStatus: displayStatusFromCanonicalState({
       activeTurn,
-      initialActivationTurnPending: initialActivationTurnIsPending(
-        state,
-        id,
-        latestTurn
-      ),
       latestTurn,
       pendingInteractions,
       runtimeActivity: state.sessionLifecycle.operationBySessionId[id] ?? null
@@ -567,7 +557,6 @@ export function selectWorkspaceAgentConsumerCounts(
 
 function displayStatusFromCanonicalState(state: {
   activeTurn: AgentActivityTurn | null;
-  initialActivationTurnPending: boolean;
   latestTurn: AgentActivityTurn | null;
   pendingInteractions: readonly AgentActivityInteraction[];
   runtimeActivity: SessionOperationState | null;
@@ -577,9 +566,7 @@ function displayStatusFromCanonicalState(state: {
     return state.activeTurn.phase === "waiting" ? "waiting" : "working";
   }
   if (runtimeActivityCanOverrideCanonicalTurn(state)) return "working";
-  if (!state.latestTurn) {
-    return state.initialActivationTurnPending ? "working" : "idle";
-  }
+  if (!state.latestTurn) return "idle";
   if (state.latestTurn.phase !== "settled") return "idle";
   switch (state.latestTurn.outcome) {
     case "failed":
@@ -607,20 +594,6 @@ function runtimeActivityCanOverrideCanonicalTurn(state: {
   return (
     state.runtimeActivity.runtimeActivityOccurredAtUnixMs >
     canonicalTerminalAtUnixMs
-  );
-}
-
-function initialActivationTurnIsPending(
-  state: AgentSessionEngineStateBase,
-  agentSessionId: string,
-  latestTurn: AgentActivityTurn | null
-): boolean {
-  if (latestTurn) return false;
-  const activation = selectLatestActivationForSession(state, agentSessionId);
-  return (
-    activation?.mode === "new" &&
-    activation.initialTurnExpected &&
-    isPendingActivationViable(activation)
   );
 }
 

--- a/packages/agent/activity-core/src/engine/sessionStop.semantic.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionStop.semantic.test.ts
@@ -3,7 +3,10 @@ import { test } from "node:test";
 import { normalizeAgentActivitySession } from "../sessionNormalization.ts";
 import type { AgentActivityTurn } from "../types.ts";
 import { createAgentSessionEngine } from "./createAgentSessionEngine.ts";
-import { selectLatestStopTargetSubmitForSession } from "./pendingIntents.selectors.ts";
+import {
+  selectLatestStopTargetSubmitForSession,
+  selectSessionHasPendingSubmitStopTarget
+} from "./pendingIntents.selectors.ts";
 import { selectEngineCancelState } from "./sessionLifecycle.selectors.ts";
 import { createTestEngineCommandPort } from "./testEngineCommandPort.ts";
 import type { EngineExternalCommand, EngineScheduler } from "./types.ts";
@@ -119,6 +122,13 @@ test("semantic session stop targets the latest pending prompt admission", () => 
     }),
     { accepted: true, queued: false }
   );
+  assert.equal(
+    selectSessionHasPendingSubmitStopTarget(
+      harness.engine.getSnapshot(),
+      "session-1"
+    ),
+    true
+  );
 
   harness.engine.stopSession({ agentSessionId: "session-1" });
 
@@ -211,6 +221,13 @@ test("stop target selection ignores a submit whose canonical Turn is settled", (
       "session-1"
     ),
     null
+  );
+  assert.equal(
+    selectSessionHasPendingSubmitStopTarget(
+      harness.engine.getSnapshot(),
+      "session-1"
+    ),
+    false
   );
 });
 

--- a/packages/agent/activity-core/src/index.ts
+++ b/packages/agent/activity-core/src/index.ts
@@ -350,6 +350,7 @@ export {
   selectPendingSubmitsForSession,
   selectSessionActivationPresentations,
   selectSessionHasUnconfirmedSubmit,
+  selectSessionHasPendingSubmitStopTarget,
   selectSessionIsSubmitting
 } from "./engine/pendingIntents.selectors.ts";
 export type { SessionActivationPresentation } from "./engine/pendingIntents.selectors.ts";

--- a/packages/agent/gui/AgentGUIQuickComposer.tsx
+++ b/packages/agent/gui/AgentGUIQuickComposer.tsx
@@ -37,6 +37,7 @@ export type { AgentGUIQuickComposerSettings } from "./quickComposerSettings";
 
 const readyGate: AgentGUIComposerGate = {
   conversationBusy: false,
+  isAwaitingTurnStart: false,
   editor: { reason: null, status: "editable" },
   runtime: {
     reason: null,

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.memo.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.memo.spec.tsx
@@ -576,6 +576,7 @@ function createViewModel(
     queueStatus: "active",
     gate: {
       conversationBusy: false,
+      isAwaitingTurnStart: false,
       runtime: {
         status: "ready",
         reason: null,
@@ -586,6 +587,7 @@ function createViewModel(
     },
     isSubmitting: false,
     isInterrupting: false,
+    hasPendingSubmitStopTarget: false,
     promptImagesSupported: true,
     availability: "ready",
     listError: null,

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.status.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.status.spec.tsx
@@ -584,6 +584,7 @@ function createViewModel(
     queueStatus: "active",
     gate: {
       conversationBusy: false,
+      isAwaitingTurnStart: false,
       runtime: {
         status: "ready",
         reason: null,
@@ -594,6 +595,7 @@ function createViewModel(
     },
     isSubmitting: false,
     isInterrupting: false,
+    hasPendingSubmitStopTarget: false,
     promptImagesSupported: true,
     availability: "ready",
     listError: null,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.draftMessageHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.draftMessageHelpers.ts
@@ -176,13 +176,10 @@ export function agentActivityDisplayStatusBusy(
   return status === "working" || status === "waiting";
 }
 
-export function conversationBusyStatusFromAgentActivityDisplayStatus(
+export function conversationStatusFromAgentActivityDisplayStatus(
   status: AgentActivityDisplayStatus | null | undefined
-): "working" | "waiting" | null {
-  if (status === "working" || status === "waiting") {
-    return status;
-  }
-  return null;
+): AgentGUIConversationSummary["status"] | null {
+  return status === "idle" ? "ready" : (status ?? null);
 }
 
 export function agentActivitySessionHasLiveTurn(

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.reporting.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.reporting.ts
@@ -272,7 +272,7 @@ export function reportAgentGUIRenderStateDiagnostic(input: {
   activeEngineAvailability: "available" | "blocked" | "missing";
   activeEngineLatestTurn: AgentActivityTurn | null;
   activeEngineRuntimeActivity: "idle" | "running";
-  activeHasPendingSubmittedTurn: boolean;
+  isAwaitingTurnStart: boolean;
   activeLiveState: "inactive" | "activating" | "active" | "failed";
   activeRuntimeSession: CanonicalAgentSession | null;
   activeSessionState: AgentSessionState | null;
@@ -308,7 +308,7 @@ export function reportAgentGUIRenderStateDiagnostic(input: {
             input.activeEngineLatestTurn
           ),
           activeEngineRuntimeActivity: input.activeEngineRuntimeActivity,
-          activeHasPendingSubmittedTurn: input.activeHasPendingSubmittedTurn,
+          isAwaitingTurnStart: input.isAwaitingTurnStart,
           activeLiveState: input.activeLiveState,
           activeSubmitBlocked: input.activeSubmitBlocked,
           canQueueWhileBusy: input.canQueueWhileBusy,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationPresentation.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationPresentation.spec.tsx
@@ -9,6 +9,51 @@ type PresentationInput = Parameters<
 >[0];
 
 describe("useAgentGUIConversationPresentation", () => {
+  it("does not project a pending submit into Conversation working status", () => {
+    const conversation = createConversation();
+    const input = createInput(conversation);
+    const pendingInput = {
+      ...input,
+      activeLatestPendingSubmitTurnId: "turn-pending",
+      hasUnconfirmedSubmit: true,
+      isCreatingConversation: true,
+      isSubmitting: true
+    };
+    const rendered = renderHook(
+      ({ value }: { value: PresentationInput }) =>
+        useAgentGUIConversationPresentation(value),
+      { initialProps: { value: pendingInput } }
+    );
+
+    expect(rendered.result.current.activeConversation?.status).toBe("ready");
+
+    rendered.rerender({
+      value: { ...pendingInput, conversations: [] }
+    });
+    expect(rendered.result.current.activeConversation?.status).toBe("ready");
+  });
+
+  it("projects canonical activity status into Conversation status", () => {
+    const conversation = createConversation();
+    const input = createInput(conversation);
+    const rendered = renderHook(
+      ({ value }: { value: PresentationInput }) =>
+        useAgentGUIConversationPresentation(value),
+      {
+        initialProps: {
+          value: {
+            ...input,
+            activityDisplayStatuses: new Map([
+              [conversation.id, "working" as const]
+            ])
+          }
+        }
+      }
+    );
+
+    expect(rendered.result.current.activeConversation?.status).toBe("working");
+  });
+
   it("does not project the provider name as a fallback conversation title", () => {
     const conversation = createConversation();
     const input = createInput(conversation);

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationPresentation.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationPresentation.spec.tsx
@@ -54,6 +54,22 @@ describe("useAgentGUIConversationPresentation", () => {
     expect(rendered.result.current.activeConversation?.status).toBe("working");
   });
 
+  it("lets canonical idle clear stale Conversation working status", () => {
+    const conversation = createConversation();
+    const input = createInput({ ...conversation, status: "working" });
+    const rendered = renderHook(() =>
+      useAgentGUIConversationPresentation({
+        ...input,
+        activityDisplayStatuses: new Map([[conversation.id, "idle" as const]])
+      })
+    );
+
+    expect(rendered.result.current.activeConversation?.status).toBe("ready");
+    expect(rendered.result.current.visibleConversations[0]?.status).toBe(
+      "ready"
+    );
+  });
+
   it("does not project the provider name as a fallback conversation title", () => {
     const conversation = createConversation();
     const input = createInput(conversation);
@@ -294,6 +310,35 @@ describe("useAgentGUIConversationPresentation", () => {
         title: "Delegated task"
       })
     );
+  });
+
+  it("projects exact activity for a hidden transient conversation", () => {
+    const conversation = createConversation();
+    const hiddenTransient: AgentGUIConversationSummary = {
+      ...createConversation(),
+      hiddenFromRail: true,
+      id: "hidden-delegate-1",
+      status: "working",
+      title: "Delegated task"
+    };
+    const input = createInput(conversation);
+    const rendered = renderHook(() =>
+      useAgentGUIConversationPresentation({
+        ...input,
+        activeConversationId: hiddenTransient.id,
+        activityDisplayStatuses: new Map([
+          [hiddenTransient.id, "idle" as const]
+        ]),
+        transientConversation: hiddenTransient
+      })
+    );
+
+    expect(rendered.result.current.activeConversation?.status).toBe("ready");
+    expect(
+      rendered.result.current.visibleConversations.some(
+        (entry) => entry.id === hiddenTransient.id
+      )
+    ).toBe(false);
   });
 });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationPresentation.ts
@@ -7,7 +7,6 @@ import {
 } from "../../../agentTargets";
 import type { AgentGUINodeData, AgentGUIAgentTarget } from "../../../types";
 import type { AgentComposerDraft } from "../model/agentGuiNodeTypes";
-import { resolveAgentComposerDraftScopeKey } from "../model/agentComposerDraftScope";
 import {
   applyAgentGUIConversationProjects,
   type AgentGUIConversationSummary
@@ -126,15 +125,9 @@ export function useAgentGUIConversationPresentation(
         activityDisplayStatus === "failed" ||
         activityDisplayStatus === "canceled";
       const status =
-        (input.isSubmitting || input.hasUnconfirmedSubmit
-          ? ("working" as const)
-          : hasCanonicalTerminalStatus
-            ? activityDisplayStatus
-            : activityBusyStatus) ??
-        (resolved.status === "ready" &&
-        (input.activeLatestPendingSubmitTurnId || input.isSubmitting)
-          ? ("working" as const)
-          : resolved.status);
+        (hasCanonicalTerminalStatus
+          ? activityDisplayStatus
+          : activityBusyStatus) ?? resolved.status;
       return stabilize(
         status === resolved.status ? resolved : { ...resolved, status }
       );
@@ -147,17 +140,6 @@ export function useAgentGUIConversationPresentation(
       agentTargets: input.normalizedProviderTargets,
       useStaticCatalog: input.shouldUseStaticProviderTargets
     });
-    const fallbackStatus =
-      input.isSubmitting ||
-      input.isCreatingConversation ||
-      Object.prototype.hasOwnProperty.call(
-        input.draftByScopeKey,
-        resolveAgentComposerDraftScopeKey({
-          agentSessionId: input.activeConversationId
-        })
-      )
-        ? ("working" as const)
-        : ("ready" as const);
     const activityBusyStatus =
       conversationBusyStatusFromAgentActivityDisplayStatus(
         input.activityDisplayStatuses.get(input.activeConversationId)
@@ -176,7 +158,7 @@ export function useAgentGUIConversationPresentation(
       provider: input.data.provider,
       title: "",
       titleFallback: "untitled-conversation",
-      status: activityBusyStatus ?? fallbackStatus,
+      status: activityBusyStatus ?? "ready",
       cwd: input.workspacePath,
       project: null,
       sortTimeUnixMs: fallbackUpdatedAtUnixMs,
@@ -184,16 +166,11 @@ export function useAgentGUIConversationPresentation(
     });
   }, [
     input.activeConversationId,
-    input.activeLatestPendingSubmitTurnId,
     input.activityDisplayStatuses,
     input.currentUserId,
     input.data.agentTargetId,
     input.data.provider,
     input.defaultAgentTargetId,
-    input.draftByScopeKey,
-    input.hasUnconfirmedSubmit,
-    input.isCreatingConversation,
-    input.isSubmitting,
     input.normalizedProviderTargets,
     input.shouldUseStaticProviderTargets,
     conversationProjection.semanticConversations,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationPresentation.ts
@@ -18,7 +18,7 @@ import {
   conversationSummariesRenderEqual,
   stableConversationSummaryList
 } from "./agentGuiController.stableHelpers";
-import { conversationBusyStatusFromAgentActivityDisplayStatus } from "./agentGuiController.draftMessageHelpers";
+import { conversationStatusFromAgentActivityDisplayStatus } from "./agentGuiController.draftMessageHelpers";
 import { mergeVisibleConversations } from "./agentGuiController.conversationHelpers";
 import { rememberAgentGUIActiveConversation } from "../model/agentGuiSessionNavigationMemory";
 import { resolveConversationSummaryById } from "./useAgentConversationSelection";
@@ -64,12 +64,11 @@ export function useAgentGUIConversationPresentation(
       input.transientConversation
     );
     const mapped = source.map((conversation) => {
-      const activityBusyStatus =
-        conversationBusyStatusFromAgentActivityDisplayStatus(
-          input.activityDisplayStatuses.get(conversation.id)
-        );
-      return activityBusyStatus && conversation.status !== activityBusyStatus
-        ? { ...conversation, status: activityBusyStatus }
+      const activityStatus = conversationStatusFromAgentActivityDisplayStatus(
+        input.activityDisplayStatuses.get(conversation.id)
+      );
+      return activityStatus && conversation.status !== activityStatus
+        ? { ...conversation, status: activityStatus }
         : conversation;
     });
     const next = applyAgentGUIConversationProjects(mapped, input.userProjects);
@@ -113,21 +112,10 @@ export function useAgentGUIConversationPresentation(
       input.activeConversationId
     );
     if (resolved) {
-      const activityDisplayStatus = input.activityDisplayStatuses.get(
-        resolved.id
-      );
-      const activityBusyStatus =
-        conversationBusyStatusFromAgentActivityDisplayStatus(
-          activityDisplayStatus
-        );
-      const hasCanonicalTerminalStatus =
-        activityDisplayStatus === "completed" ||
-        activityDisplayStatus === "failed" ||
-        activityDisplayStatus === "canceled";
       const status =
-        (hasCanonicalTerminalStatus
-          ? activityDisplayStatus
-          : activityBusyStatus) ?? resolved.status;
+        conversationStatusFromAgentActivityDisplayStatus(
+          input.activityDisplayStatuses.get(resolved.id)
+        ) ?? resolved.status;
       return stabilize(
         status === resolved.status ? resolved : { ...resolved, status }
       );
@@ -140,10 +128,9 @@ export function useAgentGUIConversationPresentation(
       agentTargets: input.normalizedProviderTargets,
       useStaticCatalog: input.shouldUseStaticProviderTargets
     });
-    const activityBusyStatus =
-      conversationBusyStatusFromAgentActivityDisplayStatus(
-        input.activityDisplayStatuses.get(input.activeConversationId)
-      );
+    const activityStatus = conversationStatusFromAgentActivityDisplayStatus(
+      input.activityDisplayStatuses.get(input.activeConversationId)
+    );
     const previousActiveConversation = activeConversationRef.current?.[0];
     const fallbackUpdatedAtUnixMs =
       previousActiveConversation?.id === input.activeConversationId
@@ -158,7 +145,7 @@ export function useAgentGUIConversationPresentation(
       provider: input.data.provider,
       title: "",
       titleFallback: "untitled-conversation",
-      status: activityBusyStatus ?? "ready",
+      status: activityStatus ?? "ready",
       cwd: input.workspacePath,
       project: null,
       sortTimeUnixMs: fallbackUpdatedAtUnixMs,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -1,6 +1,7 @@
 import {
   createAgentSessionFamilySnapshotSelector,
   selectEngineSessionIsRespondingToInteraction,
+  selectWorkspaceAgentConsumerSession,
   selectWorkspaceAgentConsumerSessions
 } from "@tutti-os/agent-activity-core";
 import { useCallback, useEffect, useMemo, useRef } from "react";
@@ -175,18 +176,6 @@ export function useAgentGUINodeController({
     selectedAgentTargetIsExplicit,
     setHomeComposerTargetOverride
   } = providerCatalogSelection;
-  const agentActivityDisplayStatuses = useEngineSelector(
-    sessionEngine,
-    (state) =>
-      new Map(
-        selectWorkspaceAgentConsumerSessions(state).map((item) => [
-          item.session.agentSessionId,
-          item.displayStatus
-        ])
-      ),
-    (left, right) =>
-      reuseAgentActivityDisplayStatusesIfUnchanged(left, right) === left
-  );
   const localState = useAgentGUILocalState({
     data,
     userProjectsApi: agentHostApi.userProjects
@@ -210,6 +199,32 @@ export function useAgentGUINodeController({
     setUserProjects,
     userProjects
   } = localState;
+  const agentActivityDisplayStatuses = useEngineSelector(
+    sessionEngine,
+    (state) => {
+      const statuses = new Map(
+        selectWorkspaceAgentConsumerSessions(state).map((item) => [
+          item.session.agentSessionId,
+          item.displayStatus
+        ])
+      );
+      if (activeConversationId && !statuses.has(activeConversationId)) {
+        const activeConsumer = selectWorkspaceAgentConsumerSession(
+          state,
+          activeConversationId
+        );
+        if (activeConsumer) {
+          statuses.set(activeConversationId, activeConsumer.displayStatus);
+        }
+      }
+      return statuses;
+    },
+    (left, right) =>
+      reuseAgentActivityDisplayStatusesIfUnchanged(left, right) === left
+  );
+  const activeAgentActivityDisplayStatus = activeConversationId
+    ? (agentActivityDisplayStatuses.get(activeConversationId) ?? null)
+    : null;
   const tuttiModeDraftKey = useMemo(
     () => resolveAgentGUITuttiModeDraftKey(nodeId),
     [nodeId]
@@ -695,9 +710,7 @@ export function useAgentGUINodeController({
     isRespondingToInteraction: activeRelatedIsRespondingToInteraction,
     activeConversationLiveState,
     activationState: activeConversationLiveState,
-    activityDisplayStatus: activeConversationId
-      ? (agentActivityDisplayStatuses.get(activeConversationId) ?? null)
-      : null,
+    activityDisplayStatus: activeAgentActivityDisplayStatus,
     activityDisplayStatuses: agentActivityDisplayStatuses,
     agentActivityRuntime,
     avoidGroupingEdits,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionEngineState.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionEngineState.ts
@@ -23,6 +23,7 @@ import {
   selectLatestPendingSubmitForSession,
   selectPendingSubmitsForSession,
   selectSessionHasUnconfirmedSubmit,
+  selectSessionHasPendingSubmitStopTarget,
   selectSessionGoalControlPresentation,
   selectSessionIsSubmitting,
   sessionGoalControlPresentationsEqual,
@@ -80,6 +81,11 @@ export function useAgentGUISessionEngineState(input: {
   );
   const hasUnconfirmedSubmit = useEngineSelector(sessionEngine, (state) =>
     selectSessionHasUnconfirmedSubmit(state, activeConversationId)
+  );
+  const activeHasPendingSubmitStopTarget = useEngineSelector(
+    sessionEngine,
+    (state) =>
+      selectSessionHasPendingSubmitStopTarget(state, activeConversationId)
   );
   const activeCancelState = useEngineSelector(sessionEngine, (state) =>
     selectEngineCancelState(state, activeConversationId)
@@ -227,6 +233,7 @@ export function useAgentGUISessionEngineState(input: {
     activeEngineSessionDeleted,
     activeEngineSettingsUpdate,
     activeGoalControlPresentation,
+    activeHasPendingSubmitStopTarget,
     activeLatestPendingSubmit,
     activePendingActivation,
     activePendingSubmits,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.spec.tsx
@@ -92,7 +92,7 @@ describe("useAgentGUISessionPresentation", () => {
     });
   });
 
-  it("keeps confirmed initial work busy until canonical state takes over", () => {
+  it("separates Turn-start feedback from canonical execution busy", () => {
     const sessionEngine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
       commandPort: createTestEngineCommandPort({
@@ -107,6 +107,7 @@ describe("useAgentGUISessionPresentation", () => {
       activeEngineActiveTurn: null,
       activeEngineAvailability: "available",
       activeEngineHasPendingInteractions: false,
+      activeHasPendingSubmitStopTarget: false,
       activeEngineLatestTurn: null as AgentActivityTurn | null,
       activeEngineRuntimeAvailability: null,
       activeEngineRuntimeActivity: "idle" as "idle" | "running",
@@ -166,18 +167,28 @@ describe("useAgentGUISessionPresentation", () => {
 
     const rendered = renderHook(() => useAgentGUISessionPresentation(input));
 
-    expect(rendered.result.current.activeConversationBusy).toBe(true);
+    expect(rendered.result.current.activeConversationBusy).toBe(false);
+    expect(rendered.result.current.isAwaitingTurnStart).toBe(true);
+    expect(rendered.result.current.composerGate.submission).toEqual({
+      status: "blocked",
+      reason: "submitting"
+    });
 
     input.activeLatestPendingSubmitTurnId = "turn-1";
     input.hasUnconfirmedSubmit = false;
     rendered.rerender();
 
     expect(rendered.result.current.activeConversationBusy).toBe(false);
+    expect(rendered.result.current.isAwaitingTurnStart).toBe(false);
 
     input.activeLiveState = "activating";
     rendered.rerender();
 
-    expect(rendered.result.current.activeConversationBusy).toBe(true);
+    expect(rendered.result.current.activeConversationBusy).toBe(false);
+    expect(rendered.result.current.isAwaitingTurnStart).toBe(false);
+    expect(rendered.result.current.composerGate.submission.status).not.toBe(
+      "queue"
+    );
 
     input.activeLiveState = "active";
     rendered.rerender();
@@ -206,7 +217,8 @@ describe("useAgentGUISessionPresentation", () => {
       workspaceId: "workspace-1"
     };
     rendered.rerender();
-    expect(rendered.result.current.activeConversationBusy).toBe(true);
+    expect(rendered.result.current.activeConversationBusy).toBe(false);
+    expect(rendered.result.current.isAwaitingTurnStart).toBe(true);
 
     input.activeEngineLatestTurn = {
       agentSessionId: "session-1",
@@ -227,7 +239,7 @@ describe("useAgentGUISessionPresentation", () => {
     input.activeEngineRuntimeActivity = "running";
     input.activityDisplayStatus = "idle";
     rendered.rerender();
-    expect(rendered.result.current.activeConversationBusy).toBe(true);
+    expect(rendered.result.current.activeConversationBusy).toBe(false);
 
     input.activeEngineRuntimeActivity = "idle";
     input.activityDisplayStatus = "idle";
@@ -244,6 +256,7 @@ describe("useAgentGUISessionPresentation", () => {
     };
     rendered.rerender();
     expect(rendered.result.current.activeConversationBusy).toBe(true);
+    expect(rendered.result.current.isAwaitingTurnStart).toBe(false);
 
     input.activeEngineActiveTurn = null;
     rendered.rerender();
@@ -280,7 +293,8 @@ describe("useAgentGUISessionPresentation", () => {
       status: "pending_create"
     };
     rendered.rerender();
-    expect(rendered.result.current.activeConversationBusy).toBe(true);
+    expect(rendered.result.current.activeConversationBusy).toBe(false);
+    expect(rendered.result.current.isAwaitingTurnStart).toBe(true);
 
     input.activePendingActivation = {
       ...input.activePendingActivation,
@@ -328,7 +342,8 @@ describe("useAgentGUISessionPresentation", () => {
       }
     };
     rendered.rerender();
-    expect(rendered.result.current.activeConversationBusy).toBe(true);
+    expect(rendered.result.current.activeConversationBusy).toBe(false);
+    expect(rendered.result.current.isAwaitingTurnStart).toBe(true);
 
     input.activeEngineSession = {
       ...input.activeEngineSession!,
@@ -362,7 +377,8 @@ describe("useAgentGUISessionPresentation", () => {
       }
     };
     rendered.rerender();
-    expect(rendered.result.current.activeConversationBusy).toBe(true);
+    expect(rendered.result.current.activeConversationBusy).toBe(false);
+    expect(rendered.result.current.isAwaitingTurnStart).toBe(true);
 
     for (const syncStatus of ["pending", "unknown"] as const) {
       input.activeEngineSession = {
@@ -374,7 +390,8 @@ describe("useAgentGUISessionPresentation", () => {
         }
       };
       rendered.rerender();
-      expect(rendered.result.current.activeConversationBusy).toBe(true);
+      expect(rendered.result.current.activeConversationBusy).toBe(false);
+      expect(rendered.result.current.isAwaitingTurnStart).toBe(true);
     }
 
     input.activeEngineSession = {
@@ -399,6 +416,7 @@ describe("useAgentGUISessionPresentation", () => {
     input.activityDisplayStatus = "working";
     rendered.rerender();
     expect(rendered.result.current.activeConversationBusy).toBe(true);
+    expect(rendered.result.current.isAwaitingTurnStart).toBe(false);
 
     input.activeEngineLatestTurn = {
       ...input.activeEngineLatestTurn,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.spec.tsx
@@ -174,6 +174,14 @@ describe("useAgentGUISessionPresentation", () => {
 
     expect(rendered.result.current.activeConversationBusy).toBe(false);
 
+    input.activeLiveState = "activating";
+    rendered.rerender();
+
+    expect(rendered.result.current.activeConversationBusy).toBe(true);
+
+    input.activeLiveState = "active";
+    rendered.rerender();
+
     input.activePendingActivation = {
       agentSessionId: "session-1",
       agentTargetId: "local:claude-code",
@@ -217,12 +225,27 @@ describe("useAgentGUISessionPresentation", () => {
     input.activePendingActivation = null;
     input.activeEngineLatestTurn = null;
     input.activeEngineRuntimeActivity = "running";
-    input.activityDisplayStatus = "working";
+    input.activityDisplayStatus = "idle";
     rendered.rerender();
     expect(rendered.result.current.activeConversationBusy).toBe(true);
 
     input.activeEngineRuntimeActivity = "idle";
     input.activityDisplayStatus = "idle";
+    rendered.rerender();
+    expect(rendered.result.current.activeConversationBusy).toBe(false);
+
+    input.activeEngineActiveTurn = {
+      agentSessionId: "session-1",
+      origin: "user_prompt",
+      phase: "running",
+      startedAtUnixMs: 5,
+      turnId: "turn-2",
+      updatedAtUnixMs: 5
+    };
+    rendered.rerender();
+    expect(rendered.result.current.activeConversationBusy).toBe(true);
+
+    input.activeEngineActiveTurn = null;
     rendered.rerender();
     expect(rendered.result.current.activeConversationBusy).toBe(false);
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts
@@ -134,6 +134,7 @@ interface UseAgentGUISessionPresentationInput {
   activeEngineActiveTurn: AgentActivityTurn | null;
   activeEngineAvailability: "available" | "blocked" | "missing";
   activeEngineHasPendingInteractions: boolean;
+  activeHasPendingSubmitStopTarget: boolean;
   activeEngineLatestTurn: AgentActivityTurn | null;
   activeEngineRuntimeAvailability: SessionRuntimeAvailability | null;
   activeEngineRuntimeActivity: "idle" | "running";
@@ -290,7 +291,7 @@ export function useAgentGUISessionPresentation(
     }) &&
     !input.activeEngineLatestTurn
   );
-  const activeHasPendingSubmittedTurn = Boolean(
+  const hasPendingTurnStartEvidence = Boolean(
     input.activeConversationId &&
     (activeActivationAwaitsInitialTurn ||
       activeInitialGoalSetHasPendingOperation ||
@@ -319,19 +320,17 @@ export function useAgentGUISessionPresentation(
     input.activityDisplayStatus === "canceled";
   const executing =
     !hasCanonicalTerminalActivity &&
-    (input.activeEngineRuntimeActivity === "running" ||
+    (agentActivityDisplayStatusBusy(input.activityDisplayStatus) ||
       (input.activeEngineActiveTurn !== null &&
-        input.activeEngineActiveTurn.phase !== "settled"));
+        input.activeEngineActiveTurn.phase !== "settled") ||
+      (!input.activeEngineSession &&
+        input.activeEngineRuntimeActivity === "running"));
+  const isAwaitingTurnStart = hasPendingTurnStartEvidence && !executing;
   const activeConversationBusy =
-    input.activeLiveState === "activating" ||
-    activeHasPendingSubmittedTurn ||
-    executing ||
-    (input.activeEngineSession
-      ? agentActivityDisplayStatusBusy(input.activityDisplayStatus) ||
-        input.activeEngineAvailability === "blocked"
-      : agentActivityDisplayStatusBusy(input.activityDisplayStatus) ||
-        conversationBusyStatus(input.activeConversation?.status ?? null) ||
-        activeSubmitBlocked);
+    !hasCanonicalTerminalActivity &&
+    (executing ||
+      (!input.activeEngineSession &&
+        conversationBusyStatus(input.activeConversation?.status ?? null)));
   const activeSessionResumable =
     input.activeEngineSession?.resumable ??
     input.activeConversation?.resumable ??
@@ -572,6 +571,7 @@ export function useAgentGUISessionPresentation(
         isCollaboratorConversation,
         isCreatingConversation: input.isCreatingConversation,
         isInterrupting: input.isInterrupting,
+        isAwaitingTurnStart,
         isSubmitting: input.isSubmitting,
         pendingApproval: hasPendingApproval,
         pendingInteractivePrompt: hasPendingInteractivePrompt,
@@ -600,6 +600,7 @@ export function useAgentGUISessionPresentation(
       input.providerReadinessGate,
       input.selectedAgentTargetUnavailable,
       isCollaboratorConversation,
+      isAwaitingTurnStart,
       hasPendingApproval,
       sessionRuntimeBlockedReason,
       settingsUpdatePending,
@@ -638,7 +639,7 @@ export function useAgentGUISessionPresentation(
       input.activeEngineAvailability,
       input.activeEngineRuntimeActivity,
       activeConversationBusy ? "busy" : "ready",
-      activeHasPendingSubmittedTurn ? "pending-turn" : "no-pending-turn",
+      isAwaitingTurnStart ? "awaiting-turn-start" : "turn-start-observed",
       activeSubmitBlocked ? "submit-blocked" : "submit-open",
       pendingApproval?.requestId ?? "",
       promptRequestId(pendingInteractivePrompt) ?? "",
@@ -671,7 +672,7 @@ export function useAgentGUISessionPresentation(
       activeEngineAvailability: input.activeEngineAvailability,
       activeEngineLatestTurn: input.activeEngineLatestTurn,
       activeEngineRuntimeActivity: input.activeEngineRuntimeActivity,
-      activeHasPendingSubmittedTurn,
+      isAwaitingTurnStart,
       activeLiveState: input.activeLiveState,
       activeRuntimeSession: input.activeEngineSession,
       activeSessionState: input.activeSessionState,
@@ -689,7 +690,7 @@ export function useAgentGUISessionPresentation(
     });
   }, [
     activeConversationBusy,
-    activeHasPendingSubmittedTurn,
+    isAwaitingTurnStart,
     activeSubmitBlocked,
     canQueueWhileBusy,
     canSubmit,
@@ -720,12 +721,14 @@ export function useAgentGUISessionPresentation(
       : null,
     activeConversationBusy,
     composerGate,
+    hasPendingSubmitStopTarget: input.activeHasPendingSubmitStopTarget,
     hasSentUserMessage,
     interactivePromptDisabledReason: interactiveReadiness.block
       ? interactionReadinessReasonMessage(interactiveReadiness.block.reason)
       : null,
     isRespondingApproval,
     isRespondingInteractivePrompt,
+    isAwaitingTurnStart,
     pendingApproval,
     pendingInteractivePrompt,
     sessionChrome

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts
@@ -313,13 +313,23 @@ export function useAgentGUISessionPresentation(
     input.activeEngineActiveTurn?.turnId,
     input.observationGapSource
   );
+  const hasCanonicalTerminalActivity =
+    input.activityDisplayStatus === "completed" ||
+    input.activityDisplayStatus === "failed" ||
+    input.activityDisplayStatus === "canceled";
+  const executing =
+    !hasCanonicalTerminalActivity &&
+    (input.activeEngineRuntimeActivity === "running" ||
+      (input.activeEngineActiveTurn !== null &&
+        input.activeEngineActiveTurn.phase !== "settled"));
   const activeConversationBusy =
+    input.activeLiveState === "activating" ||
     activeHasPendingSubmittedTurn ||
+    executing ||
     (input.activeEngineSession
       ? agentActivityDisplayStatusBusy(input.activityDisplayStatus) ||
         input.activeEngineAvailability === "blocked"
-      : input.activeEngineRuntimeActivity === "running" ||
-        agentActivityDisplayStatusBusy(input.activityDisplayStatus) ||
+      : agentActivityDisplayStatusBusy(input.activityDisplayStatus) ||
         conversationBusyStatus(input.activeConversation?.status ?? null) ||
         activeSubmitBlocked);
   const activeSessionResumable =

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIViewAssembly.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIViewAssembly.ts
@@ -279,6 +279,7 @@ export function useAgentGUIViewAssembly(input: UseAgentGUIViewAssemblyInput) {
       isSubmitting: input.isSubmitting,
       isInterrupting: detail.isInterrupting,
       isCancelPending: detail.isCancelPending,
+      hasPendingSubmitStopTarget: session.hasPendingSubmitStopTarget,
       promptImagesSupported: input.promptImagesSupported,
       compactSupported: input.compactSupported,
       goalPauseSupported: input.goalPauseSupported,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/AgentGUINodeViewModel.fixture.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/AgentGUINodeViewModel.fixture.ts
@@ -66,6 +66,7 @@ export function groupAgentGUINodeViewModelFixture(
       isSubmitting: flat.isSubmitting,
       isInterrupting: flat.isInterrupting,
       isCancelPending: flat.isCancelPending,
+      hasPendingSubmitStopTarget: flat.hasPendingSubmitStopTarget,
       promptImagesSupported: flat.promptImagesSupported,
       compactSupported: flat.compactSupported,
       goalPauseSupported: flat.goalPauseSupported,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/AgentGUINodeViewModel.renderBudget.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/AgentGUINodeViewModel.renderBudget.spec.tsx
@@ -21,6 +21,7 @@ describe("useAgentGUIViewModel render budgets", () => {
     const initial = createViewModel();
     const connectingGate: AgentGUINodeViewModel["composer"]["gate"] = {
       conversationBusy: false,
+      isAwaitingTurnStart: false,
       runtime: {
         status: "blocked",
         reason: "target_connection",
@@ -31,6 +32,7 @@ describe("useAgentGUIViewModel render budgets", () => {
     };
     const readyGate: AgentGUINodeViewModel["composer"]["gate"] = {
       conversationBusy: false,
+      isAwaitingTurnStart: false,
       runtime: {
         status: "ready",
         reason: null,
@@ -160,11 +162,13 @@ function createViewModel(): AgentGUINodeViewModel {
       isSubmitting: false,
       isInterrupting: false,
       isCancelPending: false,
+      hasPendingSubmitStopTarget: false,
       promptImagesSupported: false,
       compactSupported: false,
       goalPauseSupported: false,
       gate: {
         conversationBusy: false,
+        isAwaitingTurnStart: false,
         runtime: {
           status: "ready",
           reason: null,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiComposerGate.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiComposerGate.spec.ts
@@ -17,6 +17,7 @@ const readyInput: ResolveAgentGUIComposerGateInput = {
   isCollaboratorConversation: false,
   isCreatingConversation: false,
   isInterrupting: false,
+  isAwaitingTurnStart: false,
   isSubmitting: false,
   pendingApproval: false,
   pendingInteractivePrompt: false,
@@ -35,6 +36,7 @@ describe("resolveAgentGUIComposerGate", () => {
     });
     expect(connecting).toEqual({
       conversationBusy: false,
+      isAwaitingTurnStart: false,
       runtime: {
         status: "blocked",
         reason: "target_connection",
@@ -47,6 +49,7 @@ describe("resolveAgentGUIComposerGate", () => {
     const ready = resolveAgentGUIComposerGate(readyInput);
     expect(ready).toEqual({
       conversationBusy: false,
+      isAwaitingTurnStart: false,
       runtime: {
         status: "ready",
         reason: null,
@@ -127,17 +130,19 @@ describe("resolveAgentGUIComposerGate", () => {
     });
   });
 
-  it("keeps submitting in the same busy/queue gate snapshot", () => {
+  it("blocks a prompt awaiting Turn start without exposing queue semantics", () => {
     expect(
       resolveAgentGUIComposerGate({
         ...readyInput,
+        isAwaitingTurnStart: true,
         isSubmitting: true
       })
     ).toMatchObject({
-      conversationBusy: true,
+      conversationBusy: false,
+      isAwaitingTurnStart: true,
       runtime: { status: "ready" },
-      editor: { status: "editable", reason: null },
-      submission: { status: "queue", reason: "conversation_busy" }
+      editor: { status: "blocked", reason: "submitting" },
+      submission: { status: "blocked", reason: "submitting" }
     });
   });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiComposerGate.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiComposerGate.ts
@@ -18,6 +18,7 @@ export interface ResolveAgentGUIComposerGateInput {
   isCollaboratorConversation: boolean;
   isCreatingConversation: boolean;
   isInterrupting: boolean;
+  isAwaitingTurnStart: boolean;
   isSubmitting: boolean;
   pendingApproval: boolean;
   pendingInteractivePrompt: boolean;
@@ -36,7 +37,7 @@ export interface ResolveAgentGUIComposerGateInput {
 export function resolveAgentGUIComposerGate(
   input: ResolveAgentGUIComposerGateInput
 ): AgentGUIComposerGate {
-  const conversationBusy = input.activeConversationBusy || input.isSubmitting;
+  const conversationBusy = input.activeConversationBusy;
   const sharingRevoked =
     input.sessionRuntimeBlockedReason === "agent_sharing_revoked";
   const runtime: AgentGUIComposerGate["runtime"] = sharingRevoked
@@ -78,6 +79,7 @@ export function resolveAgentGUIComposerGate(
     !input.pendingInteractivePrompt &&
     !input.authBlocked &&
     !input.settingsUpdatePending &&
+    !input.isAwaitingTurnStart &&
     !conversationBusy &&
     !input.isCreatingConversation &&
     !input.isInterrupting;
@@ -116,6 +118,7 @@ export function resolveAgentGUIComposerGate(
 
   return {
     conversationBusy,
+    isAwaitingTurnStart: input.isAwaitingTurnStart,
     runtime,
     editor,
     submission
@@ -177,6 +180,7 @@ function resolveSubmissionBlockReason(
   if (input.pendingInteractivePrompt) return "pending_interactive_prompt";
   if (input.authBlocked) return "authentication_required";
   if (input.settingsUpdatePending) return "settings_update_pending";
+  if (input.isAwaitingTurnStart) return "submitting";
   if (input.activeConversationBusy) return "conversation_busy";
   if (input.isCreatingConversation) return "creating_conversation";
   if (input.isSubmitting) return "submitting";

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
@@ -452,6 +452,8 @@ export type AgentGUIComposerSubmissionBlockedReason =
 export interface AgentGUIComposerGate {
   /** Canonical busy projection captured with the same gate snapshot. */
   conversationBusy: boolean;
+  /** A submitted prompt is waiting for its canonical Turn to appear. */
+  isAwaitingTurnStart?: boolean;
   /**
    * Runtime-dependent command availability used by Composer-adjacent
    * controls such as Stop and interactive responses.
@@ -491,6 +493,8 @@ export interface AgentGUIComposerViewModel {
   isSubmitting: boolean;
   isInterrupting: boolean;
   isCancelPending: boolean;
+  /** The Engine can stop a pending prompt before its Turn is visible. */
+  hasPendingSubmitStopTarget?: boolean;
   promptImagesSupported: boolean;
   compactSupported: boolean | null;
   /** Provider goal exposes a real paused state and pause/resume controls. */

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/useAgentGUIViewModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/useAgentGUIViewModel.ts
@@ -58,6 +58,7 @@ export function useAgentGUIViewModel(
       candidate.composer.drainingQueuedPromptId,
       candidate.composer.goalPauseSupported,
       candidate.composer.gate,
+      candidate.composer.hasPendingSubmitStopTarget,
       candidate.composer.handoffAgentTargets,
       candidate.composer.isCancelPending,
       candidate.composer.isCreatingConversation,

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.spec.ts
@@ -54,6 +54,7 @@ describe("shouldShowAgentGUIStopButton", () => {
     isCancelPending: false,
     isConversationBusy: false,
     isCreatingConversation: false,
+    hasPendingSubmitStopTarget: false,
     isInterrupting: false,
     isSubmitting: false,
     isUnavailable: false
@@ -73,6 +74,16 @@ describe("shouldShowAgentGUIStopButton", () => {
     expect(shouldShowAgentGUIStopButton({ ...idle, isSubmitting: true })).toBe(
       false
     );
+  });
+
+  it("shows Stop when Activity Core has an exact pending-submit target", () => {
+    expect(
+      shouldShowAgentGUIStopButton({
+        ...idle,
+        hasPendingSubmitStopTarget: true,
+        isSubmitting: true
+      })
+    ).toBe(true);
   });
 
   it("keeps authentication and availability gates authoritative", () => {
@@ -251,6 +262,7 @@ describe("Home status presentation", () => {
         isCancelPending: false,
         isConversationBusy: true,
         isCreatingConversation: false,
+        hasPendingSubmitStopTarget: false,
         isInterrupting: false,
         isSubmitting: false,
         isUnavailable: false

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.ts
@@ -228,12 +228,14 @@ export function shouldShowAgentGUIStopButton(input: {
   isCancelPending: boolean;
   isConversationBusy: boolean;
   isCreatingConversation: boolean;
+  hasPendingSubmitStopTarget: boolean;
   isInterrupting: boolean;
   isSubmitting: boolean;
   isUnavailable: boolean;
 }): boolean {
   if (input.isUnavailable || input.isAuthBlocked) return false;
   if (input.isCreatingConversation || input.isCancelPending) return true;
+  if (input.hasPendingSubmitStopTarget) return true;
   return (
     !input.isSubmitting &&
     (input.isConversationBusy ||
@@ -289,6 +291,7 @@ export function resolveAgentGUIStopControl(input: {
   isCancelPending: boolean;
   isConversationBusy: boolean;
   isCreatingConversation: boolean;
+  hasPendingSubmitStopTarget: boolean;
   isInterrupting: boolean;
   isSubmitting: boolean;
   isUnavailable: boolean;

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailModel.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailModel.tsx
@@ -221,6 +221,7 @@ export function useAgentGUIDetailModel(input: Input) {
   const activeConversationTurnBusy = viewModel.composer.gate.conversationBusy;
   const isComposerSending =
     activeConversationTurnBusy ||
+    viewModel.composer.gate.isAwaitingTurnStart === true ||
     (!hasActiveConversation &&
       viewModel.composer.gate.submission.status === "blocked" &&
       viewModel.composer.gate.submission.reason === "creating_conversation");
@@ -238,6 +239,8 @@ export function useAgentGUIDetailModel(input: Input) {
     isCancelPending: viewModel.composer.isCancelPending,
     isConversationBusy: activeConversationTurnBusy,
     isCreatingConversation: viewModel.composer.isCreatingConversation,
+    hasPendingSubmitStopTarget:
+      viewModel.composer.hasPendingSubmitStopTarget === true,
     isInterrupting: viewModel.composer.isInterrupting,
     isSubmitting: viewModel.composer.isSubmitting,
     isUnavailable: viewModel.readiness.activeLiveState === "failed"

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList.spec.tsx
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList.spec.tsx
@@ -449,6 +449,7 @@ describe("useAgentGuiConversationList", () => {
       expect.objectContaining({
         id: "session-1",
         provider: "codex",
+        status: "ready",
         title: "test1",
         titleFallback: null
       })
@@ -477,7 +478,7 @@ describe("useAgentGuiConversationList", () => {
     expect(result.current?.conversations).toEqual([
       expect.objectContaining({
         id: "session-1",
-        status: "working",
+        status: "ready",
         title: "test1",
         titleFallback: null
       })
@@ -519,7 +520,7 @@ describe("useAgentGuiConversationList", () => {
     expect(result.current?.conversations).toEqual([
       expect.objectContaining({
         id: "session-1",
-        status: "working",
+        status: "ready",
         title: "Pending task"
       })
     ]);
@@ -546,7 +547,46 @@ describe("useAgentGuiConversationList", () => {
       });
     });
     expect(result.current?.conversations).toEqual([
-      expect.objectContaining({ id: "session-1", title: "Durable task" })
+      expect.objectContaining({
+        id: "session-1",
+        status: "ready",
+        title: "Durable task"
+      })
+    ]);
+
+    act(() => {
+      engine.dispatch({
+        type: "session/snapshotReceived",
+        sessions: [
+          {
+            activeTurn: {
+              agentSessionId: "session-1",
+              origin: "user_prompt",
+              phase: "running",
+              startedAtUnixMs: 3,
+              turnId: "turn-1",
+              updatedAtUnixMs: 3
+            },
+            activeTurnId: "turn-1",
+            agentSessionId: "session-1",
+            createdAtUnixMs: 2,
+            cwd: "/workspace",
+            latestTurnInteractions: [],
+            pendingInteractions: [],
+            provider: "codex",
+            title: "Durable task",
+            updatedAtUnixMs: 3,
+            workspaceId: "workspace-1"
+          }
+        ]
+      });
+    });
+    expect(result.current?.conversations).toEqual([
+      expect.objectContaining({
+        id: "session-1",
+        status: "working",
+        title: "Durable task"
+      })
     ]);
   });
 

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList.ts
@@ -134,7 +134,7 @@ export function useAgentGuiConversationList(
           id: activation.agentSessionId,
           provider,
           sortTimeUnixMs: activation.requestedAtUnixMs,
-          status: "working",
+          status: "ready",
           projectionSource: "pending_activation",
           railSectionKey: activation.railSectionKey,
           title,


### PR DESCRIPTION
## Summary
- Separate Turn admission feedback from canonical execution: pending submit/initial launch shows immediate Composer progress without inventing Conversation `working` or queue semantics.
- Let fenced Engine display status and exact active Turn state own execution busy, including terminal/idle recovery for hidden active conversations.
- Reuse Activity Core's exact pending-submit stop correlation so Stop is available before Turn identity without adding resend/retry state.
- Keep the added ViewModel facts optional for external fixture compatibility; `AgentGUIProps`, Host API, runtime DTOs, and event protocols are unchanged.

## Validation
- `make dev-gui`: Tutti Dev launched from this worktree; Rail, detail, and Composer rendered successfully.
- Real UI smoke: sent `只回复 STATE_LAYERING_SMOKE_OK`; Stop appeared immediately, Composer became editable during canonical execution, and completion cleared Stop with the expected response.
- `pnpm check:changed -- --push-ready` (14 lanes passed; also rerun by the push hook).
- Activity Core: 471 tests passed during focused iteration.
- AgentGUI focused state tests: 49 tests passed.

## Consumer assessment
- Tutti Desktop consumes the unchanged AgentGUI host contract.
- TSH requires no source adaptation; it only needs the normal coordinated Tutti dependency upgrade after release.
