### PR TITLE
fix(agent-gui): close full access warning before opening details

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { useState } from "react";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -253,7 +253,14 @@ describe("AgentPermissionModeDropdown", () => {
       type: "open-url",
       url: "https://deploymentsafety.openai.com/gpt-5-6"
     });
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Enable full access?" })
+      ).not.toBeInTheDocument();
+    });
+    expect(onSettingsChange).not.toHaveBeenCalled();
 
+    await selectPermissionOption("Full access");
     fireEvent.click(screen.getByRole("button", { name: "Enable full access" }));
 
     expect(onSettingsChange).toHaveBeenCalledTimes(1);

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFullAccessWarningDialog.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFullAccessWarningDialog.tsx
@@ -71,6 +71,7 @@ export function AgentFullAccessWarningDialog({
           rel="noreferrer"
           target="_blank"
           onClick={(event) => {
+            onOpenChange(false);
             if (!onLinkAction) {
               return;
             }


### PR DESCRIPTION
## Summary

- close the full-access warning dialog before dispatching the Learn more link action
- keep the permission setting unchanged when Learn more is selected
- cover dialog dismissal and the existing confirmation flow with a focused test

## Root cause

The Learn more handler dispatched the host `open-url` action without closing the controlled confirmation dialog. Hosts such as TSH correctly focused the Browser surface, but the still-open modal remained above it and made the Browser appear not to be topmost.

## User impact

Selecting Learn more now dismisses the warning first, then opens the safety details. The Browser can therefore become the visible top surface as intended.

## Validation

- `corepack pnpm@10.11.0 check:changed` — 11 lanes passed
- pre-push `pnpm check:changed -- --push-ready` — 12 lanes passed
- focused AgentGUI test covers link dispatch, dialog dismissal, unchanged permission state, and subsequent confirmation
- TSH consumer validation: locally linked `@tutti-os/agent-gui` and its 16-package closure, verified the package export, passed Desktop type/boundary checks, and passed the Browser focus test (2/2)

## AgentGUI review

| Lane | Trigger | Result | Evidence | Affected consumers |
| --- | --- | --- | --- | --- |
| Architecture | Composer confirmation interaction changed | pass | Dialog state remains owned by the existing `onOpenChange` callback; the host `open-url` action path and permission-state owner are unchanged | Desktop and external AgentGUI hosts |
| Performance | No hot path, subscription, projection, timer, or layout code changed | not applicable | One additional state callback in a user click handler | Full-access warning dialog |
| Consumers | Host-visible interaction ordering changed | pass | No export or input shape changed; focused test verifies dismissal and link action, and TSH local-link validation verifies the consuming package and Browser-focus path | Desktop, TSH, and other AgentGUI hosts |

## Platform and documentation impact

The change is platform-neutral React interaction code and introduces no filesystem, process, path, packaging, or native behavior. No durable documentation update is needed because ownership, data flow, public contracts, and supported configuration remain unchanged.

## Unresolved risks

None identified.