### PR TITLE
Establish durable test-audit guidance for Tutti

### DIFF
--- a/.codex/skills/tutti-test-audit/SKILL.md
+++ b/.codex/skills/tutti-test-audit/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: tutti-test-audit
+description: Audit, design, write, materially revise, or remove Tutti tests. Use whenever Codex changes or reviews unit, component, conformance, integration, regression, platform, or repository tests; enforce a protected product contract, credible failure, correct owning boundary, negative-control evidence, overlap review, deterministic setup, and an executing CI lane.
+---
+
+# Tutti Test Audit
+
+Make every changed test earn its maintenance cost. A green test, a coverage
+increase, or a larger test count is not a quality verdict.
+
+Read the root and closest scoped `AGENTS.md`, then read
+`docs/conventions/unit-testing.md` before a non-trivial test change or review.
+Follow `docs/conventions/testing.md#validation-selection` for commands and
+validation scope.
+
+## Establish the evidence map
+
+Before editing, inspect:
+
+1. the production owner, public entry point, relevant caller and callee;
+2. sibling implementations that share the same invariant;
+3. existing tests, fixtures, conformance suites, and repository checks;
+4. the changed-aware and platform lane that will select the evidence;
+5. relevant history for a regression or a suspicious existing test.
+
+For Agent Host lifecycle semantics, also read
+`packages/agent/host/README.md` and start with the conformance contract. Do not
+reimplement lifecycle tests in an adapter.
+
+## Pass the authoring gate
+
+Answer all six questions before adding or materially rewriting a test:
+
+1. **Protected contract:** What observable behavior, invariant, compatibility
+   promise, or prior failure matters?
+2. **Credible failure:** What plausible faulty implementation must make the
+   test fail?
+3. **Coverage gap:** Why would existing evidence not catch that failure? Can an
+   existing table, scenario, or fixture express it without duplication?
+4. **Owner and observer:** Which module owns the decision, and what is the
+   lowest boundary that can observe the risk without mocking it away?
+5. **Production seam:** Does the test require an export, flag, wrapper, global,
+   or injection hook that no production caller needs? If so, move to the real
+   boundary or redesign the owner.
+6. **Execution:** Which blocking lane selects the test, and which native OS must
+   execute it?
+
+A missing answer means the test is not ready. “No new test” is a valid outcome
+when stronger existing evidence already protects the contract or the proposed
+assertion only restates a type, literal, implementation detail, or presentation
+choice.
+
+## Choose the proof shape
+
+- Extend an existing table or conformance scenario when it owns the same
+  contract and fixture.
+- Add a new scenario when the behavior, failure mechanism, setup, or execution
+  lane is independently meaningful.
+- Move upward to a component, narrow integration, conformance, or E2E boundary
+  when a unit double would replace the semantics under test.
+- Use a repository check, not a unit test, when source structure, imports,
+  generated artifacts, manifests, or architecture are the actual contract.
+- Keep visual styling in visual evidence unless styling changes native behavior
+  such as pointer ownership or window dragging.
+
+Prefer one vertical proof through the owning boundary plus narrow tests for
+important decision partitions over many stub-backed branch tests.
+
+## Build sensitive evidence
+
+For a confirmed bug, capture the failing reproduction before the fix whenever
+possible. The regression test must fail on pre-fix behavior for the intended
+reason and pass after the owner-boundary repair. If the old revision cannot be
+run safely, temporarily inject or restore the faulty decision as a local
+negative control and report that limitation; never commit the mutation.
+
+For new behavior, first demonstrate that the focused test fails because the
+contract is absent, not because setup, imports, or fixtures are broken.
+
+For a read-only audit, do not edit production code merely to manufacture a
+negative control. Name the smallest plausible faulty implementation, determine
+whether the current assertions would detect it, and label that sensitivity
+unverified when it cannot be executed safely.
+
+Then:
+
+- assert stable outcomes and important non-effects;
+- include neighboring valid, rejection, cleanup, retry, or preservation cases
+  only when they address a credible risk;
+- use real isolated SQLite, filesystem, Git, HTTP, IPC, parser, or process
+  boundaries when their semantics are the subject;
+- keep external doubles narrow and fail closed on unexpected calls;
+- coordinate concurrency with events, channels, barriers, or latches rather
+  than sleeps or lucky elapsed-time bounds;
+- control clocks, IDs, randomness, ports, user state, credentials, globals,
+  listeners, timers, processes, and temporary resources;
+- assert call counts only when count is itself a contract such as idempotency,
+  single-flight, or at-most-once dispatch.
+
+## Apply Tutti routing
+
+- Session, Turn, Goal, runtime-operation, and recovery semantics start in
+  `packages/agent/host/conformance`; consumers provide drivers.
+- Adapter tests own transport, DTO, authorization, query, presentation, and
+  product-policy behavior only.
+- SQLite, filesystem, path, shell, executable, process, signal, permission, and
+  native API behavior cross the real isolated receiver boundary.
+- UI behavior drives accessible keyboard, pointer, focus, and state transitions
+  and observes callbacks or user-visible state.
+- HTTP, IPC, and provider protocol tests cross the real parser, middleware, or
+  codec boundary when receiver behavior is the risk.
+- Platform-dependent behavior runs on the native platform. A serialized
+  request shape or a skipped Linux test is not Windows proof.
+
+## Audit existing tests
+
+Treat these as review candidates, not automatic deletions:
+
+- no meaningful assertion, self-comparison, or only “does not throw”;
+- copied production algorithm, catalog, defaults, or current inventory;
+- source strings or regexes presented as runtime behavior proof;
+- private call-shape or mocked call-graph assertions;
+- static render, class, style, SVG path, or incidental DOM assertions;
+- duplicate coverage weaker than an existing boundary scenario;
+- sleeps, polling delays, pass-on-retry, silent skips, or zero-selected lanes;
+- test-only production exports, wrappers, flags, globals, or dead code.
+
+Before weakening or removing a test, identify the failure it can actually catch,
+its history, and the stronger evidence that remains. Preserve independent
+public API, protocol, config, migration, storage, security, platform, generated,
+release, and architecture contracts even when they are static or slow.
+
+Classify each candidate as:
+
+- **keep** — protects an independent contract;
+- **strengthen or move** — right risk, wrong oracle or boundary;
+- **consolidate** — useful contract already has a canonical owner;
+- **delete** — no credible failure remains protected, including any test-only
+  production seam it kept alive.
+
+## Validate and hand off
+
+1. Run the smallest owner and sibling tests that prove the contract.
+2. For authored behavior changes, demonstrate the pre-fix failure or another
+   credible negative control. For a read-only audit, report the failure model
+   without mutating the checkout.
+3. Apply the repository validation-selection policy; verify the intended lane
+   selected and ran non-zero evidence.
+4. Run native-platform proof when required, or name the remaining manual gate.
+5. Inspect the final diff for duplicated setup, weakened assertions, snapshot
+   churn, leaked resources, and unnecessary production seams.
+
+Report this compact evidence for non-trivial test changes:
+
+```md
+Test evidence
+
+- Protected contract or prior failure:
+- Credible faulty implementation / negative control:
+- Existing coverage gap:
+- Owning seam and test level:
+- Observable outcomes and important non-effects:
+- Blocking lane and native OS, when relevant:
+- Residual risk left to integration, E2E, visual, or manual proof:
+```

--- a/.codex/skills/tutti-test-audit/agents/openai.yaml
+++ b/.codex/skills/tutti-test-audit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Tutti Test Audit"
+  short_description: "Design and audit behavior-protecting Tutti tests"
+  default_prompt: "Use $tutti-test-audit to design or review tests that protect this change’s real behavior."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,9 @@ documentation impact was found.
 
 ## Common Checks
 
+- Writing, materially rewriting, reviewing, or removing tests invokes
+  `$tutti-test-audit`; the durable quality rules live in
+  [Unit Testing](docs/conventions/unit-testing.md).
 - UI-only exception: if a change modifies only UI presentation and does not alter logic or behavior, do not run any checks. This exception takes precedence over the checks below and includes tests, lint, typecheck, builds, boundary checks, and visual checks.
 - For every other change, follow the single validation-selection policy in
   [Testing](docs/conventions/testing.md#validation-selection). Closest-area

--- a/docs/conventions/README.md
+++ b/docs/conventions/README.md
@@ -21,6 +21,7 @@ Current documents:
 - [Runtime Image Assets](./runtime-image-assets.md)
 - [Static Analysis](./static-analysis.md)
 - [Testing](./testing.md)
+- [Unit Testing](./unit-testing.md)
 - [Troubleshooting](./troubleshooting/README.md)
 - [Tutti Agent Skills Repository](./tutti-agent-skills-repository.md)
 - [Tutti CLI Contract](./tutti-cli-contract.md)

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -450,58 +450,30 @@ read or expose host credential metadata.
 
 ## Unit Test Quality
 
-A unit test should protect behavior a reviewer could regress, not re-state the
-implementation or pin presentation details. Apply these guidelines when writing
-or reviewing a unit test:
+Agent work that writes, materially rewrites, reviews, or removes tests invokes
+`$tutti-test-audit`. The durable design rules live in
+[Unit Testing](./unit-testing.md); this document continues to own command and
+validation selection.
 
-**Test behavior, not presentation wiring.**
+A test must protect a product contract that a plausible implementation mistake
+could violate. It must execute the production owner and observe a stable result;
+test count, assertion count, and coverage percentage are not substitutes for
+that evidence. In particular:
 
-Prefer a test that performs an action and verifies its effect — a user event
-followed by a callback or state change — over a test that only asserts what a
-fixed set of props renders. A test whose body contains no interaction, no
-callback verification, and no state transition, and whose only assertions are
-DOM text/class/attribute presence, is a static snapshot: it breaks on any CSS or
-JSX reformat and never catches a behavioral regression. It belongs in a visual
-regression or component browser test, not a unit suite.
+- test behavior, invariants, state transitions, and important non-effects;
+- choose the lowest test level capable of crossing the boundary named by the
+  risk;
+- do not duplicate production logic or use source regexes to infer runtime
+  wiring;
+- cross a real isolated boundary when its semantics are the risk; otherwise use
+  narrow fail-closed doubles;
+- synchronize concurrency with events, channels, barriers, or latches rather
+  than short sleeps;
+- prove that platform-specific tests execute in a native blocking lane;
+- reject constant restatements, mock call-graph tests, style assertions, empty
+  or silently skipped evidence, and tests whose old bug would still pass.
 
-**Do not assert on styling details.**
-
-`className`, `toHaveClass`, svg `width`/`height`/`viewBox`/`path d`, and
-`toHaveStyle` assertions pin implementation details of styling and icon
-libraries. They add maintenance cost and no behavioral signal. If a visual
-variant matters, assert the variant-selection behavior (which state maps to
-which variant), not the CSS class.
-
-**Do not test the type system.**
-
-Trivial branches, boolean toggles, constants, and pure data-mapping tables are
-already constrained by TypeScript and by the call sites that consume them. A
-test that only re-states `input.isDev === true` or a lookup table duplicates the
-implementation. Prefer a type-level constraint, or no test, for these.
-
-**Exercise feature-state transitions.**
-
-When a component has states (loading, ready, disabled, pending), test that the
-state _changes_ the output or enables/ disables an action — not that a single
-static state happens to render some text. Prefer a `rerender` plus an
-interaction that verifies the transition over a lone presence check.
-
-**Keep data-transformation logic tested.**
-
-Functions that parse, format, project, or extract from nested structures carry
-real logic. Rendering tests that verify transformed output for non-trivial input
-(e.g. markdown parsing, nested `toolCall` payload extraction, projection) are
-valuable; keep them even when they assert text, because the text depends on
-computation.
-
-**One test file per module.**
-
-If the same module is covered by both a `*.test.*` and a `*.spec.*` file, or by
-multiple name-suffixed files, consolidate them. Name the file for the module it
-actually tests. Small helper tests belong in the module's main spec as a nested
-`describe`, not in a separate file.
-
-**Keep tiny tests meaningful.**
-
-A test file that only holds one or two trivial assertions provides no regression
-protection. Delete it or fold its coverage into a behavioral test.
+Organize tests by behavioral ownership. A small module usually has one colocated
+suite; a large seam may split lifecycle, recovery, concurrency, rendering, or
+platform scenarios into explicitly named files. Do not trade arbitrary file
+fragmentation for giant suites that a reviewer cannot reason about.

--- a/docs/conventions/unit-testing.md
+++ b/docs/conventions/unit-testing.md
@@ -1,0 +1,237 @@
+# Unit Testing
+
+This document contains Tutti's durable test-design rules. The executable
+authoring and review workflow lives in `$tutti-test-audit`; test discovery,
+commands, changed-aware validation, performance scenarios, and Session Replay
+live in [Testing](./testing.md).
+
+Apply these rules to new and materially rewritten tests. They do not require a
+mass rewrite of legacy suites, but a touched test must not preserve a known
+low-value pattern without reason.
+
+## Quality bar
+
+A test earns its place when it protects a product contract that a plausible
+implementation mistake could violate. It must execute the production owner and
+observe a stable result at a boundary capable of exposing that mistake.
+
+Start with this statement:
+
+```text
+When ACTION occurs under CONDITION, the owner must produce OUTCOME while
+preserving or avoiding NON_EFFECT. A faulty implementation that REGRESSION
+must make this test fail.
+```
+
+A merge-worthy test has all of these properties:
+
+- **Contract:** it protects observable behavior, an invariant, compatibility,
+  or a previously observed failure that matters.
+- **Sensitivity:** a credible wrong implementation, including the old bug for a
+  regression, fails an assertion for the intended reason.
+- **Fidelity:** it invokes the production owner through the lowest credible
+  boundary instead of reproducing or mocking away the behavior.
+- **Oracle:** it asserts stable outcomes and important non-effects rather than
+  incidental structure.
+- **Determinism:** time, concurrency, randomness, state, and external resources
+  produce the same verdict on a busy runner.
+- **Execution:** the blocking repository lane discovers the test, and every
+  platform-specific arm runs on its native platform.
+
+Adding no test is preferable to adding evidence that only restates a constant,
+type, mock arrangement, or presentation detail. Test count, assertion count,
+and line coverage are diagnostic metrics, not quality verdicts.
+
+## Choose the lowest credible boundary
+
+“Unit” describes isolation, not importance. Use the lowest level that can
+observe the named risk without replacing it.
+
+| Level                 | Appropriate risk                                                           | Boundary that remains real                |
+| --------------------- | -------------------------------------------------------------------------- | ----------------------------------------- |
+| Pure unit             | Parsing, normalization, projection, policy, deterministic algorithms       | None                                      |
+| Behavioral component  | One controller, store, service, or UI interaction                          | Internal production wiring                |
+| Conformance           | A contract shared by implementations or consumers                          | Public contract and driver                |
+| Narrow integration    | SQLite, filesystem, Git, HTTP, IPC, parser, subprocess, or OS semantics    | The boundary named by the risk            |
+| End to end            | A journey through a composition root                                       | Public entry point to user-visible result |
+| Visual or performance | Pixels, layout, animation, responsiveness, or timing budgets               | Real renderer or trace                    |
+| Repository check      | Imports, generated artifacts, manifests, ownership, or source architecture | Repository files themselves               |
+
+A test named E2E that bypasses the composition root and replaces all internal
+collaborators is a component test. A colocated test that launches a real
+subprocess is an integration test.
+
+Prefer one vertical proof through the owning boundary plus narrow unit cases for
+important decisions. A helper-only unit test cannot prove that production
+callers still invoke the helper. Tutti has encountered this exact failure with
+remote-image materialization; see the
+[troubleshooting entry](./troubleshooting/agent-session-lifecycle.md#remote-agent-image-reaches-the-provider-as-an-unsupported-url).
+
+### Tutti routing rules
+
+- New Session, Turn, Goal, runtime-operation, or recovery semantics start as a
+  scenario in `packages/agent/host/conformance`. Consumer adapters implement
+  drivers; they do not clone lifecycle semantics.
+- Adapter tests own transport, DTO, authorization, query, presentation, and
+  product-policy behavior.
+- SQLite, filesystem, paths, Git, command quoting, executable discovery,
+  process lifecycle, IPC, and native API behavior require a real isolated
+  instance of the relevant boundary.
+- UI behavior belongs in a behavioral component test that drives accessible
+  keyboard, pointer, focus, or state transitions. Pixels and layout belong in
+  visual evidence.
+- HTTP and provider protocol behavior should cross the real parser, middleware,
+  codec, or receiver when that behavior is the risk.
+- Host filesystem, shell, process, registry, signal, permission, and executable
+  behavior must run on the native OS. A request-shape assertion cannot replace
+  the receiving Windows API or process boundary.
+
+## Design from risk
+
+Identify the module that owns the decision and the boundary where a caller can
+observe it. Stable observations include:
+
+- returned domain values and typed errors;
+- canonical or persisted state read through the owning store;
+- emitted events and observable ordering;
+- the final provider, HTTP, IPC, parser, or process request;
+- filesystem contents, permissions, and executable behavior;
+- accessible UI state, callbacks, enabled actions, and focus;
+- absence of a write, dispatch, retry, duplicate, secret, or leaked resource.
+
+Select only input partitions that can change the decision or represent a real
+failure mode: missing and malformed input, exact boundaries, identity reuse,
+ordering, partial failure, response loss, restart, cancellation, competing
+writers, preservation of unrelated state, and native-platform differences.
+
+One test may use several assertions when they jointly prove one behavior. Test
+names should state cause and observable effect, such as `retries transient
+catalog failures but not permanent failures`, rather than `works` or a private
+method name.
+
+### Prove regression sensitivity
+
+Capture a confirmed bug's failing reproduction before the fix whenever safe.
+The resulting regression test must fail on pre-fix behavior for the intended
+reason. If the old revision cannot run, temporarily restore or inject the faulty
+decision as a local negative control; do not commit that mutation.
+
+For new behavior, first show that the focused test fails because the contract is
+missing, not because test setup, imports, or fixtures are broken. When
+sensitivity is not obvious, include the negative-control evidence in the PR.
+
+## Assert contracts, not implementation shape
+
+Prefer observations in this order:
+
+1. externally visible result or typed error;
+2. durable state and preservation of unrelated state;
+3. event or protocol sequence at an owned boundary;
+4. side-effect count when count is itself the contract;
+5. a narrow internal observation only when no stable boundary exists.
+
+Failure-path tests should normally assert both what happened and what did not:
+no provider request, no canonical row, no rollback of an earlier commit, no
+stale output, no secret in diagnostics, or no new identity during a retry.
+`does not throw` or `err == nil` alone is rarely a sufficient oracle.
+
+### Prefer invariants to change detectors
+
+A change detector freezes data expected to evolve: an exact catalog size,
+current model name, schema-version literal, copied defaults object, snapshot of
+a registry, or duplicated lookup table. Protect the relationship consumers rely
+on instead: every selectable model has required metadata, migrations end at the
+declared current version, identities stay unique, or forbidden sets do not
+overlap.
+
+Use snapshots only for deliberately stable public serialization, generated
+contracts, or normalized CLI output. Keep them small, normalize paths, IDs,
+time, width, and platform noise, and pair them with semantic assertions.
+
+### Keep source contracts out of runtime unit tests
+
+A runtime test must not read production `.go`, `.ts`, or `.tsx` text and use a
+string, regex, or `indexOf` as proof that a call or option is wired correctly.
+Execute the runtime seam or extract the real decision into its owner.
+
+When source shape is intentionally the contract—imports, generated files,
+manifests, architecture, or security policy—implement a named repository check
+under `tools/scripts` and register it with the repository-check infrastructure.
+That check is valuable, but it is not runtime unit coverage.
+
+## Use real owned resources and narrow doubles
+
+Use temporary real implementations when their semantics are part of the risk:
+SQLite for transactions and recovery, a filesystem for paths and atomic writes,
+a local HTTP server for redirects and streaming, a temporary Git repository for
+worktree behavior, and a subprocess or parser for quoting and wire contracts.
+
+Use a double when the collaborator is externally owned, nondeterministic,
+unsafe, or irrelevant to the current decision. A double should implement the
+smallest owning port, return explicit configured outcomes, fail immediately on
+unexpected calls, and capture only contract observations. Never make every
+method silently succeed. A test that stubs every layer and verifies that the
+stubs called one another proves its arrangement, not the product.
+
+Isolate state before production imports can capture it. Tests must not read or
+write real Tutti state, credentials, provider configuration, user Git config,
+or developer services. Always restore environment variables, clocks, globals,
+listeners, timers, stores, sockets, subprocesses, and temporary resources,
+including on failure.
+
+## Make concurrency deterministic
+
+Express the required happens-before relationship with signals:
+
+1. operation A reaches a named gate;
+2. operation B is submitted while A is held;
+3. the test observes the contract in that state;
+4. the gate is released;
+5. both operations settle and final state is asserted.
+
+Use channels, barriers, latches, deferred values, or domain events. A timeout is
+a generous deadlock guard around an awaited signal, not readiness evidence or
+the behavioral oracle. “Nothing happened for 20 ms” does not prove that nothing
+can happen.
+
+Inject clocks, timers, deadline errors, random sources, IDs, or schedulers when
+the decision depends on them. Test immediately before, at, and after thresholds.
+Retries may expose a flake, but they do not repair it; a pass-on-retry must remain
+visible as a defect.
+
+## Preserve suite and CI integrity
+
+- Keep small suites beside their owner. Split large lifecycle, recovery,
+  concurrency, migration, rendering, or platform scenarios by behavior rather
+  than creating one file per private helper or one giant suite.
+- Keep tests order-independent. Parallelize only when they do not share mutable
+  globals, environment, ports, clocks, files, or fixtures.
+- Every test must be discovered by its package command and the appropriate root
+  changed-aware lane. A selected suite that collects zero tests must fail.
+- Empty files, committed `.only`, required missing fixtures, and suites whose
+  meaningful cases all skip are defects.
+- Platform markers, build tags, and filename filters must map to a blocking
+  native CI lane.
+- Keep unit tests offline. Live-provider qualification belongs in an explicit,
+  isolated lane or sanitized record/replay workflow.
+
+Coverage can identify unvisited branches, but a repository-wide percentage
+rewards shallow render tests, copied constants, and mocked call graphs. For
+critical lifecycle, authorization, persistence, recovery, and security logic,
+targeted fault injection or mutation sampling is a stronger audit.
+
+## Repository examples
+
+Use these as patterns for their specific risks, not as templates to copy:
+
+- [Agent Host conformance](../../packages/agent/host/conformance/scenarios.go)
+  expresses lifecycle behavior once for multiple consumers.
+- [Managed runtime tests](../../services/tuttid/service/managedruntime/runtime_test.go)
+  distinguish transient and permanent failures, use a local HTTP server, and
+  assert retries, cancellation, and response cleanup.
+- [Combobox behavior](../../packages/ui/system/src/components/combobox/combobox.spec.tsx)
+  drives keyboard and pointer actions and observes selection, disabled behavior,
+  filtering, accessibility, and closure.
+- [Windows Codex contract](../../packages/agent/daemon/runtime/codex_appserver_windows_contract_test.go)
+  checks behavior against the real Windows receiver instead of trusting a
+  serialized request shape.


### PR DESCRIPTION
## Summary

- Add the `tutti-test-audit` skill for behavior-focused test design and review
- Document test quality, ownership, boundary selection, determinism, and CI execution standards
- Link the durable unit-testing guidance from repository conventions and agent instructions

## Testing

- Not run (documentation and skill guidance only)