### PR TITLE
fix(agent): make idle Standard ACP process release recoverable

### DIFF
--- a/docs/architecture/agent-extensions.md
+++ b/docs/architecture/agent-extensions.md
@@ -181,6 +181,14 @@ contract supplies an empty MCP array and does not manage an agent's private MCP
 configuration; adding a non-empty product-level MCP input is a separate Host
 contract change.
 
+Standard ACP process recycling is capability-driven rather than extension-name
+driven. When the live `initialize` response advertises `session/load` or
+`session/resume`, the shared 30-minute idle reaper may close only that ACP
+transport and CLI process while retaining the Tutti session and provider
+session id. The next execution launches a new process and restores the provider
+session. The reaper does not send `session/close`, skips providers without a
+proven restore method, and treats pending interactive requests as busy.
+
 Extension composer controls stay runtime-owned after the model list is
 discovered. `tuttid` selects the newest context only within the exact workspace,
 normalized project, Agent Target, fixed installation, and request-settings

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -46,7 +46,9 @@ Use the focused runtime index or open one area directly:
   empty query never creates a durable provider child. It also covers a Claude
   Query that keeps returning connection errors after the machine network recovers.
   Also covers inactive Claude Resume timing out the queue send and leaving later
-  prompts stuck as 排队中 behind `uncertainDelivery`.
+  prompts stuck as 排队中 behind `uncertainDelivery`, and Standard ACP process
+  cleanup failures that stop a send before provider dispatch while preserving
+  the composer draft.
 - [Agent Approvals And Child Sessions](./agent-approvals-subagents.md): Approval gates, plan exits, root/parent/child event attribution, child sessions, and Message Center.
   Includes provider-native work that continues invisibly after root cancellation
   and late child creation racing the durable cancel boundary.

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -4877,6 +4877,43 @@ agent target`, although the current model picker does not offer that model.
   unsupported explicit selection separately with generic extension fixtures.
   Inject a `session/set_model` rejection into the standard ACP transport test.
 
+### Standard ACP send is stopped while an earlier process is still exiting
+
+- Symptom:
+  After an idle Standard ACP session is released, the next message may reconnect
+  once, but a later Start/Resume returns
+  `workspace_operation_failed` with reason
+  `agent.process_cleanup_pending`. The message does not reach the provider; in
+  AgentGUI the submitted draft is restored and a localized retry message is
+  shown.
+- Quick checks:
+  Correlate `agent_session.acp.close` stages with
+  `agent_session.live_resource_cleanup.failed`. A close failure followed by one
+  replacement-process start, then no additional start for the rejected retry,
+  confirms cleanup backpressure rather than provider prompt rejection.
+- Root cause:
+  A provider process can ignore graceful termination and fail the bounded
+  transport Close. Dropping that handle allows unbounded orphan processes;
+  allowing its late inbound handler to remain active can also attribute old
+  output or approval requests to the replacement Turn.
+- Fix:
+  Keep failed and replaced clients under adapter ownership, quarantine their
+  message handlers, and retry at most one failed Close budget per adapter sweep.
+  Once a failed handle is retired, Start/Resume performs one bounded cleanup
+  attempt and refuses to spawn another process while cleanup remains pending.
+  Preserve the stable reason through the Host/API boundary so AgentGUI can
+  restore the draft and present i18n copy.
+- Validation:
+  Cover release failure followed by one successful replacement, a blocked next
+  Resume with unchanged spawn/prompt counts, startup/load failure retention,
+  stale retired-client output, Plan-mode persistence without an eager spawn,
+  per-adapter sweep budgets, API classification, localized presentation, and
+  failed-submit draft restoration.
+- References:
+  [standard_acp_session.go](../../../packages/agent/daemon/runtime/standard_acp_session.go)
+  [standard_acp_resource_ownership.go](../../../packages/agent/daemon/runtime/standard_acp_resource_ownership.go)
+  [AgentGUIEngineSettlementController.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIEngineSettlementController.ts)
+
 ### Codex rejects `turn/start` with `AbsolutePathBuf deserialized without a base path`
 
 - Symptom:

--- a/packages/agent/activity-core/src/engine/pendingIntents.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.reducer.test.ts
@@ -102,6 +102,26 @@ test("command timeout is uncertain until the same client submit id is durable", 
   assert.deepEqual(confirmed.commands, []);
 });
 
+test("failed submit preserves the structured protocol reason for presentation", () => {
+  let state = reduce(createInitialPendingIntentsState(), submit()).state;
+  state = reduce(state, {
+    type: "engine/commandResult",
+    commandId: "queue:send:session-1:1",
+    commandType: "queue/sendPrompt",
+    correlationId: "submit-1",
+    errorCode: "workspace_operation_failed",
+    errorMessage: "agent process cleanup is still pending",
+    errorReason: "agent.process_cleanup_pending",
+    outcome: "failed"
+  }).state;
+
+  const record = state.submitsByClientSubmitId["submit-1"];
+  assert.equal(record?.errorCode, "workspace_operation_failed");
+  assert.equal(record?.errorMessage, "agent process cleanup is still pending");
+  assert.equal(record?.errorReason, "agent.process_cleanup_pending");
+  assert.equal(record?.status, "failed");
+});
+
 test("successful send records the authoritative turn result", () => {
   let state = reduce(createInitialPendingIntentsState(), submit()).state;
   state = reduce(state, {

--- a/packages/agent/activity-core/src/engine/pendingIntents.types.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.types.ts
@@ -123,6 +123,7 @@ export interface PendingSubmitIntentRecord {
   displayPrompt?: string;
   errorCode: string | null;
   errorMessage: string | null;
+  errorReason: string | null;
   expiresAtUnixMs: number;
   submitDiagnostics?: Readonly<AgentActivitySubmitDiagnostics>;
   requestedAtUnixMs: number;

--- a/packages/agent/activity-core/src/engine/pendingSubmit.reducer.ts
+++ b/packages/agent/activity-core/src/engine/pendingSubmit.reducer.ts
@@ -47,6 +47,7 @@ export function requestSubmit(
       : {}),
     errorCode: null,
     errorMessage: null,
+    errorReason: null,
     expiresAtUnixMs: intent.expiresAtUnixMs,
     ...(intent.submitDiagnostics
       ? { submitDiagnostics: { ...intent.submitDiagnostics } }
@@ -97,6 +98,7 @@ export function settleSubmitCommand(
           ...record,
           errorCode: "invalid_command_result",
           errorMessage: null,
+          errorReason: null,
           status: "uncertain"
         })
       };
@@ -132,6 +134,10 @@ export function settleSubmitCommand(
         intent.outcome === "timedOut"
           ? null
           : intent.errorMessage?.trim() || null,
+      errorReason:
+        intent.outcome === "timedOut"
+          ? null
+          : intent.errorReason?.trim() || null,
       status: intent.outcome === "timedOut" ? "uncertain" : "failed"
     })
   };

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.test.ts
@@ -2294,6 +2294,7 @@ function reduce(
             content: [],
             errorCode: null,
             errorMessage: null,
+            errorReason: null,
             expiresAtUnixMs: 1,
             requestedAtUnixMs: 1,
             status: "requested",

--- a/packages/agent/daemon/README.md
+++ b/packages/agent/daemon/README.md
@@ -194,6 +194,33 @@ record. Idle live-session release must not emit completion activity, clear the
 provider session id, remove runtime directories, or interrupt active turns and
 pending interactive requests.
 
+Standard ACP Agent Extensions participate in the default idle reaper only when
+their live `initialize` handshake advertises `session/load` or
+`session/resume`. After 30 minutes of inactivity, release closes only the ACP
+transport and its CLI process; it does not send `session/close`. The next
+`Exec` launches a replacement CLI process and restores the preserved provider
+session. Extensions that do not advertise a restore method remain live, and a
+pending interactive request makes the session busy rather than releasable.
+Replacement processes continue the durable Session's lifecycle snapshot
+sequence so restored activity cannot be rejected as stale. Release, resume,
+and live settings RPCs (including permission changes) share the per-Session
+lifecycle fence; a failed transport close keeps the live handle registered so
+a later release can retry.
+The local process transport serializes concurrent close attempts and retries
+termination after a failed attempt instead of caching that failure forever.
+An ACP client whose release failed remains owned as a physical handle but is
+not considered usable. One replacement may reconnect the durable provider
+session, but the old client's inbound handler is quarantined before close so
+late output cannot enter the replacement Turn. If that old handle still cannot
+close, later Start/Resume attempts spend one bounded cleanup attempt and return
+`agent.process_cleanup_pending` without spawning another process while the
+retired handle remains.
+The Controller also sweeps adapter-owned retired handles independently of its
+canonical Session registry, so provisional or preserve-state removal cannot
+orphan cleanup ownership. Each sweep gives every cleanup-capable adapter at
+most one failed Close budget across canonical and detached handles, and reports
+resource counters separately from canonical idle-session release results.
+
 Claude Code SDK sessions keep the SDK `session_id` in `ProviderSessionID` and
 mirror the opaque SDK resume cursor in `runtimeContext.resumeCursor`. The sidecar
 owns SDK stream ordering, turn cancellation, orphan result draining, and cursor

--- a/packages/agent/daemon/runtime.go
+++ b/packages/agent/daemon/runtime.go
@@ -189,14 +189,18 @@ func (r *Runtime) closeAllLiveSessions() {
 	ctx, cancel := context.WithTimeout(context.Background(), shutdownCloseAllLiveSessionsTimeout)
 	defer cancel()
 	result := r.controller.CloseAllLiveSessions(ctx)
-	if result.Scanned == 0 {
+	if result.Scanned == 0 && result.ResourceCleanupAttempted == 0 {
 		return
 	}
 	slog.Info("agent live session shutdown close completed",
 		"event", "agent_session.shutdown_close.completed",
 		"scanned", result.Scanned,
 		"closed", result.Closed,
+		"skipped_cleanup_budget", result.SkippedCleanupBudget,
 		"failed", result.Failed,
+		"resource_cleanup_attempted", result.ResourceCleanupAttempted,
+		"resource_cleanup_cleaned", result.ResourceCleanupCleaned,
+		"resource_cleanup_failed", result.ResourceCleanupFailed,
 	)
 }
 
@@ -228,7 +232,7 @@ func (r *Runtime) startLiveSessionReaper(config LiveSessionReaperConfig) {
 					IdleAfter: idleAfter,
 					Now:       time.Now(),
 				})
-				if result.Scanned == 0 {
+				if result.Scanned == 0 && result.ResourceCleanupAttempted == 0 {
 					continue
 				}
 				slog.Info("agent live session reaper sweep completed",
@@ -240,7 +244,11 @@ func (r *Runtime) startLiveSessionReaper(config LiveSessionReaperConfig) {
 					"skipped_unsupported", result.SkippedUnsupported,
 					"skipped_not_live", result.SkippedNotLive,
 					"skipped_busy", result.SkippedBusy,
+					"skipped_cleanup_budget", result.SkippedCleanupBudget,
 					"failed", result.Failed,
+					"resource_cleanup_attempted", result.ResourceCleanupAttempted,
+					"resource_cleanup_cleaned", result.ResourceCleanupCleaned,
+					"resource_cleanup_failed", result.ResourceCleanupFailed,
 				)
 			}
 		}

--- a/packages/agent/daemon/runtime/adapter.go
+++ b/packages/agent/daemon/runtime/adapter.go
@@ -341,8 +341,28 @@ type LiveSessionProbeAdapter interface {
 	HasLiveSession(Session) bool
 }
 
+type LiveSessionResourceCleanupResult struct {
+	Attempted int
+	Cleaned   int
+	Failed    int
+}
+
+// LiveSessionResourceCleanupAdapter owns physical handles that can outlive a
+// canonical runtime Session after a failed close. Cleanup is bounded by limit
+// so one reaper or shutdown pass cannot block on every retired process.
+type LiveSessionResourceCleanupAdapter interface {
+	CleanupLiveSessionResources(context.Context, int) LiveSessionResourceCleanupResult
+}
+
 type LiveSessionReleaseAdapter interface {
 	ReleaseLiveSession(context.Context, Session) error
+}
+
+// LiveSessionReleaseCapabilityAdapter narrows live-session release for
+// adapters whose ability to resume is learned from the current provider
+// handshake rather than known statically by adapter type.
+type LiveSessionReleaseCapabilityAdapter interface {
+	CanReleaseLiveSession(Session) bool
 }
 
 type StateAdapter interface {

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -150,22 +150,30 @@ type ReleaseIdleLiveSessionsInput struct {
 }
 
 type ReleaseIdleLiveSessionsResult struct {
-	Scanned            int
-	Released           int
-	SkippedFresh       int
-	SkippedActiveTurn  int
-	SkippedUnsupported int
-	SkippedNotLive     int
-	SkippedBusy        int
-	Failed             int
+	Scanned                  int
+	Released                 int
+	SkippedFresh             int
+	SkippedActiveTurn        int
+	SkippedUnsupported       int
+	SkippedNotLive           int
+	SkippedBusy              int
+	SkippedCleanupBudget     int
+	Failed                   int
+	ResourceCleanupAttempted int
+	ResourceCleanupCleaned   int
+	ResourceCleanupFailed    int
 }
 
 // CloseAllLiveSessionsResult reports the outcome of CloseAllLiveSessions.
 type CloseAllLiveSessionsResult struct {
 	// Scanned counts sessions whose adapter reported a live provider process.
-	Scanned int
-	Closed  int
-	Failed  int
+	Scanned                  int
+	Closed                   int
+	SkippedCleanupBudget     int
+	Failed                   int
+	ResourceCleanupAttempted int
+	ResourceCleanupCleaned   int
+	ResourceCleanupFailed    int
 }
 
 type asyncActivityReporter interface {

--- a/packages/agent/daemon/runtime/controller_exec_test.go
+++ b/packages/agent/daemon/runtime/controller_exec_test.go
@@ -15,6 +15,79 @@ func boolPtr(value bool) *bool {
 	return &value
 }
 
+func TestControllerExecCleanupBackpressurePrecedesTurnAndProviderDispatch(t *testing.T) {
+	t.Parallel()
+
+	transport := &multiProcStandardACPTransport{
+		agentTitle:               "Kimi Code",
+		sessionID:                "kimi-session-exec-backpressure",
+		supportsAgentLoadSession: true,
+	}
+	adapter := newKimiCodeExtensionTestAdapter(t, transport)
+	controller := NewController([]Adapter{adapter}, &recordingReporter{})
+	started, err := controller.Start(context.Background(), StartInput{
+		RoomID:         "room-exec-backpressure",
+		AgentSessionID: "agent-exec-backpressure",
+		Provider:       "acp:kimi-code",
+		CWD:            "/workspace",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	transport.mu.Lock()
+	oldConnection := transport.conns[0]
+	transport.mu.Unlock()
+	oldConnection.mu.Lock()
+	oldConnection.closeFailures = 3
+	oldConnection.mu.Unlock()
+
+	if err := adapter.ReleaseLiveSession(context.Background(), started.Session); err == nil {
+		t.Fatal("ReleaseLiveSession error = nil, want injected close failure")
+	}
+	if err := adapter.Resume(context.Background(), started.Session); err != nil {
+		t.Fatalf("first replacement Resume: %v", err)
+	}
+	if err := adapter.ReleaseLiveSession(context.Background(), started.Session); err != nil {
+		t.Fatalf("replacement release: %v", err)
+	}
+	spawnedBefore, _ := transport.snapshot()
+
+	result, err := controller.Exec(context.Background(), ExecInput{
+		RoomID:                          started.Session.RoomID,
+		AgentSessionID:                  started.Session.AgentSessionID,
+		ClientSubmitID:                  "submit-exec-backpressure",
+		CanonicalSubmitOccurredAtUnixMS: time.Now().UnixMilli(),
+		Content:                         textPrompt("keep this draft"),
+		RequireProviderAcceptance:       true,
+		TurnID:                          "turn-must-not-exist",
+	})
+	if AppErrorCode(err) != AppErrorProcessCleanupPending {
+		t.Fatalf("Exec error code = %q (err=%v), want %q", AppErrorCode(err), err, AppErrorProcessCleanupPending)
+	}
+	if result.ProviderDispatch == nil || result.ProviderDispatch.Disposition != DispatchDispositionNotDispatched {
+		t.Fatalf("provider dispatch = %#v, want not dispatched", result.ProviderDispatch)
+	}
+	if controller.HasActiveTurn(started.Session.RoomID, started.Session.AgentSessionID) {
+		t.Fatal("cleanup backpressure created an active Turn")
+	}
+	if session, ok := controller.Session(started.Session.RoomID, started.Session.AgentSessionID); !ok || session.Status != SessionStatusReady {
+		t.Fatalf("session after blocked Exec = %#v (ok=%v), want ready canonical session", session, ok)
+	}
+	spawnedAfter, _ := transport.snapshot()
+	if spawnedAfter != spawnedBefore {
+		t.Fatalf("spawned processes after blocked Exec = %d, want %d", spawnedAfter, spawnedBefore)
+	}
+	transport.mu.Lock()
+	replacementConnection := transport.conns[1]
+	transport.mu.Unlock()
+	replacementConnection.mu.Lock()
+	promptCalls := replacementConnection.promptCallCount
+	replacementConnection.mu.Unlock()
+	if promptCalls != 0 {
+		t.Fatalf("provider prompt calls = %d, want 0", promptCalls)
+	}
+}
+
 func TestControllerHiddenSessionPublishesLiveEventsAndReportsActivity(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/controller_live_sessions.go
+++ b/packages/agent/daemon/runtime/controller_live_sessions.go
@@ -67,13 +67,27 @@ func (c *Controller) ReleaseIdleLiveSessions(ctx context.Context, input ReleaseI
 		})
 	}
 	c.mu.Unlock()
+	failedProviders := make(map[string]bool)
 	for _, candidate := range candidates {
 		if input.Limit > 0 && result.Scanned >= input.Limit {
 			break
 		}
 		result.Scanned++
-		result.add(c.releaseIdleLiveSession(ctx, candidate.session, candidate.adapter, nowUnixMS, idleAfterMS))
+		provider := strings.TrimSpace(candidate.session.Provider)
+		if failedProviders[provider] {
+			result.SkippedCleanupBudget++
+			continue
+		}
+		next := c.releaseIdleLiveSession(ctx, candidate.session, candidate.adapter, nowUnixMS, idleAfterMS)
+		result.add(next)
+		if next.Failed > 0 {
+			failedProviders[provider] = true
+		}
 	}
+	cleanup := c.cleanupDetachedLiveSessionResources(ctx, failedProviders)
+	result.ResourceCleanupAttempted = cleanup.Attempted
+	result.ResourceCleanupCleaned = cleanup.Cleaned
+	result.ResourceCleanupFailed = cleanup.Failed
 	return result
 }
 
@@ -85,7 +99,7 @@ func (c *Controller) releaseIdleLiveSession(
 	idleAfterMS int64,
 ) ReleaseIdleLiveSessionsResult {
 	var result ReleaseIdleLiveSessionsResult
-	_, probe, ok := liveSessionReleaseAdapter(adapter)
+	_, probe, ok := liveSessionReleaseAdapter(adapter, session)
 	if !ok {
 		result.SkippedUnsupported = 1
 		return result
@@ -115,7 +129,7 @@ func (c *Controller) releaseIdleLiveSession(
 		result.SkippedNotLive = 1
 		return result
 	}
-	releaseAdapter, probe, ok := liveSessionReleaseAdapter(adapter)
+	releaseAdapter, probe, ok := liveSessionReleaseAdapter(adapter, refreshed)
 	if !ok {
 		result.SkippedUnsupported = 1
 		return result
@@ -153,10 +167,51 @@ func (c *Controller) releaseIdleLiveSession(
 	return result
 }
 
-func liveSessionReleaseAdapter(adapter Adapter) (LiveSessionReleaseAdapter, LiveSessionProbeAdapter, bool) {
+func liveSessionReleaseAdapter(adapter Adapter, session Session) (LiveSessionReleaseAdapter, LiveSessionProbeAdapter, bool) {
 	releaseAdapter, releaseOK := adapter.(LiveSessionReleaseAdapter)
 	probe, probeOK := adapter.(LiveSessionProbeAdapter)
-	return releaseAdapter, probe, releaseOK && probeOK
+	if !releaseOK || !probeOK {
+		return releaseAdapter, probe, false
+	}
+	if capability, ok := adapter.(LiveSessionReleaseCapabilityAdapter); ok && !capability.CanReleaseLiveSession(session) {
+		return releaseAdapter, probe, false
+	}
+	return releaseAdapter, probe, true
+}
+
+func (c *Controller) cleanupDetachedLiveSessionResources(ctx context.Context, failedProviders map[string]bool) LiveSessionResourceCleanupResult {
+	var result LiveSessionResourceCleanupResult
+	if c == nil {
+		return result
+	}
+	c.mu.Lock()
+	adapters := make([]Adapter, 0, len(c.adapters))
+	for _, adapter := range c.adapters {
+		adapters = append(adapters, adapter)
+	}
+	c.mu.Unlock()
+	for _, adapter := range adapters {
+		if failedProviders[strings.TrimSpace(adapter.Provider())] {
+			continue
+		}
+		cleanup, ok := adapter.(LiveSessionResourceCleanupAdapter)
+		if !ok {
+			continue
+		}
+		next := cleanup.CleanupLiveSessionResources(ctx, 1)
+		result.Attempted += next.Attempted
+		result.Cleaned += next.Cleaned
+		result.Failed += next.Failed
+		if next.Failed > 0 {
+			slog.Warn("agent detached live session resource cleanup failed",
+				"event", "agent_session.live_resource_cleanup.failed",
+				"provider", adapter.Provider(),
+				"attempted", next.Attempted,
+				"failed", next.Failed,
+			)
+		}
+	}
+	return result
 }
 
 // CloseAllLiveSessions force-terminates every live provider process across
@@ -192,8 +247,14 @@ func (c *Controller) CloseAllLiveSessions(ctx context.Context) CloseAllLiveSessi
 		})
 	}
 	c.mu.Unlock()
+	failedProviders := make(map[string]bool)
 
 	for _, cand := range candidates {
+		provider := strings.TrimSpace(cand.session.Provider)
+		if failedProviders[provider] {
+			result.SkippedCleanupBudget++
+			continue
+		}
 		probe, ok := cand.adapter.(LiveSessionProbeAdapter)
 		if !ok || !probe.HasLiveSession(cand.session) {
 			continue
@@ -204,6 +265,7 @@ func (c *Controller) CloseAllLiveSessions(ctx context.Context) CloseAllLiveSessi
 		releaseLifecycleLock()
 		if err != nil {
 			result.Failed++
+			failedProviders[provider] = true
 			slog.Warn("agent live session shutdown close failed",
 				"event", "agent_session.shutdown_close.failed",
 				"room_id", cand.session.RoomID,
@@ -215,6 +277,10 @@ func (c *Controller) CloseAllLiveSessions(ctx context.Context) CloseAllLiveSessi
 		}
 		result.Closed++
 	}
+	cleanup := c.cleanupDetachedLiveSessionResources(ctx, failedProviders)
+	result.ResourceCleanupAttempted = cleanup.Attempted
+	result.ResourceCleanupCleaned = cleanup.Cleaned
+	result.ResourceCleanupFailed = cleanup.Failed
 	return result
 }
 
@@ -232,6 +298,7 @@ func (r *ReleaseIdleLiveSessionsResult) add(next ReleaseIdleLiveSessionsResult) 
 	r.SkippedUnsupported += next.SkippedUnsupported
 	r.SkippedNotLive += next.SkippedNotLive
 	r.SkippedBusy += next.SkippedBusy
+	r.SkippedCleanupBudget += next.SkippedCleanupBudget
 	r.Failed += next.Failed
 }
 

--- a/packages/agent/daemon/runtime/controller_live_sessions_test.go
+++ b/packages/agent/daemon/runtime/controller_live_sessions_test.go
@@ -88,7 +88,7 @@ func TestControllerReleaseIdleLiveSessionsSkipsFreshActiveUnsupportedAndNotLive(
 	waitForSessionStatus(t, controller, active.Session.RoomID, active.Session.AgentSessionID, SessionStatusReady)
 }
 
-func TestControllerReleaseIdleLiveSessionsFailureContinuesAndDoesNotReportCompletion(t *testing.T) {
+func TestControllerReleaseIdleLiveSessionsFailureDefersSameAdapterAndDoesNotReportCompletion(t *testing.T) {
 	t.Parallel()
 
 	reporter := &recordingReporter{}
@@ -100,14 +100,15 @@ func TestControllerReleaseIdleLiveSessionsFailureContinuesAndDoesNotReportComple
 	setSessionUpdatedAt(t, controller, failing.Session, stale)
 	setSessionUpdatedAt(t, controller, released.Session, stale)
 	adapter.releaseErrByAgentSessionID[failing.Session.AgentSessionID] = errors.New("close failed")
+	adapter.releaseErrByAgentSessionID[released.Session.AgentSessionID] = errors.New("close failed too")
 	reporter.waitForCalls(t, 2)
 
 	result := controller.ReleaseIdleLiveSessions(context.Background(), ReleaseIdleLiveSessionsInput{
 		IdleAfter: 30 * time.Minute,
 		Now:       time.Now(),
 	})
-	if result.Failed != 1 || result.Released != 1 {
-		t.Fatalf("release result = %#v, want one failure and one release", result)
+	if result.Failed != 1 || result.Released != 0 || result.SkippedCleanupBudget != 1 {
+		t.Fatalf("release result = %#v, want one failure and one same-adapter defer", result)
 	}
 	time.Sleep(50 * time.Millisecond)
 	for _, call := range reporter.snapshot() {
@@ -146,6 +147,114 @@ func TestControllerExecResumesAfterIdleLiveSessionRelease(t *testing.T) {
 	}
 	if adapter.resumeCalls != 1 {
 		t.Fatalf("resume calls = %d, want 1", adapter.resumeCalls)
+	}
+}
+
+func TestControllerRecyclesIdleKimiCodeProcessAndResumesOnNextExec(t *testing.T) {
+	t.Parallel()
+
+	transport := &multiProcStandardACPTransport{
+		agentTitle:               "Kimi Code",
+		sessionID:                "kimi-session-idle-recycle",
+		supportsAgentLoadSession: true,
+	}
+	adapter := newKimiCodeExtensionTestAdapter(t, transport)
+	controller := NewController([]Adapter{adapter}, nil)
+	started, err := controller.Start(context.Background(), StartInput{
+		RoomID:         "room-kimi-idle-recycle",
+		AgentSessionID: "kimi-agent-session-idle-recycle",
+		Provider:       "acp:kimi-code",
+		CWD:            "/workspace/kimi-idle-recycle",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() {
+		_, _ = controller.Close(context.Background(), CloseInput{
+			RoomID:         started.Session.RoomID,
+			AgentSessionID: started.Session.AgentSessionID,
+		})
+	}()
+
+	nowTime := time.Now()
+	setSessionUpdatedAt(t, controller, started.Session, nowTime.Add(-30*time.Minute))
+	result := controller.ReleaseIdleLiveSessions(context.Background(), ReleaseIdleLiveSessionsInput{
+		IdleAfter: 30 * time.Minute,
+		Now:       nowTime,
+	})
+	if result.Released != 1 || result.Scanned != 1 {
+		t.Fatalf("release result = %#v, want one released Kimi Code process", result)
+	}
+	if spawned, live := transport.snapshot(); spawned != 1 || len(live) != 0 {
+		t.Fatalf("processes after release = spawned %d live %d, want 1 spawned and 0 live", spawned, len(live))
+	}
+	stored, ok := controller.Session(started.Session.RoomID, started.Session.AgentSessionID)
+	if !ok || stored.ProviderSessionID != "kimi-session-idle-recycle" {
+		t.Fatalf("stored session = %#v ok=%v, want preserved provider session id", stored, ok)
+	}
+
+	execResult, err := controller.Exec(context.Background(), ExecInput{
+		RoomID:         started.Session.RoomID,
+		AgentSessionID: started.Session.AgentSessionID,
+		Content:        textPrompt("resume after idle release"),
+	})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if !execResult.Accepted {
+		t.Fatalf("Exec result = %#v, want accepted", execResult)
+	}
+	spawned, live := transport.snapshot()
+	if spawned != 2 || len(live) != 1 {
+		t.Fatalf("processes after Exec = spawned %d live %d, want replacement process", spawned, len(live))
+	}
+	transport.mu.Lock()
+	resumedConnection := transport.conns[1]
+	transport.mu.Unlock()
+	resumedConnection.mu.Lock()
+	providerSessionID := asString(resumedConnection.lastLoadSessionParams["sessionId"])
+	resumedConnection.mu.Unlock()
+	if providerSessionID != "kimi-session-idle-recycle" {
+		t.Fatalf("resumed provider session id = %q, want preserved Kimi Code session", providerSessionID)
+	}
+}
+
+func TestControllerKeepsIdleStandardACPProcessWithoutResumeCapability(t *testing.T) {
+	t.Parallel()
+
+	transport := &multiProcStandardACPTransport{
+		agentTitle: "Non-resumable ACP Agent",
+		sessionID:  "non-resumable-session",
+	}
+	adapter := newKimiCodeExtensionTestAdapter(t, transport)
+	controller := NewController([]Adapter{adapter}, nil)
+	started, err := controller.Start(context.Background(), StartInput{
+		RoomID:         "room-non-resumable",
+		AgentSessionID: "agent-session-non-resumable",
+		Provider:       "acp:kimi-code",
+		CWD:            "/workspace/non-resumable",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() {
+		_, _ = controller.Close(context.Background(), CloseInput{
+			RoomID:         started.Session.RoomID,
+			AgentSessionID: started.Session.AgentSessionID,
+		})
+	}()
+
+	nowTime := time.Now()
+	setSessionUpdatedAt(t, controller, started.Session, nowTime.Add(-31*time.Minute))
+	result := controller.ReleaseIdleLiveSessions(context.Background(), ReleaseIdleLiveSessionsInput{
+		IdleAfter: 30 * time.Minute,
+		Now:       nowTime,
+	})
+	if result.SkippedUnsupported != 1 || result.Released != 0 {
+		t.Fatalf("release result = %#v, want non-resumable handshake skipped", result)
+	}
+	if spawned, live := transport.snapshot(); spawned != 1 || len(live) != 1 {
+		t.Fatalf("processes after release = spawned %d live %d, want original process retained", spawned, len(live))
 	}
 }
 
@@ -288,7 +397,7 @@ func TestControllerCloseAllLiveSessionsForcesClosureDuringActiveTurn(t *testing.
 	}
 }
 
-func TestControllerCloseAllLiveSessionsFailureIsCountedAndDoesNotStopOtherSessions(t *testing.T) {
+func TestControllerCloseAllLiveSessionsBoundsFailedCloseBudgetPerAdapter(t *testing.T) {
 	t.Parallel()
 
 	adapter := newReleasableAdapter()
@@ -296,17 +405,95 @@ func TestControllerCloseAllLiveSessionsFailureIsCountedAndDoesNotStopOtherSessio
 	failing := startReleasableSession(t, controller, "failing-session")
 	closes := startReleasableSession(t, controller, "closes-session")
 	adapter.closeErrByAgentSessionID[failing.Session.AgentSessionID] = errors.New("close failed")
+	adapter.closeErrByAgentSessionID[closes.Session.AgentSessionID] = errors.New("close failed too")
 
 	result := controller.CloseAllLiveSessions(context.Background())
-	if result.Scanned != 2 || result.Failed != 1 || result.Closed != 1 {
-		t.Fatalf("close-all result = %#v, want one failure and one closed session", result)
+	if result.Scanned != 1 || result.Failed != 1 || result.Closed != 0 || result.SkippedCleanupBudget != 1 {
+		t.Fatalf("close-all result = %#v, want one failure budget and one deferred session", result)
 	}
 	if !adapter.hasLiveSession(failing.Session.AgentSessionID) {
 		t.Fatalf("failing session should remain live since Close returned an error")
 	}
-	if adapter.hasLiveSession(closes.Session.AgentSessionID) {
-		t.Fatalf("closes-session still live, want it closed despite the other session's failure")
+	if !adapter.hasLiveSession(closes.Session.AgentSessionID) {
+		t.Fatalf("closes-session was attempted after the adapter spent its failed close budget")
 	}
+}
+
+func TestControllerDetachedCleanupGivesEveryAdapterOneBoundedAttempt(t *testing.T) {
+	t.Parallel()
+
+	first := &detachedCleanupTestAdapter{
+		Adapter: &recordingStartAdapter{provider: "acp:cleanup-first"},
+		result:  LiveSessionResourceCleanupResult{Attempted: 1, Cleaned: 1},
+	}
+	second := &detachedCleanupTestAdapter{
+		Adapter: &recordingStartAdapter{provider: "acp:cleanup-second"},
+		result:  LiveSessionResourceCleanupResult{Attempted: 1, Failed: 1},
+	}
+	controller := NewController([]Adapter{first, second}, nil)
+	result := controller.ReleaseIdleLiveSessions(context.Background(), ReleaseIdleLiveSessionsInput{
+		IdleAfter: time.Minute,
+	})
+	if result.Scanned != 0 || result.Released != 0 || result.Failed != 0 {
+		t.Fatalf("canonical release counters = %#v, want unchanged", result)
+	}
+	if result.ResourceCleanupAttempted != 2 || result.ResourceCleanupCleaned != 1 || result.ResourceCleanupFailed != 1 {
+		t.Fatalf("resource cleanup counters = %#v", result)
+	}
+	if first.callCount() != 1 || second.callCount() != 1 {
+		t.Fatalf("cleanup calls = first:%d second:%d, want one each", first.callCount(), second.callCount())
+	}
+}
+
+func TestControllerReleaseIdleLiveSessionsBoundsFailedCloseBudgetPerAdapter(t *testing.T) {
+	t.Parallel()
+
+	adapter := newReleasableAdapter()
+	controller := NewController([]Adapter{adapter}, nil)
+	first := startReleasableSession(t, controller, "first-failing-session")
+	second := startReleasableSession(t, controller, "second-failing-session")
+	adapter.releaseErrByAgentSessionID[first.Session.AgentSessionID] = errors.New("release failed")
+	adapter.releaseErrByAgentSessionID[second.Session.AgentSessionID] = errors.New("release failed too")
+	now := time.Now()
+	setSessionUpdatedAt(t, controller, first.Session, now.Add(-2*time.Hour))
+	setSessionUpdatedAt(t, controller, second.Session, now.Add(-2*time.Hour))
+
+	result := controller.ReleaseIdleLiveSessions(context.Background(), ReleaseIdleLiveSessionsInput{
+		IdleAfter: time.Hour,
+		Now:       now,
+	})
+	if result.Scanned != 2 || result.Failed != 1 || result.SkippedCleanupBudget != 1 {
+		t.Fatalf("release result = %#v, want one failed budget and one deferred session", result)
+	}
+	adapter.mu.Lock()
+	releaseCalls := adapter.releaseCalls
+	adapter.mu.Unlock()
+	if releaseCalls != 1 {
+		t.Fatalf("release calls = %d, want one per failed adapter sweep", releaseCalls)
+	}
+}
+
+type detachedCleanupTestAdapter struct {
+	Adapter
+	mu     sync.Mutex
+	calls  int
+	result LiveSessionResourceCleanupResult
+}
+
+func (a *detachedCleanupTestAdapter) CleanupLiveSessionResources(_ context.Context, limit int) LiveSessionResourceCleanupResult {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if limit != 1 {
+		return LiveSessionResourceCleanupResult{Failed: 1}
+	}
+	a.calls++
+	return a.result
+}
+
+func (a *detachedCleanupTestAdapter) callCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.calls
 }
 
 type releasableAdapter struct {
@@ -484,6 +671,20 @@ func setSessionUpdatedAt(t *testing.T, controller *Controller, session Session, 
 	stored.UpdatedAtUnixMS = unixMS(updatedAt)
 	controller.sessions[key] = stored
 	controller.mu.Unlock()
+}
+
+func newKimiCodeExtensionTestAdapter(t *testing.T, transport ProcessTransport) *standardACPAdapter {
+	t.Helper()
+	adapter, err := NewStandardACPAdapter(StandardACPAdapterConfig{
+		Provider:    "acp:kimi-code",
+		Name:        "kimi-code-acp",
+		DisplayName: "Kimi Code",
+		Command:     []string{"kimi", "acp"},
+	}, transport, LegacyHostMetadata())
+	if err != nil {
+		t.Fatalf("NewStandardACPAdapter: %v", err)
+	}
+	return adapter.(*standardACPAdapter)
 }
 
 func TestControllerCloseReportsSessionCompleted(t *testing.T) {

--- a/packages/agent/daemon/runtime/controller_session_lifecycle.go
+++ b/packages/agent/daemon/runtime/controller_session_lifecycle.go
@@ -79,13 +79,16 @@ func (c *Controller) Start(ctx context.Context, input StartInput) (StartResult, 
 	}
 	events, err := adapter.Start(ctx, session)
 	if err != nil {
-		detail := cleanVisibleErrorText(err.Error())
-		code := visibleFailureCode(detail)
-		startError := &AppError{
-			Code:         code,
-			Message:      visibleFailureContent(provider, "start", code),
-			DebugMessage: detail,
-			Cause:        err,
+		startError := err
+		if AppErrorCode(err) == "" {
+			detail := cleanVisibleErrorText(err.Error())
+			code := visibleFailureCode(detail)
+			startError = &AppError{
+				Code:         code,
+				Message:      visibleFailureContent(provider, "start", code),
+				DebugMessage: detail,
+				Cause:        err,
+			}
 		}
 		// Provider adapters may emit command/config snapshots before Start returns.
 		// Roll those provisional side channels back with the failed transaction so

--- a/packages/agent/daemon/runtime/controller_start_test.go
+++ b/packages/agent/daemon/runtime/controller_start_test.go
@@ -52,6 +52,24 @@ func TestControllerStartFailureDoesNotCreateCanonicalSessionOrTurnlessMessage(t 
 	}
 }
 
+func TestControllerStartPreservesStructuredCleanupBackpressureError(t *testing.T) {
+	t.Parallel()
+
+	controller := NewController([]Adapter{cleanupPendingStartAdapter{}}, nil)
+	_, err := controller.Start(context.Background(), StartInput{
+		RoomID:         "room-cleanup-pending",
+		AgentSessionID: "agent-cleanup-pending",
+		Provider:       hermesExtensionTestProvider,
+		CWD:            "/workspace",
+	})
+	if AppErrorCode(err) != AppErrorProcessCleanupPending {
+		t.Fatalf("Start error code = %q (err=%v), want %q", AppErrorCode(err), err, AppErrorProcessCleanupPending)
+	}
+	if AppErrorDebugMessage(err) != "old process close failed" {
+		t.Fatalf("Start debug message = %q", AppErrorDebugMessage(err))
+	}
+}
+
 func TestControllerStartupOperationsDoNotBlockIndependentSessions(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -716,6 +734,16 @@ func (a *recordingPromptAdapter) ValidatePromptContent(_ Session, content []Prom
 }
 
 type failingStartAdapter struct{}
+
+type cleanupPendingStartAdapter struct{ failingStartAdapter }
+
+func (cleanupPendingStartAdapter) Start(context.Context, Session) ([]activityshared.Event, error) {
+	return nil, &AppError{
+		Code:         AppErrorProcessCleanupPending,
+		Message:      "agent process cleanup is still pending",
+		DebugMessage: "old process close failed",
+	}
+}
 
 func (failingStartAdapter) Provider() string { return hermesExtensionTestProvider }
 

--- a/packages/agent/daemon/runtime/errors.go
+++ b/packages/agent/daemon/runtime/errors.go
@@ -4,6 +4,7 @@ import "errors"
 
 const (
 	AppErrorProviderSessionNotFound = "agent.provider_session_not_found"
+	AppErrorProcessCleanupPending   = "agent.process_cleanup_pending"
 	AppErrorResumeSessionNotLocal   = "agent.resume_session_not_local"
 )
 

--- a/packages/agent/daemon/runtime/process_transport.go
+++ b/packages/agent/daemon/runtime/process_transport.go
@@ -46,10 +46,10 @@ type localProcessConnection struct {
 	frames             chan ProcessFrame
 	stdin              io.WriteCloser
 
-	closeOnce sync.Once
-	sendMu    sync.Mutex
-	inputOnce sync.Once
-	closeErr  error
+	closeMu     sync.Mutex
+	closingOnce sync.Once
+	sendMu      sync.Mutex
+	inputOnce   sync.Once
 }
 
 func NewLocalProcessTransport() ProcessTransport {
@@ -303,29 +303,34 @@ func (c *localProcessConnection) Close() error {
 	if c == nil {
 		return nil
 	}
-	c.closeOnce.Do(func() {
-		close(c.closing)
-		_ = c.CloseInput()
-		if !c.waitDone(250 * time.Millisecond) {
-			_ = c.Terminate()
-		}
-		if !c.waitDone(750 * time.Millisecond) {
-			killErr := c.Kill()
-			if !c.waitDone(2 * time.Second) {
-				if killErr != nil {
-					c.closeErr = killErr
-					return
-				}
-				c.closeErr = errors.New("process did not exit after kill")
-				return
-			}
-		}
-	})
-	if c.closeErr != nil {
-		return c.closeErr
+	c.closeMu.Lock()
+	defer c.closeMu.Unlock()
+	if c.waitDone(0) {
+		return nil
 	}
-	<-c.done
-	return nil
+	c.closingOnce.Do(func() { close(c.closing) })
+	return closeLocalProcessAttempt(c.waitDone, c.CloseInput, c.Terminate, c.Kill)
+}
+
+func closeLocalProcessAttempt(
+	waitDone func(time.Duration) bool,
+	closeInput func() error,
+	terminate func() error,
+	kill func() error,
+) error {
+	_ = closeInput()
+	if waitDone(250 * time.Millisecond) {
+		return nil
+	}
+	_ = terminate()
+	if waitDone(750 * time.Millisecond) {
+		return nil
+	}
+	killErr := kill()
+	if waitDone(2 * time.Second) {
+		return nil
+	}
+	return errors.Join(killErr, errors.New("process did not exit after kill"))
 }
 
 func (c *localProcessConnection) CloseInput() error {

--- a/packages/agent/daemon/runtime/process_transport_close_test.go
+++ b/packages/agent/daemon/runtime/process_transport_close_test.go
@@ -1,0 +1,66 @@
+package agentruntime
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestCloseLocalProcessAttemptCanRetryAfterFailure(t *testing.T) {
+	t.Parallel()
+
+	exited := false
+	attempts := 0
+	killErr := errors.New("injected kill failure")
+	waitDone := func(time.Duration) bool { return exited }
+	closeInput := func() error { return nil }
+	terminate := func() error { return nil }
+	kill := func() error {
+		attempts++
+		if attempts == 1 {
+			return killErr
+		}
+		exited = true
+		return nil
+	}
+
+	if err := closeLocalProcessAttempt(waitDone, closeInput, terminate, kill); !errors.Is(err, killErr) {
+		t.Fatalf("first close error = %v, want %v", err, killErr)
+	}
+	if err := closeLocalProcessAttempt(waitDone, closeInput, terminate, kill); err != nil {
+		t.Fatalf("retry close: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("kill attempts = %d, want 2", attempts)
+	}
+}
+
+func TestLocalProcessConnectionCloseIsConcurrentAndIdempotentAfterExit(t *testing.T) {
+	t.Parallel()
+
+	done := make(chan struct{})
+	close(done)
+	connection := &localProcessConnection{
+		done:    done,
+		closing: make(chan struct{}),
+	}
+
+	const callers = 8
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- connection.Close()
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	}
+}

--- a/packages/agent/daemon/runtime/standard_acp_adapter.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter.go
@@ -110,6 +110,7 @@ type standardACPAdapter struct {
 	preparer                   ProviderLaunchPreparer
 	mu                         sync.Mutex
 	sessions                   map[string]*standardACPSession
+	retiredSessions            map[string][]*standardACPSession
 	terminalInteractions       terminalInteractiveDispositionStore
 	interactiveDispositionSink InteractiveDispositionSink
 	commandSink                CommandSnapshotSink
@@ -122,8 +123,19 @@ type standardACPAdapter struct {
 }
 
 type standardACPSession struct {
-	client            *acpClient
+	client *acpClient
+	// releasing fences new live-client work while idle release is closing the
+	// transport. The lifecycle lock serializes mutating entrypoints; this flag
+	// also makes liveness probes fail closed during the close call.
+	releasing bool
+	// releaseFailed keeps a physical client registered for another Close
+	// attempt while preventing new work from reusing its closed stdin.
+	releaseFailed     bool
 	providerSessionID string
+	// resumeMethod records the capability proven by this process's initialize
+	// handshake. Idle release is safe only when the next process can restore
+	// the provider session through this method.
+	resumeMethod string
 	// resumeRuntimeContext preserves the historical adapter projection only
 	// when replay attaches at an already-initialized connection checkpoint.
 	resumeRuntimeContext map[string]any

--- a/packages/agent/daemon/runtime/standard_acp_launch_settings_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_launch_settings_test.go
@@ -407,6 +407,75 @@ func TestStandardACPLaunchPermissionPlanRestartsAndLoadsSameSession(t *testing.T
 	}
 }
 
+func TestStandardACPLaunchPermissionPlanPersistsWithoutSpawnAfterReleaseFailure(t *testing.T) {
+	t.Parallel()
+
+	transport := &multiProcStandardACPTransport{
+		agentTitle:          "Grok Build",
+		sessionID:           "grok-provider-session-deferred-plan",
+		supportsLoadSession: true,
+	}
+	adapterRaw, err := NewStandardACPAdapter(StandardACPAdapterConfig{
+		Provider:                     "acp:grok-launch-plan-deferred",
+		Name:                         "grok-launch-plan-deferred-acp",
+		DisplayName:                  "Grok Build",
+		Command:                      []string{"grok", "--permission-mode", "${permissionMode}", "agent", "stdio"},
+		PermissionModes:              map[string]string{"ask-before-write": "default", "auto": "auto", "full-access": "bypassPermissions"},
+		PlanModeRuntimeID:            "plan",
+		PlanModeDisabledRuntimeID:    "default",
+		PlanModeUsesLaunchPermission: true,
+		LaunchPermission: &StandardACPLaunchPermissionSetting{
+			Placeholder:     "${permissionMode}",
+			DefaultSemantic: "ask-before-write",
+			Values:          map[string]string{"ask-before-write": "default", "auto": "auto", "full-access": "bypassPermissions"},
+		},
+	}, transport, LegacyHostMetadata())
+	if err != nil {
+		t.Fatalf("NewStandardACPAdapter: %v", err)
+	}
+	adapter := adapterRaw.(*standardACPAdapter)
+	session := standardTestSession("acp:grok-launch-plan-deferred")
+	session.PermissionModeID = "auto"
+	session.Settings = &SessionSettings{PermissionModeID: "auto"}
+	events, err := adapter.Start(context.Background(), session)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	session.ProviderSessionID = events[0].ProviderSessionID
+	transport.mu.Lock()
+	firstConnection := transport.conns[0]
+	transport.mu.Unlock()
+	firstConnection.mu.Lock()
+	firstConnection.closeFailures = 1
+	firstConnection.mu.Unlock()
+	if err := adapter.ReleaseLiveSession(context.Background(), session); err == nil {
+		t.Fatal("ReleaseLiveSession error = nil, want injected close failure")
+	}
+
+	enabled := true
+	session.Settings.PlanMode = enabled
+	if err := adapter.ApplySessionSettings(context.Background(), session, SessionSettingsPatch{PlanMode: &enabled}); err != nil {
+		t.Fatalf("ApplySessionSettings: %v", err)
+	}
+	spawned, _ := transport.snapshot()
+	if spawned != 1 {
+		t.Fatalf("process starts after settings persistence = %d, want 1", spawned)
+	}
+	if err := adapter.Resume(context.Background(), session); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	transport.mu.Lock()
+	specs := append([]ProcessSpec(nil), transport.specs...)
+	connections := append([]*standardACPConnection(nil), transport.conns...)
+	transport.mu.Unlock()
+	if len(specs) != 2 || specs[1].Command[2] != "plan" {
+		t.Fatalf("resume command = %#v, want persisted Plan launch", specs)
+	}
+	if got := asString(connections[1].lastLoadSessionParams["sessionId"]); got != session.ProviderSessionID {
+		t.Fatalf("resumed provider session = %q, want %q", got, session.ProviderSessionID)
+	}
+}
+
 func TestStandardACPLaunchPermissionRejectsUnknownSessionSemantic(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/standard_acp_permissions.go
+++ b/packages/agent/daemon/runtime/standard_acp_permissions.go
@@ -9,7 +9,12 @@ func (a *standardACPAdapter) ApplyPermissionMode(ctx context.Context, session Se
 	if a != nil && a.config.launchPermission != nil {
 		return nil
 	}
-	acpSession := a.getSession(session.AgentSessionID)
+	// Permission changes are live settings RPCs too. Keep their client lookup
+	// and protocol call in the same lifecycle fence as other settings updates
+	// so idle release cannot close the transport between them.
+	unlockLifecycle := a.lockSessionLifecycle(session.AgentSessionID)
+	defer unlockLifecycle()
+	acpSession := a.getUsableSession(session.AgentSessionID)
 	if acpSession == nil || acpSession.client == nil {
 		return nil
 	}

--- a/packages/agent/daemon/runtime/standard_acp_resource_ownership.go
+++ b/packages/agent/daemon/runtime/standard_acp_resource_ownership.go
@@ -1,0 +1,356 @@
+package agentruntime
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+)
+
+func (a *standardACPAdapter) retainRetiredSession(agentSessionID string, session *standardACPSession) {
+	if a == nil || session == nil || session.client == nil {
+		return
+	}
+	agentSessionID = strings.TrimSpace(agentSessionID)
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.retiredSessions == nil {
+		a.retiredSessions = make(map[string][]*standardACPSession)
+	}
+	for _, retained := range a.retiredSessions[agentSessionID] {
+		if retained == session || (retained != nil && retained.client == session.client) {
+			return
+		}
+	}
+	a.retiredSessions[agentSessionID] = append(a.retiredSessions[agentSessionID], session)
+}
+
+func (a *standardACPAdapter) closeOrRetainSession(session Session, acpSession *standardACPSession) {
+	if a == nil || acpSession == nil || acpSession.client == nil {
+		return
+	}
+	// Once ownership is being retired, no late provider frame may be attributed
+	// to a replacement session or its recent Turn.
+	acpSession.client.SetMessageHandler(nil)
+	if err := acpSession.client.Close(); err != nil {
+		a.retainRetiredSession(session.AgentSessionID, acpSession)
+		a.logACPCloseDiagnostics("failed_client.transport_close.failed", session, acpSession, err)
+		return
+	}
+	a.logACPCloseDiagnostics("failed_client.transport_close.succeeded", session, acpSession, nil)
+}
+
+func (a *standardACPAdapter) hasRetiredSessionsLocked(agentSessionID string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.retiredSessions[strings.TrimSpace(agentSessionID)]) > 0
+}
+
+func (*standardACPAdapter) processCleanupPendingError(cause error) error {
+	debugMessage := "an earlier ACP process is still shutting down"
+	if cause != nil {
+		debugMessage = cause.Error()
+	}
+	return &AppError{
+		Code:         AppErrorProcessCleanupPending,
+		Message:      "agent process cleanup is still pending",
+		DebugMessage: debugMessage,
+		Cause:        cause,
+	}
+}
+
+// admitReplacementLocked applies bounded backpressure before another process
+// is spawned. A failed current release is allowed one replacement attempt; it
+// becomes retired when that replacement succeeds. From then on, each user
+// retry spends at most one Close budget and starts no process while any retired
+// handle remains owned by the adapter.
+func (a *standardACPAdapter) admitReplacementLocked(agentSessionID string) error {
+	agentSessionID = strings.TrimSpace(agentSessionID)
+	if !a.hasRetiredSessionsLocked(agentSessionID) {
+		return nil
+	}
+	_, err := a.retryOneTrackedSessionLocked(agentSessionID)
+	if err != nil {
+		return a.processCleanupPendingError(err)
+	}
+	if a.hasRetiredSessionsLocked(agentSessionID) {
+		return a.processCleanupPendingError(errors.New("multiple earlier ACP processes still require cleanup"))
+	}
+	return nil
+}
+
+func (a *standardACPAdapter) isUsableCurrentClient(agentSessionID string, client *acpClient) bool {
+	if a == nil || client == nil {
+		return false
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	current := a.sessions[strings.TrimSpace(agentSessionID)]
+	return current != nil && current.client == client && !current.releasing && !current.releaseFailed
+}
+
+func (a *standardACPAdapter) hasTrackedLiveSession(session Session) bool {
+	if a == nil {
+		return false
+	}
+	agentSessionID := strings.TrimSpace(session.AgentSessionID)
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	current := a.sessions[agentSessionID]
+	return (current != nil && current.client != nil) || len(a.retiredSessions[agentSessionID]) > 0
+}
+
+func (a *standardACPAdapter) CanReleaseLiveSession(session Session) bool {
+	if a == nil {
+		return false
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	acpSession := a.sessions[strings.TrimSpace(session.AgentSessionID)]
+	// Let the live-session probe classify an already released session as not
+	// live. A live process is releasable only when its handshake proved that
+	// the provider session can be restored by a replacement process.
+	return acpSession == nil || acpSession.client == nil || strings.TrimSpace(acpSession.resumeMethod) != ""
+}
+
+// ReleaseLiveSession disconnects the ACP transport without sending
+// session/close. The latter is a destructive provider-history operation for
+// providers that implement it and therefore cannot be used by idle
+// reprepare/reconnect flows.
+func (a *standardACPAdapter) ReleaseLiveSession(_ context.Context, session Session) error {
+	if a == nil || a.transport == nil {
+		return nil
+	}
+	agentSessionID := strings.TrimSpace(session.AgentSessionID)
+	unlockLifecycle := a.lockSessionLifecycle(agentSessionID)
+	defer unlockLifecycle()
+
+	a.mu.Lock()
+	acpSession := a.sessions[agentSessionID]
+	if acpSession == nil || acpSession.client == nil {
+		a.mu.Unlock()
+		return nil
+	}
+	if strings.TrimSpace(acpSession.resumeMethod) == "" {
+		a.mu.Unlock()
+		return errors.New("ACP live session cannot be released without resume support")
+	}
+	for _, approval := range acpSession.pendingApprovals {
+		if approval == nil {
+			continue
+		}
+		state := approval.disposition()
+		if state == pendingInteractiveRequestStatePending || state == pendingInteractiveRequestStateResolving {
+			a.mu.Unlock()
+			return ErrLiveSessionBusy
+		}
+	}
+	acpSession.releasing = true
+	acpSession.client.SetMessageHandler(nil)
+	a.mu.Unlock()
+
+	// Do not send session/close here: the durable provider session id must stay
+	// valid so the next Exec can start a new CLI process and load/resume it.
+	if err := acpSession.client.Close(); err != nil {
+		a.mu.Lock()
+		if a.sessions[agentSessionID] == acpSession {
+			acpSession.releasing = false
+			acpSession.releaseFailed = true
+		}
+		a.mu.Unlock()
+		a.logACPCloseDiagnostics("live_release.transport_close.failed", session, acpSession, err)
+		return err
+	}
+	a.mu.Lock()
+	if a.sessions[agentSessionID] == acpSession {
+		delete(a.sessions, agentSessionID)
+	}
+	a.mu.Unlock()
+	a.logACPCloseDiagnostics("live_release.succeeded", session, acpSession, nil)
+	return nil
+}
+
+func (a *standardACPAdapter) Close(ctx context.Context, session Session) error {
+	if a == nil || a.transport == nil {
+		return nil
+	}
+	agentSessionID := strings.TrimSpace(session.AgentSessionID)
+	unlockLifecycle := a.lockSessionLifecycle(agentSessionID)
+	defer unlockLifecycle()
+	a.rejectPendingApprovals(agentSessionID, errPermissionRequestCanceled)
+	a.mu.Lock()
+	acpSession := a.sessions[agentSessionID]
+	delete(a.sessions, agentSessionID)
+	a.mu.Unlock()
+	if acpSession != nil && acpSession.client != nil {
+		a.closeProviderSession(ctx, session, acpSession)
+		acpSession.client.SetMessageHandler(nil)
+		closeErr := acpSession.client.Close()
+		if closeErr != nil {
+			a.logACPCloseDiagnostics("transport_close.failed", session, acpSession, closeErr)
+			a.retainRetiredSession(agentSessionID, acpSession)
+		} else {
+			a.logACPCloseDiagnostics("closed", session, acpSession, nil)
+		}
+		return closeErr
+	}
+	return nil
+}
+
+func (a *standardACPAdapter) closeProviderSession(ctx context.Context, session Session, acpSession *standardACPSession) {
+	if a == nil || acpSession == nil || acpSession.client == nil || !acpSession.sessionClose {
+		return
+	}
+	providerSessionID := strings.TrimSpace(firstNonEmptyString(acpSession.providerSessionID, session.ProviderSessionID))
+	if providerSessionID == "" {
+		a.logACPCloseDiagnostics("protocol_close.skipped_missing_session_id", session, acpSession, nil)
+		return
+	}
+	params := map[string]any{"sessionId": providerSessionID}
+	if _, err := acpSession.client.CallNoHandlerWithTimeout(ctx, acpCloseCallTimeout, acpMethodCloseSession, params); err != nil {
+		a.logACPCloseDiagnostics("protocol_close.failed", session, acpSession, err)
+		return
+	}
+	a.logACPCloseDiagnostics("protocol_close.succeeded", session, acpSession, nil)
+	a.waitForACPClientDone(acpSession.client, acpCloseGraceTimeout)
+}
+
+func (a *standardACPAdapter) closeReplacedSession(agentSessionID string, previousSession *standardACPSession, currentClient *acpClient) {
+	if previousSession == nil || previousSession.client == nil || previousSession.client == currentClient {
+		return
+	}
+	previousSession.client.SetMessageHandler(nil)
+	if err := previousSession.client.Close(); err != nil {
+		a.retainRetiredSession(agentSessionID, previousSession)
+		slog.Warn("agent session ACP replaced client close failed",
+			"event", "agent_session.acp.replaced_client.close_failed",
+			"provider", a.config.provider,
+			"error", err.Error(),
+		)
+	}
+}
+
+func (a *standardACPAdapter) retryOneTrackedSession(agentSessionID string) (bool, error) {
+	if a == nil {
+		return false, nil
+	}
+	agentSessionID = strings.TrimSpace(agentSessionID)
+	a.mu.Lock()
+	if agentSessionID == "" {
+		for candidate, session := range a.sessions {
+			if session != nil && session.client != nil && session.releaseFailed && !session.releasing {
+				agentSessionID = candidate
+				break
+			}
+		}
+		if agentSessionID == "" {
+			for candidate, sessions := range a.retiredSessions {
+				if len(sessions) > 0 {
+					agentSessionID = candidate
+					break
+				}
+			}
+		}
+	}
+	a.mu.Unlock()
+	if agentSessionID == "" {
+		return false, nil
+	}
+	unlockLifecycle := a.lockSessionLifecycle(agentSessionID)
+	defer unlockLifecycle()
+	return a.retryOneTrackedSessionLocked(agentSessionID)
+}
+
+func (a *standardACPAdapter) retryOneTrackedSessionLocked(agentSessionID string) (bool, error) {
+	a.mu.Lock()
+	current := a.sessions[agentSessionID]
+	if current != nil && current.client != nil && current.releaseFailed && !current.releasing {
+		current.releasing = true
+		current.client.SetMessageHandler(nil)
+		a.mu.Unlock()
+		if err := current.client.Close(); err != nil {
+			a.mu.Lock()
+			if a.sessions[agentSessionID] == current {
+				current.releasing = false
+			}
+			a.mu.Unlock()
+			return true, err
+		}
+		a.mu.Lock()
+		if a.sessions[agentSessionID] == current {
+			delete(a.sessions, agentSessionID)
+		}
+		a.mu.Unlock()
+		return true, nil
+	}
+	retired := a.retiredSessions[agentSessionID]
+	var session *standardACPSession
+	for _, candidate := range retired {
+		if candidate != nil && !candidate.releasing {
+			session = candidate
+			break
+		}
+	}
+	if session == nil {
+		a.mu.Unlock()
+		return false, nil
+	}
+	session.releasing = true
+	if session.client != nil {
+		session.client.SetMessageHandler(nil)
+	}
+	a.mu.Unlock()
+	if session.client == nil {
+		a.removeRetiredSession(agentSessionID, session)
+		return true, nil
+	}
+	if err := session.client.Close(); err != nil {
+		a.mu.Lock()
+		session.releasing = false
+		a.mu.Unlock()
+		return true, err
+	}
+	a.removeRetiredSession(agentSessionID, session)
+	return true, nil
+}
+
+func (a *standardACPAdapter) removeRetiredSession(agentSessionID string, target *standardACPSession) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	retired := a.retiredSessions[agentSessionID]
+	for index, session := range retired {
+		if session != target {
+			continue
+		}
+		retired = append(retired[:index], retired[index+1:]...)
+		if len(retired) == 0 {
+			delete(a.retiredSessions, agentSessionID)
+		} else {
+			a.retiredSessions[agentSessionID] = retired
+		}
+		return
+	}
+}
+
+func (a *standardACPAdapter) CleanupLiveSessionResources(ctx context.Context, limit int) LiveSessionResourceCleanupResult {
+	var result LiveSessionResourceCleanupResult
+	if limit <= 0 {
+		return result
+	}
+	select {
+	case <-ctx.Done():
+		return result
+	default:
+	}
+	attempted, err := a.retryOneTrackedSession("")
+	if !attempted {
+		return result
+	}
+	result.Attempted = 1
+	if err != nil {
+		result.Failed = 1
+	} else {
+		result.Cleaned = 1
+	}
+	return result
+}

--- a/packages/agent/daemon/runtime/standard_acp_session.go
+++ b/packages/agent/daemon/runtime/standard_acp_session.go
@@ -23,6 +23,10 @@ func (a *standardACPAdapter) startupCallTimeout() time.Duration {
 func (a *standardACPAdapter) Start(ctx context.Context, session Session) ([]activityshared.Event, error) {
 	unlockLifecycle := a.lockSessionLifecycle(session.AgentSessionID)
 	defer unlockLifecycle()
+	if err := a.admitReplacementLocked(session.AgentSessionID); err != nil {
+		return nil, err
+	}
+	previousSession := a.getSession(session.AgentSessionID)
 	a.logStandardACPStartupDiagnostics("start.enter", map[string]any{
 		"room_id":            session.RoomID,
 		"agent_session_id":   session.AgentSessionID,
@@ -50,10 +54,10 @@ func (a *standardACPAdapter) Start(ctx context.Context, session Session) ([]acti
 	}
 	started := false
 	keepSession := false
-	previousSession := a.getSession(session.AgentSessionID)
+	var acpSession *standardACPSession
 	defer func() {
-		if !started {
-			_ = client.Close()
+		if !started && acpSession != nil {
+			a.closeOrRetainSession(session, acpSession)
 		}
 		if !keepSession {
 			if previousSession != nil {
@@ -67,15 +71,17 @@ func (a *standardACPAdapter) Start(ctx context.Context, session Session) ([]acti
 	if err != nil {
 		return nil, err
 	}
-	acpSession := &standardACPSession{
+	acpSession = &standardACPSession{
 		client:               client,
 		agentInfo:            acpAgentInfo(initializeResult),
 		promptImage:          standardACPProviderPromptImageSupported(a.config.provider, initializeResult),
 		sessionClose:         standardACPSessionCloseSupported(initializeResult),
+		resumeMethod:         acpResumeMethod(initializeResult),
 		acpLiveState:         standardACPInitialLiveState(),
 		pendingApprovals:     make(map[string]*pendingACPApproval),
 		permissionModeID:     strings.TrimSpace(session.PermissionModeID),
 		planMode:             session.SettingsValue().PlanMode,
+		lifecycleSeq:         session.LifecycleSeq,
 		initialPromptContext: initialPromptContext,
 	}
 	a.storeSession(session.AgentSessionID, acpSession)
@@ -166,7 +172,7 @@ func (a *standardACPAdapter) Start(ctx context.Context, session Session) ([]acti
 
 	started = true
 	keepSession = true
-	a.closeReplacedSession(previousSession, client)
+	a.closeReplacedSession(session.AgentSessionID, previousSession, client)
 	a.logStandardACPStartupDiagnostics("start.succeeded", map[string]any{
 		"room_id":             session.RoomID,
 		"agent_session_id":    session.AgentSessionID,
@@ -186,6 +192,18 @@ func (a *standardACPAdapter) Resume(ctx context.Context, session Session) error 
 	}
 	unlockLifecycle := a.lockSessionLifecycle(session.AgentSessionID)
 	defer unlockLifecycle()
+	if err := a.admitReplacementLocked(session.AgentSessionID); err != nil {
+		return err
+	}
+	return a.resumeLocked(ctx, session)
+}
+
+// resumeLocked reconnects a provider process while the caller owns the
+// per-session lifecycle lock. ApplySessionSettings uses it when a launch-time
+// Plan setting must replace an already usable process without re-entering the
+// same lock.
+func (a *standardACPAdapter) resumeLocked(ctx context.Context, session Session) error {
+	previousSession := a.getSession(session.AgentSessionID)
 	client, initializeResult, attachedCheckpoint, err := a.startClient(ctx, session, true, true)
 	if err != nil {
 		return err
@@ -201,10 +219,10 @@ func (a *standardACPAdapter) Resume(ctx context.Context, session Session) error 
 	}
 	started := false
 	keepSession := false
-	previousSession := a.getSession(session.AgentSessionID)
+	var acpSession *standardACPSession
 	defer func() {
-		if !started {
-			_ = client.Close()
+		if !started && acpSession != nil {
+			a.closeOrRetainSession(session, acpSession)
 		}
 		if !keepSession {
 			if previousSession != nil {
@@ -225,7 +243,7 @@ func (a *standardACPAdapter) Resume(ctx context.Context, session Session) error 
 			a.startupModeID(session),
 		)
 		agentInfo, _ := session.RuntimeContext["agent"].(map[string]any)
-		acpSession := &standardACPSession{
+		acpSession = &standardACPSession{
 			client:               client,
 			providerSessionID:    session.ProviderSessionID,
 			resumeRuntimeContext: clonePayload(session.RuntimeContext),
@@ -234,24 +252,27 @@ func (a *standardACPAdapter) Resume(ctx context.Context, session Session) error 
 			pendingApprovals:     make(map[string]*pendingACPApproval),
 			permissionModeID:     strings.TrimSpace(session.PermissionModeID),
 			planMode:             session.SettingsValue().PlanMode,
+			lifecycleSeq:         session.LifecycleSeq,
 			initialPromptContext: initialPromptContext,
 		}
 		started = true
 		keepSession = true
 		a.storeSession(session.AgentSessionID, acpSession)
-		a.closeReplacedSession(previousSession, client)
+		a.closeReplacedSession(session.AgentSessionID, previousSession, client)
 		return nil
 	}
-	acpSession := &standardACPSession{
+	acpSession = &standardACPSession{
 		client:               client,
 		providerSessionID:    session.ProviderSessionID,
 		agentInfo:            acpAgentInfo(initializeResult),
 		promptImage:          standardACPProviderPromptImageSupported(a.config.provider, initializeResult),
 		sessionClose:         standardACPSessionCloseSupported(initializeResult),
+		resumeMethod:         acpResumeMethod(initializeResult),
 		acpLiveState:         standardACPInitialLiveState(),
 		pendingApprovals:     make(map[string]*pendingACPApproval),
 		permissionModeID:     strings.TrimSpace(session.PermissionModeID),
 		planMode:             session.SettingsValue().PlanMode,
+		lifecycleSeq:         session.LifecycleSeq,
 		initialPromptContext: initialPromptContext,
 	}
 	if previousSession != nil {
@@ -259,7 +280,7 @@ func (a *standardACPAdapter) Resume(ctx context.Context, session Session) error 
 	}
 	a.storeSession(session.AgentSessionID, acpSession)
 
-	method := acpResumeMethod(initializeResult)
+	method := acpSession.resumeMethod
 	if method == "" {
 		return unsupportedACPResumeError(session)
 	}
@@ -289,7 +310,7 @@ func (a *standardACPAdapter) Resume(ctx context.Context, session Session) error 
 	}
 	started = true
 	keepSession = true
-	a.closeReplacedSession(previousSession, client)
+	a.closeReplacedSession(session.AgentSessionID, previousSession, client)
 	return nil
 }
 
@@ -331,7 +352,7 @@ func (*standardACPAdapter) CanResume(session Session) bool {
 }
 
 func (a *standardACPAdapter) HasLiveSession(session Session) bool {
-	acpSession := a.getSession(session.AgentSessionID)
+	acpSession := a.getUsableSession(session.AgentSessionID)
 	if acpSession == nil || acpSession.client == nil {
 		return false
 	}
@@ -340,93 +361,6 @@ func (a *standardACPAdapter) HasLiveSession(session Session) bool {
 		return false
 	default:
 		return true
-	}
-}
-
-// ReleaseLiveSession disconnects the ACP transport without sending
-// session/close. The latter is a destructive provider-history operation for
-// providers that implement it and therefore cannot be used by idle
-// reprepare/reconnect flows.
-func (a *standardACPAdapter) ReleaseLiveSession(_ context.Context, session Session) error {
-	if a == nil || a.transport == nil {
-		return nil
-	}
-	agentSessionID := strings.TrimSpace(session.AgentSessionID)
-	unlockLifecycle := a.lockSessionLifecycle(agentSessionID)
-	defer unlockLifecycle()
-	a.mu.Lock()
-	acpSession := a.sessions[agentSessionID]
-	if acpSession != nil {
-		for _, pending := range acpSession.pendingApprovals {
-			if pending != nil {
-				state := pending.disposition()
-				if state == pendingInteractiveRequestStatePending || state == pendingInteractiveRequestStateResolving {
-					a.mu.Unlock()
-					return ErrLiveSessionBusy
-				}
-			}
-		}
-	}
-	delete(a.sessions, agentSessionID)
-	a.mu.Unlock()
-	if acpSession == nil || acpSession.client == nil {
-		return nil
-	}
-	return acpSession.client.Close()
-}
-
-func (a *standardACPAdapter) Close(ctx context.Context, session Session) error {
-	if a == nil || a.transport == nil {
-		return nil
-	}
-	agentSessionID := strings.TrimSpace(session.AgentSessionID)
-	unlockLifecycle := a.lockSessionLifecycle(agentSessionID)
-	defer unlockLifecycle()
-	a.rejectPendingApprovals(agentSessionID, errPermissionRequestCanceled)
-	a.mu.Lock()
-	acpSession := a.sessions[agentSessionID]
-	delete(a.sessions, agentSessionID)
-	a.mu.Unlock()
-	if acpSession != nil && acpSession.client != nil {
-		a.closeProviderSession(ctx, session, acpSession)
-		closeErr := acpSession.client.Close()
-		if closeErr != nil {
-			a.logACPCloseDiagnostics("transport_close.failed", session, acpSession, closeErr)
-			return closeErr
-		}
-		a.logACPCloseDiagnostics("closed", session, acpSession, nil)
-	}
-	return nil
-}
-
-func (a *standardACPAdapter) closeProviderSession(ctx context.Context, session Session, acpSession *standardACPSession) {
-	if a == nil || acpSession == nil || acpSession.client == nil || !acpSession.sessionClose {
-		return
-	}
-	providerSessionID := strings.TrimSpace(firstNonEmptyString(acpSession.providerSessionID, session.ProviderSessionID))
-	if providerSessionID == "" {
-		a.logACPCloseDiagnostics("protocol_close.skipped_missing_session_id", session, acpSession, nil)
-		return
-	}
-	params := map[string]any{"sessionId": providerSessionID}
-	if _, err := acpSession.client.CallNoHandlerWithTimeout(ctx, acpCloseCallTimeout, acpMethodCloseSession, params); err != nil {
-		a.logACPCloseDiagnostics("protocol_close.failed", session, acpSession, err)
-		return
-	}
-	a.logACPCloseDiagnostics("protocol_close.succeeded", session, acpSession, nil)
-	a.waitForACPClientDone(acpSession.client, acpCloseGraceTimeout)
-}
-
-func (a *standardACPAdapter) closeReplacedSession(previousSession *standardACPSession, currentClient *acpClient) {
-	if previousSession == nil || previousSession.client == nil || previousSession.client == currentClient {
-		return
-	}
-	if err := previousSession.client.Close(); err != nil {
-		slog.Warn("agent session ACP replaced client close failed",
-			"event", "agent_session.acp.replaced_client.close_failed",
-			"provider", a.config.provider,
-			"error", err.Error(),
-		)
 	}
 }
 
@@ -577,6 +511,9 @@ func (a *standardACPAdapter) startClient(
 	})
 	client := newACPClientWithStderrMessageMapper(conn, a.config.stderrMessageMapper)
 	client.SetMessageHandler(func(ctx context.Context, message acpMessage) error {
+		if !a.isUsableCurrentClient(session.AgentSessionID, client) {
+			return nil
+		}
 		endInputUnit := a.inputUnits.begin(ctx, session.AgentSessionID)
 		defer endInputUnit()
 		turnSession := session
@@ -588,9 +525,13 @@ func (a *standardACPAdapter) startClient(
 		return err
 	})
 	started := false
+	failedSession := &standardACPSession{
+		client:           client,
+		pendingApprovals: make(map[string]*pendingACPApproval),
+	}
 	defer func() {
 		if !started {
-			_ = client.Close()
+			a.closeOrRetainSession(session, failedSession)
 		}
 	}()
 	captureOrigin := processCassetteCaptureOrigin(conn)

--- a/packages/agent/daemon/runtime/standard_acp_session_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_session_test.go
@@ -2,10 +2,12 @@ package agentruntime
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
@@ -306,6 +308,7 @@ func TestStandardACPAdapterReleaseLiveSessionClosesOnlyTransport(t *testing.T) {
 	t.Parallel()
 
 	transport := newStandardACPTransport("Hermes Agent", "hermes-session-release")
+	transport.conn.supportsAgentLoadSession = true
 	transport.conn.supportsCloseSession = true
 	adapter := newHermesExtensionTestAdapter(transport)
 	session := standardTestSession(hermesExtensionTestProvider)
@@ -313,17 +316,614 @@ func TestStandardACPAdapterReleaseLiveSessionClosesOnlyTransport(t *testing.T) {
 	if _, err := adapter.Start(context.Background(), session); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
+	if !adapter.CanReleaseLiveSession(session) {
+		t.Fatal("CanReleaseLiveSession = false, want load-capable Hermes session releasable")
+	}
 	if err := adapter.ReleaseLiveSession(context.Background(), session); err != nil {
 		t.Fatalf("ReleaseLiveSession: %v", err)
 	}
-	if params := transport.conn.closeSessionParams(); len(params) != 0 {
-		t.Fatalf("ReleaseLiveSession sent destructive session/close params %#v", params)
-	}
 	if !transport.conn.closed() {
-		t.Fatal("ReleaseLiveSession did not close ACP transport")
+		t.Fatal("transport was not closed by live-session release")
+	}
+	if params := transport.conn.closeSessionParams(); params != nil {
+		t.Fatalf("session/close params = %#v, want no destructive protocol close", params)
 	}
 	if adapter.HasLiveSession(session) {
-		t.Fatal("HasLiveSession = true after release")
+		t.Fatal("adapter still reports a live session after release")
+	}
+}
+
+func TestStandardACPAdapterResumeContinuesLifecycleSequenceAfterRelease(t *testing.T) {
+	t.Parallel()
+
+	transport := &multiProcStandardACPTransport{
+		agentTitle:               "Kimi Code",
+		sessionID:                "kimi-session-lifecycle",
+		supportsAgentLoadSession: true,
+	}
+	adapter := newKimiCodeExtensionTestAdapter(t, transport)
+	session := standardTestSession("acp:kimi-code")
+	session.ProviderSessionID = transport.sessionID
+
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	live := adapter.getSession(session.AgentSessionID)
+	first := adapter.stampTurnLifecycleSnapshots(live, []activityshared.Event{
+		standardACPRootProviderTurnStartedEvent(session, "turn-before-release"),
+	})
+	snapshot, ok := activityshared.TurnLifecycleSnapshotFromEvent(first[0])
+	if !ok || snapshot.Seq == 0 {
+		t.Fatalf("initial lifecycle snapshot = %#v, want non-zero sequence", snapshot)
+	}
+	session = applyTurnLifecycleSnapshot(session, snapshot, "turn-before-release")
+
+	if err := adapter.ReleaseLiveSession(context.Background(), session); err != nil {
+		t.Fatalf("ReleaseLiveSession: %v", err)
+	}
+	if err := adapter.Resume(context.Background(), session); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	resumed := adapter.getSession(session.AgentSessionID)
+	next := adapter.stampTurnLifecycleSnapshots(resumed, []activityshared.Event{
+		standardACPRootProviderTurnStartedEvent(session, "turn-after-release"),
+	})
+	nextSnapshot, ok := activityshared.TurnLifecycleSnapshotFromEvent(next[0])
+	if !ok {
+		t.Fatal("resumed lifecycle event has no snapshot")
+	}
+	if nextSnapshot.Seq <= session.LifecycleSeq {
+		t.Fatalf("resumed lifecycle sequence = %d, want > persisted %d", nextSnapshot.Seq, session.LifecycleSeq)
+	}
+	updated := applyTurnLifecycleSnapshot(session, nextSnapshot, "turn-after-release")
+	if updated.LifecycleSeq != nextSnapshot.Seq {
+		t.Fatalf("controller lifecycle sequence = %d, want accepted %d", updated.LifecycleSeq, nextSnapshot.Seq)
+	}
+}
+
+func TestStandardACPAdapterReleaseLiveSessionRetainsClientAfterCloseFailure(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Kimi Code", "kimi-session-close-retry")
+	transport.conn.supportsAgentLoadSession = true
+	transport.conn.closeFailures = 1
+	adapter := newKimiCodeExtensionTestAdapter(t, transport)
+	session := standardTestSession("acp:kimi-code")
+
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := adapter.ReleaseLiveSession(context.Background(), session); err == nil {
+		t.Fatal("first ReleaseLiveSession error = nil, want injected close failure")
+	}
+	if adapter.HasLiveSession(session) {
+		t.Fatal("failed release exposed the client as usable after closing its input")
+	}
+	if !adapter.hasTrackedLiveSession(session) {
+		t.Fatal("failed release lost ownership of the physical client")
+	}
+	cleanup := adapter.CleanupLiveSessionResources(context.Background(), 1)
+	if cleanup.Attempted != 1 || cleanup.Cleaned != 1 || cleanup.Failed != 0 {
+		t.Fatalf("cleanup result = %#v, want one successful retry", cleanup)
+	}
+	if adapter.HasLiveSession(session) {
+		t.Fatal("successful release kept the live client")
+	}
+	transport.conn.mu.Lock()
+	closeCalls := transport.conn.closeCalls
+	transport.conn.mu.Unlock()
+	if closeCalls != 2 {
+		t.Fatalf("transport close calls = %d, want 2", closeCalls)
+	}
+}
+
+func TestStandardACPAdapterResumesAfterReleaseFailureAndRetainsOldHandle(t *testing.T) {
+	t.Parallel()
+
+	transport := &multiProcStandardACPTransport{
+		agentTitle:               "Kimi Code",
+		sessionID:                "kimi-session-release-recovery",
+		supportsAgentLoadSession: true,
+	}
+	adapter := newKimiCodeExtensionTestAdapter(t, transport)
+	session := standardTestSession("acp:kimi-code")
+	session.ProviderSessionID = transport.sessionID
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	transport.mu.Lock()
+	oldConnection := transport.conns[0]
+	transport.mu.Unlock()
+	oldConnection.mu.Lock()
+	oldConnection.closeFailures = 3
+	oldConnection.mu.Unlock()
+
+	if err := adapter.ReleaseLiveSession(context.Background(), session); err == nil {
+		t.Fatal("ReleaseLiveSession error = nil, want injected close failure")
+	}
+	if adapter.HasLiveSession(session) {
+		t.Fatal("failed release client remained usable")
+	}
+	if err := adapter.Resume(context.Background(), session); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if !adapter.HasLiveSession(session) {
+		t.Fatal("replacement client is not live")
+	}
+	if _, err := adapter.Exec(context.Background(), session, textPrompt("continue after release"), "", "turn-after-release-failure", nil, nil); err != nil {
+		t.Fatalf("Exec on replacement client: %v", err)
+	}
+	transport.mu.Lock()
+	replacementConnection := transport.conns[1]
+	transport.mu.Unlock()
+	replacementConnection.mu.Lock()
+	promptCallsBeforeBackpressure := replacementConnection.promptCallCount
+	replacementConnection.mu.Unlock()
+
+	// Releasing the replacement does not retry the retired handle in the same
+	// canonical sweep. The next replacement attempt gets one bounded cleanup
+	// budget and is rejected before spawning another process when cleanup still
+	// fails.
+	if err := adapter.ReleaseLiveSession(context.Background(), session); err != nil {
+		t.Fatalf("replacement release: %v", err)
+	}
+	if !adapter.hasTrackedLiveSession(session) {
+		t.Fatal("retired handle was not tracked after replacement release")
+	}
+	spawnedBefore, _ := transport.snapshot()
+	err := adapter.Resume(context.Background(), session)
+	if AppErrorCode(err) != AppErrorProcessCleanupPending {
+		t.Fatalf("Resume error code = %q (err=%v), want %q", AppErrorCode(err), err, AppErrorProcessCleanupPending)
+	}
+	spawnedAfter, _ := transport.snapshot()
+	if spawnedAfter != spawnedBefore {
+		t.Fatalf("spawned processes = %d after blocked resume, want %d", spawnedAfter, spawnedBefore)
+	}
+	replacementConnection.mu.Lock()
+	promptCallsAfterBackpressure := replacementConnection.promptCallCount
+	replacementConnection.mu.Unlock()
+	if promptCallsAfterBackpressure != promptCallsBeforeBackpressure {
+		t.Fatalf("provider prompt calls changed from %d to %d after blocked resume", promptCallsBeforeBackpressure, promptCallsAfterBackpressure)
+	}
+	otherSession := session
+	otherSession.AgentSessionID = "agent-session-unaffected"
+	otherSession.ProviderSessionID = ""
+	if _, err := adapter.Start(context.Background(), otherSession); err != nil {
+		t.Fatalf("Start other session while first is backpressured: %v", err)
+	}
+	spawnedWithOtherSession, _ := transport.snapshot()
+	if spawnedWithOtherSession != spawnedAfter+1 {
+		t.Fatalf("spawned processes after other session start = %d, want %d", spawnedWithOtherSession, spawnedAfter+1)
+	}
+	if !adapter.HasLiveSession(otherSession) {
+		t.Fatal("other session was affected by first session cleanup backpressure")
+	}
+	cleanup := adapter.CleanupLiveSessionResources(context.Background(), 1)
+	if cleanup.Attempted != 1 || cleanup.Cleaned != 1 || cleanup.Failed != 0 {
+		t.Fatalf("cleanup result = %#v, want retired handle cleanup", cleanup)
+	}
+	oldConnection.mu.Lock()
+	closeCalls := oldConnection.closeCalls
+	oldConnection.mu.Unlock()
+	if closeCalls != 4 {
+		t.Fatalf("old transport close calls = %d, want release + replacement + admission + cleanup", closeCalls)
+	}
+	adapter.mu.Lock()
+	retired := len(adapter.retiredSessions[session.AgentSessionID])
+	adapter.mu.Unlock()
+	if retired != 0 {
+		t.Fatalf("retired handles = %d, want 0", retired)
+	}
+	spawnedBeforeRecovery, _ := transport.snapshot()
+	if err := adapter.Resume(context.Background(), session); err != nil {
+		t.Fatalf("Resume after retired cleanup: %v", err)
+	}
+	spawnedAfterRecovery, _ := transport.snapshot()
+	if spawnedAfterRecovery != spawnedBeforeRecovery+1 {
+		t.Fatalf("spawned processes after cleanup recovery = %d, want %d", spawnedAfterRecovery, spawnedBeforeRecovery+1)
+	}
+	if !adapter.HasLiveSession(session) {
+		t.Fatal("session did not recover after retired handle cleanup")
+	}
+}
+
+func TestStandardACPAdapterRetainsInitializeFailureWhenTransportCloseFails(t *testing.T) {
+	t.Parallel()
+
+	transport := &multiProcStandardACPTransport{
+		agentTitle:      "Kimi Code",
+		sessionID:       "kimi-session-initialize-failure",
+		initializeError: &acpError{Code: -32603, Message: "initialize failed"},
+		closeFailures:   1,
+	}
+	adapter := newKimiCodeExtensionTestAdapter(t, transport)
+	session := standardTestSession("acp:kimi-code")
+
+	if _, err := adapter.Start(context.Background(), session); err == nil {
+		t.Fatal("Start error = nil, want initialize failure")
+	}
+	spawned, _ := transport.snapshot()
+	if spawned != 1 || !adapter.hasTrackedLiveSession(session) {
+		t.Fatalf("spawned=%d tracked=%v, want failed client retained", spawned, adapter.hasTrackedLiveSession(session))
+	}
+	cleanup := adapter.CleanupLiveSessionResources(context.Background(), 1)
+	if cleanup.Attempted != 1 || cleanup.Cleaned != 1 || cleanup.Failed != 0 {
+		t.Fatalf("cleanup result = %#v", cleanup)
+	}
+}
+
+func TestStandardACPAdapterRetainsStartAndResumeFailuresWhenTransportCloseFails(t *testing.T) {
+	t.Parallel()
+
+	t.Run("session new", func(t *testing.T) {
+		transport := &multiProcStandardACPTransport{
+			agentTitle:      "Kimi Code",
+			sessionID:       "kimi-session-new-failure",
+			newSessionError: &acpError{Code: -32603, Message: "new failed"},
+			closeFailures:   1,
+		}
+		adapter := newKimiCodeExtensionTestAdapter(t, transport)
+		session := standardTestSession("acp:kimi-code")
+		if _, err := adapter.Start(context.Background(), session); err == nil {
+			t.Fatal("Start error = nil, want session/new failure")
+		}
+		if !adapter.hasTrackedLiveSession(session) {
+			t.Fatal("session/new failed client was not retained")
+		}
+	})
+
+	t.Run("session load", func(t *testing.T) {
+		transport := &multiProcStandardACPTransport{
+			agentTitle:               "Kimi Code",
+			sessionID:                "kimi-session-load-failure",
+			supportsAgentLoadSession: true,
+		}
+		adapter := newKimiCodeExtensionTestAdapter(t, transport)
+		session := standardTestSession("acp:kimi-code")
+		if _, err := adapter.Start(context.Background(), session); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+		if err := adapter.ReleaseLiveSession(context.Background(), session); err != nil {
+			t.Fatalf("ReleaseLiveSession: %v", err)
+		}
+		transport.mu.Lock()
+		transport.loadSessionError = &acpError{Code: -32603, Message: "load failed"}
+		transport.closeFailures = 1
+		transport.mu.Unlock()
+		if err := adapter.Resume(context.Background(), session); err == nil {
+			t.Fatal("Resume error = nil, want session/load failure")
+		}
+		if !adapter.hasTrackedLiveSession(session) {
+			t.Fatal("session/load failed client was not retained")
+		}
+	})
+}
+
+func TestStandardACPAdapterQuarantinesRetiredClientMessages(t *testing.T) {
+	t.Parallel()
+
+	transport := &multiProcStandardACPTransport{
+		agentTitle:               "Kimi Code",
+		sessionID:                "kimi-session-stale-message",
+		supportsAgentLoadSession: true,
+	}
+	adapter := newKimiCodeExtensionTestAdapter(t, transport)
+	session := standardTestSession("acp:kimi-code")
+	session.ProviderSessionID = transport.sessionID
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	transport.mu.Lock()
+	oldConnection := transport.conns[0]
+	transport.mu.Unlock()
+	oldConnection.mu.Lock()
+	oldConnection.closeFailures = 2
+	oldConnection.mu.Unlock()
+	if err := adapter.ReleaseLiveSession(context.Background(), session); err == nil {
+		t.Fatal("ReleaseLiveSession error = nil, want injected close failure")
+	}
+	if err := adapter.Resume(context.Background(), session); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if _, err := adapter.Exec(context.Background(), session, textPrompt("new generation"), "", "turn-new", nil, nil); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+
+	staleEvents := make(chan []activityshared.Event, 1)
+	adapter.SetSessionEventSink(func(_ string, events []activityshared.Event) {
+		staleEvents <- events
+	})
+	oldConnection.sendJSON(map[string]any{
+		"jsonrpc": "2.0",
+		"method":  acpMethodUpdate,
+		"params": map[string]any{
+			"sessionId": transport.sessionID,
+			"update": map[string]any{
+				"sessionUpdate": "agent_message_chunk",
+				"content":       map[string]any{"type": "text", "text": "stale output"},
+			},
+		},
+	})
+	select {
+	case events := <-staleEvents:
+		t.Fatalf("retired client emitted events into replacement timeline: %#v", events)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestStandardACPAdapterDefersSettingsAfterReleaseFailureUntilResume(t *testing.T) {
+	t.Parallel()
+
+	transport := &multiProcStandardACPTransport{
+		agentTitle:               "Kimi Code",
+		sessionID:                "kimi-session-settings-recovery",
+		supportsAgentLoadSession: true,
+		configOptions: []map[string]any{{
+			"id":      "model",
+			"options": []any{map[string]any{"name": "Model B", "value": "model-b"}},
+		}},
+	}
+	adapterValue, err := NewStandardACPAdapter(StandardACPAdapterConfig{
+		Provider:            "acp:kimi-code",
+		Name:                "kimi-code-acp",
+		DisplayName:         "Kimi Code",
+		Command:             []string{"kimi", "acp"},
+		ModelConfigOptionID: "model",
+		PermissionModes:     map[string]string{"full-access": "yolo"},
+	}, transport, LegacyHostMetadata())
+	if err != nil {
+		t.Fatalf("NewStandardACPAdapter: %v", err)
+	}
+	adapter := adapterValue.(*standardACPAdapter)
+	session := standardTestSession("acp:kimi-code")
+	session.ProviderSessionID = transport.sessionID
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	transport.mu.Lock()
+	oldConnection := transport.conns[0]
+	transport.mu.Unlock()
+	oldConnection.mu.Lock()
+	oldConnection.closeFailures = 1
+	oldConnection.mu.Unlock()
+	if err := adapter.ReleaseLiveSession(context.Background(), session); err == nil {
+		t.Fatal("ReleaseLiveSession error = nil, want injected close failure")
+	}
+
+	model := "model-b"
+	if err := adapter.ApplySessionSettings(context.Background(), session, SessionSettingsPatch{Model: &model}); err != nil {
+		t.Fatalf("ApplySessionSettings on unusable client: %v", err)
+	}
+	session.PermissionModeID = "full-access"
+	if err := adapter.ApplyPermissionMode(context.Background(), session); err != nil {
+		t.Fatalf("ApplyPermissionMode on unusable client: %v", err)
+	}
+	if calls := oldConnection.setConfigOptionCalls(); len(calls) != 0 {
+		t.Fatalf("unusable client settings calls = %#v, want none", calls)
+	}
+	if got := oldConnection.lastModeID(); got != "" {
+		t.Fatalf("unusable client mode = %q, want no RPC", got)
+	}
+
+	session.Settings = &SessionSettings{Model: model}
+	if err := adapter.Resume(context.Background(), session); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	transport.mu.Lock()
+	resumedConnection := transport.conns[1]
+	transport.mu.Unlock()
+	calls := resumedConnection.setConfigOptionCalls()
+	if len(calls) != 1 || calls[0]["configId"] != "model" || calls[0]["value"] != model {
+		t.Fatalf("resumed settings calls = %#v, want durable model", calls)
+	}
+	if got := resumedConnection.lastModeID(); got != "yolo" {
+		t.Fatalf("resumed mode = %q, want durable permission mode", got)
+	}
+}
+
+func TestControllerCleansRetiredACPHandleAfterCanonicalSessionRemoval(t *testing.T) {
+	t.Parallel()
+
+	transport := &multiProcStandardACPTransport{
+		agentTitle:               "Kimi Code",
+		sessionID:                "kimi-session-detached-cleanup",
+		supportsAgentLoadSession: true,
+	}
+	adapter := newKimiCodeExtensionTestAdapter(t, transport)
+	controller := NewController([]Adapter{adapter}, &recordingReporter{})
+	started, err := controller.Start(context.Background(), StartInput{
+		RoomID:         "room-detached-cleanup",
+		AgentSessionID: "agent-detached-cleanup",
+		Provider:       "acp:kimi-code",
+		CWD:            "/workspace",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	transport.mu.Lock()
+	connection := transport.conns[0]
+	transport.mu.Unlock()
+	connection.mu.Lock()
+	connection.closeFailures = 2
+	connection.mu.Unlock()
+
+	if _, err := controller.Close(context.Background(), CloseInput{
+		RoomID:                 started.Session.RoomID,
+		AgentSessionID:         started.Session.AgentSessionID,
+		PreserveCanonicalState: true,
+	}); err == nil {
+		t.Fatal("Close error = nil, want retained physical handle failure")
+	}
+	if _, ok := controller.Session(started.Session.RoomID, started.Session.AgentSessionID); ok {
+		t.Fatal("controller retained canonical session")
+	}
+	if !adapter.hasTrackedLiveSession(started.Session) {
+		t.Fatal("adapter lost detached physical handle")
+	}
+
+	result := controller.CloseAllLiveSessions(context.Background())
+	if result.Scanned != 0 || result.Closed != 0 || result.Failed != 0 ||
+		result.ResourceCleanupAttempted != 1 || result.ResourceCleanupCleaned != 0 || result.ResourceCleanupFailed != 1 {
+		t.Fatalf("CloseAllLiveSessions result = %#v, want one bounded detached cleanup failure", result)
+	}
+	if !adapter.hasTrackedLiveSession(started.Session) {
+		t.Fatal("detached physical handle was dropped after bounded cleanup failure")
+	}
+	result = controller.CloseAllLiveSessions(context.Background())
+	if result.Scanned != 0 || result.Closed != 0 || result.Failed != 0 ||
+		result.ResourceCleanupAttempted != 1 || result.ResourceCleanupCleaned != 1 || result.ResourceCleanupFailed != 0 {
+		t.Fatalf("second CloseAllLiveSessions result = %#v, want detached cleanup success", result)
+	}
+	if adapter.hasTrackedLiveSession(started.Session) {
+		t.Fatal("detached physical handle remained after cleanup")
+	}
+}
+
+func TestStandardACPAdapterReleaseWaitsForLiveSettingsRPC(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Kimi Code", "kimi-session-settings-release")
+	transport.conn.supportsAgentLoadSession = true
+	transport.conn.configOptions = []map[string]any{{
+		"id":      "model",
+		"options": []any{map[string]any{"name": "Model B", "value": "model-b"}},
+	}}
+	adapter := newKimiCodeExtensionTestAdapter(t, transport)
+	session := standardTestSession("acp:kimi-code")
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	started := make(chan struct{}, 1)
+	releaseRPC := make(chan struct{})
+	transport.conn.mu.Lock()
+	transport.conn.pauseSettingsRPCStarted = started
+	transport.conn.pauseSettingsRPCRelease = releaseRPC
+	transport.conn.mu.Unlock()
+
+	settingsDone := make(chan error, 1)
+	go func() {
+		settingsDone <- adapter.ApplySessionSettings(context.Background(), session, SessionSettingsPatch{Model: stringPtr("model-b")})
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("settings RPC did not start")
+	}
+
+	releaseDone := make(chan error, 1)
+	go func() {
+		releaseDone <- adapter.ReleaseLiveSession(context.Background(), session)
+	}()
+	select {
+	case err := <-releaseDone:
+		t.Fatalf("release completed while settings RPC was blocked: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	if !adapter.HasLiveSession(session) {
+		t.Fatal("release closed the client while settings RPC was blocked")
+	}
+
+	close(releaseRPC)
+	if err := <-settingsDone; err != nil {
+		t.Fatalf("ApplySessionSettings: %v", err)
+	}
+	if err := <-releaseDone; err != nil {
+		t.Fatalf("ReleaseLiveSession: %v", err)
+	}
+	if adapter.HasLiveSession(session) {
+		t.Fatal("release did not close the client after settings completed")
+	}
+}
+
+func TestStandardACPAdapterReleaseWaitsForPermissionModeRPC(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Kimi Code", "kimi-session-permission-release")
+	transport.conn.supportsAgentLoadSession = true
+	adapterValue, err := NewStandardACPAdapter(StandardACPAdapterConfig{
+		Provider:        "acp:kimi-code",
+		Name:            "kimi-code-acp",
+		DisplayName:     "Kimi Code",
+		Command:         []string{"kimi", "acp"},
+		PermissionModes: map[string]string{"full-access": "yolo"},
+	}, transport, LegacyHostMetadata())
+	if err != nil {
+		t.Fatalf("NewStandardACPAdapter: %v", err)
+	}
+	adapter := adapterValue.(*standardACPAdapter)
+	session := standardTestSession("acp:kimi-code")
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	started := make(chan struct{}, 1)
+	releaseRPC := make(chan struct{})
+	transport.conn.mu.Lock()
+	transport.conn.pauseSettingsRPCStarted = started
+	transport.conn.pauseSettingsRPCRelease = releaseRPC
+	transport.conn.mu.Unlock()
+	session.PermissionModeID = "full-access"
+
+	settingsDone := make(chan error, 1)
+	go func() {
+		settingsDone <- adapter.ApplyPermissionMode(context.Background(), session)
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("permission mode RPC did not start")
+	}
+
+	releaseDone := make(chan error, 1)
+	go func() {
+		releaseDone <- adapter.ReleaseLiveSession(context.Background(), session)
+	}()
+	select {
+	case err := <-releaseDone:
+		t.Fatalf("release completed while permission RPC was blocked: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	if !adapter.HasLiveSession(session) {
+		t.Fatal("release closed the client while permission RPC was blocked")
+	}
+
+	close(releaseRPC)
+	if err := <-settingsDone; err != nil {
+		t.Fatalf("ApplyPermissionMode: %v", err)
+	}
+	if err := <-releaseDone; err != nil {
+		t.Fatalf("ReleaseLiveSession: %v", err)
+	}
+}
+
+func TestStandardACPAdapterReleaseLiveSessionRejectsPendingApproval(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Kimi Code", "kimi-session-pending-approval")
+	transport.conn.supportsAgentLoadSession = true
+	adapter := newKimiCodeExtensionTestAdapter(t, transport)
+	session := standardTestSession("acp:kimi-code")
+
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	adapter.storePendingApproval(&pendingACPApproval{
+		agentSessionID: session.AgentSessionID,
+		requestID:      "approval-1",
+		response:       make(chan pendingInteractiveResponse, 1),
+	})
+	if err := adapter.ReleaseLiveSession(context.Background(), session); !errors.Is(err, ErrLiveSessionBusy) {
+		t.Fatalf("ReleaseLiveSession error = %v, want ErrLiveSessionBusy", err)
+	}
+	if transport.conn.closed() {
+		t.Fatal("transport closed while an approval was pending")
+	}
+	if !adapter.HasLiveSession(session) {
+		t.Fatal("adapter lost live session while an approval was pending")
+	}
+	if err := adapter.Close(context.Background(), session); err != nil {
+		t.Fatalf("Close: %v", err)
 	}
 }
 

--- a/packages/agent/daemon/runtime/standard_acp_settings.go
+++ b/packages/agent/daemon/runtime/standard_acp_settings.go
@@ -466,7 +466,36 @@ func (a *standardACPAdapter) ApplySessionSettings(
 	if a.RequiresNewSessionForSettings(session, patch) {
 		return ErrSessionSettingsRequireNewSession
 	}
-	acpSession := a.getSession(session.AgentSessionID)
+	if patch.PlanMode != nil && a.config.planModeUsesLaunchPermission {
+		unlockLifecycle := a.lockSessionLifecycle(session.AgentSessionID)
+		defer unlockLifecycle()
+		live := a.getUsableSession(session.AgentSessionID)
+		if live == nil || live.client == nil {
+			// The Host persists the setting. Starting a replacement process is
+			// deferred until the next user operation reconnects this session.
+			return nil
+		}
+		if strings.TrimSpace(session.ProviderSessionID) == "" {
+			session.ProviderSessionID = live.providerSessionID
+		}
+		if strings.TrimSpace(session.ProviderSessionID) == "" {
+			return errors.New("agent session ACP Plan restart requires a provider session id")
+		}
+		if err := a.admitReplacementLocked(session.AgentSessionID); err != nil {
+			return err
+		}
+		if err := a.resumeLocked(ctx, session); err != nil {
+			return fmt.Errorf("agent session ACP Plan restart failed: %w", err)
+		}
+		return nil
+	}
+
+	// Serialize every live-client settings RPC with start, resume, close, and
+	// idle release. In particular, the reaper must not close the process while
+	// an in-place config request is awaiting its provider response.
+	unlockLifecycle := a.lockSessionLifecycle(session.AgentSessionID)
+	defer unlockLifecycle()
+	acpSession := a.getUsableSession(session.AgentSessionID)
 	if acpSession == nil || acpSession.client == nil {
 		return nil
 	}
@@ -475,15 +504,6 @@ func (a *standardACPAdapter) ApplySessionSettings(
 	}
 
 	if patch.PlanMode != nil {
-		if a.config.planModeUsesLaunchPermission {
-			if strings.TrimSpace(session.ProviderSessionID) == "" {
-				return errors.New("agent session ACP Plan restart requires a provider session id")
-			}
-			if err := a.Resume(ctx, session); err != nil {
-				return fmt.Errorf("agent session ACP Plan restart failed: %w", err)
-			}
-			return nil
-		}
 		if err := a.applyACPMode(ctx, acpSession.client, session, a.effectiveModeID(session)); err != nil {
 			return err
 		}

--- a/packages/agent/daemon/runtime/standard_acp_stream.go
+++ b/packages/agent/daemon/runtime/standard_acp_stream.go
@@ -326,6 +326,19 @@ func (a *standardACPAdapter) getSession(agentSessionID string) *standardACPSessi
 	return a.sessions[agentSessionID]
 }
 
+func (a *standardACPAdapter) getUsableSession(agentSessionID string) *standardACPSession {
+	if a == nil {
+		return nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	session := a.sessions[strings.TrimSpace(agentSessionID)]
+	if session == nil || session.releasing || session.releaseFailed {
+		return nil
+	}
+	return session
+}
+
 func (a *standardACPAdapter) rememberSessionTurn(agentSessionID string, turnID string) {
 	turnID = strings.TrimSpace(turnID)
 	if a == nil || turnID == "" {

--- a/packages/agent/daemon/runtime/standard_acp_test_connection_rpc_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_test_connection_rpc_test.go
@@ -23,7 +23,16 @@ func (c *standardACPConnection) Send(data []byte) error {
 			if request.Params != nil {
 				c.lastInitializeParamsSnapshot = maps.Clone(request.Params)
 			}
+			initializeError := c.initializeError
 			c.mu.Unlock()
+			if initializeError != nil {
+				c.sendJSON(map[string]any{
+					"jsonrpc": "2.0",
+					"id":      message.ID,
+					"error":   initializeError,
+				})
+				continue
+			}
 			result := map[string]any{
 				"protocolVersion": acpProtocolVersion,
 				"agentInfo": map[string]any{
@@ -44,10 +53,15 @@ func (c *standardACPConnection) Send(data []byte) error {
 			if len(sessionCapabilities) > 0 {
 				result["sessionCapabilities"] = sessionCapabilities
 			}
+			agentCapabilities := map[string]any{}
+			if c.supportsAgentLoadSession {
+				agentCapabilities["loadSession"] = true
+			}
 			if c.supportsHTTPMCP {
-				result["agentCapabilities"] = map[string]any{
-					"mcpCapabilities": map[string]any{"http": true},
-				}
+				agentCapabilities["mcpCapabilities"] = map[string]any{"http": true}
+			}
+			if len(agentCapabilities) > 0 {
+				result["agentCapabilities"] = agentCapabilities
 			}
 			if len(c.authMethods) > 0 {
 				result["authMethods"] = c.authMethods
@@ -199,7 +213,18 @@ func (c *standardACPConnection) Send(data []byte) error {
 				c.lastSetModeParamsSnapshot = maps.Clone(request.Params)
 			}
 			setModeError := c.setModeError
+			started := c.pauseSettingsRPCStarted
+			release := c.pauseSettingsRPCRelease
 			c.mu.Unlock()
+			if started != nil {
+				select {
+				case started <- struct{}{}:
+				default:
+				}
+			}
+			if release != nil {
+				<-release
+			}
 			if setModeError != nil {
 				c.sendJSON(map[string]any{
 					"jsonrpc": "2.0",
@@ -251,7 +276,18 @@ func (c *standardACPConnection) Send(data []byte) error {
 				c.setConfigOptionSnapshots = append(c.setConfigOptionSnapshots, maps.Clone(request.Params))
 			}
 			rejectModelValue := c.rejectModelValue
+			started := c.pauseSettingsRPCStarted
+			release := c.pauseSettingsRPCRelease
 			c.mu.Unlock()
+			if started != nil {
+				select {
+				case started <- struct{}{}:
+				default:
+				}
+			}
+			if release != nil {
+				<-release
+			}
 			if rejectModelValue != "" && request.Params != nil {
 				configID, _ := request.Params["configId"].(string)
 				value, _ := request.Params["value"].(string)

--- a/packages/agent/daemon/runtime/standard_acp_test_transport_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_test_transport_test.go
@@ -3,6 +3,7 @@ package agentruntime
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"sync"
 )
@@ -14,12 +15,18 @@ type standardACPTransport struct {
 }
 
 type multiProcStandardACPTransport struct {
-	mu                  sync.Mutex
-	agentTitle          string
-	sessionID           string
-	supportsLoadSession bool
-	specs               []ProcessSpec
-	conns               []*standardACPConnection
+	mu                       sync.Mutex
+	agentTitle               string
+	sessionID                string
+	supportsLoadSession      bool
+	supportsAgentLoadSession bool
+	configOptions            []map[string]any
+	initializeError          *acpError
+	newSessionError          *acpError
+	loadSessionError         *acpError
+	closeFailures            int
+	specs                    []ProcessSpec
+	conns                    []*standardACPConnection
 }
 
 func newStandardACPTransport(agentTitle string, sessionID string) *standardACPTransport {
@@ -43,12 +50,22 @@ func (t *standardACPTransport) Start(_ context.Context, spec ProcessSpec) (Proce
 func (t *multiProcStandardACPTransport) Start(_ context.Context, spec ProcessSpec) (ProcessConnection, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	configOptions := make([]map[string]any, 0, len(t.configOptions))
+	for _, option := range t.configOptions {
+		configOptions = append(configOptions, clonePayloadDeep(option))
+	}
 	conn := &standardACPConnection{
-		recv:                make(chan ProcessFrame, 32),
-		agentTitle:          t.agentTitle,
-		sessionID:           t.sessionID,
-		supportsLoadSession: t.supportsLoadSession,
-		supportsHTTPMCP:     true,
+		recv:                     make(chan ProcessFrame, 32),
+		agentTitle:               t.agentTitle,
+		sessionID:                t.sessionID,
+		supportsLoadSession:      t.supportsLoadSession,
+		supportsAgentLoadSession: t.supportsAgentLoadSession,
+		supportsHTTPMCP:          true,
+		configOptions:            configOptions,
+		initializeError:          t.initializeError,
+		newSessionError:          t.newSessionError,
+		loadSessionError:         t.loadSessionError,
+		closeFailures:            t.closeFailures,
 	}
 	t.specs = append(t.specs, spec)
 	t.conns = append(t.conns, conn)
@@ -85,6 +102,8 @@ type standardACPConnection struct {
 	pauseBeforePromptResult       chan struct{}
 	pauseBeforeToolCallCompletion chan struct{}
 	pauseBeforeAskUserToolUpdate  chan struct{}
+	pauseSettingsRPCStarted       chan struct{}
+	pauseSettingsRPCRelease       chan struct{}
 	pendingPermissionCallID       json.RawMessage
 	selectedPermissionOption      string
 	selectedInteractiveResult     map[string]any
@@ -98,6 +117,7 @@ type standardACPConnection struct {
 	closeSessionError             *acpError
 	rejectModelValue              string
 	supportsLoadSession           bool
+	supportsAgentLoadSession      bool
 	supportsHTTPMCP               bool
 	supportsCloseSession          bool
 	closeSessionExits             bool
@@ -136,8 +156,11 @@ type standardACPConnection struct {
 	authMethods              []map[string]any
 	authenticateResult       map[string]any
 	authenticateError        *acpError
+	initializeError          *acpError
 	newSessionError          *acpError
 	requireAuthentication    bool
+	closeFailures            int
+	closeCalls               int
 }
 
 func (c *standardACPConnection) Recv() (ProcessFrame, error) {
@@ -150,6 +173,12 @@ func (c *standardACPConnection) Recv() (ProcessFrame, error) {
 
 func (c *standardACPConnection) Close() error {
 	c.mu.Lock()
+	c.closeCalls++
+	if c.closeFailures > 0 {
+		c.closeFailures--
+		c.mu.Unlock()
+		return errors.New("injected transport close failure")
+	}
 	c.isClosed = true
 	c.mu.Unlock()
 	c.closeRecv()

--- a/packages/agent/daemon/runtime/standard_acp_turn.go
+++ b/packages/agent/daemon/runtime/standard_acp_turn.go
@@ -20,7 +20,7 @@ func (a *standardACPAdapter) Exec(
 	emit EventSink,
 	emitCommands CommandSnapshotSink,
 ) ([]activityshared.Event, error) {
-	acpSession := a.getSession(session.AgentSessionID)
+	acpSession := a.getUsableSession(session.AgentSessionID)
 	if acpSession == nil || acpSession.client == nil {
 		return []activityshared.Event{standardACPRootProviderTurnCompletedEvent(
 			session,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIEngineSettlementController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIEngineSettlementController.spec.ts
@@ -104,10 +104,16 @@ describe("AgentGUIEngineSettlementController", () => {
   });
 
   it("restores the original image preview after a non-visible send fails", async () => {
+    const failed = vi.fn();
     const engine = createTestAgentSessionEngine("test-workspace", {
       execute(command) {
         return command.type === "queue/sendPrompt"
-          ? Promise.reject(new Error("send failed"))
+          ? Promise.reject(
+              Object.assign(new Error("send failed"), {
+                code: "workspace_operation_failed",
+                reason: "agent.process_cleanup_pending"
+              })
+            )
           : Promise.resolve({ ok: true });
       }
     });
@@ -151,6 +157,8 @@ describe("AgentGUIEngineSettlementController", () => {
         drafts = update(drafts);
       },
       engine,
+      isCurrentConversation: (agentSessionId) => agentSessionId === "session-1",
+      onSubmitFailed: failed,
       snapshots
     });
     const detach = controller.attach();
@@ -176,6 +184,14 @@ describe("AgentGUIEngineSettlementController", () => {
       expect(drafts[sourceScopeKey]).toEqual(submittedDraft);
     });
     expect(snapshots).toEqual({});
+    expect(failed).toHaveBeenCalledTimes(1);
+    expect(failed.mock.calls[0]?.[0]).toMatchObject({
+      agentSessionId: "session-1",
+      errorCode: "workspace_operation_failed",
+      errorMessage: "send failed",
+      errorReason: "agent.process_cleanup_pending",
+      status: "failed"
+    });
     detach();
     engine.dispose();
   });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIEngineSettlementController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIEngineSettlementController.ts
@@ -5,6 +5,7 @@ import {
   selectSessionGoalControlSettlement,
   type AgentSessionEngine,
   type AgentSessionEngineState,
+  type PendingSubmitIntentRecord,
   type SessionGoalControlSettlement
 } from "@tutti-os/agent-activity-core";
 import type { AgentActivityGoalControlAction } from "@tutti-os/agent-activity-core";
@@ -32,6 +33,7 @@ interface AgentGUIEngineSettlementControllerInput {
   isCurrentConversation?(agentSessionId: string): boolean;
   onGoalControlCleared?(): void;
   onGoalControlFailed?(settlement: SessionGoalControlSettlement): void;
+  onSubmitFailed?(submit: PendingSubmitIntentRecord): void;
   snapshots: Record<string, SubmittedDraftSnapshot>;
 }
 
@@ -51,6 +53,9 @@ export class AgentGUIEngineSettlementController {
   private readonly onGoalControlFailed: NonNullable<
     AgentGUIEngineSettlementControllerInput["onGoalControlFailed"]
   >;
+  private readonly onSubmitFailed: NonNullable<
+    AgentGUIEngineSettlementControllerInput["onSubmitFailed"]
+  >;
   private readonly snapshots: Record<string, SubmittedDraftSnapshot>;
   private unsubscribe: (() => void) | null = null;
 
@@ -61,6 +66,7 @@ export class AgentGUIEngineSettlementController {
     this.isCurrentConversation = input.isCurrentConversation ?? (() => false);
     this.onGoalControlCleared = input.onGoalControlCleared ?? (() => undefined);
     this.onGoalControlFailed = input.onGoalControlFailed ?? (() => undefined);
+    this.onSubmitFailed = input.onSubmitFailed ?? (() => undefined);
     this.snapshots = input.snapshots;
   }
 
@@ -130,6 +136,12 @@ export class AgentGUIEngineSettlementController {
         )
       ) {
         continue;
+      }
+      if (
+        submit.status === "failed" &&
+        this.isCurrentConversation(submit.agentSessionId)
+      ) {
+        this.onSubmitFailed(submit);
       }
       this.applyDraftUpdate((drafts) =>
         submit.status === "failed"

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.errors.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.errors.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { setAgentGuiI18nTestLocale } from "../../../i18n/testUtils";
 import {
+  AGENT_PROCESS_CLEANUP_PENDING_REASON,
   AGENT_SESSION_TITLE_TOO_LONG_REASON,
   getAgentGUIErrorMessage
 } from "./agentGuiController.errors";
@@ -22,6 +23,19 @@ describe("getAgentGUIErrorMessage", () => {
         }
       })
     ).toBe("Codex 的配置引用了当前不可用的文件，请检查本机配置后重试");
+  });
+
+  it("localizes pending process cleanup without exposing runtime copy", () => {
+    setAgentGuiI18nTestLocale("zh-CN");
+
+    expect(
+      getAgentGUIErrorMessage({
+        debugMessage: "injected transport close failure",
+        reason: AGENT_PROCESS_CLEANUP_PENDING_REASON
+      })
+    ).toBe(
+      "上一个 Agent 进程仍在退出。为避免重复启动，本次操作已停止，请稍后重试"
+    );
   });
 
   it("localizes the structured session title limit error", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.errors.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.errors.ts
@@ -11,6 +11,8 @@ export const AGENT_SETTINGS_REQUIRE_NEW_SESSION_ERROR =
   "agent.settings_require_new_session";
 export const AGENT_CONFIG_DEPENDENCY_UNAVAILABLE_REASON =
   "agent.config_dependency_unavailable";
+export const AGENT_PROCESS_CLEANUP_PENDING_REASON =
+  "agent.process_cleanup_pending";
 export const AGENT_SESSION_TITLE_TOO_LONG_REASON =
   "workspace_agent_session_title_too_long";
 export const AGENT_SESSION_NOT_FOUND_ERROR = "session.not_found";
@@ -202,6 +204,8 @@ export function getAgentGUIErrorMessage(error: unknown): string {
       provider
     });
   }
+  if (getAgentGUIErrorReason(error) === AGENT_PROCESS_CLEANUP_PENDING_REASON)
+    return translate("messages.agentProcessCleanupPending");
   const code = getAgentGUIErrorCode(error);
   if (isProviderSessionNotFoundErrorCode(code))
     return translate("messages.agentProviderSessionNotFound");

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActiveMessages.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActiveMessages.spec.tsx
@@ -200,6 +200,7 @@ function pendingSubmit(): PendingSubmitIntentRecord {
     ],
     errorCode: null,
     errorMessage: null,
+    errorReason: null,
     expiresAtUnixMs: 120_000,
     requestedAtUnixMs: 200,
     status: "requested",

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.spec.ts
@@ -15,11 +15,26 @@ import {
   restoreFailedAgentGUIHomeDraft
 } from "./agentGuiController.homeDraftHelpers";
 import {
+  agentGUISubmitSettlementError,
   typedGoalControlFromComposer,
   useAgentGUISubmitInteractionActions
 } from "./useAgentGUISubmitInteractionActions";
 
 const draftKey = "node-default:codex:local:codex";
+
+it("preserves a failed submit reason for package-owned presentation", () => {
+  expect(
+    agentGUISubmitSettlementError({
+      errorCode: "workspace_operation_failed",
+      errorMessage: "agent process cleanup is still pending",
+      errorReason: "agent.process_cleanup_pending"
+    })
+  ).toMatchObject({
+    code: "workspace_operation_failed",
+    message: "agent process cleanup is still pending",
+    reason: "agent.process_cleanup_pending"
+  });
+});
 
 function draft(prompt: string): AgentComposerDraft {
   return [{ type: "text", text: prompt }];

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.ts
@@ -4,6 +4,7 @@ import {
   type AgentActivityInteraction,
   type AgentActivityTurn,
   type AgentSessionEngine,
+  type PendingSubmitIntentRecord,
   type SessionGoalControlSettlement
 } from "@tutti-os/agent-activity-core";
 import type { Dispatch, RefObject, SetStateAction } from "react";
@@ -370,6 +371,11 @@ export function useAgentGUISubmitInteractionActions(
           settlement.errorMessage
             ? getAgentGUIErrorMessage(goalControlSettlementError(settlement))
             : translate("agentHost.agentGui.goalControlFailed")
+        );
+      },
+      onSubmitFailed: (submit) => {
+        setDetailError(
+          getAgentGUIErrorMessage(agentGUISubmitSettlementError(submit))
         );
       },
       snapshots: submittedDraftSnapshotsRef.current
@@ -742,4 +748,21 @@ function goalControlSettlementError(
   if (settlement.errorCode) error.code = settlement.errorCode;
   if (settlement.errorReason) error.reason = settlement.errorReason;
   return error;
+}
+
+export function agentGUISubmitSettlementError(
+  submit: Pick<
+    PendingSubmitIntentRecord,
+    "errorCode" | "errorMessage" | "errorReason"
+  >
+): Error {
+  return Object.assign(
+    new Error(
+      submit.errorMessage?.trim() || translate("agentHost.agentGui.sendFailed")
+    ),
+    {
+      ...(submit.errorCode ? { code: submit.errorCode } : {}),
+      ...(submit.errorReason ? { reason: submit.errorReason } : {})
+    }
+  );
 }

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGuiComposer.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGuiComposer.ts
@@ -4,5 +4,6 @@ export const enAgentGuiComposer = {
   composerOptionsRetry: "Retry",
   composerOptionsRetryTooltip:
     "Unable to load shared Agent information. Click to retry",
+  sendFailed: "The message could not be sent.",
   inheritedUnavailable: "Inherited / unavailable"
 };

--- a/packages/agent/gui/app/renderer/i18n/locales/en.messages.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.messages.ts
@@ -12,6 +12,8 @@ export const enMessages = {
   agentSessionReconnecting: "Reconnecting to the live agent session…",
   agentSettingsRequireNewSession:
     "This model can only be used in a new session to preserve context.",
+  agentProcessCleanupPending:
+    "The previous Agent process is still shutting down. To avoid starting a duplicate process, this request was stopped. Try again shortly.",
   agentConfigDependencyUnavailable:
     "{{provider}} configuration references a file that is unavailable. Check its local configuration and try again.",
   agentSessionTitleTooLong:

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGuiComposer.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGuiComposer.ts
@@ -3,5 +3,6 @@ export const zhCNAgentGuiComposer = {
   composerOptionsLoadFailed: "配置加载失败",
   composerOptionsRetry: "重试",
   composerOptionsRetryTooltip: "共享 Agent 信息加载失败，点击重试",
+  sendFailed: "消息未能发送",
   inheritedUnavailable: "继承 / 不可用"
 };

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.messages.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.messages.ts
@@ -10,6 +10,8 @@ export const zhCNMessages = {
     "这段对话已导入成功，新开会话并 @ 这段对话，接着继续聊。",
   agentSessionReconnecting: "正在重新连接 Agent 会话…",
   agentSettingsRequireNewSession: "为了保留上下文，这个模型只能在新会话中使用",
+  agentProcessCleanupPending:
+    "上一个 Agent 进程仍在退出。为避免重复启动，本次操作已停止，请稍后重试",
   agentConfigDependencyUnavailable:
     "{{provider}} 的配置引用了当前不可用的文件，请检查本机配置后重试",
   agentSessionTitleTooLong: "会话标题不能超过 {{maxCharacters}} 个字符。",

--- a/services/tuttid/apierrors/apierrors.go
+++ b/services/tuttid/apierrors/apierrors.go
@@ -376,7 +376,9 @@ func Classify(err error) *ProtocolError {
 		if reason == "" {
 			reason = ReasonWorkspaceOperationFailed
 		}
-		return New(StatusWorkspaceOperationFailed, tuttigenerated.WorkspaceOperationFailed, reason, WithCause(err))
+		result := New(StatusWorkspaceOperationFailed, tuttigenerated.WorkspaceOperationFailed, reason, WithCause(err))
+		result.Retryable = reason == agentruntime.AppErrorProcessCleanupPending
+		return result
 	}
 	var providerUnavailableErr *agentservice.ProviderUnavailableError
 	if errors.As(err, &providerUnavailableErr) {

--- a/services/tuttid/apierrors/apierrors_test.go
+++ b/services/tuttid/apierrors/apierrors_test.go
@@ -4,12 +4,33 @@ import (
 	"errors"
 	"testing"
 
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	runtimeprep "github.com/tutti-os/tutti/packages/agent/runtimeprep"
 	workspaceissues "github.com/tutti-os/tutti/packages/workspace/issues"
 	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 	workspaceservice "github.com/tutti-os/tutti/services/tuttid/service/workspace"
 )
+
+func TestClassifyPendingAgentProcessCleanupPreservesRetryableReason(t *testing.T) {
+	runtimeErr := &agentruntime.AppError{
+		Code:         agentruntime.AppErrorProcessCleanupPending,
+		Message:      "agent process cleanup is still pending",
+		DebugMessage: "injected transport close failure",
+	}
+	classified := Classify(agenthost.NewProviderError(
+		runtimeErr.Code,
+		runtimeErr.Message,
+		runtimeErr.DebugMessage,
+		runtimeErr,
+	))
+	if classified.Code != tuttigenerated.WorkspaceOperationFailed ||
+		classified.Reason != agentruntime.AppErrorProcessCleanupPending ||
+		!classified.Retryable {
+		t.Fatalf("classified = %#v, want retryable process cleanup reason", classified)
+	}
+}
 
 func TestClassifyConfigDependencyUnavailable(t *testing.T) {
 	classified := Classify(&runtimeprep.ConfigDependencyUnavailableError{


### PR DESCRIPTION
## Summary

- Backport the net changes from #1984 onto `release/0813`
- Preserve recoverable idle Standard ACP process release behavior and its coverage
- Include the architecture and troubleshooting documentation updates from the source PR

## Why

`release/0813` needs the ACP idle-process cleanup and recovery fix already merged through #1984 on `main`.

## Impact

Idle Standard ACP processes can be released without making an existing session unrecoverable, and AgentGUI reports the recoverable release path consistently.

## Validation

- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready` (21 lanes passed)

Source PR: #1984
Cherry-picked source commit: `00f6c404c906141c47e165f16023ac12d73c5325`