### PR TITLE
fix(desktop): backport native close intent fix to release/0813

### DIFF
--- a/apps/desktop/src/main/windows/workspaceWindow.ts
+++ b/apps/desktop/src/main/windows/workspaceWindow.ts
@@ -262,7 +262,7 @@ export function createWorkspaceWindow(
     const requestId = randomUUID();
     pendingWorkspaceWindowCloseRequests.set(workspaceWindow, requestId);
     sendWorkspaceWindowCloseRequest(workspaceWindow, {
-      reason: "window-close",
+      reason: "native-window-close",
       requestId
     });
   });

--- a/apps/desktop/src/preload/api/host.ts
+++ b/apps/desktop/src/preload/api/host.ts
@@ -218,14 +218,21 @@ export function createHostDesktopApi(): DesktopHostApi {
         const handler = (
           _event: Electron.IpcRendererEvent,
           payload?: { reason?: unknown; requestId?: unknown }
-        ) =>
+        ) => {
+          const reason =
+            payload?.reason === "native-window-close"
+              ? "native-window-close"
+              : payload?.reason === "quit"
+                ? "quit"
+                : "window-close";
           listener({
             requestId:
               typeof payload?.requestId === "string"
                 ? payload.requestId
                 : undefined,
-            reason: payload?.reason === "quit" ? "quit" : "window-close"
+            reason
           });
+        };
         ipcRenderer.on(desktopIpcChannels.host.window.closeRequest, handler);
         return () => {
           ipcRenderer.removeListener(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWindowCloseCoordinator.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWindowCloseCoordinator.test.ts
@@ -54,6 +54,85 @@ test("confirmWorkspaceWindowClose requests focused workbench node close before w
   assert.equal(outcome, "blocked");
 });
 
+test("confirmWorkspaceWindowClose approves native window close without closing workbench nodes", async () => {
+  const events: string[] = [];
+  const outcome = await confirmWorkspaceWindowClose({
+    confirmCloseGuard: async () => {
+      events.push("confirm");
+      return true;
+    },
+    host: createWorkbenchHostHandleStub({
+      focusedNodeId: "agent-gui-1",
+      nodeIds: ["browser-1", "agent-gui-1"],
+      onCloseNode: (nodeId) => events.push(`node-close:${nodeId}`),
+      onMinimizeNode: (nodeId) => events.push(`node-minimize:${nodeId}`),
+      onRequestNodeClose: (nodeId) =>
+        events.push(`node-request-close:${nodeId}`)
+    }),
+    hostInput: {
+      createWindowCloseDialogRequest: () => ({
+        cancelLabel: "Cancel",
+        confirmLabel: "Close",
+        description: "There is work running.",
+        scope: "window",
+        title: "Close window?"
+      }),
+      prepareHostClose: async ({ workspaceId }) => {
+        events.push(`prepare:${workspaceId}`);
+        return true;
+      },
+      workspaceId: "workspace-native-close"
+    },
+    reason: "native-window-close",
+    requestApprovedClose: async () => {
+      events.push("approve");
+    },
+    tracker: createWindowCloseRequestTracker()
+  });
+
+  assert.deepEqual(events, [
+    "confirm",
+    "prepare:workspace-native-close",
+    "approve"
+  ]);
+  assert.equal(outcome, "approved");
+});
+
+test("confirmWorkspaceWindowClose keeps native window open when close guard is declined", async () => {
+  const events: string[] = [];
+  const outcome = await confirmWorkspaceWindowClose({
+    confirmCloseGuard: async () => false,
+    host: createWorkbenchHostHandleStub({
+      focusedNodeId: "agent-gui-1",
+      nodeIds: ["agent-gui-1"],
+      onRequestNodeClose: (nodeId) =>
+        events.push(`node-request-close:${nodeId}`)
+    }),
+    hostInput: {
+      createWindowCloseDialogRequest: () => ({
+        cancelLabel: "Cancel",
+        confirmLabel: "Close",
+        description: "There is work running.",
+        scope: "window",
+        title: "Close window?"
+      }),
+      prepareHostClose: async () => {
+        events.push("prepare");
+        return true;
+      },
+      workspaceId: "workspace-native-close"
+    },
+    reason: "native-window-close",
+    requestApprovedClose: async () => {
+      events.push("approve");
+    },
+    tracker: createWindowCloseRequestTracker()
+  });
+
+  assert.deepEqual(events, []);
+  assert.equal(outcome, "blocked");
+});
+
 test("confirmWorkspaceWindowClose does not prepare host close before approving window close", async () => {
   let approvedCloseCount = 0;
   const preparedWorkspaceIds: string[] = [];

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWindowCloseCoordinator.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWindowCloseCoordinator.ts
@@ -12,10 +12,36 @@ export async function confirmWorkspaceWindowClose(input: {
     WorkspaceWorkbenchHostInput,
     "createWindowCloseDialogRequest" | "prepareHostClose" | "workspaceId"
   >;
-  reason: "quit" | "window-close";
+  reason: "native-window-close" | "quit" | "window-close";
   requestApprovedClose(): Promise<void>;
   tracker: WindowCloseRequestTracker;
 }): Promise<"approved" | "blocked"> {
+  if (input.reason === "native-window-close") {
+    const host = input.host;
+    if (host) {
+      const effects = await host.collectWindowCloseEffects();
+      const request =
+        input.hostInput.createWindowCloseDialogRequest?.(effects) ?? null;
+      if (request && !(await input.confirmCloseGuard(request))) {
+        return "blocked";
+      }
+      if (
+        input.hostInput.prepareHostClose &&
+        !(await input.hostInput.prepareHostClose({
+          host,
+          workspaceId: input.hostInput.workspaceId
+        }))
+      ) {
+        return "blocked";
+      }
+    }
+
+    return requestWorkspaceWindowClose({
+      requestApprovedClose: () => input.requestApprovedClose(),
+      tracker: input.tracker
+    });
+  }
+
   if (input.reason === "window-close") {
     const host = input.host;
     if (host) {

--- a/apps/desktop/src/shared/contracts/ipc.ts
+++ b/apps/desktop/src/shared/contracts/ipc.ts
@@ -353,7 +353,7 @@ export interface DesktopHostWindowResizeContentWidthResult {
 
 export interface DesktopHostWindowCloseRequestPayload {
   requestId?: string;
-  reason: "quit" | "window-close";
+  reason: "native-window-close" | "quit" | "window-close";
 }
 
 export interface DesktopHostWindowCloseGuardInput {

--- a/docs/architecture/desktop-windows.md
+++ b/docs/architecture/desktop-windows.md
@@ -318,6 +318,13 @@ show product close guards, and clean up renderer-owned sessions. Once that
 work has completed, renderer calls the approved-close host capability and main
 destroys the window.
 
+Native titlebar close and Workbench node close are distinct intents. Windows
+caption close and the macOS traffic-light close use `native-window-close` and
+must approve destruction of the owning Electron window without first closing
+the focused Workbench node. `window-close` remains the node-oriented command
+used by interactions such as `Command+W`; `quit` remains the application-wide
+shutdown path.
+
 Renderer workspace code should not infer native close intent from
 `beforeunload`. Reload and close are distinct intents, and `beforeunload`
 cannot reliably distinguish Electron menu accelerators, keyboard shortcuts,


### PR DESCRIPTION
## 背景

将已合入 main 的 #2348 回灌到 release/0813，修复 Windows 点击原生标题栏 X 时先关闭 Workbench 节点的问题。

## 变更

- Cherry-pick main squash commit 505724e47088f87e7d63b98db89a456c3918f305。
- 补丁 patch-id 与 main 完全一致，无冲突。

## 验证

#2348 的 TypeScript tests、lint、typecheck、Tooling Consistency 和 Windows x64 打包测试均已通过。