### PR TITLE
fix(agent): disconnect stale workspace runtimes

### DIFF
--- a/packages/agent/daemon/hostadapter/runtime.go
+++ b/packages/agent/daemon/hostadapter/runtime.go
@@ -39,6 +39,10 @@ type RuntimeBackend interface {
 	GoalCapabilities(context.Context, agentruntime.GoalReconcileInput) (agentruntime.GoalAdapterCapabilities, error)
 }
 
+type runtimeRetainedSettingsBackend interface {
+	UpdateRetainedSettings(context.Context, agentruntime.UpdateSettingsInput) (agentruntime.UpdateSettingsResult, error)
+}
+
 type runtimeHistoryBackend interface {
 	SupportsEffectiveHistory(context.Context, agentruntime.EffectiveHistoryInput) (bool, error)
 	ReadEffectiveHistory(context.Context, agentruntime.EffectiveHistoryInput) (agentruntime.EffectiveHistorySnapshot, error)
@@ -58,6 +62,9 @@ var (
 	_ host.RuntimeHistoryController                = (*RuntimeController)(nil)
 	_ host.RuntimeProviderTurnAcceptanceReconciler = (*RuntimeController)(nil)
 	_ host.RuntimeSessionLiveness                  = (*RuntimeController)(nil)
+	_ host.RuntimeWorkspaceDisconnector            = (*RuntimeController)(nil)
+	_ host.RuntimeWorkspaceDisconnectTargeter      = (*RuntimeController)(nil)
+	_ host.RuntimeRetainedSettingsUpdater          = (*RuntimeController)(nil)
 	_ host.RuntimeSubmitProvenanceReporter         = (*RuntimeController)(nil)
 	_ host.SessionForkRuntime                      = (*RuntimeController)(nil)
 	_ host.SessionForkTurnBindingRecoveryRuntime   = (*RuntimeController)(nil)
@@ -373,6 +380,25 @@ func (a *RuntimeController) UpdateSettings(ctx context.Context, input host.Runti
 		return err
 	}
 	_, err := a.Backend.UpdateSettings(ctx, agentruntime.UpdateSettingsInput{
+		RoomID: input.WorkspaceID, AgentSessionID: input.AgentSessionID,
+		Settings: agentruntime.SessionSettingsPatch{
+			Model: input.Settings.Model, ReasoningEffort: input.Settings.ReasoningEffort, Speed: input.Settings.Speed,
+			PlanMode: input.Settings.PlanMode, BrowserUse: input.Settings.BrowserUse,
+			ComputerUse: input.Settings.ComputerUse, PermissionModeID: input.Settings.PermissionModeID,
+		},
+	})
+	return mapRuntimeError(err)
+}
+
+func (a *RuntimeController) UpdateRetainedSettings(ctx context.Context, input host.RuntimeUpdateSettingsInput) error {
+	if err := a.requireBackend(); err != nil {
+		return err
+	}
+	backend, ok := a.Backend.(runtimeRetainedSettingsBackend)
+	if !ok {
+		return host.ErrWorkspaceDisconnectUnavailable
+	}
+	_, err := backend.UpdateRetainedSettings(ctx, agentruntime.UpdateSettingsInput{
 		RoomID: input.WorkspaceID, AgentSessionID: input.AgentSessionID,
 		Settings: agentruntime.SessionSettingsPatch{
 			Model: input.Settings.Model, ReasoningEffort: input.Settings.ReasoningEffort, Speed: input.Settings.Speed,

--- a/packages/agent/daemon/hostadapter/runtime_test.go
+++ b/packages/agent/daemon/hostadapter/runtime_test.go
@@ -34,6 +34,78 @@ type closeRuntimeBackend struct {
 	input agentruntime.CloseInput
 }
 
+type workspaceDisconnectBackend struct {
+	RuntimeBackend
+	sessions  []agentruntime.Session
+	roomID    string
+	sessionID string
+	target    agentruntime.RuntimeDisconnectTarget
+}
+
+func (*workspaceDisconnectBackend) SnapshotRuntimeDisconnectTargets(string) []agentruntime.RuntimeDisconnectTarget {
+	return []agentruntime.RuntimeDisconnectTarget{{
+		RoomID: "workspace-1", AgentSessionID: "session-1", ConnectionGeneration: 7,
+	}}
+}
+
+func (b *workspaceDisconnectBackend) DisconnectRuntimeSessionTarget(
+	_ context.Context,
+	target agentruntime.RuntimeDisconnectTarget,
+) (agentruntime.DisconnectRuntimeSessionResult, error) {
+	b.target = target
+	return agentruntime.DisconnectRuntimeSessionResult{Disconnected: true}, nil
+}
+
+func (b *workspaceDisconnectBackend) RuntimeSessions(context.Context, string) ([]agentruntime.Session, error) {
+	return append([]agentruntime.Session(nil), b.sessions...), nil
+}
+
+func (*workspaceDisconnectBackend) State(_, _ string) (agentruntime.SessionStateSnapshot, error) {
+	return agentruntime.SessionStateSnapshot{}, nil
+}
+
+func (b *workspaceDisconnectBackend) DisconnectRuntimeSession(
+	_ context.Context,
+	roomID string,
+	sessionID string,
+) (agentruntime.DisconnectRuntimeSessionResult, error) {
+	b.roomID = roomID
+	b.sessionID = sessionID
+	return agentruntime.DisconnectRuntimeSessionResult{Disconnected: true}, nil
+}
+
+func TestRuntimeControllerBridgesWorkspaceRuntimeDisconnect(t *testing.T) {
+	t.Parallel()
+	backend := &workspaceDisconnectBackend{sessions: []agentruntime.Session{{
+		RoomID: "workspace-1", AgentSessionID: "session-1", ProviderSessionID: "provider-1",
+	}}}
+	controller := &RuntimeController{Backend: backend}
+	sessions, err := controller.WorkspaceRuntimeSessions(t.Context(), " workspace-1 ")
+	if err != nil {
+		t.Fatalf("WorkspaceRuntimeSessions: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].ID != "session-1" || sessions[0].ProviderSessionID != "provider-1" {
+		t.Fatalf("sessions=%#v", sessions)
+	}
+	disconnected, err := controller.DisconnectRuntimeSession(t.Context(), host.SessionRef{
+		WorkspaceID: " workspace-1 ", AgentSessionID: " session-1 ",
+	})
+	if err != nil || !disconnected {
+		t.Fatalf("disconnected=%v err=%v", disconnected, err)
+	}
+	if backend.roomID != "workspace-1" || backend.sessionID != "session-1" {
+		t.Fatalf("backend ref=%q/%q", backend.roomID, backend.sessionID)
+	}
+	targets := controller.SnapshotWorkspaceRuntimeDisconnectTargets("workspace-1")
+	if len(targets) != 1 || targets[0].ConnectionGeneration != 7 {
+		t.Fatalf("targets=%#v", targets)
+	}
+	disconnected, err = controller.DisconnectRuntimeSessionTarget(t.Context(), targets[0])
+	if err != nil || !disconnected || backend.target.ConnectionGeneration != 7 {
+		t.Fatalf("target disconnect=%v err=%v backend=%#v", disconnected, err, backend.target)
+	}
+}
+
 func (b *closeRuntimeBackend) Close(_ context.Context, input agentruntime.CloseInput) (agentruntime.CloseResult, error) {
 	b.input = input
 	return agentruntime.CloseResult{AgentSessionID: input.AgentSessionID, Disconnected: true}, nil

--- a/packages/agent/daemon/hostadapter/workspace_runtime_disconnect.go
+++ b/packages/agent/daemon/hostadapter/workspace_runtime_disconnect.go
@@ -1,0 +1,94 @@
+package hostadapter
+
+import (
+	"context"
+	"strings"
+
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
+	host "github.com/tutti-os/tutti/packages/agent/host"
+)
+
+type runtimeWorkspaceDisconnectBackend interface {
+	RuntimeSessions(context.Context, string) ([]agentruntime.Session, error)
+	DisconnectRuntimeSession(context.Context, string, string) (agentruntime.DisconnectRuntimeSessionResult, error)
+}
+
+type runtimeWorkspaceDisconnectTargetBackend interface {
+	SnapshotRuntimeDisconnectTargets(string) []agentruntime.RuntimeDisconnectTarget
+	DisconnectRuntimeSessionTarget(context.Context, agentruntime.RuntimeDisconnectTarget) (agentruntime.DisconnectRuntimeSessionResult, error)
+}
+
+func (a *RuntimeController) WorkspaceRuntimeSessions(ctx context.Context, workspaceID string) ([]host.ProviderRuntimeSession, error) {
+	if a == nil || a.Backend == nil {
+		return nil, host.ErrWorkspaceDisconnectUnavailable
+	}
+	backend, ok := a.Backend.(runtimeWorkspaceDisconnectBackend)
+	if !ok {
+		return nil, host.ErrWorkspaceDisconnectUnavailable
+	}
+	sessions, err := backend.RuntimeSessions(ctx, strings.TrimSpace(workspaceID))
+	if err != nil {
+		return nil, mapRuntimeError(err)
+	}
+	result := make([]host.ProviderRuntimeSession, 0, len(sessions))
+	for _, session := range sessions {
+		result = append(result, a.sessionWithState(session))
+	}
+	return result, nil
+}
+
+func (a *RuntimeController) DisconnectRuntimeSession(
+	ctx context.Context,
+	ref host.SessionRef,
+) (bool, error) {
+	if err := a.requireBackend(); err != nil {
+		return false, err
+	}
+	backend, ok := a.Backend.(runtimeWorkspaceDisconnectBackend)
+	if !ok {
+		return false, host.ErrWorkspaceDisconnectUnavailable
+	}
+	result, err := backend.DisconnectRuntimeSession(
+		ctx,
+		strings.TrimSpace(ref.WorkspaceID),
+		strings.TrimSpace(ref.AgentSessionID),
+	)
+	return result.Disconnected, mapRuntimeError(err)
+}
+
+func (a *RuntimeController) SnapshotWorkspaceRuntimeDisconnectTargets(workspaceID string) []host.RuntimeDisconnectTarget {
+	if a == nil || a.Backend == nil {
+		return nil
+	}
+	backend, ok := a.Backend.(runtimeWorkspaceDisconnectTargetBackend)
+	if !ok {
+		return nil
+	}
+	targets := backend.SnapshotRuntimeDisconnectTargets(strings.TrimSpace(workspaceID))
+	result := make([]host.RuntimeDisconnectTarget, 0, len(targets))
+	for _, target := range targets {
+		result = append(result, host.RuntimeDisconnectTarget{
+			WorkspaceID: target.RoomID, AgentSessionID: target.AgentSessionID,
+			ConnectionGeneration: target.ConnectionGeneration,
+		})
+	}
+	return result
+}
+
+func (a *RuntimeController) DisconnectRuntimeSessionTarget(
+	ctx context.Context,
+	target host.RuntimeDisconnectTarget,
+) (bool, error) {
+	if a == nil || a.Backend == nil {
+		return false, host.ErrWorkspaceDisconnectUnavailable
+	}
+	backend, ok := a.Backend.(runtimeWorkspaceDisconnectTargetBackend)
+	if !ok {
+		return false, host.ErrWorkspaceDisconnectUnavailable
+	}
+	result, err := backend.DisconnectRuntimeSessionTarget(ctx, agentruntime.RuntimeDisconnectTarget{
+		RoomID: target.WorkspaceID, AgentSessionID: target.AgentSessionID,
+		ConnectionGeneration: target.ConnectionGeneration,
+	})
+	return result.Disconnected, mapRuntimeError(err)
+}

--- a/packages/agent/daemon/runtime/adapter.go
+++ b/packages/agent/daemon/runtime/adapter.go
@@ -358,6 +358,14 @@ type LiveSessionReleaseAdapter interface {
 	ReleaseLiveSession(context.Context, Session) error
 }
 
+// LiveSessionDisconnectAdapter force-releases a live provider transport when
+// its owning Workspace runtime becomes unavailable. Unlike Adapter.Close it
+// must not send a destructive provider session-close operation; unlike the
+// idle reaper it must settle active work and pending interactions.
+type LiveSessionDisconnectAdapter interface {
+	DisconnectLiveSession(context.Context, Session) error
+}
+
 // LiveSessionReleaseCapabilityAdapter narrows live-session release for
 // adapters whose ability to resume is learned from the current provider
 // handshake rather than known statically by adapter type.

--- a/packages/agent/daemon/runtime/claude_sdk_events.go
+++ b/packages/agent/daemon/runtime/claude_sdk_events.go
@@ -693,6 +693,15 @@ func (a *ClaudeCodeSDKAdapter) completeClaudeSDKWaiterEvent(
 }
 
 func (a *ClaudeCodeSDKAdapter) failClaudeSDKReader(agentSessionID string, adapterSession *claudeSDKAdapterSession, err error) {
+	a.failClaudeSDKReaderWithOwnership(agentSessionID, adapterSession, err, false)
+}
+
+func (a *ClaudeCodeSDKAdapter) failClaudeSDKReaderWithOwnership(
+	agentSessionID string,
+	adapterSession *claudeSDKAdapterSession,
+	err error,
+	retainSession bool,
+) {
 	if a == nil || adapterSession == nil {
 		return
 	}
@@ -733,7 +742,9 @@ func (a *ClaudeCodeSDKAdapter) failClaudeSDKReader(agentSessionID string, adapte
 		pendingFailureEvents,
 		a.failAllClaudeSDKRootProviderTurns(adapterSession, session, err)...,
 	)
-	a.removeSession(agentSessionID, adapterSession)
+	if !retainSession {
+		a.removeSession(agentSessionID, adapterSession)
+	}
 	a.emitClaudeSDKSessionEvents(agentSessionID, pendingFailureEvents)
 	for _, waiter := range turns {
 		waiter.mu.Lock()

--- a/packages/agent/daemon/runtime/claude_sdk_lifecycle.go
+++ b/packages/agent/daemon/runtime/claude_sdk_lifecycle.go
@@ -240,3 +240,25 @@ func (a *ClaudeCodeSDKAdapter) HasLiveSession(session Session) bool {
 func (a *ClaudeCodeSDKAdapter) ReleaseLiveSession(ctx context.Context, session Session) error {
 	return a.Close(ctx, session)
 }
+
+// DisconnectLiveSession terminalizes provider-owned work through the same
+// external-failure path as a broken sidecar connection, then closes only the
+// transport. It deliberately does not send the sidecar "close" request,
+// which is the graceful provider-session close contract.
+func (a *ClaudeCodeSDKAdapter) DisconnectLiveSession(_ context.Context, session Session) error {
+	adapterSession := a.getSession(session.AgentSessionID)
+	if adapterSession == nil {
+		return nil
+	}
+	a.failClaudeSDKReaderWithOwnership(
+		session.AgentSessionID,
+		adapterSession,
+		ErrSessionDisconnected,
+		true,
+	)
+	if err := adapterSession.conn.Close(); err != nil {
+		return err
+	}
+	a.removeSession(session.AgentSessionID, adapterSession)
+	return nil
+}

--- a/packages/agent/daemon/runtime/claude_sdk_session_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_session_test.go
@@ -104,6 +104,122 @@ func TestClaudeCodeSDKAdapterCloseStartsReaderBeforeRoundTrip(t *testing.T) {
 	}
 }
 
+func TestClaudeCodeSDKAdapterDisconnectLiveSessionClosesColdTransportWithoutCloseRequest(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	session.ProviderSessionID = "provider-session-1"
+	conn := newBlockingClaudeSDKConnection()
+	adapterSession := &claudeSDKAdapterSession{
+		conn:              conn,
+		reader:            &claudeSDKLineReader{conn: conn},
+		session:           session,
+		providerSessionID: session.ProviderSessionID,
+		pendingRequests:   make(map[string]*pendingInteractiveRequest),
+		pendingResponses:  make(map[string]chan claudeSDKSidecarEvent),
+		turns:             make(map[string]*claudeSDKTurnWaiter),
+		liveState:         newClaudeSDKLiveState(),
+	}
+	adapter.storeSession(session.AgentSessionID, adapterSession)
+
+	if err := adapter.DisconnectLiveSession(context.Background(), session); err != nil {
+		t.Fatalf("DisconnectLiveSession: %v", err)
+	}
+	if sent := conn.sentRequests(); len(sent) != 0 {
+		t.Fatalf("DisconnectLiveSession sent provider close request %#v", sent)
+	}
+	if adapter.HasLiveSession(session) {
+		t.Fatal("HasLiveSession = true after disconnect")
+	}
+	select {
+	case <-conn.closed:
+	default:
+		t.Fatal("cold Claude transport was not closed")
+	}
+}
+
+func TestClaudeCodeSDKAdapterDisconnectLiveSessionRetriesCloseFailedHandle(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	conn := newBlockingClaudeSDKConnection()
+	conn.closeFailures = 1
+	adapterSession := &claudeSDKAdapterSession{
+		conn: conn, reader: &claudeSDKLineReader{conn: conn}, session: session,
+		pendingRequests:  make(map[string]*pendingInteractiveRequest),
+		pendingResponses: make(map[string]chan claudeSDKSidecarEvent),
+		turns:            make(map[string]*claudeSDKTurnWaiter), liveState: newClaudeSDKLiveState(),
+	}
+	adapter.storeSession(session.AgentSessionID, adapterSession)
+	if err := adapter.DisconnectLiveSession(context.Background(), session); err == nil {
+		t.Fatal("first DisconnectLiveSession error=nil, want close failure")
+	}
+	if adapter.getSession(session.AgentSessionID) != adapterSession {
+		t.Fatal("close-failed Claude handle lost ownership")
+	}
+	if err := adapter.DisconnectLiveSession(context.Background(), session); err != nil {
+		t.Fatalf("retry DisconnectLiveSession: %v", err)
+	}
+	if adapter.getSession(session.AgentSessionID) != nil {
+		t.Fatal("Claude handle remained after successful retry")
+	}
+	conn.mu.Lock()
+	closeCalls := conn.closeCalls
+	conn.mu.Unlock()
+	if closeCalls != 2 {
+		t.Fatalf("transport close calls=%d, want 2", closeCalls)
+	}
+}
+
+func TestClaudeCodeSDKAdapterDisconnectLiveSessionConvergesPendingInteractiveAndProviderTurn(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	conn := newBlockingClaudeSDKConnection()
+	adapterSession := &claudeSDKAdapterSession{
+		conn: conn, reader: &claudeSDKLineReader{conn: conn}, session: session,
+		pendingRequests:  make(map[string]*pendingInteractiveRequest),
+		pendingResponses: make(map[string]chan claudeSDKSidecarEvent),
+		turns:            make(map[string]*claudeSDKTurnWaiter), liveState: newClaudeSDKLiveState(),
+	}
+	adapter.storeSession(session.AgentSessionID, adapterSession)
+	adapter.beginClaudeSDKRootTurn(adapterSession, "turn-disconnect", "provider-turn-disconnect")
+	waiter := adapter.registerClaudeSDKTurn(adapterSession, "turn-disconnect", nil)
+	if _, _, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-disconnect", claudeSDKSidecarEvent{
+		Type: "approval_requested",
+		Payload: map[string]any{
+			"turnId": "turn-disconnect", "requestId": "approval-disconnect",
+			"toolName": "Bash", "input": map[string]any{"command": "sleep 10"},
+		},
+	}); err != nil {
+		t.Fatalf("approval_requested: %v", err)
+	}
+	var received []activityshared.Event
+	adapter.SetSessionEventSink(func(_ string, events []activityshared.Event) {
+		received = append(received, events...)
+	})
+	if err := adapter.DisconnectLiveSession(context.Background(), session); err != nil {
+		t.Fatalf("DisconnectLiveSession: %v", err)
+	}
+	if len(received) != 3 ||
+		received[0].Type != activityshared.EventInteractionSuperseded ||
+		received[1].Type != activityshared.EventCallFailed ||
+		received[2].Type != activityshared.EventRootProviderTurnCompleted {
+		t.Fatalf("disconnect events=%#v", received)
+	}
+	select {
+	case result := <-waiter.done:
+		if !errors.Is(result.err, ErrSessionDisconnected) {
+			t.Fatalf("waiter error=%v, want ErrSessionDisconnected", result.err)
+		}
+	default:
+		t.Fatal("active Claude turn was not terminalized")
+	}
+}
+
 func TestClaudeCodeSDKAdapterResumeClassifiesMissingProviderSession(t *testing.T) {
 	session := standardTestSession(ProviderClaudeCode)
 	session.ProviderSessionID = "00000000-0000-4000-8000-000000000000"

--- a/packages/agent/daemon/runtime/claude_sdk_test_support_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_test_support_test.go
@@ -272,11 +272,13 @@ func (c *scriptedClaudeSDKConnection) sentRequests() []claudeSDKSidecarRequest {
 }
 
 type blockingClaudeSDKConnection struct {
-	mu     sync.Mutex
-	sent   []claudeSDKSidecarRequest
-	frames chan ProcessFrame
-	closed chan struct{}
-	once   sync.Once
+	mu            sync.Mutex
+	sent          []claudeSDKSidecarRequest
+	frames        chan ProcessFrame
+	closed        chan struct{}
+	once          sync.Once
+	closeFailures int
+	closeCalls    int
 }
 
 func newBlockingClaudeSDKConnection() *blockingClaudeSDKConnection {
@@ -307,6 +309,14 @@ func (c *blockingClaudeSDKConnection) Recv() (ProcessFrame, error) {
 }
 
 func (c *blockingClaudeSDKConnection) Close() error {
+	c.mu.Lock()
+	c.closeCalls++
+	if c.closeFailures > 0 {
+		c.closeFailures--
+		c.mu.Unlock()
+		return errors.New("injected Claude sidecar close failure")
+	}
+	c.mu.Unlock()
 	c.once.Do(func() {
 		close(c.closed)
 	})

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_session_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_session_test.go
@@ -709,6 +709,69 @@ func TestCodexAppServerAdapterReleaseLiveSessionClosesClientAndKeepsProviderSess
 	}
 }
 
+func TestCodexAppServerAdapterDisconnectLiveSessionClosesClientAndKeepsProviderSession(t *testing.T) {
+	t.Parallel()
+
+	transport := newScriptedAppServerTransport()
+	adapter := NewCodexAppServerAdapter(transport)
+	session := testAppServerSession()
+	events, err := adapter.Start(context.Background(), session)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	session = applySessionEvents(session, events)
+	providerSessionID := session.ProviderSessionID
+	if err := adapter.DisconnectLiveSession(context.Background(), session); err != nil {
+		t.Fatalf("DisconnectLiveSession: %v", err)
+	}
+	if adapter.HasLiveSession(session) {
+		t.Fatal("HasLiveSession = true after disconnect")
+	}
+	if session.ProviderSessionID != providerSessionID || providerSessionID == "" {
+		t.Fatalf("provider session id=%q, want preserved %q", session.ProviderSessionID, providerSessionID)
+	}
+	transport.conn.mu.Lock()
+	closeCount := transport.conn.closeCount
+	transport.conn.mu.Unlock()
+	if closeCount == 0 {
+		t.Fatal("connection was not closed")
+	}
+}
+
+func TestCodexAppServerAdapterDisconnectLiveSessionRetriesCloseFailedHandle(t *testing.T) {
+	t.Parallel()
+
+	transport := newScriptedAppServerTransport()
+	adapter := NewCodexAppServerAdapter(transport)
+	session := testAppServerSession()
+	events, err := adapter.Start(context.Background(), session)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	session = applySessionEvents(session, events)
+	transport.conn.mu.Lock()
+	transport.conn.closeFailures = 1
+	transport.conn.mu.Unlock()
+	if err := adapter.DisconnectLiveSession(context.Background(), session); err == nil {
+		t.Fatal("first DisconnectLiveSession error=nil, want close failure")
+	}
+	if adapter.getSession(session.AgentSessionID) == nil {
+		t.Fatal("close-failed app-server handle lost ownership")
+	}
+	if err := adapter.DisconnectLiveSession(context.Background(), session); err != nil {
+		t.Fatalf("retry DisconnectLiveSession: %v", err)
+	}
+	if adapter.getSession(session.AgentSessionID) != nil {
+		t.Fatal("app-server handle remained after successful retry")
+	}
+	transport.conn.mu.Lock()
+	closeCount := transport.conn.closeCount
+	transport.conn.mu.Unlock()
+	if closeCount != 2 {
+		t.Fatalf("transport close calls=%d, want 2", closeCount)
+	}
+}
+
 func TestCodexAppServerAdapterReleaseLiveSessionSkipsPendingRequests(t *testing.T) {
 	t.Parallel()
 
@@ -743,5 +806,39 @@ func TestCodexAppServerAdapterReleaseLiveSessionSkipsPendingRequests(t *testing.
 	case <-execDone:
 	case <-time.After(5 * time.Second):
 		t.Fatal("exec did not finish after resolving pending approval")
+	}
+}
+
+func TestCodexAppServerAdapterDisconnectLiveSessionSettlesPendingRequest(t *testing.T) {
+	t.Parallel()
+
+	adapter, transport, session := startedAppServerAdapter(t)
+	transport.server.commandApproval = true
+	execDone := make(chan struct{})
+	go func() {
+		_, _ = adapter.Exec(context.Background(), session, []PromptContentBlock{{
+			Type: "text", Text: "clean the build dir",
+		}}, "", "turn-local-1", nil, nil)
+		close(execDone)
+	}()
+	var pending *pendingInteractiveRequest
+	waitForCondition(t, func() bool {
+		pending = adapter.getPendingRequest(session.AgentSessionID, "turn-local-1", "approval-1")
+		return pending != nil
+	})
+
+	if err := adapter.DisconnectLiveSession(context.Background(), session); err != nil {
+		t.Fatalf("DisconnectLiveSession: %v", err)
+	}
+	select {
+	case <-execDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("exec did not settle after workspace runtime disconnect")
+	}
+	if state := pending.disposition(); state != pendingInteractiveRequestStateInterrupted {
+		t.Fatalf("pending request state=%q, want interrupted", state)
+	}
+	if adapter.HasLiveSession(session) {
+		t.Fatal("HasLiveSession = true after pending request disconnect")
 	}
 }

--- a/packages/agent/daemon/runtime/codex_appserver_client.go
+++ b/packages/agent/daemon/runtime/codex_appserver_client.go
@@ -14,11 +14,10 @@ import (
 
 type codexAppServerClient struct {
 	raw *acpClient
-	// closeOnce makes Close idempotent: the client is closed from several
-	// owners (session replacement, lifecycle Close/Release, force-cancel,
-	// startup failure defers) and only the first close may reach the process.
-	closeOnce sync.Once
-	closeErr  error
+	// Close remains idempotent after success but retries a failed physical
+	// transport close so lifecycle cleanup never loses process ownership.
+	closeMu sync.Mutex
+	closed  bool
 	// parsedNotificationMethods tracks notification methods already run
 	// through the typed schema parse (telemetry only).
 	parsedNotificationMethods sync.Map
@@ -64,10 +63,16 @@ func (c *codexAppServerClient) Close() error {
 	if c == nil || c.raw == nil {
 		return nil
 	}
-	c.closeOnce.Do(func() {
-		c.closeErr = c.raw.Close()
-	})
-	return c.closeErr
+	c.closeMu.Lock()
+	defer c.closeMu.Unlock()
+	if c.closed {
+		return nil
+	}
+	err := c.raw.Close()
+	if err == nil {
+		c.closed = true
+	}
+	return err
 }
 
 func (c *codexAppServerClient) Done() <-chan struct{} {

--- a/packages/agent/daemon/runtime/codex_appserver_scripted_connection_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_scripted_connection_test.go
@@ -51,6 +51,7 @@ type scriptedAppServerConnection struct {
 	closed               chan struct{}
 	closeOnce            sync.Once
 	closeCount           int
+	closeFailures        int
 	server               *fakeCodexAppServer
 	providerProgressWait func(context.Context, time.Duration) error
 }
@@ -155,6 +156,11 @@ func (c *scriptedAppServerConnection) recvWithWaitSignal(waitEntered chan<- stru
 func (c *scriptedAppServerConnection) Close() error {
 	c.mu.Lock()
 	c.closeCount++
+	if c.closeFailures > 0 {
+		c.closeFailures--
+		c.mu.Unlock()
+		return errors.New("injected app-server close failure")
+	}
 	c.mu.Unlock()
 	c.closeOnce.Do(func() { close(c.closed) })
 	return nil

--- a/packages/agent/daemon/runtime/codex_appserver_session.go
+++ b/packages/agent/daemon/runtime/codex_appserver_session.go
@@ -410,13 +410,33 @@ func (a *CodexAppServerAdapter) ReleaseLiveSession(_ context.Context, session Se
 	return a.closeLiveSession(agentSessionID)
 }
 
+// DisconnectLiveSession resolves pending interactions and drops only the
+// app-server transport. The Codex thread remains resumable; no provider
+// thread/session deletion request is sent.
+func (a *CodexAppServerAdapter) DisconnectLiveSession(_ context.Context, session Session) error {
+	if a == nil {
+		return nil
+	}
+	agentSessionID := strings.TrimSpace(session.AgentSessionID)
+	unlockLifecycle := a.lockSessionLifecycle(agentSessionID)
+	defer unlockLifecycle()
+	a.rejectPendingRequests(agentSessionID, ErrSessionDisconnected)
+	return a.closeLiveSession(agentSessionID)
+}
+
 func (a *CodexAppServerAdapter) closeLiveSession(agentSessionID string) error {
 	a.mu.Lock()
 	appSession := a.sessions[agentSessionID]
-	delete(a.sessions, agentSessionID)
 	a.mu.Unlock()
 	if appSession != nil && appSession.client != nil {
-		return appSession.client.Close()
+		if err := appSession.client.Close(); err != nil {
+			return err
+		}
+		a.mu.Lock()
+		if a.sessions[agentSessionID] == appSession {
+			delete(a.sessions, agentSessionID)
+		}
+		a.mu.Unlock()
 	}
 	return nil
 }

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -26,32 +26,34 @@ const interactiveDenyFollowUpPollInterval = 25 * time.Millisecond
 type execMetadataContextKey struct{}
 
 type Controller struct {
-	mu                          sync.Mutex
-	streamObserverMu            sync.RWMutex
-	providerObservationMu       sync.RWMutex
-	goalControlObserverMu       sync.RWMutex
-	sessions                    map[string]Session
-	sessionAvailabilityWaiters  map[string]*sessionAvailabilityWaiter
-	adapters                    map[string]Adapter
-	adapterResolver             AdapterResolver
-	turns                       map[string]activeTurn
-	commands                    map[string]AgentSessionCommandSnapshot
-	pendingCommandSnapshots     map[string]AgentSessionCommandSnapshot
-	configOptionsUpdates        map[string]AgentSessionConfigOptionsUpdate
-	pendingConfigOptionsUpdates map[string][]AgentSessionConfigOptionsUpdate
-	provisionalSessions         map[string]bool
-	sessionInitializations      map[string]*controllerSessionInitialization
-	goalGenerationFences        map[string]*controllerGoalGenerationFenceRegistry
-	startupLocks                map[startupLockKey]*controllerLifecycleLock
-	lifecycleLocks              map[string]*controllerLifecycleLock
-	hub                         *EventHub
-	reporter                    DurableActivityReporter
-	reportQueue                 *reportRequestQueue
-	providerGoalAdoptionSink    ProviderGoalAdoptionSink
-	terminalInteractions        terminalInteractiveDispositionStore
-	streamObserver              RuntimeStreamEventObserver
-	providerObservationObserver ProviderObservationObserver
-	goalControlObserver         GoalControlLifecycleObserver
+	mu                           sync.Mutex
+	streamObserverMu             sync.RWMutex
+	providerObservationMu        sync.RWMutex
+	goalControlObserverMu        sync.RWMutex
+	sessions                     map[string]Session
+	liveConnectionGenerations    map[string]uint64
+	nextLiveConnectionGeneration uint64
+	sessionAvailabilityWaiters   map[string]*sessionAvailabilityWaiter
+	adapters                     map[string]Adapter
+	adapterResolver              AdapterResolver
+	turns                        map[string]activeTurn
+	commands                     map[string]AgentSessionCommandSnapshot
+	pendingCommandSnapshots      map[string]AgentSessionCommandSnapshot
+	configOptionsUpdates         map[string]AgentSessionConfigOptionsUpdate
+	pendingConfigOptionsUpdates  map[string][]AgentSessionConfigOptionsUpdate
+	provisionalSessions          map[string]bool
+	sessionInitializations       map[string]*controllerSessionInitialization
+	goalGenerationFences         map[string]*controllerGoalGenerationFenceRegistry
+	startupLocks                 map[startupLockKey]*controllerLifecycleLock
+	lifecycleLocks               map[string]*controllerLifecycleLock
+	hub                          *EventHub
+	reporter                     DurableActivityReporter
+	reportQueue                  *reportRequestQueue
+	providerGoalAdoptionSink     ProviderGoalAdoptionSink
+	terminalInteractions         terminalInteractiveDispositionStore
+	streamObserver               RuntimeStreamEventObserver
+	providerObservationObserver  ProviderObservationObserver
+	goalControlObserver          GoalControlLifecycleObserver
 }
 
 // RuntimeStreamEventObserver receives the ordered precommit stream projection
@@ -99,8 +101,9 @@ type GoalControlLifecycleObserver interface {
 }
 
 type controllerLifecycleLock struct {
-	gate chan struct{}
-	refs int
+	gate              chan struct{}
+	refs              int
+	startupOperations map[chan struct{}]struct{}
 }
 
 // controllerSessionInitialization retains every provider observation emitted
@@ -176,6 +179,20 @@ type CloseAllLiveSessionsResult struct {
 	ResourceCleanupFailed    int
 }
 
+// DisconnectRuntimeSessionResult reports whether a live provider connection
+// was released. The Controller session record and provider session id remain.
+type DisconnectRuntimeSessionResult struct {
+	Disconnected bool
+}
+
+// RuntimeDisconnectTarget identifies one exact live-connection incarnation.
+// A stale target must never disconnect a later Resume for the same Session.
+type RuntimeDisconnectTarget struct {
+	RoomID               string
+	AgentSessionID       string
+	ConnectionGeneration uint64
+}
+
 type asyncActivityReporter interface {
 	DurableActivityReporter
 	AsyncActivityReporter()
@@ -198,6 +215,7 @@ func NewControllerWithAdapterResolver(adapters []Adapter, reporter DurableActivi
 	}
 	controller := &Controller{
 		sessions:                    make(map[string]Session),
+		liveConnectionGenerations:   make(map[string]uint64),
 		sessionAvailabilityWaiters:  make(map[string]*sessionAvailabilityWaiter),
 		adapters:                    byProvider,
 		adapterResolver:             resolver,

--- a/packages/agent/daemon/runtime/controller_live_sessions.go
+++ b/packages/agent/daemon/runtime/controller_live_sessions.go
@@ -26,6 +26,7 @@ func (c *Controller) ensureLiveAdapterSession(ctx context.Context, session Sessi
 	if err := adapter.Resume(ctx, session); err != nil {
 		return err
 	}
+	c.advanceLiveConnectionGeneration(session.RoomID, session.AgentSessionID)
 	if err := c.applyRetainedGoalGenerationFencesOrClose(ctx, session, adapter); err != nil {
 		return err
 	}
@@ -177,6 +178,117 @@ func liveSessionReleaseAdapter(adapter Adapter, session Session) (LiveSessionRel
 		return releaseAdapter, probe, false
 	}
 	return releaseAdapter, probe, true
+}
+
+// DisconnectRuntimeSession force-releases one Workspace-scoped provider
+// transport while preserving the Controller session and its provider resume
+// identity. It serializes with admission for the same Session and never calls
+// Adapter.Close, whose provider protocol semantics may be destructive.
+func (c *Controller) DisconnectRuntimeSession(
+	ctx context.Context,
+	roomID string,
+	agentSessionID string,
+) (DisconnectRuntimeSessionResult, error) {
+	roomID = strings.TrimSpace(roomID)
+	agentSessionID = strings.TrimSpace(agentSessionID)
+	if c == nil || roomID == "" || agentSessionID == "" {
+		return DisconnectRuntimeSessionResult{}, errors.New("room id and agent session id are required")
+	}
+	releaseLifecycleLock, err := c.acquireLifecycleLockContext(ctx, roomID, agentSessionID)
+	if err != nil {
+		return DisconnectRuntimeSessionResult{}, err
+	}
+	defer releaseLifecycleLock()
+	return c.disconnectRuntimeSessionLocked(ctx, roomID, agentSessionID)
+}
+
+// SnapshotRuntimeDisconnectTargets captures exact provider-connection
+// incarnations without waiting for startup publication. It is used only by a
+// reentrant attachment cleanup that cannot wait for its own Host operation.
+func (c *Controller) SnapshotRuntimeDisconnectTargets(roomID string) []RuntimeDisconnectTarget {
+	if c == nil {
+		return nil
+	}
+	roomID = strings.TrimSpace(roomID)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	targets := make([]RuntimeDisconnectTarget, 0)
+	for key, session := range c.sessions {
+		if strings.TrimSpace(session.RoomID) != roomID {
+			continue
+		}
+		generation := c.liveConnectionGenerations[key]
+		if generation == 0 {
+			c.nextLiveConnectionGeneration++
+			generation = c.nextLiveConnectionGeneration
+			c.liveConnectionGenerations[key] = generation
+		}
+		targets = append(targets, RuntimeDisconnectTarget{
+			RoomID: roomID, AgentSessionID: session.AgentSessionID,
+			ConnectionGeneration: generation,
+		})
+	}
+	return targets
+}
+
+// DisconnectRuntimeSessionTarget releases a provider connection only when the
+// captured incarnation is still current.
+func (c *Controller) DisconnectRuntimeSessionTarget(
+	ctx context.Context,
+	target RuntimeDisconnectTarget,
+) (DisconnectRuntimeSessionResult, error) {
+	roomID := strings.TrimSpace(target.RoomID)
+	agentSessionID := strings.TrimSpace(target.AgentSessionID)
+	if c == nil || roomID == "" || agentSessionID == "" || target.ConnectionGeneration == 0 {
+		return DisconnectRuntimeSessionResult{}, errors.New("runtime disconnect target is invalid")
+	}
+	releaseLifecycleLock, err := c.acquireLifecycleLockContext(ctx, roomID, agentSessionID)
+	if err != nil {
+		return DisconnectRuntimeSessionResult{}, err
+	}
+	defer releaseLifecycleLock()
+	c.mu.Lock()
+	current := c.liveConnectionGenerations[sessionKey(roomID, agentSessionID)]
+	c.mu.Unlock()
+	if current != target.ConnectionGeneration {
+		return DisconnectRuntimeSessionResult{}, nil
+	}
+	return c.disconnectRuntimeSessionLocked(ctx, roomID, agentSessionID)
+}
+
+func (c *Controller) disconnectRuntimeSessionLocked(
+	ctx context.Context,
+	roomID string,
+	agentSessionID string,
+) (DisconnectRuntimeSessionResult, error) {
+
+	session, adapter, err := c.sessionAndAdapter(roomID, agentSessionID)
+	if errors.Is(err, ErrSessionNotFound) {
+		return DisconnectRuntimeSessionResult{}, nil
+	}
+	if err != nil {
+		return DisconnectRuntimeSessionResult{}, err
+	}
+	probe, probeOK := adapter.(LiveSessionProbeAdapter)
+	disconnector, disconnectOK := adapter.(LiveSessionDisconnectAdapter)
+	if !probeOK || !disconnectOK {
+		return DisconnectRuntimeSessionResult{}, fmt.Errorf(
+			"agent provider %q does not support workspace runtime disconnect",
+			session.Provider,
+		)
+	}
+	wasLive := probe.HasLiveSession(session)
+	if wasLive {
+		c.cancelActiveTurn(roomID, agentSessionID)
+	}
+	// Always invoke the idempotent adapter cleanup, even when its liveness probe
+	// is false. A raw transport death can make the probe false while the adapter
+	// still owns pending interactions or a close-failed physical handle.
+	if err := disconnector.DisconnectLiveSession(ctx, session); err != nil {
+		return DisconnectRuntimeSessionResult{}, err
+	}
+	c.invalidateAppliedGoalGenerationFences(session)
+	return DisconnectRuntimeSessionResult{Disconnected: wasLive}, nil
 }
 
 func (c *Controller) cleanupDetachedLiveSessionResources(ctx context.Context, failedProviders map[string]bool) LiveSessionResourceCleanupResult {
@@ -337,6 +449,7 @@ func (c *Controller) recreateAdapterSession(ctx context.Context, session Session
 	if err != nil {
 		return err
 	}
+	c.advanceLiveConnectionGeneration(fresh.RoomID, fresh.AgentSessionID)
 	fresh = applySessionEvents(fresh, events)
 	c.invalidateAppliedGoalGenerationFences(fresh)
 	if err := c.applyRetainedGoalGenerationFencesOrClose(ctx, fresh, adapter); err != nil {

--- a/packages/agent/daemon/runtime/controller_live_sessions_test.go
+++ b/packages/agent/daemon/runtime/controller_live_sessions_test.go
@@ -445,6 +445,253 @@ func TestControllerDetachedCleanupGivesEveryAdapterOneBoundedAttempt(t *testing.
 	}
 }
 
+func TestControllerRuntimeSessionsWaitsForWorkspaceStartBeforeEnumerating(t *testing.T) {
+	t.Parallel()
+
+	adapter := newReleasableAdapter()
+	adapter.startEntered = make(chan struct{})
+	adapter.startRelease = make(chan struct{})
+	controller := NewController([]Adapter{adapter}, nil)
+
+	startDone := make(chan error, 1)
+	go func() {
+		_, err := controller.Start(context.Background(), StartInput{
+			RoomID: "room-starting", AgentSessionID: "session-starting",
+			Provider: ProviderCodex, CWD: "/workspace",
+		})
+		startDone <- err
+	}()
+	select {
+	case <-adapter.startEntered:
+	case <-time.After(time.Second):
+		t.Fatal("adapter Start did not enter")
+	}
+
+	sessionsDone := make(chan []Session, 1)
+	errDone := make(chan error, 1)
+	go func() {
+		sessions, err := controller.RuntimeSessions(context.Background(), "room-starting")
+		sessionsDone <- sessions
+		errDone <- err
+	}()
+	select {
+	case sessions := <-sessionsDone:
+		t.Fatalf("RuntimeSessions returned before Start stored its Session: %#v", sessions)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(adapter.startRelease)
+	if err := <-startDone; err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	sessions := <-sessionsDone
+	if err := <-errDone; err != nil {
+		t.Fatalf("RuntimeSessions: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].AgentSessionID != "session-starting" {
+		t.Fatalf("RuntimeSessions=%#v, want completed startup Session", sessions)
+	}
+	result, err := controller.DisconnectRuntimeSession(
+		context.Background(), "room-starting", "session-starting",
+	)
+	if err != nil || !result.Disconnected {
+		t.Fatalf("DisconnectRuntimeSession result=%#v err=%v", result, err)
+	}
+	if adapter.hasLiveSession("session-starting") {
+		t.Fatal("startup provider handle remained live after disconnect")
+	}
+}
+
+func TestControllerDisconnectRuntimeSessionPreservesSessionAndResumesOnce(t *testing.T) {
+	t.Parallel()
+
+	adapter := newReleasableAdapter()
+	controller := NewController([]Adapter{adapter}, nil)
+	started := startReleasableSession(t, controller, "agent-session-disconnect")
+	result, err := controller.DisconnectRuntimeSession(
+		context.Background(), started.Session.RoomID, started.Session.AgentSessionID,
+	)
+	if err != nil || !result.Disconnected {
+		t.Fatalf("DisconnectRuntimeSession result=%#v err=%v", result, err)
+	}
+	stored, ok := controller.Session(started.Session.RoomID, started.Session.AgentSessionID)
+	if !ok || stored.ProviderSessionID != started.Session.ProviderSessionID {
+		t.Fatalf("stored session=%#v found=%v, want preserved provider identity", stored, ok)
+	}
+	if calls := adapter.closeCallCount(started.Session.AgentSessionID); calls != 0 {
+		t.Fatalf("destructive Close calls=%d, want 0", calls)
+	}
+	if _, err := controller.Exec(context.Background(), ExecInput{
+		RoomID: started.Session.RoomID, AgentSessionID: started.Session.AgentSessionID,
+		Content: textPrompt("resume after disconnect"),
+	}); err != nil {
+		t.Fatalf("Exec after disconnect: %v", err)
+	}
+	if adapter.resumeCalls != 1 {
+		t.Fatalf("resume calls=%d, want 1", adapter.resumeCalls)
+	}
+	adapter.releaseNext()
+}
+
+func TestControllerDeferredDisconnectTargetDoesNotCloseNewlyResumedConnection(t *testing.T) {
+	t.Parallel()
+
+	adapter := newReleasableAdapter()
+	controller := NewController([]Adapter{adapter}, nil)
+	started := startReleasableSession(t, controller, "agent-session-generation-cas")
+	targets := controller.SnapshotRuntimeDisconnectTargets(started.Session.RoomID)
+	if len(targets) != 1 || targets[0].ConnectionGeneration == 0 {
+		t.Fatalf("disconnect targets=%#v, want one versioned target", targets)
+	}
+
+	// Raw attachment fencing closes the old physical process before the
+	// semantic cleanup deferred by the reentrant Host operation can run.
+	adapter.dropLiveSession(started.Session.AgentSessionID)
+	if _, err := controller.Exec(context.Background(), ExecInput{
+		RoomID: started.Session.RoomID, AgentSessionID: started.Session.AgentSessionID,
+		Content: textPrompt("resume on the new attachment"),
+	}); err != nil {
+		t.Fatalf("Exec after raw old-attachment close: %v", err)
+	}
+	if adapter.resumeCalls != 1 || !adapter.hasLiveSession(started.Session.AgentSessionID) {
+		t.Fatalf("new provider connection resume/live = %d/%v", adapter.resumeCalls, adapter.hasLiveSession(started.Session.AgentSessionID))
+	}
+
+	result, err := controller.DisconnectRuntimeSessionTarget(context.Background(), targets[0])
+	if err != nil {
+		t.Fatalf("DisconnectRuntimeSessionTarget: %v", err)
+	}
+	if result.Disconnected {
+		t.Fatalf("stale target disconnected the new provider connection: %#v", result)
+	}
+	if !adapter.hasLiveSession(started.Session.AgentSessionID) {
+		t.Fatal("new provider connection was closed by old attachment cleanup")
+	}
+	adapter.releaseNext()
+}
+
+func TestControllerDisconnectRuntimeSessionCleansRegisteredDeadAdapterHandle(t *testing.T) {
+	t.Parallel()
+
+	adapter := newReleasableAdapter()
+	controller := NewController([]Adapter{adapter}, nil)
+	started := startReleasableSession(t, controller, "agent-session-dead-handle")
+	adapter.dropLiveSession(started.Session.AgentSessionID)
+	result, err := controller.DisconnectRuntimeSession(
+		context.Background(), started.Session.RoomID, started.Session.AgentSessionID,
+	)
+	if err != nil || result.Disconnected {
+		t.Fatalf("DisconnectRuntimeSession result=%#v err=%v, want cleanup-only no-op result", result, err)
+	}
+	if adapter.disconnectCalls != 1 {
+		t.Fatalf("DisconnectLiveSession calls=%d, want stale-handle cleanup", adapter.disconnectCalls)
+	}
+}
+
+func TestControllerDisconnectRuntimeSessionSettlesActiveTurnAndIsWorkspaceScoped(t *testing.T) {
+	t.Parallel()
+
+	adapter := newReleasableAdapter()
+	controller := NewController([]Adapter{adapter}, nil)
+	active := startReleasableSession(t, controller, "active-disconnect-session")
+	other, err := controller.Start(context.Background(), StartInput{
+		RoomID: "room-2", AgentSessionID: "other-session", Provider: ProviderCodex, CWD: "/workspace",
+	})
+	if err != nil {
+		t.Fatalf("Start other workspace: %v", err)
+	}
+	if _, err := controller.Exec(context.Background(), ExecInput{
+		RoomID: active.Session.RoomID, AgentSessionID: active.Session.AgentSessionID,
+		Content: textPrompt("in flight disconnect"),
+	}); err != nil {
+		t.Fatalf("Exec active: %v", err)
+	}
+	adapter.waitForExec(t, "in flight disconnect")
+	result, err := controller.DisconnectRuntimeSession(
+		context.Background(), active.Session.RoomID, active.Session.AgentSessionID,
+	)
+	if err != nil || !result.Disconnected {
+		t.Fatalf("DisconnectRuntimeSession result=%#v err=%v", result, err)
+	}
+	waitForSessionStatus(t, controller, active.Session.RoomID, active.Session.AgentSessionID, SessionStatusCanceled)
+	if !adapter.hasLiveSession(other.Session.AgentSessionID) {
+		t.Fatal("other workspace provider was disconnected")
+	}
+	replay, err := controller.DisconnectRuntimeSession(
+		context.Background(), active.Session.RoomID, active.Session.AgentSessionID,
+	)
+	if err != nil || replay.Disconnected {
+		t.Fatalf("idempotent disconnect result=%#v err=%v", replay, err)
+	}
+}
+
+func TestControllerRuntimeSessionsIncludesCanonicalPublicationPendingSession(t *testing.T) {
+	t.Parallel()
+
+	adapter := newReleasableAdapter()
+	controller := NewController([]Adapter{adapter}, nil)
+	started, err := controller.Start(context.Background(), StartInput{
+		RoomID: "room-1", AgentSessionID: "pending-session", Provider: ProviderCodex,
+		CWD: "/workspace", CanonicalInitPending: true,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if sessions := controller.Sessions("room-1"); len(sessions) != 0 {
+		t.Fatalf("public Sessions=%#v, want pending session hidden", sessions)
+	}
+	runtimeSessions, err := controller.RuntimeSessions(context.Background(), "room-1")
+	if err != nil {
+		t.Fatalf("RuntimeSessions: %v", err)
+	}
+	if len(runtimeSessions) != 1 || runtimeSessions[0].AgentSessionID != started.Session.AgentSessionID {
+		t.Fatalf("RuntimeSessions=%#v, want pending live session", runtimeSessions)
+	}
+}
+
+func TestControllerDisconnectRuntimeSessionSerializesWithExecAdmission(t *testing.T) {
+	t.Parallel()
+
+	adapter := newReleasableAdapter()
+	adapter.validateEntered = make(chan struct{})
+	adapter.validateRelease = make(chan struct{})
+	controller := NewController([]Adapter{adapter}, nil)
+	started := startReleasableSession(t, controller, "agent-session-serialized-disconnect")
+	execDone := make(chan error, 1)
+	go func() {
+		_, err := controller.Exec(context.Background(), ExecInput{
+			RoomID: started.Session.RoomID, AgentSessionID: started.Session.AgentSessionID,
+			Content: textPrompt("racing exec"),
+		})
+		execDone <- err
+	}()
+	select {
+	case <-adapter.validateEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for Exec admission")
+	}
+	disconnectDone := make(chan DisconnectRuntimeSessionResult, 1)
+	go func() {
+		result, _ := controller.DisconnectRuntimeSession(
+			context.Background(), started.Session.RoomID, started.Session.AgentSessionID,
+		)
+		disconnectDone <- result
+	}()
+	select {
+	case result := <-disconnectDone:
+		t.Fatalf("disconnect bypassed Exec lifecycle lock: %#v", result)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(adapter.validateRelease)
+	if err := <-execDone; err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if result := <-disconnectDone; !result.Disconnected {
+		t.Fatalf("disconnect result=%#v", result)
+	}
+	waitForSessionStatus(t, controller, started.Session.RoomID, started.Session.AgentSessionID, SessionStatusCanceled)
+}
+
 func TestControllerReleaseIdleLiveSessionsBoundsFailedCloseBudgetPerAdapter(t *testing.T) {
 	t.Parallel()
 
@@ -501,6 +748,7 @@ type releasableAdapter struct {
 	live                       map[string]bool
 	resumeCalls                int
 	releaseCalls               int
+	disconnectCalls            int
 	releaseErrByAgentSessionID map[string]error
 	closeCalls                 map[string]int
 	closeErrByAgentSessionID   map[string]error
@@ -510,6 +758,8 @@ type releasableAdapter struct {
 	validateRelease            chan struct{}
 	execStarted                chan string
 	execRelease                chan struct{}
+	startEntered               chan struct{}
+	startRelease               chan struct{}
 }
 
 func newReleasableAdapter() *releasableAdapter {
@@ -530,6 +780,16 @@ func (a *releasableAdapter) Start(_ context.Context, session Session) ([]activit
 	a.mu.Lock()
 	a.live[session.AgentSessionID] = true
 	a.mu.Unlock()
+	if a.startEntered != nil {
+		select {
+		case <-a.startEntered:
+		default:
+			close(a.startEntered)
+		}
+	}
+	if a.startRelease != nil {
+		<-a.startRelease
+	}
 	return []activityshared.Event{
 		newSessionActivityEvent(session, EventSessionStarted, SessionStatusReady, nil),
 	}, nil
@@ -588,10 +848,18 @@ func (a *releasableAdapter) ValidatePromptContent(Session, []PromptContentBlock)
 	return nil
 }
 
-func (a *releasableAdapter) Exec(_ context.Context, session Session, content []PromptContentBlock, _ string, turnID string, _ EventSink, _ CommandSnapshotSink) ([]activityshared.Event, error) {
+func (a *releasableAdapter) Exec(ctx context.Context, session Session, content []PromptContentBlock, _ string, turnID string, _ EventSink, _ CommandSnapshotSink) ([]activityshared.Event, error) {
+	return a.exec(ctx, session, content, turnID)
+}
+
+func (a *releasableAdapter) exec(ctx context.Context, session Session, content []PromptContentBlock, turnID string) ([]activityshared.Event, error) {
 	prompt := promptDisplayText(content)
 	a.execStarted <- prompt
-	<-a.execRelease
+	select {
+	case <-a.execRelease:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 	return []activityshared.Event{
 		newTurnActivityEvent(session, EventTurnCompleted, turnID, SessionStatusReady, "", "", nil),
 	}, nil
@@ -615,6 +883,17 @@ func (a *releasableAdapter) ReleaseLiveSession(_ context.Context, session Sessio
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.releaseCalls++
+	if err := a.releaseErrByAgentSessionID[session.AgentSessionID]; err != nil {
+		return err
+	}
+	a.live[session.AgentSessionID] = false
+	return nil
+}
+
+func (a *releasableAdapter) DisconnectLiveSession(_ context.Context, session Session) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.disconnectCalls++
 	if err := a.releaseErrByAgentSessionID[session.AgentSessionID]; err != nil {
 		return err
 	}

--- a/packages/agent/daemon/runtime/controller_session_lifecycle.go
+++ b/packages/agent/daemon/runtime/controller_session_lifecycle.go
@@ -99,6 +99,7 @@ func (c *Controller) Start(ctx context.Context, input StartInput) (StartResult, 
 		c.mu.Unlock()
 		return StartResult{}, startError
 	}
+	c.advanceLiveConnectionGeneration(roomID, agentSessionID)
 	session = applySessionEvents(session, events)
 	c.mu.Lock()
 	key := sessionKey(roomID, agentSessionID)
@@ -294,6 +295,7 @@ func (c *Controller) Resume(ctx context.Context, input ResumeInput) (Session, er
 		}
 		return session, nil
 	}
+	c.advanceLiveConnectionGeneration(roomID, agentSessionID)
 	if err := c.applyRetainedGoalGenerationFencesOrClose(ctx, session, adapter); err != nil {
 		return Session{}, err
 	}
@@ -375,6 +377,7 @@ func (c *Controller) Reprepare(ctx context.Context, input ResumeInput) (Session,
 	if err := adapter.Resume(withProviderLaunchRuntimeContext(ctx, input.ProviderLaunchRuntimeContext), replacement); err != nil {
 		return Session{}, err
 	}
+	c.advanceLiveConnectionGeneration(roomID, agentSessionID)
 	if err := c.applyRetainedGoalGenerationFences(ctx, replacement, adapter); err != nil {
 		_ = releaser.ReleaseLiveSession(context.WithoutCancel(ctx), replacement)
 		return Session{}, err
@@ -441,6 +444,7 @@ func (c *Controller) Close(ctx context.Context, input CloseInput) (CloseResult, 
 		delete(c.provisionalSessions, key)
 		delete(c.sessionInitializations, key)
 		delete(c.sessions, key)
+		delete(c.liveConnectionGenerations, key)
 		delete(c.turns, key)
 		delete(c.commands, key)
 		delete(c.pendingCommandSnapshots, session.AgentSessionID)
@@ -464,6 +468,7 @@ func (c *Controller) Close(ctx context.Context, input CloseInput) (CloseResult, 
 	c.enqueueSessionReport(ctx, session, events)
 	c.mu.Lock()
 	delete(c.sessions, key)
+	delete(c.liveConnectionGenerations, key)
 	delete(c.turns, key)
 	delete(c.commands, key)
 	delete(c.pendingCommandSnapshots, session.AgentSessionID)

--- a/packages/agent/daemon/runtime/controller_session_registry.go
+++ b/packages/agent/daemon/runtime/controller_session_registry.go
@@ -141,6 +141,61 @@ func (c *Controller) Sessions(roomID string) []Session {
 	return result
 }
 
+// RuntimeSessions lists every registered runtime Session in a Workspace,
+// including sessions still behind the canonical initialization publication
+// barrier. Lifecycle teardown uses this broader view so a provider process
+// cannot outlive the Workspace merely because its canonical report is pending.
+func (c *Controller) RuntimeSessions(ctx context.Context, roomID string) ([]Session, error) {
+	if c == nil {
+		return nil, nil
+	}
+	roomID = strings.TrimSpace(roomID)
+	if err := c.waitForWorkspaceStartupOperations(ctx, roomID); err != nil {
+		return nil, err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	result := make([]Session, 0)
+	for key, session := range c.sessions {
+		if strings.TrimSpace(session.RoomID) != roomID {
+			continue
+		}
+		session = c.reconcileSessionStatusLocked(key, session)
+		c.sessions[key] = session
+		result = append(result, session)
+	}
+	return result, nil
+}
+
+// waitForWorkspaceStartupOperations waits only for startup operations that had
+// entered before this call took its snapshot. A later Start is intentionally
+// outside this barrier; the caller must fence new transport admission first.
+func (c *Controller) waitForWorkspaceStartupOperations(ctx context.Context, roomID string) error {
+	if c == nil {
+		return nil
+	}
+	roomID = strings.TrimSpace(roomID)
+	c.mu.Lock()
+	operations := make([]<-chan struct{}, 0)
+	for key, lock := range c.startupLocks {
+		if key.roomID != roomID || lock == nil {
+			continue
+		}
+		for done := range lock.startupOperations {
+			operations = append(operations, done)
+		}
+	}
+	c.mu.Unlock()
+	for _, done := range operations {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-done:
+		}
+	}
+	return nil
+}
+
 func (c *Controller) adapter(provider string) Adapter {
 	if c == nil {
 		return nil
@@ -275,32 +330,45 @@ func (c *Controller) acquireStartupLockContext(
 	c.mu.Lock()
 	lock := c.startupLocks[key]
 	if lock == nil {
-		lock = &controllerLifecycleLock{gate: make(chan struct{}, 1)}
+		lock = &controllerLifecycleLock{
+			gate:              make(chan struct{}, 1),
+			startupOperations: make(map[chan struct{}]struct{}),
+		}
 		lock.gate <- struct{}{}
 		c.startupLocks[key] = lock
 	}
+	operationDone := make(chan struct{})
+	lock.startupOperations[operationDone] = struct{}{}
 	lock.refs++
 	c.mu.Unlock()
 
 	select {
 	case <-ctx.Done():
-		c.releaseStartupLockReference(key, lock)
+		c.releaseStartupLockReference(key, lock, operationDone)
 		return func() {}, ctx.Err()
 	case <-lock.gate:
 	}
 	if err := ctx.Err(); err != nil {
 		lock.gate <- struct{}{}
-		c.releaseStartupLockReference(key, lock)
+		c.releaseStartupLockReference(key, lock, operationDone)
 		return func() {}, err
 	}
 	return func() {
 		lock.gate <- struct{}{}
-		c.releaseStartupLockReference(key, lock)
+		c.releaseStartupLockReference(key, lock, operationDone)
 	}, nil
 }
 
-func (c *Controller) releaseStartupLockReference(key startupLockKey, lock *controllerLifecycleLock) {
+func (c *Controller) releaseStartupLockReference(
+	key startupLockKey,
+	lock *controllerLifecycleLock,
+	operationDone chan struct{},
+) {
 	c.mu.Lock()
+	if _, ok := lock.startupOperations[operationDone]; ok {
+		delete(lock.startupOperations, operationDone)
+		close(operationDone)
+	}
 	lock.refs--
 	if lock.refs <= 0 && c.startupLocks[key] == lock {
 		delete(c.startupLocks, key)
@@ -388,6 +456,19 @@ func (c *Controller) store(session Session) {
 	c.sessions[key] = session
 	c.notifySessionAvailableLocked(key)
 	c.mu.Unlock()
+}
+
+func (c *Controller) advanceLiveConnectionGeneration(roomID, agentSessionID string) uint64 {
+	if c == nil {
+		return 0
+	}
+	key := sessionKey(strings.TrimSpace(roomID), strings.TrimSpace(agentSessionID))
+	c.mu.Lock()
+	c.nextLiveConnectionGeneration++
+	generation := c.nextLiveConnectionGeneration
+	c.liveConnectionGenerations[key] = generation
+	c.mu.Unlock()
+	return generation
 }
 
 func (c *Controller) notifySessionAvailableLocked(key string) {

--- a/packages/agent/daemon/runtime/controller_state.go
+++ b/packages/agent/daemon/runtime/controller_state.go
@@ -74,6 +74,46 @@ func (c *Controller) UpdateSettings(ctx context.Context, input UpdateSettingsInp
 	}, nil
 }
 
+// UpdateRetainedSettings changes only the Controller Session snapshot. It is
+// used while the provider connection is absent so the next just-in-time Resume
+// receives current canonical settings without reconnecting early.
+func (c *Controller) UpdateRetainedSettings(_ context.Context, input UpdateSettingsInput) (UpdateSettingsResult, error) {
+	session, ok := c.get(strings.TrimSpace(input.RoomID), strings.TrimSpace(input.AgentSessionID))
+	if !ok {
+		return UpdateSettingsResult{}, ErrSessionNotFound
+	}
+	settings := normalizeSessionSettings(session.Settings, session.Provider, session.PermissionModeID)
+	if input.Settings.Model != nil {
+		settings.Model = strings.TrimSpace(*input.Settings.Model)
+	}
+	if input.Settings.ReasoningEffort != nil {
+		settings.ReasoningEffort = strings.TrimSpace(*input.Settings.ReasoningEffort)
+	}
+	if input.Settings.Speed != nil {
+		settings.Speed = strings.TrimSpace(*input.Settings.Speed)
+	}
+	if input.Settings.PlanMode != nil {
+		settings.PlanMode = *input.Settings.PlanMode
+	}
+	if input.Settings.BrowserUse != nil {
+		value := *input.Settings.BrowserUse
+		settings.BrowserUse = &value
+	}
+	if input.Settings.ComputerUse != nil {
+		value := *input.Settings.ComputerUse
+		settings.ComputerUse = &value
+	}
+	if input.Settings.PermissionModeID != nil {
+		settings.PermissionModeID = normalizePermissionModeIDWithFallback(
+			session.Provider, strings.TrimSpace(*input.Settings.PermissionModeID), session.PermissionModeID,
+		)
+		session.PermissionModeID = settings.PermissionModeID
+	}
+	session.Settings = cloneSessionSettings(settings)
+	c.store(session)
+	return UpdateSettingsResult{AgentSessionID: session.AgentSessionID, Settings: settings}, nil
+}
+
 func shouldAdvanceSessionUpdatedAtFromEvents(events []activityshared.Event) bool {
 	for _, event := range events {
 		switch event.Type {

--- a/packages/agent/daemon/runtime/standard_acp_resource_ownership.go
+++ b/packages/agent/daemon/runtime/standard_acp_resource_ownership.go
@@ -170,6 +170,55 @@ func (a *standardACPAdapter) ReleaseLiveSession(_ context.Context, session Sessi
 	return nil
 }
 
+// DisconnectLiveSession settles pending interactions and releases every
+// physical handle owned by one runtime Session without sending session/close.
+// Failed transport closes remain owned and are retried by the next idempotent
+// disconnect instead of being forgotten.
+func (a *standardACPAdapter) DisconnectLiveSession(_ context.Context, session Session) error {
+	if a == nil || a.transport == nil {
+		return nil
+	}
+	agentSessionID := strings.TrimSpace(session.AgentSessionID)
+	unlockLifecycle := a.lockSessionLifecycle(agentSessionID)
+	defer unlockLifecycle()
+	a.rejectPendingApprovals(agentSessionID, ErrSessionDisconnected)
+
+	a.mu.Lock()
+	current := a.sessions[agentSessionID]
+	if current != nil && current.client != nil {
+		current.releasing = true
+		current.client.SetMessageHandler(nil)
+	}
+	a.mu.Unlock()
+	if current != nil && current.client != nil {
+		if err := current.client.Close(); err != nil {
+			a.mu.Lock()
+			if a.sessions[agentSessionID] == current {
+				current.releasing = false
+				current.releaseFailed = true
+			}
+			a.mu.Unlock()
+			a.logACPCloseDiagnostics("workspace_disconnect.transport_close.failed", session, current, err)
+			return err
+		}
+		a.mu.Lock()
+		if a.sessions[agentSessionID] == current {
+			delete(a.sessions, agentSessionID)
+		}
+		a.mu.Unlock()
+		a.logACPCloseDiagnostics("workspace_disconnect.succeeded", session, current, nil)
+	}
+	for {
+		attempted, err := a.retryOneTrackedSessionLocked(agentSessionID)
+		if err != nil {
+			return err
+		}
+		if !attempted {
+			return nil
+		}
+	}
+}
+
 func (a *standardACPAdapter) Close(ctx context.Context, session Session) error {
 	if a == nil || a.transport == nil {
 		return nil

--- a/packages/agent/daemon/runtime/standard_acp_session_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_session_test.go
@@ -333,6 +333,80 @@ func TestStandardACPAdapterReleaseLiveSessionClosesOnlyTransport(t *testing.T) {
 	}
 }
 
+func TestStandardACPAdapterDisconnectLiveSessionClosesOnlyTransport(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Hermes Agent", "hermes-session-disconnect")
+	transport.conn.supportsCloseSession = true
+	adapter := newHermesExtensionTestAdapter(transport)
+	session := standardTestSession(hermesExtensionTestProvider)
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := adapter.DisconnectLiveSession(context.Background(), session); err != nil {
+		t.Fatalf("DisconnectLiveSession: %v", err)
+	}
+	if params := transport.conn.closeSessionParams(); params != nil {
+		t.Fatalf("DisconnectLiveSession sent destructive session/close params %#v", params)
+	}
+	if !transport.conn.closed() || adapter.HasLiveSession(session) {
+		t.Fatal("DisconnectLiveSession did not drop the ACP transport")
+	}
+}
+
+func TestStandardACPAdapterDisconnectLiveSessionRetriesCloseFailedHandle(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Kimi Code", "kimi-session-disconnect-retry")
+	transport.conn.closeFailures = 1
+	adapter := newKimiCodeExtensionTestAdapter(t, transport)
+	session := standardTestSession("acp:kimi-code")
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := adapter.DisconnectLiveSession(context.Background(), session); err == nil {
+		t.Fatal("first DisconnectLiveSession error=nil, want close failure")
+	}
+	if !adapter.hasTrackedLiveSession(session) {
+		t.Fatal("close-failed ACP handle lost ownership")
+	}
+	if err := adapter.DisconnectLiveSession(context.Background(), session); err != nil {
+		t.Fatalf("retry DisconnectLiveSession: %v", err)
+	}
+	if adapter.hasTrackedLiveSession(session) {
+		t.Fatal("ACP handle remained after successful retry")
+	}
+	transport.conn.mu.Lock()
+	closeCalls := transport.conn.closeCalls
+	transport.conn.mu.Unlock()
+	if closeCalls != 2 {
+		t.Fatalf("transport close calls=%d, want 2", closeCalls)
+	}
+}
+
+func TestStandardACPAdapterDisconnectLiveSessionRejectsPendingApproval(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Kimi Code", "kimi-session-disconnect-pending")
+	adapter := newKimiCodeExtensionTestAdapter(t, transport)
+	session := standardTestSession("acp:kimi-code")
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	pending := &pendingACPApproval{
+		agentSessionID: session.AgentSessionID,
+		requestID:      "approval-disconnect",
+		response:       make(chan pendingInteractiveResponse, 1),
+	}
+	adapter.storePendingApproval(pending)
+	if err := adapter.DisconnectLiveSession(context.Background(), session); err != nil {
+		t.Fatalf("DisconnectLiveSession: %v", err)
+	}
+	if state := pending.disposition(); state != pendingInteractiveRequestStateInterrupted {
+		t.Fatalf("pending approval state=%q, want interrupted", state)
+	}
+}
+
 func TestStandardACPAdapterResumeContinuesLifecycleSequenceAfterRelease(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -132,6 +132,14 @@ history. Its trusted `RuntimeContextOverlay` is visible only to runtime
 preparation (for example to mint an Invocation-scoped bearer); it is not
 persisted or installed as provider RuntimeContext. A successful reprepare must
 precede the Turn whose tools use that binding.
+`DisconnectWorkspaceRuntime` is the attachment-loss boundary for releasing
+every live provider transport in one Workspace without deleting canonical or
+Controller Session state. Host serializes each Session against ordinary
+mutations, preserves the provider Session identity and history, and never
+resumes a provider or replays a prompt. Provider adapters terminalize active
+work and pending interactions before dropping the transport, and transport-only
+disconnect must not invoke a destructive provider `session/close`. A later
+user command follows the ordinary just-in-time Resume path.
 `CreateSessionInput.RailPlacement` optionally carries the caller-selected,
 versioned canonical rail identity. Host validates it before provider startup
 and persists its opaque `SectionKey` exactly on first creation. An idempotent

--- a/packages/agent/host/conformance/conformance.go
+++ b/packages/agent/host/conformance/conformance.go
@@ -203,6 +203,33 @@ type Driver interface {
 	Metrics() Metrics
 }
 
+// WorkspaceRuntimeDisconnectDriver is a narrow opt-in lifecycle contract so a
+// new Host capability does not source-break existing external conformance
+// drivers that implement the stable Driver interface.
+type WorkspaceRuntimeDisconnectDriver interface {
+	Driver
+	DisconnectWorkspaceRuntime(context.Context, string) (agenthost.DisconnectWorkspaceRuntimeResult, error)
+}
+
+type WorkspaceRuntimeDisconnectScenario struct {
+	Name string
+	run  func(context.Context, WorkspaceRuntimeDisconnectDriver) error
+}
+
+func RunWorkspaceRuntimeDisconnect(
+	ctx context.Context,
+	driver WorkspaceRuntimeDisconnectDriver,
+	scenario WorkspaceRuntimeDisconnectScenario,
+) error {
+	if driver == nil {
+		return fmt.Errorf("workspace runtime disconnect conformance driver is required")
+	}
+	if scenario.run == nil {
+		return fmt.Errorf("workspace runtime disconnect scenario %q has no runner", scenario.Name)
+	}
+	return scenario.run(ctx, driver)
+}
+
 // ProviderlessTerminalDriver is the narrow fault-injection capability for a
 // Runtime that durably fails the exact canonical Turn before it acquires a
 // provider identity. It stays separate from Fixture so downstream conformance

--- a/packages/agent/host/conformance/conformance_test.go
+++ b/packages/agent/host/conformance/conformance_test.go
@@ -44,6 +44,14 @@ func TestPublishedScenarioCatalogsHaveUniqueNames(t *testing.T) {
 	}
 }
 
+func TestPublishedWorkspaceRuntimeDisconnectScenarioCatalogHasUniqueNames(t *testing.T) {
+	t.Parallel()
+	scenarios := WorkspaceRuntimeDisconnectScenarios()
+	if len(scenarios) != 1 || scenarios[0].Name == "" {
+		t.Fatalf("workspace runtime disconnect scenarios=%#v", scenarios)
+	}
+}
+
 func TestPublishedInteractionTreeScenarioCatalogHasUniqueNames(t *testing.T) {
 	t.Parallel()
 	scenarios := InteractionTreeScenarios()

--- a/packages/agent/host/conformance/workspace_runtime_disconnect_scenarios.go
+++ b/packages/agent/host/conformance/workspace_runtime_disconnect_scenarios.go
@@ -1,0 +1,108 @@
+package conformance
+
+import (
+	"context"
+	"fmt"
+
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+)
+
+func WorkspaceRuntimeDisconnectScenarios() []WorkspaceRuntimeDisconnectScenario {
+	return []WorkspaceRuntimeDisconnectScenario{{
+		Name: "disconnect workspace runtime without losing resumable sessions",
+		run:  runDisconnectWorkspaceRuntime,
+	}}
+}
+
+func runDisconnectWorkspaceRuntime(ctx context.Context, driver WorkspaceRuntimeDisconnectDriver) error {
+	fixture := liveSessionFixture("session-disconnect-a", "")
+	fixture.AdditionalSessions = []SessionSeed{
+		{
+			WorkspaceID: "workspace-1", AgentSessionID: "session-disconnect-b", Provider: "codex",
+			ProviderSessionID: "provider-session-disconnect-b", Cwd: "/workspace", Live: true,
+		},
+		{
+			WorkspaceID: "workspace-2", AgentSessionID: "session-other-workspace", Provider: "codex",
+			ProviderSessionID: "provider-session-other-workspace", Cwd: "/workspace", Live: true,
+		},
+	}
+	if err := driver.Reset(ctx, fixture); err != nil {
+		return err
+	}
+
+	result, err := driver.DisconnectWorkspaceRuntime(ctx, "workspace-1")
+	if err != nil {
+		return fmt.Errorf("disconnect workspace runtime: %w", err)
+	}
+	if result.Scanned != 2 || result.Disconnected != 2 || result.Failed != 0 {
+		return fmt.Errorf("disconnect result=%#v", result)
+	}
+	if metrics := driver.Metrics(); metrics.CloseCalls != 0 || metrics.ResumeCalls != 0 {
+		return fmt.Errorf("disconnect performed destructive close or eager resume: %#v", metrics)
+	}
+
+	for _, ref := range []agenthost.SessionRef{
+		{WorkspaceID: "workspace-1", AgentSessionID: "session-disconnect-a"},
+		{WorkspaceID: "workspace-1", AgentSessionID: "session-disconnect-b"},
+	} {
+		session, getErr := driver.GetSession(ctx, ref)
+		if getErr != nil {
+			return fmt.Errorf("get disconnected session %q: %w", ref.AgentSessionID, getErr)
+		}
+		if session.Live || session.ProviderSessionID == "" {
+			return fmt.Errorf("disconnected session=%#v", session)
+		}
+	}
+
+	other, err := driver.GetSession(ctx, agenthost.SessionRef{
+		WorkspaceID: "workspace-2", AgentSessionID: "session-other-workspace",
+	})
+	if err != nil {
+		return fmt.Errorf("get other workspace session: %w", err)
+	}
+	if !other.Live {
+		return fmt.Errorf("other workspace session was disconnected: %#v", other)
+	}
+
+	replay, err := driver.DisconnectWorkspaceRuntime(ctx, "workspace-1")
+	if err != nil {
+		return fmt.Errorf("replay workspace runtime disconnect: %w", err)
+	}
+	if replay.Scanned != 2 || replay.Disconnected != 0 || replay.Failed != 0 {
+		return fmt.Errorf("replay disconnect result=%#v", replay)
+	}
+
+	ref := agenthost.SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-disconnect-a"}
+	model, reasoningEffort, permissionMode := "model-after-disconnect", "high", "auto"
+	updated, err := driver.UpdateSettings(ctx, agenthost.UpdateSettingsInput{
+		WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
+		Settings: agenthost.ComposerSettingsPatch{
+			Model: &model, ReasoningEffort: &reasoningEffort, PermissionModeID: &permissionMode,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("update settings while workspace runtime is disconnected: %w", err)
+	}
+	if updated.Settings.Model != model || updated.Settings.ReasoningEffort != reasoningEffort ||
+		updated.Settings.PermissionModeID != permissionMode || driver.Metrics().ResumeCalls != 0 {
+		return fmt.Errorf("disconnected settings update=%#v metrics=%#v", updated, driver.Metrics())
+	}
+	sent, err := driver.SendInput(ctx, ref, agenthost.SendInput{
+		ClientSubmitID: "resume-after-workspace-disconnect",
+		Content:        []agenthost.PromptContentBlock{{Type: "text", Text: "resume once"}},
+	})
+	if err != nil {
+		return fmt.Errorf("send after workspace runtime disconnect: %w", err)
+	}
+	if sent.Session.ProviderSessionID != fixture.Session.ProviderSessionID {
+		return fmt.Errorf("provider session id=%q, want %q", sent.Session.ProviderSessionID, fixture.Session.ProviderSessionID)
+	}
+	if sent.Session.Settings.Model != model || sent.Session.Settings.ReasoningEffort != reasoningEffort ||
+		sent.Session.Settings.PermissionModeID != permissionMode {
+		return fmt.Errorf("resumed settings=%#v, want disconnected update", sent.Session.Settings)
+	}
+	if metrics := driver.Metrics(); metrics.ResumeCalls != 1 {
+		return fmt.Errorf("resume calls=%d, want 1", metrics.ResumeCalls)
+	}
+	return nil
+}

--- a/packages/agent/host/errors.go
+++ b/packages/agent/host/errors.go
@@ -22,6 +22,7 @@ var (
 	ErrRuntimeSessionActive               = errors.New("agent runtime session has an active turn")
 	ErrRuntimeSessionReprepareUnavailable = errors.New("agent runtime session reprepare is unavailable")
 	ErrRuntimeSessionPublishUnavailable   = errors.New("agent runtime session initialization publication is unavailable")
+	ErrWorkspaceDisconnectUnavailable     = errors.New("agent workspace runtime disconnect is unavailable")
 	ErrInteractionNotFound                = errors.New("agent interaction was not found")
 	ErrRuntimeOperationInProgress         = errors.New("agent runtime operation is already in progress")
 	ErrRuntimeOperationFailed             = errors.New("agent runtime operation failed")

--- a/packages/agent/host/host.go
+++ b/packages/agent/host/host.go
@@ -63,52 +63,53 @@ type Config struct {
 }
 
 type Host struct {
-	store                  CanonicalStore
-	interactionTrees       CanonicalInteractionTreeStore
-	turnSubmissions        TurnSubmissionStore
-	effectiveHistory       EffectiveHistoryStore
-	sessionManagement      SessionManagementStore
-	sessionBatchManagement SessionBatchManagementStore
-	sessionDeletionGuard   SessionDeletionGuard
-	sessionPurge           SessionPurgeStore
-	deletedSessions        DeletedSessionStore
-	historicalState        HistoricalSessionStateStore
-	sessionForks           SessionForkStore
-	sessionForkRecovery    SessionForkRecoveryStore
-	sessionForkRuntime     SessionForkRuntime
-	sessionForkContext     SessionForkContextPolicy
-	sessionForkState       SessionForkProviderStateBinder
-	sessionForkAttachments SessionForkAttachmentStager
-	runtime                RuntimeController
-	historyRuntime         RuntimeHistoryController
-	preparation            RuntimePreparationPort
-	settingsPolicy         SettingsPolicy
-	attachments            AttachmentMaterializer
-	clock                  Clock
-	locker                 SessionLocker
-	startupGate            RuntimeStartGate
-	observer               LifecycleObserver
-	terminalFailure        TerminalFailureObserver
-	commitObserver         CommitObserver
-	operations             RuntimeOperationStore
-	events                 RuntimeOperationEventPublisher
-	owner                  string
-	scheduler              Scheduler
-	staleTurns             StaleTurnSettler
-	goals                  GoalStateStore
-	goalFences             GoalGenerationFenceStore
-	goalRuntime            GoalRuntimeController
-	goalInbox              GoalReconcileInboxStore
-	goalOwner              string
-	goalClock              Clock
-	goalAttemptTimeout     time.Duration
-	goalRecoveryBudget     time.Duration
-	goalMaxAttempts        int
-	goalDispatchDeadline   time.Duration
-	goalActor              *SessionActor
-	sessionMutationActor   *SessionActor
-	editRetryDisabled      bool
-	goalFencesRestored     sync.Map
+	store                     CanonicalStore
+	interactionTrees          CanonicalInteractionTreeStore
+	turnSubmissions           TurnSubmissionStore
+	effectiveHistory          EffectiveHistoryStore
+	sessionManagement         SessionManagementStore
+	sessionBatchManagement    SessionBatchManagementStore
+	sessionDeletionGuard      SessionDeletionGuard
+	sessionPurge              SessionPurgeStore
+	deletedSessions           DeletedSessionStore
+	historicalState           HistoricalSessionStateStore
+	sessionForks              SessionForkStore
+	sessionForkRecovery       SessionForkRecoveryStore
+	sessionForkRuntime        SessionForkRuntime
+	sessionForkContext        SessionForkContextPolicy
+	sessionForkState          SessionForkProviderStateBinder
+	sessionForkAttachments    SessionForkAttachmentStager
+	runtime                   RuntimeController
+	historyRuntime            RuntimeHistoryController
+	preparation               RuntimePreparationPort
+	settingsPolicy            SettingsPolicy
+	attachments               AttachmentMaterializer
+	clock                     Clock
+	locker                    SessionLocker
+	startupGate               RuntimeStartGate
+	observer                  LifecycleObserver
+	terminalFailure           TerminalFailureObserver
+	commitObserver            CommitObserver
+	operations                RuntimeOperationStore
+	events                    RuntimeOperationEventPublisher
+	owner                     string
+	scheduler                 Scheduler
+	staleTurns                StaleTurnSettler
+	goals                     GoalStateStore
+	goalFences                GoalGenerationFenceStore
+	goalRuntime               GoalRuntimeController
+	goalInbox                 GoalReconcileInboxStore
+	goalOwner                 string
+	goalClock                 Clock
+	goalAttemptTimeout        time.Duration
+	goalRecoveryBudget        time.Duration
+	goalMaxAttempts           int
+	goalDispatchDeadline      time.Duration
+	goalActor                 *SessionActor
+	sessionMutationActor      *SessionActor
+	workspaceRuntimeAdmission *workspaceRuntimeAdmission
+	editRetryDisabled         bool
+	goalFencesRestored        sync.Map
 }
 
 func New(config Config) *Host {
@@ -143,7 +144,8 @@ func New(config Config) *Host {
 		goalAttemptTimeout: config.GoalAttemptTimeout, goalRecoveryBudget: config.GoalRecoveryBudget,
 		goalMaxAttempts: config.GoalMaxAttempts, goalDispatchDeadline: config.GoalDispatchDeadline,
 		goalActor: goalActor, sessionMutationActor: sessionMutationActor,
-		editRetryDisabled: config.EditRetryDisabled,
+		workspaceRuntimeAdmission: newWorkspaceRuntimeAdmission(),
+		editRetryDisabled:         config.EditRetryDisabled,
 	}
 	if host.interactionTrees == nil {
 		host.interactionTrees, _ = host.store.(CanonicalInteractionTreeStore)

--- a/packages/agent/host/lifecycle.go
+++ b/packages/agent/host/lifecycle.go
@@ -22,7 +22,12 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 		flow: "session_create", workspaceID: workspaceID, agentSessionID: input.AgentSessionID,
 		operationID: operationID, requestID: activationID, clientSubmitID: clientSubmitID, turnID: input.TurnID,
 	})
-	result, err := h.createSession(ctx, workspaceID, input)
+	var result CreateSessionResult
+	err := h.withWorkspaceRuntimeOperation(ctx, workspaceID, func(operationCtx context.Context) error {
+		var createErr error
+		result, createErr = h.createSession(operationCtx, workspaceID, input)
+		return createErr
+	})
 	command.finish(ctx, h, err)
 	return result, err
 }
@@ -353,6 +358,16 @@ func (h *Host) EnsureRuntimeSession(ctx context.Context, ref SessionRef) (Provid
 	if h == nil || h.runtime == nil || h.store == nil || ref.WorkspaceID == "" || ref.AgentSessionID == "" {
 		return ProviderRuntimeSession{}, ErrSessionNotFound
 	}
+	var result ProviderRuntimeSession
+	err := h.withWorkspaceRuntimeOperation(ctx, ref.WorkspaceID, func(operationCtx context.Context) error {
+		var ensureErr error
+		result, ensureErr = h.ensureRuntimeSession(operationCtx, ref)
+		return ensureErr
+	})
+	return result, err
+}
+
+func (h *Host) ensureRuntimeSession(ctx context.Context, ref SessionRef) (ProviderRuntimeSession, error) {
 	release, err := h.acquireSession(ctx, ref)
 	if err != nil {
 		return ProviderRuntimeSession{}, err

--- a/packages/agent/host/lifecycle_resume_test.go
+++ b/packages/agent/host/lifecycle_resume_test.go
@@ -3,6 +3,7 @@ package agenthost
 import (
 	"context"
 	"errors"
+	"runtime"
 	"testing"
 	"time"
 
@@ -185,6 +186,66 @@ func TestEnsureRuntimeSessionCleansPreparedResourcesWhenResumeFails(t *testing.T
 		preparation.cleanupInput.AgentSessionID != "session-1" ||
 		preparation.cleanupInput.Provider != "codex" {
 		t.Fatalf("cleanup input = %#v", preparation.cleanupInput)
+	}
+}
+
+func TestEnsureRuntimeSessionWaitsForWorkspaceRuntimeDisconnectAdmission(t *testing.T) {
+	t.Parallel()
+	store := liveResumeCanonicalStore{
+		session: storesqlite.Session{
+			ID: "session-1", WorkspaceID: "workspace-1", Kind: storesqlite.SessionKindRoot,
+			Provider: "codex", ProviderSessionID: "provider-session-1",
+		},
+		evidence: storesqlite.ProviderSessionResumeEvidence{Established: true},
+	}
+	runtimeBackend := &disconnectedReprepareRuntime{}
+	host := New(Config{CanonicalStore: store, Runtime: runtimeBackend})
+	_, releaseDisconnect, err := host.BeginWorkspaceRuntimeDisconnect(context.Background(), "workspace-1")
+	if err != nil {
+		t.Fatalf("BeginWorkspaceRuntimeDisconnect: %v", err)
+	}
+
+	ensureStarted := make(chan struct{})
+	ensureDone := make(chan error, 1)
+	go func() {
+		close(ensureStarted)
+		_, ensureErr := host.EnsureRuntimeSession(context.Background(), SessionRef{
+			WorkspaceID: "workspace-1", AgentSessionID: "session-1",
+		})
+		ensureDone <- ensureErr
+	}()
+	<-ensureStarted
+	for {
+		host.workspaceRuntimeAdmission.mu.Lock()
+		state := host.workspaceRuntimeAdmission.states["workspace-1"]
+		waiting := state != nil && state.refs >= 2
+		host.workspaceRuntimeAdmission.mu.Unlock()
+		if waiting {
+			break
+		}
+		select {
+		case ensureErr := <-ensureDone:
+			releaseDisconnect()
+			t.Fatalf("EnsureRuntimeSession bypassed disconnect admission: %v", ensureErr)
+		default:
+		}
+		runtime.Gosched()
+	}
+	if runtimeBackend.resumeCalls != 0 {
+		t.Fatalf("Resume calls while disconnect admission held = %d, want 0", runtimeBackend.resumeCalls)
+	}
+	select {
+	case ensureErr := <-ensureDone:
+		t.Fatalf("EnsureRuntimeSession returned while disconnect admission held: %v", ensureErr)
+	default:
+	}
+
+	releaseDisconnect()
+	if ensureErr := <-ensureDone; ensureErr != nil {
+		t.Fatalf("EnsureRuntimeSession after admission release: %v", ensureErr)
+	}
+	if runtimeBackend.resumeCalls != 1 {
+		t.Fatalf("Resume calls after admission release = %d, want 1", runtimeBackend.resumeCalls)
 	}
 }
 

--- a/packages/agent/host/lifecycle_workspace_disconnect.go
+++ b/packages/agent/host/lifecycle_workspace_disconnect.go
@@ -1,0 +1,99 @@
+package agenthost
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// DisconnectWorkspaceRuntime releases every live provider connection in one
+// Workspace while preserving canonical sessions, Controller session records,
+// provider session identities, and resumable history. It never resumes a
+// provider and never replays a user submission.
+func (h *Host) DisconnectWorkspaceRuntime(
+	ctx context.Context,
+	workspaceID string,
+) (DisconnectWorkspaceRuntimeResult, error) {
+	workspaceID = strings.TrimSpace(workspaceID)
+	if h == nil || h.runtime == nil || workspaceID == "" {
+		return DisconnectWorkspaceRuntimeResult{}, ErrInvalidArgument
+	}
+	if deferred, _ := ctx.Value(workspaceRuntimeDeferredDisconnectContextKey{}).(bool); deferred {
+		targeter, ok := h.runtime.(RuntimeWorkspaceDisconnectTargeter)
+		if !ok {
+			return DisconnectWorkspaceRuntimeResult{}, ErrWorkspaceDisconnectUnavailable
+		}
+		targets := targeter.SnapshotWorkspaceRuntimeDisconnectTargets(workspaceID)
+		h.workspaceRuntimeAdmission.deferDisconnect(workspaceID, func(deferredCtx context.Context) {
+			for _, target := range targets {
+				_, _ = targeter.DisconnectRuntimeSessionTarget(deferredCtx, target)
+			}
+		})
+		return DisconnectWorkspaceRuntimeResult{}, nil
+	}
+	disconnectCtx, release, err := h.workspaceRuntimeAdmission.beginDisconnect(ctx, workspaceID)
+	if err != nil {
+		if errors.Is(err, errWorkspaceRuntimeDisconnectReentrant) {
+			h.workspaceRuntimeAdmission.deferDisconnect(workspaceID, func(deferredCtx context.Context) {
+				_, _ = h.disconnectWorkspaceRuntime(deferredCtx, workspaceID)
+			})
+			return DisconnectWorkspaceRuntimeResult{}, nil
+		}
+		return DisconnectWorkspaceRuntimeResult{}, err
+	}
+	defer release()
+	return h.disconnectWorkspaceRuntime(disconnectCtx, workspaceID)
+}
+
+func (h *Host) disconnectWorkspaceRuntime(
+	ctx context.Context,
+	workspaceID string,
+) (DisconnectWorkspaceRuntimeResult, error) {
+	runtime, ok := h.runtime.(RuntimeWorkspaceDisconnector)
+	if !ok {
+		return DisconnectWorkspaceRuntimeResult{}, ErrWorkspaceDisconnectUnavailable
+	}
+
+	sessions, err := runtime.WorkspaceRuntimeSessions(ctx, workspaceID)
+	if err != nil {
+		return DisconnectWorkspaceRuntimeResult{}, err
+	}
+	sort.Slice(sessions, func(i, j int) bool {
+		return strings.TrimSpace(sessions[i].ID) < strings.TrimSpace(sessions[j].ID)
+	})
+	result := DisconnectWorkspaceRuntimeResult{}
+	var failures []error
+	seen := make(map[string]struct{}, len(sessions))
+	for _, session := range sessions {
+		sessionID := strings.TrimSpace(session.ID)
+		if strings.TrimSpace(session.WorkspaceID) != workspaceID || sessionID == "" {
+			continue
+		}
+		if _, duplicate := seen[sessionID]; duplicate {
+			continue
+		}
+		seen[sessionID] = struct{}{}
+		result.Scanned++
+		ref := SessionRef{WorkspaceID: workspaceID, AgentSessionID: sessionID}
+		var disconnected bool
+		err := h.sessionMutationActor.Do(ctx, ref, func(actorCtx context.Context) error {
+			var disconnectErr error
+			disconnected, disconnectErr = runtime.DisconnectRuntimeSession(actorCtx, ref)
+			return disconnectErr
+		})
+		if err != nil {
+			result.Failed++
+			failures = append(failures, fmt.Errorf("disconnect agent session %q runtime: %w", sessionID, err))
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				break
+			}
+			continue
+		}
+		if disconnected {
+			result.Disconnected++
+		}
+	}
+	return result, errors.Join(failures...)
+}

--- a/packages/agent/host/lifecycle_workspace_disconnect_test.go
+++ b/packages/agent/host/lifecycle_workspace_disconnect_test.go
@@ -1,0 +1,299 @@
+package agenthost
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"sync"
+	"testing"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+type workspaceDisconnectRuntime struct {
+	RuntimeController
+	sessions              []ProviderRuntimeSession
+	disconnected          map[string]bool
+	failures              map[string]error
+	calls                 []string
+	connectionGenerations map[string]uint64
+	targetCalls           []RuntimeDisconnectTarget
+}
+
+func (r *workspaceDisconnectRuntime) SnapshotWorkspaceRuntimeDisconnectTargets(workspaceID string) []RuntimeDisconnectTarget {
+	result := make([]RuntimeDisconnectTarget, 0)
+	for _, session := range r.sessions {
+		if session.WorkspaceID != workspaceID {
+			continue
+		}
+		generation := r.connectionGenerations[session.ID]
+		if generation == 0 {
+			generation = 1
+			if r.connectionGenerations == nil {
+				r.connectionGenerations = make(map[string]uint64)
+			}
+			r.connectionGenerations[session.ID] = generation
+		}
+		result = append(result, RuntimeDisconnectTarget{
+			WorkspaceID: workspaceID, AgentSessionID: session.ID, ConnectionGeneration: generation,
+		})
+	}
+	return result
+}
+
+func (r *workspaceDisconnectRuntime) DisconnectRuntimeSessionTarget(_ context.Context, target RuntimeDisconnectTarget) (bool, error) {
+	r.targetCalls = append(r.targetCalls, target)
+	if r.connectionGenerations[target.AgentSessionID] != target.ConnectionGeneration {
+		return false, nil
+	}
+	return r.DisconnectRuntimeSession(context.Background(), SessionRef{
+		WorkspaceID: target.WorkspaceID, AgentSessionID: target.AgentSessionID,
+	})
+}
+
+func TestWorkspaceRuntimeDisconnectWaitsForAdmittedStart(t *testing.T) {
+	t.Parallel()
+	host := New(Config{Runtime: &workspaceDisconnectRuntime{disconnected: make(map[string]bool)}})
+	operationEntered := make(chan struct{})
+	releaseOperation := make(chan struct{})
+	operationDone := make(chan error, 1)
+	go func() {
+		operationDone <- host.withWorkspaceRuntimeOperation(context.Background(), "workspace-1", func(context.Context) error {
+			close(operationEntered)
+			<-releaseOperation
+			return nil
+		})
+	}()
+	<-operationEntered
+
+	disconnectEntered := make(chan struct{})
+	disconnectDone := make(chan error, 1)
+	go func() {
+		disconnectCtx, release, err := host.BeginWorkspaceRuntimeDisconnect(context.Background(), "workspace-1")
+		if err == nil {
+			close(disconnectEntered)
+			release()
+			_ = disconnectCtx
+		}
+		disconnectDone <- err
+	}()
+
+	select {
+	case <-disconnectEntered:
+		t.Fatal("disconnect entered while Start was still admitted")
+	default:
+	}
+	close(releaseOperation)
+	if err := <-operationDone; err != nil {
+		t.Fatalf("Start operation: %v", err)
+	}
+	if err := <-disconnectDone; err != nil {
+		t.Fatalf("BeginWorkspaceRuntimeDisconnect: %v", err)
+	}
+}
+
+func TestWorkspaceRuntimeDisconnectFencesResumeBeforeSessionActor(t *testing.T) {
+	t.Parallel()
+	host := New(Config{Runtime: &workspaceDisconnectRuntime{disconnected: make(map[string]bool)}})
+	disconnectCtx, releaseDisconnect, err := host.BeginWorkspaceRuntimeDisconnect(context.Background(), "workspace-1")
+	if err != nil {
+		t.Fatalf("BeginWorkspaceRuntimeDisconnect: %v", err)
+	}
+	defer releaseDisconnect()
+
+	actorEntered := make(chan struct{})
+	operationDone := make(chan error, 1)
+	go func() {
+		operationDone <- host.withSessionMutationActor(context.Background(), "workspace-1", "session-1", func(context.Context) error {
+			close(actorEntered)
+			return nil
+		})
+	}()
+	select {
+	case <-actorEntered:
+		t.Fatal("Send/Resume actor entered while Workspace disconnect admission was held")
+	default:
+	}
+
+	var sweepRan bool
+	err = host.sessionMutationActor.Do(disconnectCtx, SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-1"}, func(context.Context) error {
+		sweepRan = true
+		return nil
+	})
+	if err != nil || !sweepRan {
+		t.Fatalf("disconnect session sweep err/ran = %v/%v", err, sweepRan)
+	}
+	releaseDisconnect()
+	if err := <-operationDone; err != nil {
+		t.Fatalf("Send/Resume operation: %v", err)
+	}
+}
+
+func TestReentrantAttachmentCleanupDoesNotDisconnectNewConnectionAfterOperationLeaves(t *testing.T) {
+	t.Parallel()
+	runtime := &workspaceDisconnectRuntime{
+		sessions:              []ProviderRuntimeSession{{ID: "session-1", WorkspaceID: "workspace-1"}},
+		disconnected:          make(map[string]bool),
+		connectionGenerations: map[string]uint64{"session-1": 1},
+	}
+	host := New(Config{Runtime: runtime})
+	err := host.withWorkspaceRuntimeOperation(context.Background(), "workspace-1", func(operationCtx context.Context) error {
+		detachCtx, release, beginErr := host.BeginWorkspaceRuntimeDisconnect(operationCtx, "workspace-1")
+		if beginErr != nil {
+			return beginErr
+		}
+		defer release()
+		result, disconnectErr := host.DisconnectWorkspaceRuntime(detachCtx, "workspace-1")
+		if disconnectErr != nil {
+			return disconnectErr
+		}
+		if result.Scanned != 0 || len(runtime.calls) != 0 {
+			t.Fatalf("reentrant semantic disconnect ran before operation release: result=%#v calls=%v", result, runtime.calls)
+		}
+		runtime.connectionGenerations["session-1"] = 2
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("reentrant cleanup: %v", err)
+	}
+	if len(runtime.targetCalls) != 1 || len(runtime.calls) != 0 || runtime.disconnected["session-1"] {
+		t.Fatalf("deferred target/broad calls/state = %v/%v/%v", runtime.targetCalls, runtime.calls, runtime.disconnected)
+	}
+}
+
+func TestWorkspaceRuntimeAdmissionSerializesConcurrentDisconnects(t *testing.T) {
+	t.Parallel()
+	host := New(Config{Runtime: &workspaceDisconnectRuntime{disconnected: make(map[string]bool)}})
+	ctx, release, err := host.BeginWorkspaceRuntimeDisconnect(context.Background(), "workspace-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = ctx
+	var once sync.Once
+	done := make(chan error, 1)
+	go func() {
+		_, secondRelease, beginErr := host.BeginWorkspaceRuntimeDisconnect(context.Background(), "workspace-1")
+		if beginErr == nil {
+			once.Do(secondRelease)
+		}
+		done <- beginErr
+	}()
+	select {
+	case err := <-done:
+		t.Fatalf("second disconnect was not serialized: %v", err)
+	default:
+	}
+	release()
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (r *workspaceDisconnectRuntime) Session(workspaceID, agentSessionID string) (ProviderRuntimeSession, bool) {
+	for _, session := range r.sessions {
+		if session.WorkspaceID == workspaceID && session.ID == agentSessionID {
+			return session, true
+		}
+	}
+	return ProviderRuntimeSession{}, false
+}
+
+func (r *workspaceDisconnectRuntime) RuntimeSessionLive(_, agentSessionID string) bool {
+	return !r.disconnected[agentSessionID]
+}
+
+type workspaceDisconnectStore struct {
+	CanonicalStore
+	session storesqlite.Session
+}
+
+func (workspaceDisconnectStore) SessionDeleted(context.Context, string, string) (bool, error) {
+	return false, nil
+}
+
+func (s workspaceDisconnectStore) GetSession(_ context.Context, workspaceID, agentSessionID string) (storesqlite.Session, bool, error) {
+	return s.session, s.session.WorkspaceID == workspaceID && s.session.ID == agentSessionID, nil
+}
+
+func (r *workspaceDisconnectRuntime) WorkspaceRuntimeSessions(context.Context, string) ([]ProviderRuntimeSession, error) {
+	return append([]ProviderRuntimeSession(nil), r.sessions...), nil
+}
+
+func (r *workspaceDisconnectRuntime) DisconnectRuntimeSession(
+	_ context.Context,
+	ref SessionRef,
+) (bool, error) {
+	r.calls = append(r.calls, ref.AgentSessionID)
+	if err := r.failures[ref.AgentSessionID]; err != nil {
+		return false, err
+	}
+	if r.disconnected[ref.AgentSessionID] {
+		return false, nil
+	}
+	r.disconnected[ref.AgentSessionID] = true
+	return true, nil
+}
+
+func TestDisconnectWorkspaceRuntimeContinuesAfterSessionFailure(t *testing.T) {
+	t.Parallel()
+	failure := errors.New("transport close failed")
+	runtime := &workspaceDisconnectRuntime{
+		sessions: []ProviderRuntimeSession{
+			{ID: "session-b", WorkspaceID: "workspace-1"},
+			{ID: "session-a", WorkspaceID: "workspace-1"},
+			{ID: "session-other", WorkspaceID: "workspace-2"},
+		},
+		disconnected: make(map[string]bool),
+		failures:     map[string]error{"session-a": failure},
+	}
+	host := New(Config{Runtime: runtime})
+
+	result, err := host.DisconnectWorkspaceRuntime(t.Context(), " workspace-1 ")
+	if result.Scanned != 2 || result.Disconnected != 1 || result.Failed != 1 {
+		t.Fatalf("result=%#v", result)
+	}
+	if !errors.Is(err, failure) {
+		t.Fatalf("error=%v, want failure in aggregate", err)
+	}
+	if !slices.Equal(runtime.calls, []string{"session-a", "session-b"}) {
+		t.Fatalf("calls=%#v, want stable order and continued processing", runtime.calls)
+	}
+}
+
+func TestDisconnectWorkspaceRuntimeRequiresCapability(t *testing.T) {
+	t.Parallel()
+	host := New(Config{Runtime: struct{ RuntimeController }{}})
+	_, err := host.DisconnectWorkspaceRuntime(t.Context(), "workspace-1")
+	if !errors.Is(err, ErrWorkspaceDisconnectUnavailable) {
+		t.Fatalf("error=%v, want %v", err, ErrWorkspaceDisconnectUnavailable)
+	}
+}
+
+func TestGetSessionReportsDisconnectedRegisteredRuntimeAsNotLive(t *testing.T) {
+	t.Parallel()
+	runtime := &workspaceDisconnectRuntime{
+		sessions: []ProviderRuntimeSession{{
+			ID: "session-1", WorkspaceID: "workspace-1", ProviderSessionID: "provider-1",
+		}},
+		disconnected: map[string]bool{"session-1": true},
+	}
+	host := New(Config{
+		Runtime: runtime,
+		CanonicalStore: workspaceDisconnectStore{session: storesqlite.Session{
+			ID: "session-1", WorkspaceID: "workspace-1", ProviderSessionID: "provider-1",
+		}},
+	})
+
+	result, err := host.GetSession(t.Context(), SessionRef{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1",
+	})
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if result.Live {
+		t.Fatalf("GetSession Live=true for disconnected Controller record: %#v", result)
+	}
+	if result.Session.ID != "session-1" || result.Session.ProviderSessionID != "provider-1" {
+		t.Fatalf("registered runtime observation was lost: %#v", result.Session)
+	}
+}

--- a/packages/agent/host/ports.go
+++ b/packages/agent/host/ports.go
@@ -289,6 +289,28 @@ type RuntimeSessionLiveness interface {
 	RuntimeSessionLive(workspaceID, agentSessionID string) bool
 }
 
+// RuntimeWorkspaceDisconnector exposes registered runtime sessions and
+// releases only their live provider connection. It must preserve the runtime
+// session record and provider resume identity, and must not invoke a
+// provider-history session close operation.
+type RuntimeWorkspaceDisconnector interface {
+	WorkspaceRuntimeSessions(context.Context, string) ([]ProviderRuntimeSession, error)
+	DisconnectRuntimeSession(context.Context, SessionRef) (bool, error)
+}
+
+// RuntimeWorkspaceDisconnectTargeter supports a reentrant detach that must
+// defer semantic cleanup without targeting a later provider connection.
+type RuntimeWorkspaceDisconnectTargeter interface {
+	SnapshotWorkspaceRuntimeDisconnectTargets(string) []RuntimeDisconnectTarget
+	DisconnectRuntimeSessionTarget(context.Context, RuntimeDisconnectTarget) (bool, error)
+}
+
+// RuntimeRetainedSettingsUpdater refreshes the settings snapshot kept by a
+// disconnected runtime Session without starting its provider connection.
+type RuntimeRetainedSettingsUpdater interface {
+	UpdateRetainedSettings(context.Context, RuntimeUpdateSettingsInput) error
+}
+
 // RuntimeHistoryController is an optional semantic capability. Host lifecycle
 // code never invokes provider-specific history methods directly.
 type RuntimeHistoryController interface {

--- a/packages/agent/host/session_actor.go
+++ b/packages/agent/host/session_actor.go
@@ -68,7 +68,9 @@ func (h *Host) withSessionMutationActor(ctx context.Context, workspaceID, agentS
 	if h == nil || h.sessionMutationActor == nil {
 		return ErrInvalidArgument
 	}
-	return h.sessionMutationActor.Do(ctx, SessionRef{WorkspaceID: workspaceID, AgentSessionID: agentSessionID}, fn)
+	return h.withWorkspaceRuntimeOperation(ctx, workspaceID, func(operationCtx context.Context) error {
+		return h.sessionMutationActor.Do(operationCtx, SessionRef{WorkspaceID: workspaceID, AgentSessionID: agentSessionID}, fn)
+	})
 }
 
 func (h *Host) withSessionMutationActors(ctx context.Context, workspaceID string, agentSessionIDs []string, fn func(context.Context) error) error {

--- a/packages/agent/host/session_management.go
+++ b/packages/agent/host/session_management.go
@@ -28,9 +28,13 @@ func (h *Host) GetSession(ctx context.Context, ref SessionRef) (GetSessionResult
 	if err != nil {
 		return GetSessionResult{}, err
 	}
-	live, liveFound := h.runtime.Session(ref.WorkspaceID, ref.AgentSessionID)
+	live, runtimeFound := h.runtime.Session(ref.WorkspaceID, ref.AgentSessionID)
+	liveFound := runtimeFound
+	if liveness, ok := h.runtime.(RuntimeSessionLiveness); ok {
+		liveFound = runtimeFound && liveness.RuntimeSessionLive(ref.WorkspaceID, ref.AgentSessionID)
+	}
 	if !found {
-		if liveFound {
+		if runtimeFound {
 			return GetSessionResult{}, fmt.Errorf("live workspace agent session has no persisted session")
 		}
 		return GetSessionResult{}, ErrSessionNotFound
@@ -43,6 +47,16 @@ func (h *Host) GetSession(ctx context.Context, ref SessionRef) (GetSessionResult
 // runtime first and then persist the resulting settings. The same per-session
 // lock used by resume protects both paths.
 func (h *Host) UpdateSettings(ctx context.Context, input UpdateSettingsInput) (UpdateSettingsResult, error) {
+	var result UpdateSettingsResult
+	err := h.withWorkspaceRuntimeOperation(ctx, input.WorkspaceID, func(operationCtx context.Context) error {
+		var updateErr error
+		result, updateErr = h.updateSettings(operationCtx, input)
+		return updateErr
+	})
+	return result, err
+}
+
+func (h *Host) updateSettings(ctx context.Context, input UpdateSettingsInput) (UpdateSettingsResult, error) {
 	ref := normalizedSessionRef(SessionRef{WorkspaceID: input.WorkspaceID, AgentSessionID: input.AgentSessionID})
 	if h == nil || h.store == nil || h.sessionManagement == nil || h.runtime == nil || ref.WorkspaceID == "" || ref.AgentSessionID == "" {
 		return UpdateSettingsResult{}, ErrInvalidArgument
@@ -53,7 +67,12 @@ func (h *Host) UpdateSettings(ctx context.Context, input UpdateSettingsInput) (U
 	}
 	defer release()
 
-	if _, live := h.runtime.Session(ref.WorkspaceID, ref.AgentSessionID); live {
+	_, runtimeFound := h.runtime.Session(ref.WorkspaceID, ref.AgentSessionID)
+	runtimeLive := runtimeFound
+	if liveness, ok := h.runtime.(RuntimeSessionLiveness); ok {
+		runtimeLive = runtimeFound && liveness.RuntimeSessionLive(ref.WorkspaceID, ref.AgentSessionID)
+	}
+	if runtimeLive {
 		session, err := h.ensureRuntimeSessionLocked(ctx, ref)
 		if err != nil {
 			return UpdateSettingsResult{}, err
@@ -105,6 +124,20 @@ func (h *Host) UpdateSettings(ctx context.Context, input UpdateSettingsInput) (U
 	if h.settingsPolicy != nil {
 		settings = h.settingsPolicy.NormalizePersistedSettings(ctx, canonical, settings, input.Settings)
 	}
+	if updater, ok := h.runtime.(RuntimeRetainedSettingsUpdater); ok && runtimeFound {
+		patch := ComposerSettingsPatch{
+			CodexSaverMode: boolPointer(settings.CodexSaverMode),
+			Model:          stringPointer(settings.Model), PermissionModeID: stringPointer(settings.PermissionModeID),
+			PlanMode: boolPointer(settings.PlanMode), BrowserUse: cloneBoolPointer(settings.BrowserUse),
+			ComputerUse: cloneBoolPointer(settings.ComputerUse), ReasoningEffort: stringPointer(settings.ReasoningEffort),
+			Speed: stringPointer(settings.Speed),
+		}
+		if err := updater.UpdateRetainedSettings(ctx, RuntimeUpdateSettingsInput{
+			WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID, Settings: patch,
+		}); err != nil {
+			return UpdateSettingsResult{}, err
+		}
+	}
 	canonical, updated, err := h.sessionManagement.UpdateSessionSettings(ctx, ref.WorkspaceID, ref.AgentSessionID, settings)
 	if err != nil {
 		return UpdateSettingsResult{}, err
@@ -113,6 +146,16 @@ func (h *Host) UpdateSettings(ctx context.Context, input UpdateSettingsInput) (U
 		return UpdateSettingsResult{}, ErrSessionNotFound
 	}
 	return UpdateSettingsResult{Canonical: canonical}, nil
+}
+
+func stringPointer(value string) *string { return &value }
+
+func cloneBoolPointer(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
 }
 
 func (h *Host) UpdatePin(ctx context.Context, input UpdatePinInput) (UpdatePinResult, error) {
@@ -132,8 +175,12 @@ func (h *Host) UpdatePin(ctx context.Context, input UpdatePinInput) (UpdatePinRe
 	if !updated {
 		return UpdatePinResult{}, ErrSessionNotFound
 	}
-	live, ok := h.runtime.Session(ref.WorkspaceID, ref.AgentSessionID)
-	return UpdatePinResult{Session: live, Canonical: canonical, Live: ok}, nil
+	live, runtimeFound := h.runtime.Session(ref.WorkspaceID, ref.AgentSessionID)
+	liveFound := runtimeFound
+	if liveness, ok := h.runtime.(RuntimeSessionLiveness); ok {
+		liveFound = runtimeFound && liveness.RuntimeSessionLive(ref.WorkspaceID, ref.AgentSessionID)
+	}
+	return UpdatePinResult{Session: live, Canonical: canonical, Live: liveFound}, nil
 }
 
 // DeleteSession and DeleteSessions share one deletion coordinator so child

--- a/packages/agent/host/testdata/external-consumer/consumer.go
+++ b/packages/agent/host/testdata/external-consumer/consumer.go
@@ -10,6 +10,7 @@ var (
 	_ = (*agenthost.Host).UpdateSettings
 	_ = (*agenthost.Host).UpdatePin
 	_ = (*agenthost.Host).DeleteSession
+	_ = (*agenthost.Host).DisconnectWorkspaceRuntime
 	_ = (*agenthost.Host).GetTurn
 	_ = (*agenthost.Host).GetInteraction
 	_ = (*agenthost.Host).ListSessionTurns

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -14,6 +14,22 @@ type SessionRef struct {
 	AgentSessionID string
 }
 
+// DisconnectWorkspaceRuntimeResult reports provider runtime connections
+// released without deleting their canonical or resumable session identity.
+type DisconnectWorkspaceRuntimeResult struct {
+	Scanned      int
+	Disconnected int
+	Failed       int
+}
+
+// RuntimeDisconnectTarget identifies an exact provider-connection incarnation
+// for deferred attachment cleanup.
+type RuntimeDisconnectTarget struct {
+	WorkspaceID          string
+	AgentSessionID       string
+	ConnectionGeneration uint64
+}
+
 // InteractionRef identifies one canonical interaction. Provider request IDs
 // are transport-local correlation values and are only unique within the Turn
 // that owns them.

--- a/packages/agent/host/workspace_runtime_gate.go
+++ b/packages/agent/host/workspace_runtime_gate.go
@@ -1,0 +1,254 @@
+package agenthost
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+)
+
+var errWorkspaceRuntimeDisconnectReentrant = errors.New("workspace runtime disconnect requested by an admitted operation")
+
+type workspaceRuntimeAdmission struct {
+	mu     sync.Mutex
+	states map[string]*workspaceRuntimeAdmissionState
+}
+
+type workspaceRuntimeAdmissionState struct {
+	changed       chan struct{}
+	operations    int
+	disconnecting bool
+	refs          int
+	deferred      []func(context.Context)
+}
+
+type workspaceRuntimeAdmissionContext struct {
+	gate        *workspaceRuntimeAdmission
+	workspaceID string
+	exclusive   bool
+}
+
+type workspaceRuntimeAdmissionContextKey struct{}
+type workspaceRuntimeDeferredDisconnectContextKey struct{}
+
+func newWorkspaceRuntimeAdmission() *workspaceRuntimeAdmission {
+	return &workspaceRuntimeAdmission{states: make(map[string]*workspaceRuntimeAdmissionState)}
+}
+
+func (g *workspaceRuntimeAdmission) enterOperation(
+	ctx context.Context,
+	workspaceID string,
+) (context.Context, func(), error) {
+	workspaceID = strings.TrimSpace(workspaceID)
+	if g == nil || workspaceID == "" {
+		return ctx, func() {}, ErrInvalidArgument
+	}
+	if admission, ok := ctx.Value(workspaceRuntimeAdmissionContextKey{}).(workspaceRuntimeAdmissionContext); ok &&
+		admission.gate == g && admission.workspaceID == workspaceID {
+		return ctx, func() {}, nil
+	}
+	for {
+		g.mu.Lock()
+		state := g.stateLocked(workspaceID)
+		if !state.disconnecting {
+			state.operations++
+			g.mu.Unlock()
+			operationCtx := context.WithValue(ctx, workspaceRuntimeAdmissionContextKey{}, workspaceRuntimeAdmissionContext{
+				gate: g, workspaceID: workspaceID,
+			})
+			var once sync.Once
+			return operationCtx, func() {
+				once.Do(func() { g.leaveOperation(workspaceID, state) })
+			}, nil
+		}
+		changed := state.changed
+		g.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			g.releaseReference(workspaceID, state)
+			return ctx, func() {}, ctx.Err()
+		case <-changed:
+			g.releaseReference(workspaceID, state)
+		}
+	}
+}
+
+func (g *workspaceRuntimeAdmission) beginDisconnect(
+	ctx context.Context,
+	workspaceID string,
+) (context.Context, func(), error) {
+	workspaceID = strings.TrimSpace(workspaceID)
+	if g == nil || workspaceID == "" {
+		return ctx, func() {}, ErrInvalidArgument
+	}
+	if admission, ok := ctx.Value(workspaceRuntimeAdmissionContextKey{}).(workspaceRuntimeAdmissionContext); ok &&
+		admission.gate == g && admission.workspaceID == workspaceID {
+		if admission.exclusive {
+			return ctx, func() {}, nil
+		}
+		return ctx, func() {}, errWorkspaceRuntimeDisconnectReentrant
+	}
+	for {
+		g.mu.Lock()
+		state := g.stateLocked(workspaceID)
+		if !state.disconnecting {
+			state.disconnecting = true
+			g.notifyLocked(state)
+			g.mu.Unlock()
+			if err := g.waitForOperations(ctx, workspaceID, state); err != nil {
+				g.endDisconnect(workspaceID, state)
+				return ctx, func() {}, err
+			}
+			disconnectCtx := context.WithValue(ctx, workspaceRuntimeAdmissionContextKey{}, workspaceRuntimeAdmissionContext{
+				gate: g, workspaceID: workspaceID, exclusive: true,
+			})
+			var once sync.Once
+			return disconnectCtx, func() {
+				once.Do(func() { g.endDisconnect(workspaceID, state) })
+			}, nil
+		}
+		changed := state.changed
+		g.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			g.releaseReference(workspaceID, state)
+			return ctx, func() {}, ctx.Err()
+		case <-changed:
+			g.releaseReference(workspaceID, state)
+		}
+	}
+}
+
+func (g *workspaceRuntimeAdmission) waitForOperations(ctx context.Context, workspaceID string, state *workspaceRuntimeAdmissionState) error {
+	for {
+		g.mu.Lock()
+		if state.operations == 0 {
+			g.mu.Unlock()
+			return nil
+		}
+		changed := state.changed
+		state.refs++
+		g.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			g.releaseReference(workspaceID, state)
+			return ctx.Err()
+		case <-changed:
+			g.releaseReference(workspaceID, state)
+		}
+	}
+}
+
+func (g *workspaceRuntimeAdmission) stateLocked(workspaceID string) *workspaceRuntimeAdmissionState {
+	state := g.states[workspaceID]
+	if state == nil {
+		state = &workspaceRuntimeAdmissionState{changed: make(chan struct{})}
+		g.states[workspaceID] = state
+	}
+	state.refs++
+	return state
+}
+
+func (g *workspaceRuntimeAdmission) leaveOperation(workspaceID string, state *workspaceRuntimeAdmissionState) {
+	g.mu.Lock()
+	state.operations--
+	g.notifyLocked(state)
+	var deferred []func(context.Context)
+	if state.operations == 0 && len(state.deferred) > 0 {
+		deferred = append(deferred, state.deferred...)
+		state.deferred = nil
+	}
+	if len(deferred) == 0 {
+		g.releaseReferenceLocked(workspaceID, state)
+	}
+	g.mu.Unlock()
+	if len(deferred) == 0 {
+		return
+	}
+	disconnectCtx := context.WithValue(context.Background(), workspaceRuntimeAdmissionContextKey{}, workspaceRuntimeAdmissionContext{
+		gate: g, workspaceID: workspaceID, exclusive: true,
+	})
+	for _, disconnect := range deferred {
+		disconnect(disconnectCtx)
+	}
+	g.endDisconnect(workspaceID, state)
+}
+
+func (g *workspaceRuntimeAdmission) deferDisconnect(
+	workspaceID string,
+	disconnect func(context.Context),
+) {
+	g.mu.Lock()
+	state := g.states[workspaceID]
+	if state == nil || state.operations == 0 {
+		g.mu.Unlock()
+		return
+	}
+	state.disconnecting = true
+	state.deferred = append(state.deferred, disconnect)
+	g.notifyLocked(state)
+	g.mu.Unlock()
+}
+
+func (g *workspaceRuntimeAdmission) endDisconnect(workspaceID string, state *workspaceRuntimeAdmissionState) {
+	g.mu.Lock()
+	state.disconnecting = false
+	g.notifyLocked(state)
+	g.releaseReferenceLocked(workspaceID, state)
+	g.mu.Unlock()
+}
+
+func (g *workspaceRuntimeAdmission) releaseReference(workspaceID string, state *workspaceRuntimeAdmissionState) {
+	g.mu.Lock()
+	g.releaseReferenceLocked(workspaceID, state)
+	g.mu.Unlock()
+}
+
+func (g *workspaceRuntimeAdmission) releaseReferenceLocked(workspaceID string, state *workspaceRuntimeAdmissionState) {
+	state.refs--
+	if state.refs == 0 && state.operations == 0 && !state.disconnecting && g.states[workspaceID] == state {
+		delete(g.states, workspaceID)
+	}
+}
+
+func (*workspaceRuntimeAdmission) notifyLocked(state *workspaceRuntimeAdmissionState) {
+	close(state.changed)
+	state.changed = make(chan struct{})
+}
+
+func (h *Host) withWorkspaceRuntimeOperation(
+	ctx context.Context,
+	workspaceID string,
+	fn func(context.Context) error,
+) error {
+	if h == nil || h.workspaceRuntimeAdmission == nil || fn == nil {
+		return ErrInvalidArgument
+	}
+	operationCtx, release, err := h.workspaceRuntimeAdmission.enterOperation(ctx, workspaceID)
+	if err != nil {
+		return err
+	}
+	defer release()
+	return fn(operationCtx)
+}
+
+// BeginWorkspaceRuntimeDisconnect prevents new runtime mutations in one
+// Workspace and waits for mutations already admitted there. The returned
+// context must be used for DisconnectWorkspaceRuntime while release is held.
+func (h *Host) BeginWorkspaceRuntimeDisconnect(
+	ctx context.Context,
+	workspaceID string,
+) (context.Context, func(), error) {
+	if h == nil || h.workspaceRuntimeAdmission == nil {
+		return ctx, func() {}, ErrInvalidArgument
+	}
+	disconnectCtx, release, err := h.workspaceRuntimeAdmission.beginDisconnect(ctx, workspaceID)
+	if errors.Is(err, errWorkspaceRuntimeDisconnectReentrant) {
+		// A transport may request attach cleanup while its Host operation already
+		// owns admission. Let physical cleanup continue on the caller's existing
+		// attachAxis; DisconnectWorkspaceRuntime will defer only its semantic sweep
+		// until this operation leaves.
+		return context.WithValue(ctx, workspaceRuntimeDeferredDisconnectContextKey{}, true), func() {}, nil
+	}
+	return disconnectCtx, release, err
+}

--- a/services/tuttid/agent_runtime_adapter.go
+++ b/services/tuttid/agent_runtime_adapter.go
@@ -173,6 +173,44 @@ func (a agentRuntimeAdapter) Close(ctx context.Context, input agentservice.Runti
 	return nil
 }
 
+func (a agentRuntimeAdapter) DisconnectRuntimeSession(
+	ctx context.Context,
+	workspaceID string,
+	agentSessionID string,
+) (bool, error) {
+	result, err := a.controller.DisconnectRuntimeSession(ctx, workspaceID, agentSessionID)
+	if err != nil {
+		return false, mapAgentRuntimeError(err)
+	}
+	return result.Disconnected, nil
+}
+
+func (a agentRuntimeAdapter) SnapshotWorkspaceRuntimeDisconnectTargets(workspaceID string) []agenthost.RuntimeDisconnectTarget {
+	targets := a.controller.SnapshotRuntimeDisconnectTargets(workspaceID)
+	result := make([]agenthost.RuntimeDisconnectTarget, 0, len(targets))
+	for _, target := range targets {
+		result = append(result, agenthost.RuntimeDisconnectTarget{
+			WorkspaceID: target.RoomID, AgentSessionID: target.AgentSessionID,
+			ConnectionGeneration: target.ConnectionGeneration,
+		})
+	}
+	return result
+}
+
+func (a agentRuntimeAdapter) DisconnectRuntimeSessionTarget(
+	ctx context.Context,
+	target agenthost.RuntimeDisconnectTarget,
+) (bool, error) {
+	result, err := a.controller.DisconnectRuntimeSessionTarget(ctx, agentruntime.RuntimeDisconnectTarget{
+		RoomID: target.WorkspaceID, AgentSessionID: target.AgentSessionID,
+		ConnectionGeneration: target.ConnectionGeneration,
+	})
+	if err != nil {
+		return false, mapAgentRuntimeError(err)
+	}
+	return result.Disconnected, nil
+}
+
 func (a agentRuntimeAdapter) Exec(ctx context.Context, input agentservice.RuntimeExecInput) (agentservice.RuntimeExecResult, error) {
 	if !input.Guidance && strings.TrimSpace(input.TurnID) == "" {
 		return agentservice.RuntimeExecResult{}, fmt.Errorf(

--- a/services/tuttid/service/agent/host_conformance_test.go
+++ b/services/tuttid/service/agent/host_conformance_test.go
@@ -49,6 +49,23 @@ func TestDirectHostApplicationCoreConformance(t *testing.T) {
 	}
 }
 
+func TestHostWorkspaceRuntimeDisconnectConformance(t *testing.T) {
+	for _, scenario := range hostconformance.WorkspaceRuntimeDisconnectScenarios() {
+		scenario := scenario
+		for _, directHost := range []bool{false, true} {
+			directHost := directHost
+			t.Run(fmt.Sprintf("direct=%v/%s", directHost, scenario.Name), func(t *testing.T) {
+				driver := &legacyHostConformanceDriver{t: t, directHost: directHost}
+				if err := hostconformance.RunWorkspaceRuntimeDisconnect(
+					context.Background(), driver, scenario,
+				); err != nil {
+					t.Fatal(err)
+				}
+			})
+		}
+	}
+}
+
 func TestHostHistoricalStateConformance(t *testing.T) {
 	for _, scenario := range hostconformance.HistoricalStateScenarios() {
 		scenario := scenario
@@ -550,7 +567,7 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 		additionalKey := additional.WorkspaceID + ":" + additional.AgentSessionID
 		d.sessions.sessions[additionalKey] = PersistedSession{
 			ID: additional.AgentSessionID, WorkspaceID: additional.WorkspaceID, Kind: additionalKind,
-			Provider: additional.Provider, Cwd: additional.Cwd,
+			Provider: additional.Provider, ProviderSessionID: additional.ProviderSessionID, Cwd: additional.Cwd,
 			RailSectionKind: "conversations",
 			RailSectionKey:  "conversations",
 			Metadata:        agentactivitybiz.SessionMetadata{Visible: true},
@@ -701,6 +718,13 @@ func (d *legacyHostConformanceDriver) DisconnectRuntimeSession(ctx context.Conte
 		WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
 		PreserveCanonicalState: true,
 	})
+}
+
+func (d *legacyHostConformanceDriver) DisconnectWorkspaceRuntime(
+	ctx context.Context,
+	workspaceID string,
+) (agenthost.DisconnectWorkspaceRuntimeResult, error) {
+	return d.service.ApplicationHost().DisconnectWorkspaceRuntime(ctx, workspaceID)
 }
 
 func (d *legacyHostConformanceDriver) Create(
@@ -1098,7 +1122,7 @@ func (d *legacyHostConformanceDriver) GetSession(ctx context.Context, ref agenth
 		return legacyHostSessionObservationWithLive(session, result.Live), err
 	}
 	session, err := d.service.Get(ctx, ref.WorkspaceID, ref.AgentSessionID)
-	_, live := d.runtime.Session(ref.WorkspaceID, ref.AgentSessionID)
+	live := d.runtime.RuntimeSessionLive(ref.WorkspaceID, ref.AgentSessionID)
 	return legacyHostSessionObservationWithLive(session, live), err
 }
 

--- a/services/tuttid/service/agent/host_test_adapters_test.go
+++ b/services/tuttid/service/agent/host_test_adapters_test.go
@@ -264,6 +264,46 @@ func (a serviceHostStore) DeleteSubmitClaim(ctx context.Context, workspaceID, se
 
 type serviceHostRuntime struct{ service *Service }
 
+func (a serviceHostRuntime) WorkspaceRuntimeSessions(_ context.Context, workspaceID string) ([]ProviderRuntimeSession, error) {
+	return a.service.controller().Sessions(workspaceID), nil
+}
+
+func (a serviceHostRuntime) DisconnectRuntimeSession(
+	ctx context.Context,
+	ref agenthost.SessionRef,
+) (bool, error) {
+	disconnector, ok := a.service.controller().(interface {
+		DisconnectRuntimeSession(context.Context, string, string) (bool, error)
+	})
+	if !ok {
+		return false, agenthost.ErrWorkspaceDisconnectUnavailable
+	}
+	return disconnector.DisconnectRuntimeSession(ctx, ref.WorkspaceID, ref.AgentSessionID)
+}
+
+func (a serviceHostRuntime) SnapshotWorkspaceRuntimeDisconnectTargets(workspaceID string) []agenthost.RuntimeDisconnectTarget {
+	targeter, ok := a.service.controller().(interface {
+		SnapshotWorkspaceRuntimeDisconnectTargets(string) []agenthost.RuntimeDisconnectTarget
+	})
+	if !ok {
+		return nil
+	}
+	return targeter.SnapshotWorkspaceRuntimeDisconnectTargets(workspaceID)
+}
+
+func (a serviceHostRuntime) DisconnectRuntimeSessionTarget(
+	ctx context.Context,
+	target agenthost.RuntimeDisconnectTarget,
+) (bool, error) {
+	targeter, ok := a.service.controller().(interface {
+		DisconnectRuntimeSessionTarget(context.Context, agenthost.RuntimeDisconnectTarget) (bool, error)
+	})
+	if !ok {
+		return false, agenthost.ErrWorkspaceDisconnectUnavailable
+	}
+	return targeter.DisconnectRuntimeSessionTarget(ctx, target)
+}
+
 func (a serviceHostRuntime) RuntimeSessionLive(workspaceID, agentSessionID string) bool {
 	if liveness, ok := a.service.controller().(interface {
 		RuntimeSessionLive(string, string) bool
@@ -336,6 +376,9 @@ func (a serviceHostRuntime) InteractiveDisposition(workspaceID, rootAgentSession
 	return a.service.controller().InteractiveDisposition(workspaceID, rootAgentSessionID, agentSessionID, turnID, requestID)
 }
 func (a serviceHostRuntime) UpdateSettings(ctx context.Context, input RuntimeUpdateSettingsInput) error {
+	return normalizeRuntimeError(a.service.controller().UpdateSettings(ctx, input))
+}
+func (a serviceHostRuntime) UpdateRetainedSettings(ctx context.Context, input RuntimeUpdateSettingsInput) error {
 	return normalizeRuntimeError(a.service.controller().UpdateSettings(ctx, input))
 }
 func (a serviceHostRuntime) SetTitle(ctx context.Context, input RuntimeSetTitleInput) (ProviderRuntimeSession, error) {

--- a/services/tuttid/service/agent/service_test_runtime_test.go
+++ b/services/tuttid/service/agent/service_test_runtime_test.go
@@ -51,6 +51,7 @@ type fakeRuntime struct {
 	goalGenerationFenceHook func(context.Context, RuntimeGoalGenerationFenceInput) error
 	resumeCalls             []RuntimeResumeInput
 	sessions                map[string]ProviderRuntimeSession
+	disconnectedSessions    map[string]bool
 	submitInteractiveCalls  []RuntimeSubmitInteractiveInput
 	submitInteractiveErr    error
 	interactiveDisposition  RuntimeInteractiveDisposition
@@ -463,8 +464,9 @@ func (f fakeMessageReader) ListSessionMessages(
 
 func newFakeRuntime() *fakeRuntime {
 	return &fakeRuntime{
-		sessions:     make(map[string]ProviderRuntimeSession),
-		pendingInits: make(map[string]bool),
+		sessions:             make(map[string]ProviderRuntimeSession),
+		disconnectedSessions: make(map[string]bool),
+		pendingInits:         make(map[string]bool),
 	}
 }
 
@@ -554,6 +556,21 @@ func (f *fakeRuntime) Close(_ context.Context, input RuntimeCloseInput) error {
 	return err
 }
 
+func (f *fakeRuntime) DisconnectRuntimeSession(
+	_ context.Context,
+	workspaceID string,
+	agentSessionID string,
+) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	key := strings.TrimSpace(workspaceID) + ":" + strings.TrimSpace(agentSessionID)
+	if _, ok := f.sessions[key]; !ok || f.disconnectedSessions[key] {
+		return false, nil
+	}
+	f.disconnectedSessions[key] = true
+	return true, nil
+}
+
 func (f *fakeRuntime) CanResume(input RuntimeResumeInput) bool {
 	f.canResumeCalls = append(f.canResumeCalls, input)
 	if f.canResumeHook != nil {
@@ -563,6 +580,15 @@ func (f *fakeRuntime) CanResume(input RuntimeResumeInput) bool {
 }
 
 func (f *fakeRuntime) Exec(_ context.Context, input RuntimeExecInput) (RuntimeExecResult, error) {
+	f.mu.Lock()
+	key := input.WorkspaceID + ":" + input.AgentSessionID
+	if f.disconnectedSessions[key] {
+		f.resumeCalls = append(f.resumeCalls, RuntimeResumeInput{
+			WorkspaceID: input.WorkspaceID, AgentSessionID: input.AgentSessionID,
+		})
+		delete(f.disconnectedSessions, key)
+	}
+	f.mu.Unlock()
 	f.execCalls = append(f.execCalls, input)
 	if input.Guidance && f.guidanceTargetMismatch && strings.TrimSpace(input.TurnID) != strings.TrimSpace(f.guidanceTarget) {
 		return RuntimeExecResult{
@@ -582,7 +608,6 @@ func (f *fakeRuntime) Exec(_ context.Context, input RuntimeExecInput) (RuntimeEx
 	if f.execErr != nil {
 		return RuntimeExecResult{}, f.execErr
 	}
-	key := input.WorkspaceID + ":" + input.AgentSessionID
 	if session, ok := f.sessions[key]; ok {
 		session.Status = "working"
 		session.Resumable = true
@@ -691,12 +716,22 @@ func (f *fakeRuntime) Resume(_ context.Context, input RuntimeResumeInput) (Provi
 		UpdatedAtUnixMS: input.UpdatedAtUnixMS,
 	}
 	f.sessions[input.WorkspaceID+":"+input.AgentSessionID] = session
+	delete(f.disconnectedSessions, input.WorkspaceID+":"+input.AgentSessionID)
 	return session, nil
 }
 
 func (f *fakeRuntime) Session(workspaceID string, agentSessionID string) (ProviderRuntimeSession, bool) {
-	session, ok := f.sessions[workspaceID+":"+agentSessionID]
+	key := workspaceID + ":" + agentSessionID
+	session, ok := f.sessions[key]
 	return session, ok
+}
+
+func (f *fakeRuntime) RuntimeSessionLive(workspaceID, agentSessionID string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	key := workspaceID + ":" + agentSessionID
+	_, registered := f.sessions[key]
+	return registered && !f.disconnectedSessions[key]
 }
 
 func (f *fakeRuntime) SetVisible(_ context.Context, input RuntimeSetVisibleInput) (ProviderRuntimeSession, error) {


### PR DESCRIPTION
## Summary

- add a provider-neutral Host operation that disconnects workspace-scoped live runtimes while preserving resumable session identity
- serialize runtime startup, resume, settings updates, and attachment loss with a per-workspace admission gate
- clean up Codex, Claude, and Standard ACP transports safely, including close-failure ownership and generation-fenced deferred disconnects
- add Host conformance and provider/controller concurrency coverage

## Tests

- `pre-push: pnpm check:changed -- --push-ready` (13/13 lanes passed)

## Notes

- This is the Tutti upstream half of the TSH workspace attachment fix. TSH will upgrade the published Tutti cohort in a follow-up PR.
- P2-and-lower follow-ups are intentionally out of scope.