### PR TITLE
fix(agent-gui): show web approval details

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -741,6 +741,13 @@ Interaction. This publication gate applies equally to emitted events and
 `SessionState.PendingInteractive`; a snapshot must not leak the incomplete
 request while the adapter waits for the later frame.
 
+Approval detail presentation is provider-neutral. The daemon carries generic
+`url`/`uri` and `prompt`/`instruction` display fields into the canonical
+`toolCall.input` when a provider reports them only at the tool-call root, and
+AgentGUI renders those fields from either canonical nested input or compatible
+root input. Shared and local surfaces use this same projection; they must not
+branch on a provider or tool name to recover web-action details.
+
 A child Interaction may appear in the root conversation, but submission carries the exact `(agentSessionId, turnId, requestId)` tuple.
 Every AgentGUI, Message Center, Desktop notification, and Mobile action submits
 that tuple plus the user's current answer through

--- a/packages/agent/daemon/runtime/interactive_projection.go
+++ b/packages/agent/daemon/runtime/interactive_projection.go
@@ -409,7 +409,7 @@ func normalizedApprovalToolCall(toolCall map[string]any, displayInput map[string
 }
 
 // normalizedApprovalDisplayInput builds the preview detail (command, path,
-// query, reason, ...) shown on an approval card. Some ACP providers (Cursor) omit
+// query, URL, prompt, reason, ...) shown on an approval card. Some ACP providers (Cursor) omit
 // `rawInput` on the permission request's own `toolCall` and only repeat
 // `toolCallId`/`title`/`kind`, so `knownInput` — the input captured from an
 // earlier `tool_call`/`tool_call_update` for the same call id, when available
@@ -449,6 +449,8 @@ func normalizedApprovalDisplayInput(toolCall map[string]any, knownInput map[stri
 		"searchQuery",
 		"url",
 		"uri",
+		"prompt",
+		"instruction",
 		"pattern",
 		"cwd",
 		"changes",

--- a/packages/agent/daemon/runtime/interactive_projection_test.go
+++ b/packages/agent/daemon/runtime/interactive_projection_test.go
@@ -84,6 +84,7 @@ func TestNormalizedApprovalInputRecoversTopLevelURL(t *testing.T) {
 		"toolCallId": "tool-web-fetch",
 		"name":       "WebFetch",
 		"url":        "https://example.com/fallback",
+		"prompt":     "Summarize the fallback page",
 	}, nil, "request-web-fetch", nil)
 
 	if input["url"] != "https://example.com/fallback" {
@@ -91,6 +92,26 @@ func TestNormalizedApprovalInputRecoversTopLevelURL(t *testing.T) {
 	}
 	if got := payloadMap(payloadMap(input, "toolCall"), "input")["url"]; got != "https://example.com/fallback" {
 		t.Fatalf("toolCall.input.url = %#v, want top-level fallback URL", got)
+	}
+	if got := payloadMap(payloadMap(input, "toolCall"), "input")["prompt"]; got != "Summarize the fallback page" {
+		t.Fatalf("toolCall.input.prompt = %#v, want top-level fallback prompt", got)
+	}
+}
+
+func TestNormalizedApprovalInputRecoversKnownInputWebAliases(t *testing.T) {
+	t.Parallel()
+
+	input := normalizedApprovalInput(map[string]any{
+		"toolCallId": "tool-web-fetch",
+		"name":       "WebFetch",
+	}, nil, "request-web-fetch", map[string]any{
+		"uri":         "https://example.com/known-input",
+		"instruction": "Extract the compatibility requirements",
+	})
+
+	toolCallInput := payloadMap(payloadMap(input, "toolCall"), "input")
+	if toolCallInput["uri"] != "https://example.com/known-input" || toolCallInput["instruction"] != "Extract the compatibility requirements" {
+		t.Fatalf("toolCall.input = %#v, want known-input web aliases", toolCallInput)
 	}
 }
 

--- a/packages/agent/gui/shared/agentConversation/components/interactivePromptPresentation.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/interactivePromptPresentation.tsx
@@ -246,10 +246,14 @@ export function promptToolDetailLabel(kind: PromptToolDetail["kind"]): string {
       return translate("agentHost.agentTool.details.mcp");
     case "path":
       return translate("agentHost.agentTool.details.path");
+    case "prompt":
+      return translate("agentHost.agentTool.details.prompt");
     case "query":
       return translate("agentHost.agentTool.details.query");
     case "reason":
       return translate("agentHost.agentTool.details.summary");
+    case "url":
+      return translate("agentHost.agentTool.details.url");
   }
 }
 

--- a/packages/agent/gui/shared/agentConversation/promptToolDetails.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/promptToolDetails.spec.ts
@@ -154,4 +154,169 @@ describe("getPromptToolDetails", () => {
       }
     ]);
   });
+
+  it("surfaces web approval details from canonical root input", () => {
+    expect(
+      getPromptToolDetails({
+        requestId: "approval-web-1",
+        url: "https://example.com/docs",
+        prompt: "Summarize this page",
+        options: [{ optionId: "approve", label: "Allow" }],
+        toolCall: {
+          toolCallId: "call-web-1",
+          name: "WebFetch",
+          title: "WebFetch",
+          toolName: "WebFetch"
+        }
+      })
+    ).toEqual([
+      {
+        kind: "url",
+        value: "https://example.com/docs"
+      },
+      {
+        kind: "prompt",
+        value: "Summarize this page"
+      }
+    ]);
+  });
+
+  it("supports URI and instruction aliases in nested toolCall input", () => {
+    expect(
+      getPromptToolDetails({
+        toolCall: {
+          input: {
+            uri: "https://example.com/reference",
+            instruction: "Extract the compatibility requirements"
+          }
+        }
+      })
+    ).toEqual([
+      {
+        kind: "url",
+        value: "https://example.com/reference"
+      },
+      {
+        kind: "prompt",
+        value: "Extract the compatibility requirements"
+      }
+    ]);
+  });
+
+  it("merges web approval details split across root and nested input", () => {
+    expect(
+      getPromptToolDetails({
+        url: "https://example.com/root",
+        toolCall: {
+          input: {
+            prompt: "Use the nested prompt"
+          }
+        }
+      })
+    ).toEqual([
+      {
+        kind: "url",
+        value: "https://example.com/root"
+      },
+      {
+        kind: "prompt",
+        value: "Use the nested prompt"
+      }
+    ]);
+
+    expect(
+      getPromptToolDetails({
+        instruction: "Use the root instruction",
+        toolCall: {
+          input: {
+            uri: "https://example.com/nested"
+          }
+        }
+      })
+    ).toEqual([
+      {
+        kind: "url",
+        value: "https://example.com/nested"
+      },
+      {
+        kind: "prompt",
+        value: "Use the root instruction"
+      }
+    ]);
+  });
+
+  it("prefers nested values across equivalent detail aliases", () => {
+    expect(
+      getPromptToolDetails({
+        command: "root command",
+        grantRoot: "/root/scope",
+        query: "root query",
+        url: "https://root.example",
+        prompt: "root prompt",
+        fileChanges: [{ path: "root/file.ts" }],
+        toolCall: {
+          input: {
+            cmd: "nested command",
+            path: "/nested/scope",
+            searchQuery: "nested query",
+            uri: "https://nested.example",
+            instruction: "nested prompt",
+            changes: [{ path: "nested/file.ts" }]
+          }
+        }
+      })
+    ).toEqual([
+      {
+        kind: "files",
+        value: "nested/file.ts"
+      },
+      {
+        kind: "command",
+        value: "nested command"
+      },
+      {
+        kind: "path",
+        value: "/nested/scope"
+      },
+      {
+        kind: "query",
+        value: "nested query"
+      },
+      {
+        kind: "url",
+        value: "https://nested.example"
+      },
+      {
+        kind: "prompt",
+        value: "nested prompt"
+      }
+    ]);
+  });
+
+  it("keeps command and path metadata with their source detail layer", () => {
+    expect(
+      getPromptToolDetails({
+        command: "root command",
+        description: "root command description",
+        path: "/root/file.ts",
+        startLine: 10,
+        endLine: 11,
+        toolCall: {
+          input: {
+            cmd: "nested command",
+            filePath: "/nested/file.ts"
+          }
+        }
+      })
+    ).toEqual([
+      {
+        kind: "command",
+        value: "nested command"
+      },
+      {
+        kind: "path",
+        value: "/nested/file.ts"
+      }
+    ]);
+  });
 });

--- a/packages/agent/gui/shared/agentConversation/promptToolDetails.ts
+++ b/packages/agent/gui/shared/agentConversation/promptToolDetails.ts
@@ -2,7 +2,16 @@ import { extractAgentMcpToolTarget } from "../agentMcpToolTarget";
 import { fileChangePathsFromChanges } from "../workspaceAgentFileChangePayload";
 
 export interface PromptToolDetail {
-  kind: "command" | "directory" | "files" | "mcp" | "path" | "query" | "reason";
+  kind:
+    | "command"
+    | "directory"
+    | "files"
+    | "mcp"
+    | "path"
+    | "prompt"
+    | "query"
+    | "reason"
+    | "url";
   value: string;
   meta?: string;
 }
@@ -23,9 +32,9 @@ export function getPromptToolDetails(
         }
       ]
     : [];
-  const detailInput = resolveToolDetailInput(input);
+  const detailInputs = resolveToolDetailInputs(input);
   const details: PromptToolDetail[] = [...mcpDetails];
-  const fileChanges = fileChangePaths(detailInput);
+  const fileChanges = fileChangePathsFromInputs(detailInputs);
   const fileChangePresentation = presentFileChangePaths(fileChanges);
   if (fileChanges.length > 0) {
     details.push({
@@ -39,44 +48,79 @@ export function getPromptToolDetails(
       });
     }
   }
-  const command =
-    commandStringValue(detailInput.command) ??
-    commandStringValue(detailInput.cmd);
-  if (command) {
+  const commandDetail = firstDetailEntry(
+    detailInputs,
+    (detailInput) =>
+      commandStringValue(detailInput.command) ??
+      commandStringValue(detailInput.cmd)
+  );
+  if (commandDetail) {
+    const description = stringValue(commandDetail.input.description);
     details.push({
       kind: "command",
-      value: command,
-      ...(stringValue(detailInput.description)
-        ? { meta: stringValue(detailInput.description) as string }
-        : {})
+      value: commandDetail.value,
+      ...(description ? { meta: description } : {})
     });
   }
-  const filePath =
-    stringValue(detailInput.grantRoot) ??
-    stringValue(detailInput.file_path) ??
-    stringValue(detailInput.filePath) ??
-    stringValue(detailInput.path) ??
-    stringValue(detailInput.notebook_path);
-  if (filePath && !isRedundantFileChangePath(filePath, fileChanges)) {
-    const lineRange = formatLineRange(detailInput);
+  const filePathDetail = firstDetailEntry(
+    detailInputs,
+    (detailInput) =>
+      stringValue(detailInput.grantRoot) ??
+      stringValue(detailInput.file_path) ??
+      stringValue(detailInput.filePath) ??
+      stringValue(detailInput.path) ??
+      stringValue(detailInput.notebook_path)
+  );
+  if (
+    filePathDetail &&
+    !isRedundantFileChangePath(filePathDetail.value, fileChanges)
+  ) {
+    const lineRange = formatLineRange(filePathDetail.input);
     details.push({
       kind: "path",
-      value: filePath,
+      value: filePathDetail.value,
       ...(lineRange ? { meta: lineRange } : {})
     });
   }
-  const query =
-    stringValue(detailInput.query) ??
-    stringValue(detailInput.search_query) ??
-    stringValue(detailInput.searchQuery) ??
-    stringValue(detailInput.pattern);
+  const query = firstDetailValue(
+    detailInputs,
+    (detailInput) =>
+      stringValue(detailInput.query) ??
+      stringValue(detailInput.search_query) ??
+      stringValue(detailInput.searchQuery) ??
+      stringValue(detailInput.pattern)
+  );
   if (query) {
     details.push({
       kind: "query",
       value: query
     });
   }
-  const reason = stringValue(detailInput.reason);
+  const url = firstDetailValue(
+    detailInputs,
+    (detailInput) =>
+      stringValue(detailInput.url) ?? stringValue(detailInput.uri)
+  );
+  if (url) {
+    details.push({
+      kind: "url",
+      value: url
+    });
+  }
+  const prompt = firstDetailValue(
+    detailInputs,
+    (detailInput) =>
+      stringValue(detailInput.prompt) ?? stringValue(detailInput.instruction)
+  );
+  if (prompt) {
+    details.push({
+      kind: "prompt",
+      value: prompt
+    });
+  }
+  const reason = firstDetailValue(detailInputs, (detailInput) =>
+    stringValue(detailInput.reason)
+  );
   if (reason) {
     details.push({
       kind: "reason",
@@ -90,32 +134,38 @@ export function isPromptRequestIdTitle(value: string): boolean {
   return /^requestid\s*:/iu.test(value.trim());
 }
 
-function resolveToolDetailInput(
+function resolveToolDetailInputs(
   input: Record<string, unknown>
-): Record<string, unknown> {
-  if (fileChangePaths(input).length > 0) {
-    return input;
-  }
+): readonly Record<string, unknown>[] {
   const toolCall = objectValue(input.toolCall);
-  return (
-    firstObjectValue(input, [
-      "command",
-      "cmd",
-      "reason",
-      "grantRoot",
-      "file_path",
-      "filePath",
-      "path",
-      "notebook_path",
-      "query",
-      "search_query",
-      "searchQuery",
-      "pattern"
-    ]) ??
-    firstObjectValue(toolCall, ["input", "arguments", "args"]) ??
-    toolCall ??
-    input
-  );
+  const nestedInput =
+    firstObjectValue(toolCall, ["input", "arguments", "args"]) ?? toolCall;
+  if (!nestedInput) {
+    return [input];
+  }
+  // Canonical nested input is authoritative within each semantic alias group;
+  // root input remains a field-by-field compatibility fallback.
+  return [nestedInput, input];
+}
+
+function firstDetailValue<T>(
+  inputs: readonly Record<string, unknown>[],
+  resolve: (input: Record<string, unknown>) => T | null
+): T | null {
+  return firstDetailEntry(inputs, resolve)?.value ?? null;
+}
+
+function firstDetailEntry<T>(
+  inputs: readonly Record<string, unknown>[],
+  resolve: (input: Record<string, unknown>) => T | null
+): { input: Record<string, unknown>; value: T } | null {
+  for (const input of inputs) {
+    const value = resolve(input);
+    if (value !== null) {
+      return { input, value };
+    }
+  }
+  return null;
 }
 
 function firstObjectValue(
@@ -184,6 +234,18 @@ function fileChangePaths(input: Record<string, unknown>): string[] {
   ];
   for (const candidate of candidates) {
     const paths = fileChangePathsFromChanges(candidate);
+    if (paths.length > 0) {
+      return paths;
+    }
+  }
+  return [];
+}
+
+function fileChangePathsFromInputs(
+  inputs: readonly Record<string, unknown>[]
+): string[] {
+  for (const input of inputs) {
+    const paths = fileChangePaths(input);
     if (paths.length > 0) {
       return paths;
     }


### PR DESCRIPTION
## Summary

- preserve generic `url`/`uri` and `prompt`/`instruction` approval details in canonical `toolCall.input`
- render URL and prompt details in the shared AgentGUI approval surface for local and shared hosts
- keep canonical nested input authoritative with field-by-field root compatibility fallback, including source-bound command/path metadata
- document the provider-neutral approval-detail projection

This is an Interaction transport/presentation fix. It does not change Session, Turn, Goal, or runtime-operation lifecycle semantics. TSH and other AgentGUI hosts receive the behavior through the same published projection and do not need host-specific logic.

## Verification

- `pnpm check:changed` (14 lanes)
- pre-push `pnpm check:changed -- --push-ready` (16 lanes)
- focused AgentGUI projection tests: 13 passed
- focused daemon approval-normalization tests: passed
- independent AgentGUI review: Architecture, Performance, and Consumers lanes passed; no findings after fixes

Windows impact: none. The change parses provider-neutral JSON fields and renders existing i18n text; it does not touch paths, processes, shell behavior, or platform APIs.

## Checklist

- [x] This PR does not change agent lifecycle semantics; it changes Interaction transport normalization and presentation.
- [x] I kept the change focused on one concern.
- [x] I updated documentation for the approval-detail data flow.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commit is signed off with DCO.