### PR TITLE
fix(desktop): separate native and workbench close intents

### DIFF
--- a/apps/desktop/src/main/windows/workspaceWindow.ts
+++ b/apps/desktop/src/main/windows/workspaceWindow.ts
@@ -262,7 +262,7 @@ export function createWorkspaceWindow(
     const requestId = randomUUID();
     pendingWorkspaceWindowCloseRequests.set(workspaceWindow, requestId);
     sendWorkspaceWindowCloseRequest(workspaceWindow, {
-      reason: "window-close",
+      reason: "native-window-close",
       requestId
     });
   });

--- a/apps/desktop/src/preload/api/host.ts
+++ b/apps/desktop/src/preload/api/host.ts
@@ -218,14 +218,21 @@ export function createHostDesktopApi(): DesktopHostApi {
         const handler = (
           _event: Electron.IpcRendererEvent,
           payload?: { reason?: unknown; requestId?: unknown }
-        ) =>
+        ) => {
+          const reason =
+            payload?.reason === "native-window-close"
+              ? "native-window-close"
+              : payload?.reason === "quit"
+                ? "quit"
+                : "window-close";
           listener({
             requestId:
               typeof payload?.requestId === "string"
                 ? payload.requestId
                 : undefined,
-            reason: payload?.reason === "quit" ? "quit" : "window-close"
+            reason
           });
+        };
         ipcRenderer.on(desktopIpcChannels.host.window.closeRequest, handler);
         return () => {
           ipcRenderer.removeListener(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWindowCloseCoordinator.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWindowCloseCoordinator.test.ts
@@ -54,6 +54,85 @@ test("confirmWorkspaceWindowClose requests focused workbench node close before w
   assert.equal(outcome, "blocked");
 });
 
+test("confirmWorkspaceWindowClose approves native window close without closing workbench nodes", async () => {
+  const events: string[] = [];
+  const outcome = await confirmWorkspaceWindowClose({
+    confirmCloseGuard: async () => {
+      events.push("confirm");
+      return true;
+    },
+    host: createWorkbenchHostHandleStub({
+      focusedNodeId: "agent-gui-1",
+      nodeIds: ["browser-1", "agent-gui-1"],
+      onCloseNode: (nodeId) => events.push(`node-close:${nodeId}`),
+      onMinimizeNode: (nodeId) => events.push(`node-minimize:${nodeId}`),
+      onRequestNodeClose: (nodeId) =>
+        events.push(`node-request-close:${nodeId}`)
+    }),
+    hostInput: {
+      createWindowCloseDialogRequest: () => ({
+        cancelLabel: "Cancel",
+        confirmLabel: "Close",
+        description: "There is work running.",
+        scope: "window",
+        title: "Close window?"
+      }),
+      prepareHostClose: async ({ workspaceId }) => {
+        events.push(`prepare:${workspaceId}`);
+        return true;
+      },
+      workspaceId: "workspace-native-close"
+    },
+    reason: "native-window-close",
+    requestApprovedClose: async () => {
+      events.push("approve");
+    },
+    tracker: createWindowCloseRequestTracker()
+  });
+
+  assert.deepEqual(events, [
+    "confirm",
+    "prepare:workspace-native-close",
+    "approve"
+  ]);
+  assert.equal(outcome, "approved");
+});
+
+test("confirmWorkspaceWindowClose keeps native window open when close guard is declined", async () => {
+  const events: string[] = [];
+  const outcome = await confirmWorkspaceWindowClose({
+    confirmCloseGuard: async () => false,
+    host: createWorkbenchHostHandleStub({
+      focusedNodeId: "agent-gui-1",
+      nodeIds: ["agent-gui-1"],
+      onRequestNodeClose: (nodeId) =>
+        events.push(`node-request-close:${nodeId}`)
+    }),
+    hostInput: {
+      createWindowCloseDialogRequest: () => ({
+        cancelLabel: "Cancel",
+        confirmLabel: "Close",
+        description: "There is work running.",
+        scope: "window",
+        title: "Close window?"
+      }),
+      prepareHostClose: async () => {
+        events.push("prepare");
+        return true;
+      },
+      workspaceId: "workspace-native-close"
+    },
+    reason: "native-window-close",
+    requestApprovedClose: async () => {
+      events.push("approve");
+    },
+    tracker: createWindowCloseRequestTracker()
+  });
+
+  assert.deepEqual(events, []);
+  assert.equal(outcome, "blocked");
+});
+
 test("confirmWorkspaceWindowClose does not prepare host close before approving window close", async () => {
   let approvedCloseCount = 0;
   const preparedWorkspaceIds: string[] = [];

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWindowCloseCoordinator.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWindowCloseCoordinator.ts
@@ -12,10 +12,36 @@ export async function confirmWorkspaceWindowClose(input: {
     WorkspaceWorkbenchHostInput,
     "createWindowCloseDialogRequest" | "prepareHostClose" | "workspaceId"
   >;
-  reason: "quit" | "window-close";
+  reason: "native-window-close" | "quit" | "window-close";
   requestApprovedClose(): Promise<void>;
   tracker: WindowCloseRequestTracker;
 }): Promise<"approved" | "blocked"> {
+  if (input.reason === "native-window-close") {
+    const host = input.host;
+    if (host) {
+      const effects = await host.collectWindowCloseEffects();
+      const request =
+        input.hostInput.createWindowCloseDialogRequest?.(effects) ?? null;
+      if (request && !(await input.confirmCloseGuard(request))) {
+        return "blocked";
+      }
+      if (
+        input.hostInput.prepareHostClose &&
+        !(await input.hostInput.prepareHostClose({
+          host,
+          workspaceId: input.hostInput.workspaceId
+        }))
+      ) {
+        return "blocked";
+      }
+    }
+
+    return requestWorkspaceWindowClose({
+      requestApprovedClose: () => input.requestApprovedClose(),
+      tracker: input.tracker
+    });
+  }
+
   if (input.reason === "window-close") {
     const host = input.host;
     if (host) {

--- a/apps/desktop/src/shared/contracts/ipc.ts
+++ b/apps/desktop/src/shared/contracts/ipc.ts
@@ -353,7 +353,7 @@ export interface DesktopHostWindowResizeContentWidthResult {
 
 export interface DesktopHostWindowCloseRequestPayload {
   requestId?: string;
-  reason: "quit" | "window-close";
+  reason: "native-window-close" | "quit" | "window-close";
 }
 
 export interface DesktopHostWindowCloseGuardInput {

--- a/docs/architecture/desktop-windows.md
+++ b/docs/architecture/desktop-windows.md
@@ -318,6 +318,13 @@ show product close guards, and clean up renderer-owned sessions. Once that
 work has completed, renderer calls the approved-close host capability and main
 destroys the window.
 
+Native titlebar close and Workbench node close are distinct intents. Windows
+caption close and the macOS traffic-light close use `native-window-close` and
+must approve destruction of the owning Electron window without first closing
+the focused Workbench node. `window-close` remains the node-oriented command
+used by interactions such as `Command+W`; `quit` remains the application-wide
+shutdown path.
+
 Renderer workspace code should not infer native close intent from
 `beforeunload`. Reload and close are distinct intents, and `beforeunload`
 cannot reliably distinguish Electron menu accelerators, keyboard shortcuts,


### PR DESCRIPTION
## 背景

Windows 下点击 Electron 原生标题栏 `X` 时，主进程把它标记为 `window-close`。Renderer 将该原因解释为关闭当前 Workbench 节点，因此先关闭 Agent/Browser 节点并返回 `blocked`，导致原生窗口没有关闭。

## 变更

- 新增 `native-window-close` IPC 原因，贯通 main、preload、shared contract 和 renderer。
- 原生标题栏关闭现在先收集窗口关闭副作用、执行关闭确认和 host cleanup，随后批准销毁所属 Electron 窗口，不再逐个关闭 Workbench 节点。
- 保留 `window-close` 的 Cmd+W/节点关闭语义，以及 `quit` 的应用级退出语义。
- 增加原生关闭批准/取消测试，并补充桌面窗口架构文档。

## 影响范围

- 修复 Windows 标题栏 `X`。
- 同步修正 macOS traffic-light 原生关闭语义。
- Cmd+W、应用 Quit 和 Linux 现有行为保持不变。

## 验证

- `@tutti-os/desktop typecheck`：通过。
- 关闭链路定向测试：14/14 通过。
- `check:electron-runtime-boundaries`：通过。
- `check:renderer-boundaries`：通过。
- `@tutti-os/desktop build`（含 Renderer CSS contracts）：通过。
- 全量 desktop test 已执行；仓库当前在 Windows 环境仍存在与本改动无关的既有失败，包括 POSIX 路径断言、symlink EPERM、Claude 本机配置探测及 reporter 路径拼接。
- pre-commit 的 staged 格式化、lint、Electron 边界检查通过；后续被未修改的 UI token 生成物陈旧检查拦截。pre-push changed-aware 校验运行超过 5 分钟工具上限，未返回失败结果。
