### PR TITLE
fix(agent-gui): retain active session synchronization

### DIFF
--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -1510,6 +1510,12 @@ separate command. Message paging adapters do not call back into selection or
 Rail orchestration, and hosts do not maintain a second messages-only reconcile
 entrypoint.
 
+The focused conversation controller also owns the optional host synchronization
+lease for its exact active Session. It acquires the lease when focus changes,
+keeps repeated selection idempotent, and releases the previous lease on switch,
+clear, or disposal. A host may use that lease to retain a per-Session event
+stream; React surfaces must not retain that transport independently.
+
 Event-stream continuity and command reachability are separate host facts.
 `eventStreamConnectionChanged` belongs to the coordinator and triggers
 authoritative reconnect hydration; `engine/connectionChanged` belongs to the

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -69,6 +69,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - [AgentGUI loading disappears before active turn settles](./agent-session-lifecycle.md#agentgui-loading-disappears-before-active-turn-settles)
 - [Queued AgentGUI prompt stalls after no-active-turn failure](./agent-session-lifecycle.md#queued-agentgui-prompt-stalls-after-no-active-turn-failure)
 - [Agent session stays loading after a completed turn](./agent-session-lifecycle.md#agent-session-stays-loading-after-a-completed-turn)
+- [Remote session stays planning while the provider already replied](./agent-session-lifecycle.md#remote-session-stays-planning-while-the-provider-already-replied)
 - [AgentGUI model switch changes defaults but not the active session](./agent-session-lifecycle.md#agentgui-model-switch-changes-defaults-but-not-the-active-session)
 - [New Agent conversation rejects a model that is no longer offered](./agent-session-lifecycle.md#new-agent-conversation-rejects-a-model-that-is-no-longer-offered)
 - [AgentGUI shows the selected settings but a new session does not inherit them](./agent-session-lifecycle.md#agentgui-shows-the-selected-settings-but-a-new-session-does-not-inherit-them)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -1831,6 +1831,40 @@ inline data URL instead`. Claude or standard ACP may instead receive no
   [service.go](../../../services/tuttid/service/agent/service.go)
   [service_session_list.go](../../../services/tuttid/service/agent/service_session_list.go)
 
+### Remote session stays planning while the provider already replied
+
+- Symptom:
+  A remote or cloud-backed AgentGUI conversation remains on its planning or
+  working placeholder after the provider has already settled the Turn. Reading
+  the authoritative Session directly reports `ready` with no active Turn, and
+  opening the Session event stream immediately reveals the missing assistant
+  response.
+- Quick checks:
+  First compare authoritative Session state with the renderer projection. Then
+  inspect host access logs for the exact Session event-stream subscription. If
+  the provider settled but the AgentGUI surface never requested the stream,
+  increasing HTTP or activation timeouts cannot repair the stale projection.
+- Root cause:
+  The focused conversation was hydrated once but did not retain the host's
+  optional Session synchronization lease. Hosts that use that lease to keep a
+  per-Session event stream open therefore receive no terminal state or message
+  events until another read happens to reconcile the Session.
+- Fix:
+  Keep synchronization ownership in the shared focused-conversation controller.
+  Acquire the exact Session lease on focus, keep repeated selection idempotent,
+  release the previous lease on switch or clear, and release the final lease on
+  disposal. Keep the host responsible for transport and authoritative
+  reconciliation; do not add provider-specific polling or longer timeouts.
+- Validation:
+  Add controller coverage for acquire, repeated selection, switch, clear, and
+  disposal. In the affected host, verify that selecting the conversation opens
+  the exact Session stream and that a terminal event updates both state and
+  transcript without a manual refresh.
+- References:
+  [agentConversationMessageController.ts](../../../packages/agent/gui/agentConversationMessageController.ts)
+  [useAgentConversationMessagePaging.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentConversationMessagePaging.ts)
+  [agent-activity-packages.md](../../architecture/agent-activity-packages.md)
+
 ### AgentGUI pin or unpin appears stuck for a live session
 
 - Symptom:

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.reporting.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.reporting.ts
@@ -75,6 +75,7 @@ export type AgentGUIRuntimeErrorPhase =
   | "interrupt_current_turn"
   | "load_session_messages"
   | "load_session_state"
+  | "synchronize_session"
   | "retry_activation"
   | "send_prompt"
   | "submit_interactive"

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentConversationMessagePaging.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentConversationMessagePaging.ts
@@ -164,7 +164,7 @@ export interface ConversationMessagePagingDiagnosticsPort {
     agentSessionId: string;
     context?: Record<string, unknown>;
     error: unknown;
-    phase: "load_session_messages";
+    phase: "load_session_messages" | "synchronize_session";
   }): void;
   page(input: {
     agentSessionId: string;
@@ -201,9 +201,21 @@ export function useAgentConversationMessagePaging(
               error,
               phase: "load_session_messages"
             }),
-          page: (event) => inputRef.current.diagnostics.page(event)
+          page: (event) => inputRef.current.diagnostics.page(event),
+          synchronizationError: ({ agentSessionId, error }) =>
+            inputRef.current.diagnostics.error({
+              agentSessionId,
+              error,
+              phase: "synchronize_session"
+            })
         },
         engine: input.sessionEngine,
+        ensureSessionSynchronized: ({ agentSessionId, onError, workspaceId }) =>
+          inputRef.current.runtime.ensureSessionSynchronized?.({
+            agentSessionId,
+            onError,
+            workspaceId
+          }) ?? (() => {}),
         isAvailable: (agentSessionId) =>
           inputRef.current.isMounted() &&
           (!agentSessionId ||

--- a/packages/agent/gui/agentConversationMessageController.spec.ts
+++ b/packages/agent/gui/agentConversationMessageController.spec.ts
@@ -208,6 +208,52 @@ describe("createAgentConversationMessageController", () => {
     engine.dispose();
   });
 
+  it("retains synchronization only for the active Session", () => {
+    const engine = createTestAgentSessionEngine("workspace-1");
+    const releases: string[] = [];
+    const ensureSessionSynchronized = vi.fn(
+      ({ agentSessionId }: { agentSessionId: string }) =>
+        () => {
+          releases.push(agentSessionId);
+        }
+    );
+    const controller = createController({
+      engine,
+      ensureSessionSynchronized
+    });
+
+    controller.setActiveSession("session-1");
+    controller.setActiveSession("session-1");
+    controller.setActiveSession("session-2");
+    controller.setActiveSession(null);
+    controller.setActiveSession("session-3");
+    controller.dispose();
+
+    expect(ensureSessionSynchronized.mock.calls).toEqual([
+      [
+        expect.objectContaining({
+          agentSessionId: "session-1",
+          workspaceId: "workspace-1"
+        })
+      ],
+      [
+        expect.objectContaining({
+          agentSessionId: "session-2",
+          workspaceId: "workspace-1"
+        })
+      ],
+      [
+        expect.objectContaining({
+          agentSessionId: "session-3",
+          workspaceId: "workspace-1"
+        })
+      ]
+    ]);
+    expect(releases).toEqual(["session-1", "session-2", "session-3"]);
+
+    engine.dispose();
+  });
+
   it("rejects a stale page when the host focus changes before synchronization", async () => {
     const engine = createTestAgentSessionEngine("workspace-1");
     let focusedSessionId = "session-1";
@@ -240,6 +286,9 @@ describe("createAgentConversationMessageController", () => {
 
 function createController(input: {
   engine: ReturnType<typeof createTestAgentSessionEngine>;
+  ensureSessionSynchronized?: Parameters<
+    typeof createAgentConversationMessageController
+  >[0]["ensureSessionSynchronized"];
   isAvailable?: (agentSessionId?: string | null) => boolean;
   listSessionMessages?: (
     input: AgentConversationMessagePageInput
@@ -247,6 +296,7 @@ function createController(input: {
 }) {
   return createAgentConversationMessageController({
     engine: input.engine,
+    ensureSessionSynchronized: input.ensureSessionSynchronized,
     isAvailable: input.isAvailable ?? (() => true),
     listSessionMessages:
       input.listSessionMessages ??

--- a/packages/agent/gui/agentConversationMessageController.ts
+++ b/packages/agent/gui/agentConversationMessageController.ts
@@ -40,11 +40,20 @@ export interface AgentConversationMessageControllerDiagnostics {
     level?: "debug" | "warn";
     messages?: readonly AgentActivityDurableMessage[];
   }): void;
+  synchronizationError?(input: {
+    agentSessionId: string;
+    error: unknown;
+  }): void;
 }
 
 export interface CreateAgentConversationMessageControllerInput {
   diagnostics?: AgentConversationMessageControllerDiagnostics;
   engine: Pick<AgentSessionEngine, "dispatch" | "getSnapshot">;
+  ensureSessionSynchronized?(input: {
+    agentSessionId: string;
+    onError(error: unknown): void;
+    workspaceId: string;
+  }): () => void;
   isAvailable(agentSessionId?: string | null): boolean;
   listSessionMessages(
     input: AgentConversationMessagePageInput
@@ -90,6 +99,7 @@ export function createAgentConversationMessageController(
   let disposed = false;
   let generation = 0;
   let snapshot = EMPTY_SNAPSHOT;
+  let releaseSessionSynchronization: (() => void) | null = null;
   let olderRequest: {
     abortController: AbortController;
     agentSessionId: string;
@@ -140,12 +150,30 @@ export function createAgentConversationMessageController(
     if (normalized === activeSessionId) return;
     generation += 1;
     abortOlderRequest();
+    releaseSessionSynchronization?.();
+    releaseSessionSynchronization = null;
     activeSessionId = normalized;
     publish({
       agentSessionId: normalized,
       error: null,
       olderPagePhase: "idle"
     });
+    if (!normalized || !input.ensureSessionSynchronized) return;
+    const reportSynchronizationError = (error: unknown): void => {
+      input.diagnostics?.synchronizationError?.({
+        agentSessionId: normalized,
+        error
+      });
+    };
+    try {
+      releaseSessionSynchronization = input.ensureSessionSynchronized({
+        agentSessionId: normalized,
+        onError: reportSynchronizationError,
+        workspaceId: input.workspaceId
+      });
+    } catch (error) {
+      reportSynchronizationError(error);
+    }
   };
 
   const requestReconcile = (
@@ -185,6 +213,8 @@ export function createAgentConversationMessageController(
       disposed = true;
       generation += 1;
       abortOlderRequest();
+      releaseSessionSynchronization?.();
+      releaseSessionSynchronization = null;
     },
     getSnapshot: () => snapshot,
     async loadOlder(agentSessionId) {


### PR DESCRIPTION
## Summary
- retain the host synchronization lease for the exact focused AgentGUI Session
- release it on switch, clear, or controller disposal
- report synchronization failures through the existing runtime diagnostics path
- document the stale planning symptom and ownership boundary

## Validation
- pnpm --filter @tutti-os/agent-gui exec vitest run agentConversationMessageController.spec.ts
- pnpm check:changed -- --push-ready (12 lanes passed)

## Review
- Architecture: shared focused-conversation controller owns one optional lease; the host remains transport owner
- Performance: repeated selection is idempotent and only one focused Session lease is retained
- Consumers: capability remains optional for hosts that do not expose session synchronization
- Windows: platform-neutral controller logic; no filesystem, process, or path behavior changed