### PR TITLE
fix(agent): preserve POSIX rail paths on Windows

### DIFF
--- a/docs/architecture/windows-platform-support.md
+++ b/docs/architecture/windows-platform-support.md
@@ -100,8 +100,11 @@ Project paths have one display form and one comparison form; callers must not
 compare raw strings when the path crosses a desktop/daemon boundary. The shared
 user-project core normalizes slash direction and trailing separators, then
 folds case only for Windows-shaped drive or UNC paths. POSIX paths remain
-case-sensitive. The Go rail store keeps the existing canonical filesystem path
-for display and derives a Windows-stable section key for persistence. Project
+case-sensitive. On a Windows host, a single-root POSIX project path is an
+explicit logical namespace: the Go rail store cleans it with POSIX semantics
+and never rebases it onto the current drive. Native drive and UNC paths keep
+Windows filesystem normalization. The rail store keeps the resulting canonical
+path for display and derives a stable section key for persistence. Project
 registration and deletion resolve an incoming path variant to the existing
 stored row before applying the table's ordinary unique-path write guard, so no
 second identity column is needed.

--- a/packages/agent/store-sqlite/rail.go
+++ b/packages/agent/store-sqlite/rail.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	pathpkg "path"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -273,16 +274,24 @@ func normalizeRailProjectPaths(paths []string) []string {
 }
 
 // NormalizeProjectPath canonicalizes a project or session path the same way
-// rail classification does: absolute, symlink-resolved for existing
-// directories, and cleaned.
-func NormalizeProjectPath(path string) string {
-	path = strings.TrimSpace(path)
-	if path == "" {
+// rail classification does. Native host paths are made absolute,
+// symlink-resolved for existing directories, and cleaned. A POSIX-rooted
+// logical path stays in that namespace when the host is Windows.
+func NormalizeProjectPath(projectPath string) string {
+	return normalizeProjectPathForPlatform(projectPath, runtime.GOOS)
+}
+
+func normalizeProjectPathForPlatform(projectPath string, goos string) string {
+	projectPath = strings.TrimSpace(projectPath)
+	if projectPath == "" {
 		return ""
 	}
-	absolute, err := filepath.Abs(path)
+	if goos == "windows" && isPOSIXProjectPath(projectPath) {
+		return pathpkg.Clean(strings.ReplaceAll(projectPath, `\`, "/"))
+	}
+	absolute, err := filepath.Abs(projectPath)
 	if err != nil {
-		return filepath.Clean(path)
+		return filepath.Clean(projectPath)
 	}
 	if info, statErr := os.Stat(absolute); statErr == nil && info.IsDir() {
 		if evaluated, evalErr := filepath.EvalSymlinks(absolute); evalErr == nil {
@@ -299,15 +308,30 @@ func agentSessionRailPathContains(parent string, child string) bool {
 // IsProjectPathWithin reports whether child is the same as, or nested below,
 // parent using the current platform's filesystem identity rules.
 func IsProjectPathWithin(parent string, child string) bool {
-	parent = NormalizeProjectPath(parent)
-	child = NormalizeProjectPath(child)
+	return isProjectPathWithinForPlatform(parent, child, runtime.GOOS)
+}
+
+func isProjectPathWithinForPlatform(parent string, child string, goos string) bool {
+	parent = normalizeProjectPathForPlatform(parent, goos)
+	child = normalizeProjectPathForPlatform(child, goos)
 	if parent == "" || child == "" {
 		return false
 	}
-	if sameRailPath(parent, child) {
+	if sameRailPathForPlatform(parent, child, goos) {
 		return true
 	}
-	rel, err := filepath.Rel(railPathForComparison(parent), railPathForComparison(child))
+	parentIsPOSIX := isPOSIXProjectPath(parent)
+	childIsPOSIX := isPOSIXProjectPath(child)
+	if parentIsPOSIX != childIsPOSIX {
+		return false
+	}
+	comparisonParent := railPathForComparisonForPlatform(parent, goos)
+	comparisonChild := railPathForComparisonForPlatform(child, goos)
+	if goos == "windows" && parentIsPOSIX {
+		prefix := strings.TrimSuffix(comparisonParent, "/") + "/"
+		return strings.HasPrefix(comparisonChild, prefix)
+	}
+	rel, err := filepath.Rel(comparisonParent, comparisonChild)
 	if err != nil {
 		return false
 	}
@@ -407,22 +431,56 @@ func NormalizeRailSectionKey(sectionKey string) string {
 }
 
 func railIdentityPath(path string) string {
-	path = NormalizeProjectPath(path)
-	if runtime.GOOS == "windows" {
+	return railIdentityPathForPlatform(path, runtime.GOOS)
+}
+
+func railIdentityPathForPlatform(path string, goos string) string {
+	path = normalizeProjectPathForPlatform(path, goos)
+	if goos == "windows" && isWindowsProjectPath(path) {
 		return strings.ToLower(path)
 	}
 	return path
 }
 
 func railPathForComparison(path string) string {
-	if runtime.GOOS == "windows" {
+	return railPathForComparisonForPlatform(path, runtime.GOOS)
+}
+
+func railPathForComparisonForPlatform(path string, goos string) string {
+	if goos == "windows" && isWindowsProjectPath(path) {
 		return strings.ToLower(path)
 	}
 	return path
 }
 
 func sameRailPath(left string, right string) bool {
-	return railPathForComparison(left) == railPathForComparison(right)
+	return sameRailPathForPlatform(left, right, runtime.GOOS)
+}
+
+func sameRailPathForPlatform(left string, right string, goos string) bool {
+	return railPathForComparisonForPlatform(left, goos) == railPathForComparisonForPlatform(right, goos)
+}
+
+func isPOSIXProjectPath(path string) bool {
+	return strings.HasPrefix(path, "/") && !isWindowsProjectPath(path)
+}
+
+func isWindowsProjectPath(path string) bool {
+	if len(path) >= 3 && isASCIIAlpha(path[0]) && path[1] == ':' && isProjectPathSeparator(path[2]) {
+		return true
+	}
+	return len(path) >= 3 &&
+		isProjectPathSeparator(path[0]) &&
+		isProjectPathSeparator(path[1]) &&
+		!isProjectPathSeparator(path[2])
+}
+
+func isProjectPathSeparator(value byte) bool {
+	return value == '/' || value == '\\'
+}
+
+func isASCIIAlpha(value byte) bool {
+	return value >= 'a' && value <= 'z' || value >= 'A' && value <= 'Z'
 }
 
 // AreProjectPathsEqual compares project paths using the filesystem identity

--- a/packages/agent/store-sqlite/rail.go
+++ b/packages/agent/store-sqlite/rail.go
@@ -442,10 +442,6 @@ func railIdentityPathForPlatform(path string, goos string) string {
 	return path
 }
 
-func railPathForComparison(path string) string {
-	return railPathForComparisonForPlatform(path, runtime.GOOS)
-}
-
 func railPathForComparisonForPlatform(path string, goos string) string {
 	if goos == "windows" && isWindowsProjectPath(path) {
 		return strings.ToLower(path)

--- a/packages/agent/store-sqlite/rail_normalize_test.go
+++ b/packages/agent/store-sqlite/rail_normalize_test.go
@@ -111,6 +111,36 @@ func TestRailSectionKeyForProjectUsesWindowsCaseInsensitiveIdentity(t *testing.T
 	}
 }
 
+func TestWindowsRailPreservesPOSIXProjectNamespace(t *testing.T) {
+	t.Parallel()
+
+	const projectPath = "/workspace/Snake"
+	if got := normalizeProjectPathForPlatform(projectPath, "windows"); got != projectPath {
+		t.Fatalf("NormalizeProjectPath = %q, want %q", got, projectPath)
+	}
+	if got := railIdentityPathForPlatform(projectPath, "windows"); got != projectPath {
+		t.Fatalf("rail identity = %q, want case-sensitive %q", got, projectPath)
+	}
+	if !isProjectPathWithinForPlatform(projectPath, projectPath+"/src", "windows") {
+		t.Fatalf("POSIX child should remain within %q on Windows", projectPath)
+	}
+	if isProjectPathWithinForPlatform(projectPath, "/workspace/snake/src", "windows") {
+		t.Fatalf("POSIX project identity should remain case-sensitive on Windows")
+	}
+}
+
+func TestRailSectionKeyForProjectPreservesPOSIXIdentityOnWindows(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows path normalization is platform-specific")
+	}
+	const projectPath = "/workspace/Snake"
+	if got, want := RailSectionKeyForProject(projectPath), "project:"+projectPath; got != want {
+		t.Fatalf("RailSectionKeyForProject = %q, want %q", got, want)
+	}
+}
+
 func TestIsProjectPathWithinUsesWindowsCaseInsensitiveIdentity(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- preserve single-root POSIX project paths as a logical namespace on Windows instead of rebasing them onto the current drive
- apply Windows case folding only to drive and UNC paths, while keeping POSIX rail identity and containment case-sensitive
- add focused regression coverage and document the cross-host path boundary

## Verification

- go test -count=1 . in packages/agent/store-sqlite
- go vet . in packages/agent/store-sqlite
- Windows Git diff --check for the three changed files
- pnpm check:changed selected Go test and repository boundary lanes, but the combined local run could not complete because Windows Node launched WSL bash without golangci-lint.exe; focused Go verification above passed

## Checklist

- [x] Agent lifecycle checklist item is not applicable: this changes canonical rail path identity, not session, turn, goal, runtime-operation, sendability, terminal-state, or recovery semantics.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] README and CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commit is signed off with DCO.