### PR TITLE
fix(desktop-update): retry admission after network recovery

### DIFF
--- a/packages/desktop/update-admission/README.md
+++ b/packages/desktop/update-admission/README.md
@@ -35,7 +35,10 @@ The product daemon exposes:
 
 The daemon owns the 3-second startup timeout, 10-second foreground timeout,
 30-minute foreground interval, request single-flight, and fail-open result.
-Electron owns only lifecycle signals and presentation.
+Resolved policy checks and invalid responses enter the foreground throttle
+window. Failed-open transport and timeout checks remain immediately eligible so
+a restored network can recover admission. Electron owns lifecycle signals,
+foreground recovery retries, and presentation.
 
 ## Development scenarios
 

--- a/packages/desktop/update-admission/daemon/service.go
+++ b/packages/desktop/update-admission/daemon/service.go
@@ -190,7 +190,9 @@ func (service *Service) Close() {
 
 func (service *Service) refresh(ctx context.Context, trigger string) (RefreshResult, error) {
 	service.mu.Lock()
-	if trigger == string(RefreshTriggerForeground) && service.snapshot.LastAttemptAt != nil {
+	if trigger == string(RefreshTriggerForeground) &&
+		policyUsesForegroundThrottle(service.snapshot.Policy) &&
+		service.snapshot.LastAttemptAt != nil {
 		next := service.snapshot.LastAttemptAt.Add(service.config.ForegroundInterval)
 		if service.config.Now().Before(next) {
 			snapshot := cloneSnapshot(service.snapshot)
@@ -238,9 +240,8 @@ func (service *Service) refresh(ctx context.Context, trigger string) (RefreshRes
 
 	service.mu.Lock()
 	service.snapshot.LastAttemptAt = pointerTime(completedAt)
-	nextForeground := completedAt.Add(service.config.ForegroundInterval)
-	service.snapshot.NextForegroundCheckAt = pointerTime(nextForeground)
 	if err != nil {
+		service.snapshot.NextForegroundCheckAt = nil
 		failureKind := "transport"
 		if errors.Is(err, context.DeadlineExceeded) || errors.Is(checkCtx.Err(), context.DeadlineExceeded) {
 			failureKind = "timeout"
@@ -262,6 +263,8 @@ func (service *Service) refresh(ctx context.Context, trigger string) (RefreshRes
 
 	parsed, parseErr := ParseRemoteResponse(raw)
 	if parseErr != nil {
+		nextForeground := completedAt.Add(service.config.ForegroundInterval)
+		service.snapshot.NextForegroundCheckAt = pointerTime(nextForeground)
 		service.snapshot.Policy = PolicySnapshot{
 			Status:  "failedOpen",
 			Failure: &PolicyFailure{Kind: "invalidResponse"},
@@ -278,6 +281,8 @@ func (service *Service) refresh(ctx context.Context, trigger string) (RefreshRes
 	}
 
 	policy := parsed.Policy
+	nextForeground := completedAt.Add(service.config.ForegroundInterval)
+	service.snapshot.NextForegroundCheckAt = pointerTime(nextForeground)
 	service.snapshot.Policy = PolicySnapshot{
 		Status:   "resolved",
 		Response: &policy,
@@ -324,6 +329,13 @@ func (service *Service) refresh(ctx context.Context, trigger string) (RefreshRes
 		"stage":          trigger,
 	})
 	return RefreshResult{Performed: true, Snapshot: snapshot}, nil
+}
+
+func policyUsesForegroundThrottle(policy PolicySnapshot) bool {
+	return policy.Status == "resolved" ||
+		(policy.Status == "failedOpen" &&
+			policy.Failure != nil &&
+			policy.Failure.Kind == "invalidResponse")
 }
 
 func (service *Service) markInitialDone() {

--- a/packages/desktop/update-admission/daemon/service_test.go
+++ b/packages/desktop/update-admission/daemon/service_test.go
@@ -229,6 +229,97 @@ func TestForegroundRefreshIsThrottledAndRetryBypassesThrottle(t *testing.T) {
 	}
 }
 
+func TestFailedOpenDoesNotThrottleForegroundRecovery(t *testing.T) {
+	var mu sync.Mutex
+	calls := 0
+	now := time.Date(2026, 8, 13, 1, 0, 0, 0, time.UTC)
+	service, err := New(Config{
+		Identity:           testIdentity(),
+		ChecksEnabled:      true,
+		ForegroundInterval: 30 * time.Minute,
+		Now:                func() time.Time { return now },
+		Checker: checkerFunc(func(context.Context, Identity) ([]byte, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			calls++
+			if calls == 1 {
+				return nil, errors.New("network unavailable after system resume")
+			}
+			return []byte(`{"channel":"stable","minimumVersion":"1.1.0","decision":"upgradeRequired","reason":"belowMinimum","policyRevision":"v2"}`), nil
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	service.Start(context.Background())
+	initial, err := service.WaitInitial(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if initial.Policy.Status != "failedOpen" || initial.NextForegroundCheckAt != nil {
+		t.Fatalf("initial snapshot = %#v", initial)
+	}
+
+	foreground, err := service.Refresh(context.Background(), RefreshTriggerForeground)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !foreground.Performed || foreground.SkipReason != "" {
+		t.Fatalf("foreground = %#v", foreground)
+	}
+	if foreground.Snapshot.Policy.Status != "resolved" ||
+		foreground.Snapshot.Policy.Response == nil ||
+		foreground.Snapshot.Policy.Response.Decision != "upgradeRequired" ||
+		foreground.Snapshot.NextForegroundCheckAt == nil {
+		t.Fatalf("recovered snapshot = %#v", foreground.Snapshot)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 2 {
+		t.Fatalf("calls = %d, want startup failure plus foreground recovery", calls)
+	}
+}
+
+func TestInvalidResponseRetainsForegroundThrottle(t *testing.T) {
+	calls := 0
+	now := time.Date(2026, 8, 13, 1, 0, 0, 0, time.UTC)
+	service, err := New(Config{
+		Identity:           testIdentity(),
+		ChecksEnabled:      true,
+		ForegroundInterval: 30 * time.Minute,
+		Now:                func() time.Time { return now },
+		Checker: checkerFunc(func(context.Context, Identity) ([]byte, error) {
+			calls++
+			return []byte(`{"decision":"unexpected"}`), nil
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	service.Start(context.Background())
+	initial, err := service.WaitInitial(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if initial.Policy.Status != "failedOpen" ||
+		initial.Policy.Failure == nil ||
+		initial.Policy.Failure.Kind != "invalidResponse" ||
+		initial.NextForegroundCheckAt == nil {
+		t.Fatalf("initial snapshot = %#v", initial)
+	}
+
+	foreground, err := service.Refresh(context.Background(), RefreshTriggerForeground)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if foreground.Performed || foreground.SkipReason != "throttled" {
+		t.Fatalf("foreground = %#v", foreground)
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d, want one invalid request", calls)
+	}
+}
+
 func TestStartupTimeoutFailsOpenWithoutCachingPolicy(t *testing.T) {
 	service, err := New(Config{
 		Identity:       testIdentity(),

--- a/packages/desktop/update-admission/src/electron-main/createDesktopUpdateAdmissionController.test.ts
+++ b/packages/desktop/update-admission/src/electron-main/createDesktopUpdateAdmissionController.test.ts
@@ -65,6 +65,18 @@ function upgradeRequiredSnapshot(): DesktopUpdateAdmissionSnapshot<"tutti-deskto
   };
 }
 
+function failedOpenSnapshot(): DesktopUpdateAdmissionSnapshot<"tutti-desktop"> {
+  const snapshot = upgradeRequiredSnapshot();
+  return {
+    ...snapshot,
+    nextForegroundCheckAt: null,
+    policy: {
+      failure: { kind: "timeout" },
+      status: "failedOpen"
+    }
+  };
+}
+
 function updateService(): MinimumVersionAppUpdateService {
   return {
     async acquireMandatorySession() {
@@ -255,5 +267,96 @@ test("startup admission opens a modal upgrade window over the visible business w
   assert.equal(upgradeWindowCreated, true);
   assert.equal(upgradeWindowOptions[0]?.modal, true);
   assert.equal(upgradeWindowOptions[0]?.parent, businessWindow);
+  controller.dispose();
+});
+
+test("foreground admission retries a failed-open check after network recovery", async () => {
+  const app = new EventEmitter();
+  const failedSnapshot = failedOpenSnapshot();
+  const recoveredSnapshot = upgradeRequiredSnapshot();
+  const calls: string[] = [];
+  let resolveUpgradeWindowCreated: (() => void) | undefined;
+  const upgradeWindowCreated = new Promise<void>((resolve) => {
+    resolveUpgradeWindowCreated = resolve;
+  });
+  const businessWindow = {
+    isDestroyed: () => false,
+    isFocused: () => true,
+    isVisible: () => true
+  };
+  class UpgradeWindow {
+    public readonly webContents = {
+      id: 1,
+      send() {},
+      setWindowOpenHandler() {},
+      on() {}
+    };
+
+    public constructor() {
+      resolveUpgradeWindowCreated?.();
+    }
+
+    public destroy() {}
+    public focus() {}
+    public isDestroyed() {
+      return false;
+    }
+    public loadFile() {
+      return Promise.resolve();
+    }
+    public loadURL() {
+      return Promise.resolve();
+    }
+    public on() {}
+    public once() {}
+    public show() {}
+  }
+  const controller = createDesktopUpdateAdmissionController({
+    backend: {
+      async getStartupSnapshot() {
+        return failedSnapshot;
+      },
+      async refresh(trigger) {
+        calls.push(trigger);
+        return {
+          performed: true,
+          snapshot: calls.length === 1 ? failedSnapshot : recoveredSnapshot
+        };
+      }
+    },
+    electron: {
+      app: app as never,
+      BrowserWindow: UpgradeWindow as never,
+      ipcMain: {
+        handle() {},
+        removeHandler() {}
+      } as never,
+      shell: { openExternal: async () => undefined } as never
+    },
+    foregroundFailureRetryDelayMs: 1,
+    listBusinessWindows: () => [businessWindow as never],
+    logger: { error() {}, info() {} },
+    manualDownloadUrl: () => "https://tutti.sh/desktop/download",
+    onPolicyReleased() {},
+    preloadPath: "/preload.cjs",
+    product: "tutti-desktop",
+    rendererFilePath: "/minimum-version.html",
+    runtime: {
+      checksEnabled: true,
+      currentVersion: "0.9.0",
+      development: true
+    },
+    updateService: updateService()
+  });
+
+  await controller.checkAfterForegroundRestore();
+  await Promise.race([
+    upgradeWindowCreated,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("upgrade window was not created")), 500)
+    )
+  ]);
+
+  assert.deepEqual(calls, ["foreground", "retry"]);
   controller.dispose();
 });

--- a/packages/desktop/update-admission/src/electron-main/createDesktopUpdateAdmissionController.ts
+++ b/packages/desktop/update-admission/src/electron-main/createDesktopUpdateAdmissionController.ts
@@ -65,6 +65,12 @@ export interface DesktopUpdateAdmissionControllerOptions<
   ): string;
   listBusinessWindows(): ElectronBrowserWindow[];
   icon?: BrowserWindowConstructorOptions["icon"];
+  foregroundFailureRetryDelayMs?: number;
+}
+
+interface PolicyCheckOutcome<TProduct extends DesktopProduct> {
+  response: MinimumVersionCheckResult<TProduct> | null;
+  retryable: boolean;
 }
 
 function logMinimumVersionCheck(
@@ -88,12 +94,14 @@ export function createDesktopUpdateAdmissionController<
   let forcedFlowStarted = false;
   let installRequested = false;
   let disposed = false;
-  let activeCheck: Promise<MinimumVersionCheckResult<TProduct> | null> | null =
-    null;
+  let activeCheck: Promise<PolicyCheckOutcome<TProduct>> | null = null;
   let activeForcedFlow: Promise<void> | null = null;
+  let foregroundRetryTimer: ReturnType<typeof setTimeout> | null = null;
   let appQuitStarted = false;
   let mandatoryUpdateSession: MandatoryDesktopUpdateSession | null = null;
   const lifecycleAbort = new AbortController();
+  const foregroundFailureRetryDelayMs =
+    options.foregroundFailureRetryDelayMs ?? 5_000;
 
   const handleBeforeQuit = (): void => {
     appQuitStarted = true;
@@ -209,7 +217,7 @@ export function createDesktopUpdateAdmissionController<
 
   const runPolicyCheck = async (
     stage: "startup" | "foreground" | "retry"
-  ): Promise<MinimumVersionCheckResult<TProduct> | null> => {
+  ): Promise<PolicyCheckOutcome<TProduct>> => {
     const request = requestPayload();
     if (!request) {
       logMinimumVersionCheck(options.logger, "info", {
@@ -220,7 +228,7 @@ export function createDesktopUpdateAdmissionController<
         result: "success",
         stage
       });
-      return null;
+      return { response: null, retryable: false };
     }
     const controller = new AbortController();
     const abortForLifecycle = (): void => controller.abort();
@@ -271,7 +279,12 @@ export function createDesktopUpdateAdmissionController<
             status: snapshot.policy.status
           }
         );
-        return null;
+        return {
+          response: null,
+          retryable:
+            snapshot.policy.status === "failedOpen" &&
+            snapshot.policy.failure.kind !== "invalidResponse"
+        };
       }
       const validated = validateMinimumVersionResponse(
         snapshot.policy.response,
@@ -286,14 +299,14 @@ export function createDesktopUpdateAdmissionController<
         result: "success",
         stage
       });
-      return validated;
+      return { response: validated, retryable: false };
     } catch (error) {
       logMinimumVersionCheck(options.logger, "error", {
         error: error instanceof Error ? error.message : String(error),
         result: "failure",
         stage
       });
-      return null;
+      return { response: null, retryable: true };
     } finally {
       lifecycleAbort.signal.removeEventListener("abort", abortForLifecycle);
     }
@@ -301,7 +314,7 @@ export function createDesktopUpdateAdmissionController<
 
   const checkPolicy = async (
     stage: "startup" | "foreground" | "retry"
-  ): Promise<MinimumVersionCheckResult<TProduct> | null> => {
+  ): Promise<PolicyCheckOutcome<TProduct>> => {
     if (activeCheck) {
       return activeCheck;
     }
@@ -484,7 +497,7 @@ export function createDesktopUpdateAdmissionController<
   ipcMain.handle(desktopUpdateAdmissionIpcChannels.retry, async (event) => {
     assertUpgradeWindowSender(event.sender.id);
     await activeForcedFlow;
-    const response = await checkPolicy("retry");
+    const { response } = await checkPolicy("retry");
     if (!response) {
       applyState(
         "error",
@@ -530,12 +543,61 @@ export function createDesktopUpdateAdmissionController<
     app.quit();
   });
 
+  const checkAfterForegroundRestore = async (
+    stage: "foreground" | "retry"
+  ): Promise<void> => {
+    if (
+      !options.runtime.checksEnabled ||
+      disposed ||
+      foregroundPrompted ||
+      (mode === "startup" &&
+        upgradeWindow !== null &&
+        !upgradeWindow.isDestroyed())
+    ) {
+      return;
+    }
+    const outcome = await checkPolicy(stage);
+    const response = outcome.response;
+    if (outcome.retryable && !foregroundRetryTimer) {
+      foregroundRetryTimer = setTimeout(() => {
+        foregroundRetryTimer = null;
+        if (
+          disposed ||
+          foregroundPrompted ||
+          !options
+            .listBusinessWindows()
+            .some(
+              (candidate) => !candidate.isDestroyed() && candidate.isFocused()
+            )
+        ) {
+          return;
+        }
+        void checkAfterForegroundRestore("retry");
+      }, foregroundFailureRetryDelayMs);
+    }
+    if (disposed || !response || response.decision !== "upgradeRequired") {
+      return;
+    }
+    if (foregroundRetryTimer) {
+      clearTimeout(foregroundRetryTimer);
+      foregroundRetryTimer = null;
+    }
+    foregroundPrompted = true;
+    state = {
+      check: response,
+      message: null,
+      phase: "blocked",
+      update: options.updateService.getState()
+    };
+    openUpgradeWindow("foreground");
+  };
+
   return {
     async runStartupCheck() {
       if (!options.runtime.checksEnabled) {
         return false;
       }
-      const response = await checkPolicy("startup");
+      const { response } = await checkPolicy("startup");
       if (!response || response.decision !== "upgradeRequired") {
         return false;
       }
@@ -549,31 +611,14 @@ export function createDesktopUpdateAdmissionController<
       return true;
     },
     async checkAfterForegroundRestore() {
-      if (
-        !options.runtime.checksEnabled ||
-        disposed ||
-        foregroundPrompted ||
-        (mode === "startup" &&
-          upgradeWindow !== null &&
-          !upgradeWindow.isDestroyed())
-      ) {
-        return;
-      }
-      const response = await checkPolicy("foreground");
-      if (disposed || !response || response.decision !== "upgradeRequired") {
-        return;
-      }
-      foregroundPrompted = true;
-      state = {
-        check: response,
-        message: null,
-        phase: "blocked",
-        update: options.updateService.getState()
-      };
-      openUpgradeWindow("foreground");
+      await checkAfterForegroundRestore("foreground");
     },
     dispose() {
       disposed = true;
+      if (foregroundRetryTimer) {
+        clearTimeout(foregroundRetryTimer);
+        foregroundRetryTimer = null;
+      }
       lifecycleAbort.abort();
       void releaseMandatoryUpdater(false);
       app.removeListener("before-quit", handleBeforeQuit);


### PR DESCRIPTION
## Summary

- keep transport and timeout failures immediately eligible for foreground admission checks instead of consuming the 30-minute resolved-policy throttle
- wait for foreground recovery through bounded retry attempts while the application remains focused
- preserve throttling for invalid responses to avoid request storms
- document and test the network-recovery behavior

## Verification

- `pnpm check:changed`
- `pnpm check:changed -- --push-ready`
- `pnpm release:pack:check -- --packages-json '["@tutti-os/desktop-update-admission"]'`
- linked the locally packed package into TSH and ran `pnpm --dir apps/tsh-desktop check`

## Fallback Three Questions

- Source: the operating system can focus the application before control-plane connectivity has recovered after sleep or a background transition.
- Why can it not be fixed at that source? The network monitor reports topology changes, not authenticated control-plane readiness. The admission request is the authoritative readiness probe, so transient failures must remain fail-open and retryable.
- Removal condition: the retry can be removed if the desktop lifecycle contract exposes a reliable authenticated control-plane-ready signal that gates foreground admission.

## Checklist

- [x] This change does not alter agent lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior changed.
- [x] No root README/CONTRIBUTING language variants were changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] The commit is signed off with DCO.
