### PR TITLE
fix(agent-gui): backport full-access details fix to release/0813

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { useState } from "react";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -253,7 +253,14 @@ describe("AgentPermissionModeDropdown", () => {
       type: "open-url",
       url: "https://deploymentsafety.openai.com/gpt-5-6"
     });
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Enable full access?" })
+      ).not.toBeInTheDocument();
+    });
+    expect(onSettingsChange).not.toHaveBeenCalled();
 
+    await selectPermissionOption("Full access");
     fireEvent.click(screen.getByRole("button", { name: "Enable full access" }));
 
     expect(onSettingsChange).toHaveBeenCalledTimes(1);

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFullAccessWarningDialog.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFullAccessWarningDialog.tsx
@@ -71,6 +71,7 @@ export function AgentFullAccessWarningDialog({
           rel="noreferrer"
           target="_blank"
           onClick={(event) => {
+            onOpenChange(false);
             if (!onLinkAction) {
               return;
             }


### PR DESCRIPTION
## What

Backport #2344 to `release/0813`.

Close the full-access warning dialog before dispatching the “Learn more” URL, with a focused regression test for the ordering.

## Why

The modal could remain above the browser window opened from the warning, making the details page appear hidden or blocked.

## Impact

Permission behavior is unchanged. Only the dialog/window ordering changes when users open the details link.

## Root cause

The click handler opened the external details URL without first closing the controlled warning dialog.

## Checks

- `pnpm check:changed -- --base release-current` — passed 11 lanes
- cherry-pick applied cleanly to the current `release/0813` tip
- DCO sign-off preserved from #2344

## AgentGUI review

- Architecture: UI-local dialog state and host-action ordering only; ownership and boundaries are unchanged
- Performance: click-only path; no hot-path or render-loop impact
- Consumers: no export or input-contract changes; focused shared AgentGUI test passes

## Documentation

No durable documentation impact; this preserves the original interaction fix.