### PR TITLE
feat(agent-gui): strengthen input history regression coverage

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextKeyboard.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextKeyboard.spec.ts
@@ -54,6 +54,27 @@ describe("handleAgentRichTextKeyDownCapture input history", () => {
     expect(onHistoryNavigation).not.toHaveBeenCalled();
     expect(event.preventDefault).toHaveBeenCalledOnce();
   });
+
+  it.each(["ArrowUp", "ArrowDown"])(
+    "does not enter input history on %s while IME composition is active",
+    (key) => {
+      const onHistoryNavigation = vi.fn(() => true);
+      const event = keyboardEvent(key);
+      event.nativeEvent.isComposing = true;
+
+      handleAgentRichTextKeyDownCapture(
+        event as unknown as ReactKeyboardEvent<HTMLDivElement>,
+        keyboardInput({
+          editor: editorAt({ from: 1, to: 1, documentSize: 5 }),
+          onHistoryNavigation
+        })
+      );
+
+      expect(onHistoryNavigation).not.toHaveBeenCalled();
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(event.stopPropagation).not.toHaveBeenCalled();
+    }
+  );
 });
 
 function keyboardInput(input: {

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerInputHistory.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerInputHistory.spec.tsx
@@ -158,6 +158,104 @@ describe("useComposerInputHistory", () => {
       "session:session-1"
     );
   });
+
+  it("keeps an edited recalled draft and exits history navigation", () => {
+    const onDraftContentChange = vi.fn();
+    const entries = historyEntries("sent prompt");
+    const editedDraft = buildAgentComposerDraft({ prompt: "edited prompt" });
+    const draftByScopeKeyRef = {
+      current: { "session:session-1": emptyAgentComposerDraft() }
+    };
+    const { result, rerender } = renderHook(
+      ({ currentDraft }) => {
+        draftByScopeKeyRef.current["session:session-1"] = currentDraft;
+        return useComposerInputHistory({
+          agentSessionId: "session-1",
+          currentDraft,
+          draftByScopeKeyRef,
+          draftScopeKey: "session:session-1",
+          entries,
+          hasOlderPage: false,
+          isLoadingOlderPage: false,
+          onDraftContentChange,
+          runtime: null,
+          workspaceId: "workspace-1"
+        });
+      },
+      { initialProps: { currentDraft: emptyAgentComposerDraft() } }
+    );
+
+    act(() => {
+      expect(result.current.onHistoryNavigation("older")).toBe(true);
+    });
+    rerender({ currentDraft: editedDraft });
+
+    act(() => {
+      expect(result.current.onHistoryNavigation("older")).toBe(false);
+    });
+    expect(draftByScopeKeyRef.current["session:session-1"]).toBe(editedDraft);
+    expect(onDraftContentChange).toHaveBeenCalledOnce();
+    expect(onDraftContentChange).toHaveBeenCalledWith(
+      entries[0]!.draft,
+      "session:session-1"
+    );
+  });
+
+  it("isolates recalled text and navigation cursor between Session scopes", () => {
+    const onDraftContentChange = vi.fn();
+    const sessionOneEntries = historyEntries("session one old", "session one");
+    const sessionTwoEntries = historyEntries("session two old", "session two");
+    const draftByScopeKeyRef: {
+      current: Record<string, ReturnType<typeof emptyAgentComposerDraft>>;
+    } = {
+      current: {
+        "session:session-1": emptyAgentComposerDraft(),
+        "session:session-2": emptyAgentComposerDraft()
+      }
+    };
+    const { result, rerender } = renderHook(
+      ({ agentSessionId, draftScopeKey, entries }) =>
+        useComposerInputHistory({
+          agentSessionId,
+          currentDraft: draftByScopeKeyRef.current[draftScopeKey]!,
+          draftByScopeKeyRef,
+          draftScopeKey,
+          entries,
+          hasOlderPage: false,
+          isLoadingOlderPage: false,
+          onDraftContentChange,
+          runtime: null,
+          workspaceId: "workspace-1"
+        }),
+      {
+        initialProps: {
+          agentSessionId: "session-1",
+          draftScopeKey: "session:session-1",
+          entries: sessionOneEntries
+        }
+      }
+    );
+
+    act(() => {
+      expect(result.current.onHistoryNavigation("older")).toBe(true);
+    });
+    rerender({
+      agentSessionId: "session-2",
+      draftScopeKey: "session:session-2",
+      entries: sessionTwoEntries
+    });
+
+    expect(draftByScopeKeyRef.current["session:session-2"]).toEqual(
+      emptyAgentComposerDraft()
+    );
+    act(() => {
+      expect(result.current.onHistoryNavigation("older")).toBe(true);
+    });
+    expect(onDraftContentChange).toHaveBeenLastCalledWith(
+      sessionTwoEntries[1]!.draft,
+      "session:session-2"
+    );
+  });
 });
 
 function historyEntries(

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerInputHistory.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerInputHistory.spec.ts
@@ -194,6 +194,19 @@ describe("agent composer input history", () => {
     ]);
   });
 
+  it("filters empty user messages out of input history", () => {
+    const history = projectAgentComposerInputHistory(
+      conversationWithUserMessages([
+        { id: "empty", body: "   ", sourceTimelineItems: [] },
+        { id: "text", body: "resendable" }
+      ])
+    );
+
+    expect(history).toHaveLength(1);
+    expect(history[0]!.id).toBe("turn-1:text");
+    expect(agentComposerDraftPrompt(history[0]!.draft)).toBe("resendable");
+  });
+
   it("restores mixed text and file input without dropping the file on resend", () => {
     const fileMention = createAgentComposerFileMentionMarkdown({
       id: "original-file",


### PR DESCRIPTION
## 关联 Issue

Related to #2320

## 背景

AgentGUI 已支持在 Session composer 中使用 `ArrowUp` 和 `ArrowDown` 浏览当前 Session 的历史输入。本 PR 根据输入历史功能的验收标准，补齐此前缺少的直接回归测试，防止 IME、Session 切换、召回内容编辑和空记录处理发生回归。

## 变更内容

- 验证 IME composition 期间 `ArrowUp` 和 `ArrowDown` 不触发输入历史导航，也不拦截键盘事件
- 验证编辑召回内容后退出历史导航模式，并保留编辑后的普通 draft
- 验证切换 Session 后旧 cursor 和召回文本不会泄漏，新 Session 从自身最新历史开始
- 验证空白用户消息不会生成输入历史项

## 设计说明

本 PR 不修改生产逻辑。输入历史继续：

- 从当前 Session 的 canonical 持久化用户消息和 Goal-control 记录派生
- 复用现有消息分页，在到达已加载最旧记录时按需加载上一页
- 使用 UI-local cursor，不建立第二份持久化历史
- 保持 Home composer 不读取 Session 历史
- 保持现有 submit flow、host capability 和 Session 隔离语义不变

## 验证

- `pnpm check:changed -- --push-ready`：13 个 lane 全部通过
- AgentGUI 定向测试：3 个测试文件、21 个测试通过
- 人工验证首次及重复上下导航、越过最新历史后恢复空 composer、非空及多行 draft 光标行为、召回编辑重发、Session 隔离，以及中文 IME 方向键保护与历史召回

## Windows 影响

本 PR 仅增加浏览器键盘事件和平台无关状态逻辑的测试，不修改路径、文件系统、进程、shell、环境变量或原生依赖。Windows 与 POSIX 使用相同的 AgentGUI 代码路径，无需新增平台专用实现。

## 文档影响

`discard`。`docs/architecture/agent-gui-node.md` 已记录输入历史的数据来源、分页与持久化策略、去重规则、键盘条件和 Session 隔离，本 PR 无需重复更新文档。
