### PR TITLE
fix(agent-gui): dismiss mention palette when inactive

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -340,10 +340,11 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     promptBeforeSelection
   } = paletteCatalog;
   const showFileMentionPalette =
-    !disabled && isPaletteOpen && fileMentionSuggestion !== null;
+    !disabled && isActive && isPaletteOpen && fileMentionSuggestion !== null;
   const showSlashPalette =
     !showFileMentionPalette &&
     !disabled &&
+    isActive &&
     isPaletteOpen &&
     ((slashQuery !== null &&
       (slashPaletteEntries.length > 0 ||
@@ -526,6 +527,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     isSendingTurn,
     isSubmittingPrompt,
     showStopButton,
+    isActive,
     onSettingsChange,
     handleSlashPaletteKeyDown,
     handleSlashCommandMenuKeyDown,

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerMentionActions.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerMentionActions.spec.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, fireEvent, renderHook } from "@testing-library/react";
 import type { Editor } from "@tiptap/core";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentRichTextEditorHandle } from "../agentRichText/AgentRichTextEditor";
@@ -59,6 +59,100 @@ describe("useComposerMentionActions directory navigation", () => {
 
     expect(updateQuery).not.toHaveBeenCalled();
     expect(selectFileMentionNavigationItem).not.toHaveBeenCalled();
+  });
+});
+
+describe("useComposerMentionActions palette dismissal", () => {
+  it("closes the mention palette when pointer or focus moves outside", () => {
+    const input = createInput({
+      replaceTextBeforeSelection: vi.fn(() => null),
+      selectFileMentionNavigationItem: vi.fn(() => false),
+      updateQuery: vi.fn()
+    });
+    const close = vi.fn();
+    const setIsPaletteOpen = vi.fn();
+    const composer = document.createElement("form");
+    const palette = document.createElement("div");
+    document.body.append(composer, palette);
+    input.fileMentionSuggestion = null;
+    input.showFileMentionPalette = true;
+    input.setIsPaletteOpen = setIsPaletteOpen;
+    input.mentionControllerRef.current = { close } as never;
+    input.composerRef.current = composer;
+    input.paletteContentRef.current = palette;
+
+    renderHook(() => useComposerMentionActions(input));
+
+    act(() => {
+      fireEvent.pointerDown(document.body);
+    });
+
+    expect(close).toHaveBeenCalledOnce();
+    expect(setIsPaletteOpen).toHaveBeenCalledWith(false);
+
+    act(() => {
+      fireEvent.focusIn(document.body);
+    });
+
+    expect(close).toHaveBeenCalledTimes(2);
+    expect(setIsPaletteOpen).toHaveBeenCalledTimes(2);
+    composer.remove();
+    palette.remove();
+  });
+
+  it("keeps the mention palette open when focus moves inside its portal", () => {
+    const input = createInput({
+      replaceTextBeforeSelection: vi.fn(() => null),
+      selectFileMentionNavigationItem: vi.fn(() => false),
+      updateQuery: vi.fn()
+    });
+    const close = vi.fn();
+    const setIsPaletteOpen = vi.fn();
+    const composer = document.createElement("form");
+    const palette = document.createElement("div");
+    const paletteButton = document.createElement("button");
+    palette.append(paletteButton);
+    document.body.append(composer, palette);
+    input.fileMentionSuggestion = null;
+    input.showFileMentionPalette = true;
+    input.setIsPaletteOpen = setIsPaletteOpen;
+    input.mentionControllerRef.current = { close } as never;
+    input.composerRef.current = composer;
+    input.paletteContentRef.current = palette;
+
+    renderHook(() => useComposerMentionActions(input));
+
+    act(() => {
+      fireEvent.focusIn(paletteButton);
+    });
+
+    expect(close).not.toHaveBeenCalled();
+    expect(setIsPaletteOpen).not.toHaveBeenCalled();
+    composer.remove();
+    palette.remove();
+  });
+
+  it("closes the mention palette when its host surface loses activity", () => {
+    const input = createInput({
+      replaceTextBeforeSelection: vi.fn(() => null),
+      selectFileMentionNavigationItem: vi.fn(() => false),
+      updateQuery: vi.fn()
+    });
+    const close = vi.fn();
+    const setIsPaletteOpen = vi.fn();
+    input.fileMentionSuggestion = null;
+    input.showFileMentionPalette = true;
+    input.setIsPaletteOpen = setIsPaletteOpen;
+    input.mentionControllerRef.current = { close } as never;
+    input.isActive = true;
+
+    const { rerender } = renderHook(() => useComposerMentionActions(input));
+
+    input.isActive = false;
+    rerender();
+
+    expect(close).toHaveBeenCalledOnce();
+    expect(setIsPaletteOpen).toHaveBeenCalledWith(false);
   });
 });
 
@@ -132,6 +226,7 @@ function createInput(mocks: {
     isSendingTurn: false,
     isSubmittingPrompt: false,
     showStopButton: false,
+    isActive: true,
     onSettingsChange: vi.fn(),
     handleSlashPaletteKeyDown: vi.fn(() => false),
     handleSlashCommandMenuKeyDown: vi.fn(() => false),

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerMentionActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerMentionActions.ts
@@ -62,6 +62,7 @@ interface Input {
   isSendingTurn: boolean;
   isSubmittingPrompt: boolean;
   showStopButton: boolean;
+  isActive: boolean;
   onSettingsChange: (settings: { planMode?: boolean }) => void;
   handleSlashPaletteKeyDown: (event: KeyboardEvent) => boolean;
   handleSlashCommandMenuKeyDown: (event: KeyboardEvent) => boolean;
@@ -106,6 +107,7 @@ export function useComposerMentionActions(input: Input) {
     isSendingTurn,
     isSubmittingPrompt,
     showStopButton,
+    isActive,
     onSettingsChange,
     handleSlashPaletteKeyDown,
     handleSlashCommandMenuKeyDown,
@@ -426,34 +428,77 @@ export function useComposerMentionActions(input: Input) {
   }, [shouldCenterMentionHighlight, showFileMentionPalette]);
 
   useEffect(() => {
+    if (!isActive) {
+      closeFileMentionPalette();
+      return;
+    }
     if (!showFileMentionPalette) {
       return;
     }
 
     const handlePointerDown = (event: PointerEvent): void => {
       const target = event.target;
-      if (!(target instanceof Element)) {
+      if (!(target instanceof Node)) {
         return;
       }
-      if (target.closest(MENTION_PALETTE_DISMISS_INTERACTION_SELECTOR)) {
+
+      const isInsideComposer = composerRef.current?.contains(target) ?? false;
+      const isInsidePalette =
+        paletteContentRef.current?.contains(target) ?? false;
+      if (
+        target instanceof Element &&
+        target.closest(MENTION_PALETTE_DISMISS_INTERACTION_SELECTOR)
+      ) {
+        closeOpenPalette();
+        return;
+      }
+      if (!isInsideComposer && !isInsidePalette) {
+        closeOpenPalette();
+      }
+    };
+    const handleFocusIn = (event: FocusEvent): void => {
+      const target = event.target;
+      if (!(target instanceof Node)) {
+        return;
+      }
+      const isInsideComposer = composerRef.current?.contains(target) ?? false;
+      const isInsidePalette =
+        paletteContentRef.current?.contains(target) ?? false;
+      if (!isInsideComposer && !isInsidePalette) {
         closeOpenPalette();
       }
     };
     const handleWindowResize = (): void => {
       closeOpenPalette();
     };
+    const handleWindowBlur = (): void => {
+      closeOpenPalette();
+    };
 
     document.addEventListener("pointerdown", handlePointerDown, {
       capture: true
     });
+    document.addEventListener("focusin", handleFocusIn, { capture: true });
     window.addEventListener("resize", handleWindowResize);
+    window.addEventListener("blur", handleWindowBlur);
     return () => {
       document.removeEventListener("pointerdown", handlePointerDown, {
         capture: true
       });
+      document.removeEventListener("focusin", handleFocusIn, {
+        capture: true
+      });
       window.removeEventListener("resize", handleWindowResize);
+      window.removeEventListener("blur", handleWindowBlur);
     };
-  }, [closeOpenPalette, showFileMentionPalette]);
+  }, [
+    closeFileMentionPalette,
+    closeOpenPalette,
+    composerRef,
+    paletteContentRef,
+    showFileMentionPalette,
+    isActive
+  ]);
 
   return {
     clearActiveFileMentionTrigger,


### PR DESCRIPTION
## Summary
- Close the @ mention palette when AgentGUI loses focus.
- Dismiss it on outside pointer/focus, resize, and window blur.
- Add regression coverage for portal focus and inactive surfaces.

## Tests
- `pnpm --filter @tutti-os/agent-gui exec vitest run agent-gui/agentGuiNode/composer/useComposerMentionActions.spec.tsx`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm check:agent-gui-degradation`

## Notes
- The PR is isolated from unrelated cloud/worktree changes remaining in the original worktree.