### PR TITLE
fix(agent): harden runtime recovery admission

### DIFF
--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -4877,11 +4877,11 @@ agent target`, although the current model picker does not offer that model.
   unsupported explicit selection separately with generic extension fixtures.
   Inject a `session/set_model` rejection into the standard ACP transport test.
 
-### Standard ACP send is stopped while an earlier process is still exiting
+### Agent send is stopped while an earlier provider process is still exiting
 
 - Symptom:
-  After an idle Standard ACP session is released, the next message may reconnect
-  once, but a later Start/Resume returns
+  After an idle Standard ACP, Codex, Tutti Agent, or Claude session is released,
+  the next message may reconnect once, but a later Start/Resume returns
   `workspace_operation_failed` with reason
   `agent.process_cleanup_pending`. The message does not reach the provider; in
   AgentGUI the submitted draft is restored and a localized retry message is
@@ -4897,8 +4897,11 @@ agent target`, although the current model picker does not offer that model.
   allowing its late inbound handler to remain active can also attribute old
   output or approval requests to the replacement Turn.
 - Fix:
-  Keep failed and replaced clients under adapter ownership, quarantine their
-  message handlers, and retry at most one failed Close budget per adapter sweep.
+  Keep failed and replaced clients under their adapter's ownership, quarantine
+  their message handlers, and retry at most one failed Close budget per adapter
+  sweep. Codex and Tutti Agent mark a close-failed current client unusable;
+  Claude also rejects every late event whose physical connection is no longer
+  the current Session generation.
   Once a failed handle is retired, Start/Resume performs one bounded cleanup
   attempt and refuses to spawn another process while cleanup remains pending.
   Preserve the stable reason through the Host/API boundary so AgentGUI can
@@ -4912,6 +4915,8 @@ agent target`, although the current model picker does not offer that model.
 - References:
   [standard_acp_session.go](../../../packages/agent/daemon/runtime/standard_acp_session.go)
   [standard_acp_resource_ownership.go](../../../packages/agent/daemon/runtime/standard_acp_resource_ownership.go)
+  [codex_appserver_resource_ownership.go](../../../packages/agent/daemon/runtime/codex_appserver_resource_ownership.go)
+  [claude_sdk_resource_ownership.go](../../../packages/agent/daemon/runtime/claude_sdk_resource_ownership.go)
   [AgentGUIEngineSettlementController.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIEngineSettlementController.ts)
 
 ### Codex rejects `turn/start` with `AbsolutePathBuf deserialized without a base path`

--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -29,6 +29,7 @@ type ClaudeCodeSDKAdapter struct {
 
 	mu                         sync.Mutex
 	sessions                   map[string]*claudeSDKAdapterSession
+	retiredSessions            map[string][]*claudeSDKAdapterSession
 	terminalInteractions       terminalInteractiveDispositionStore
 	interactiveDispositionSink InteractiveDispositionSink
 	commandSink                CommandSnapshotSink
@@ -36,9 +37,20 @@ type ClaudeCodeSDKAdapter struct {
 	promptImageMaterializer    providerPromptImageMaterializer
 	interactiveAckTimeout      time.Duration
 	inputUnits                 *providerInputUnitTracker
+	lifecycleMu                sync.Mutex
+	lifecycleLocks             map[string]*claudeSDKSessionLock
+}
+
+type claudeSDKSessionLock struct {
+	mu   sync.Mutex
+	refs int
 }
 
 type claudeSDKAdapterSession struct {
+	// dispatchMu is the exact-session commit axis. Event projection may run
+	// before it, but canonical publication and registry replacement must hold
+	// this mutex so a stale reader cannot commit after a new generation wins.
+	dispatchMu        sync.Mutex
 	conn              ProcessConnection
 	reader            *claudeSDKLineReader
 	session           Session
@@ -216,8 +228,10 @@ func NewClaudeCodeSDKAdapter(transport ProcessTransport) *ClaudeCodeSDKAdapter {
 	return &ClaudeCodeSDKAdapter{
 		transport:             transport,
 		sessions:              make(map[string]*claudeSDKAdapterSession),
+		retiredSessions:       make(map[string][]*claudeSDKAdapterSession),
 		interactiveAckTimeout: claudeSDKInteractiveAckTimeout,
 		inputUnits:            providerInputUnitTrackerForTransport(transport),
+		lifecycleLocks:        make(map[string]*claudeSDKSessionLock),
 	}
 }
 

--- a/packages/agent/daemon/runtime/claude_sdk_event_dispatch.go
+++ b/packages/agent/daemon/runtime/claude_sdk_event_dispatch.go
@@ -13,6 +13,12 @@ func (a *ClaudeCodeSDKAdapter) dispatchClaudeSDKEvent(
 	if a == nil || adapterSession == nil {
 		return nil
 	}
+	// This exact-session mutex is the linearization point shared with registry
+	// replacement and reader failure. Once dispatch wins it commits the whole
+	// event against this generation; once replacement wins, this reader sees a
+	// stale session before performing any canonical side effect.
+	adapterSession.dispatchMu.Lock()
+	defer adapterSession.dispatchMu.Unlock()
 	eventCtx := context.Background()
 	if event.inputUnit != nil {
 		eventCtx = contextWithProviderInputUnit(eventCtx, *event.inputUnit)
@@ -20,8 +26,18 @@ func (a *ClaudeCodeSDKAdapter) dispatchClaudeSDKEvent(
 	endInputUnit := a.inputUnits.begin(eventCtx, agentSessionID)
 	defer endInputUnit()
 	a.logClaudeSDKLifecycleEvent(agentSessionID, adapterSession, event)
+	// Protocol response waiters belong to the exact physical connection, not
+	// to the current registry generation. Always settle them so a Close on a
+	// replaced connection cannot deadlock behind stale-event suppression.
 	if response := a.takeClaudeSDKResponseWaiter(adapterSession, event); response != nil {
 		response <- event
+		return completeClaudeSDKProviderInputUnit(
+			context.Background(),
+			adapterSession.conn,
+			event,
+		)
+	}
+	if !a.sessionMayDispatch(agentSessionID, adapterSession) {
 		return completeClaudeSDKProviderInputUnit(
 			context.Background(),
 			adapterSession.conn,
@@ -55,6 +71,11 @@ func (a *ClaudeCodeSDKAdapter) dispatchClaudeSDKEvent(
 	next, terminal, err := a.sidecarTurnEvents(adapterSession, session, turnID, event)
 	next = a.stampTurnLifecycleSnapshots(adapterSession, next)
 	next = a.inputUnits.stamp(agentSessionID, next)
+	if err != nil && waiter == nil {
+		next = append(next, newSessionActivityEvent(session, EventSessionFailed, SessionStatusFailed, map[string]any{
+			"error": err.Error(),
+		}))
+	}
 	if len(next) > 0 {
 		a.updateClaudeSDKSessionSnapshot(adapterSession, next)
 	}
@@ -65,11 +86,6 @@ func (a *ClaudeCodeSDKAdapter) dispatchClaudeSDKEvent(
 			adapterSession.conn,
 			event,
 		)
-	}
-	if err != nil {
-		next = append(next, newSessionActivityEvent(session, EventSessionFailed, SessionStatusFailed, map[string]any{
-			"error": err.Error(),
-		}))
 	}
 	a.emitClaudeSDKSessionEvents(agentSessionID, next)
 	a.finishClaudeSDKGoalTurnPublication(adapterSession, next)

--- a/packages/agent/daemon/runtime/claude_sdk_event_projection_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_event_projection_test.go
@@ -211,6 +211,7 @@ func TestClaudeCodeSDKAdapterCompletesCanonicalTurnByProviderIdentity(t *testing
 		session:   session,
 		liveState: newClaudeSDKLiveState(),
 	}
+	adapter.storeSession(session.AgentSessionID, adapterSession)
 	adapter.beginClaudeSDKRootTurn(
 		adapterSession,
 		"canonical-turn-1",

--- a/packages/agent/daemon/runtime/claude_sdk_events.go
+++ b/packages/agent/daemon/runtime/claude_sdk_events.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"sort"
 	"strings"
 
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
@@ -705,8 +704,14 @@ func (a *ClaudeCodeSDKAdapter) failClaudeSDKReaderWithOwnership(
 	if a == nil || adapterSession == nil {
 		return
 	}
-	a.markSessionInvalid(adapterSession)
+	// Reader failure and replacement share the exact-session commit axis.
+	// Whichever owns dispatchMu first fully commits; the other observes that
+	// generation boundary instead of publishing a mixed old/new timeline.
+	adapterSession.dispatchMu.Lock()
+	defer adapterSession.dispatchMu.Unlock()
 	a.mu.Lock()
+	ownsCurrentSession := a.sessions[agentSessionID] == adapterSession
+	adapterSession.invalid = true
 	turns := make([]*claudeSDKTurnWaiter, 0, len(adapterSession.turns))
 	for turnID, waiter := range adapterSession.turns {
 		turns = append(turns, waiter)
@@ -727,25 +732,34 @@ func (a *ClaudeCodeSDKAdapter) failClaudeSDKReaderWithOwnership(
 	// also be resolved explicitly. Otherwise the pending approval bookkeeping
 	// is discarded silently with the session and the GUI is left without a
 	// terminal explanation.
-	session := a.claudeSDKSessionSnapshot(adapterSession)
-	if strings.TrimSpace(session.AgentSessionID) == "" {
-		session.AgentSessionID = agentSessionID
+	var pendingFailureEvents []activityshared.Event
+	if ownsCurrentSession {
+		session := a.claudeSDKSessionSnapshot(adapterSession)
+		if strings.TrimSpace(session.AgentSessionID) == "" {
+			session.AgentSessionID = agentSessionID
+		}
+		pendingFailureEvents = a.claudeSDKPendingRequestFailureEvents(adapterSession, session, "", err)
+		pendingFailureEvents = append(pendingFailureEvents, a.finishAllClaudeSDKTurnLifecycles(
+			adapterSession,
+			session,
+			claudeSDKTurnFinishFailed,
+			err.Error(),
+		)...)
+		pendingFailureEvents = append(
+			pendingFailureEvents,
+			a.failAllClaudeSDKRootProviderTurns(adapterSession, session, err)...,
+		)
 	}
-	pendingFailureEvents := a.claudeSDKPendingRequestFailureEvents(adapterSession, session, "", err)
-	pendingFailureEvents = append(pendingFailureEvents, a.finishAllClaudeSDKTurnLifecycles(
-		adapterSession,
-		session,
-		claudeSDKTurnFinishFailed,
-		err.Error(),
-	)...)
-	pendingFailureEvents = append(
-		pendingFailureEvents,
-		a.failAllClaudeSDKRootProviderTurns(adapterSession, session, err)...,
-	)
 	if !retainSession {
-		a.removeSession(agentSessionID, adapterSession)
+		a.mu.Lock()
+		if a.sessions[agentSessionID] == adapterSession {
+			delete(a.sessions, agentSessionID)
+		}
+		a.mu.Unlock()
 	}
-	a.emitClaudeSDKSessionEvents(agentSessionID, pendingFailureEvents)
+	if ownsCurrentSession {
+		a.emitClaudeSDKSessionEvents(agentSessionID, pendingFailureEvents)
+	}
 	for _, waiter := range turns {
 		waiter.mu.Lock()
 		if waiter.completed {
@@ -763,44 +777,4 @@ func (a *ClaudeCodeSDKAdapter) failClaudeSDKReaderWithOwnership(
 	for _, response := range responses {
 		response <- claudeSDKSidecarEvent{Type: "error", Payload: map[string]any{"error": err.Error(), "transport": true}}
 	}
-}
-
-func (a *ClaudeCodeSDKAdapter) failAllClaudeSDKRootProviderTurns(
-	adapterSession *claudeSDKAdapterSession,
-	session Session,
-	err error,
-) []activityshared.Event {
-	if a == nil || adapterSession == nil {
-		return nil
-	}
-	a.mu.Lock()
-	rootTurnID := strings.TrimSpace(adapterSession.rootTurnID)
-	providerTurnIDs := make([]string, 0, len(adapterSession.rootProviderTurns))
-	for providerTurnID := range adapterSession.rootProviderTurns {
-		providerTurnID = strings.TrimSpace(providerTurnID)
-		if providerTurnID != "" {
-			providerTurnIDs = append(providerTurnIDs, providerTurnID)
-		}
-	}
-	adapterSession.rootProviderTurns = make(map[string]struct{})
-	a.mu.Unlock()
-	if rootTurnID == "" || len(providerTurnIDs) == 0 {
-		return nil
-	}
-	sort.Strings(providerTurnIDs)
-	metadata := map[string]any{"adapter": claudeSDKSidecarAdapterName}
-	if err != nil {
-		metadata["error"] = err.Error()
-	}
-	events := make([]activityshared.Event, 0, len(providerTurnIDs))
-	for _, providerTurnID := range providerTurnIDs {
-		events = append(events, claudeSDKRootProviderTurnCompletedEvent(
-			session,
-			rootTurnID,
-			providerTurnID,
-			activityshared.TurnOutcomeFailed,
-			metadata,
-		))
-	}
-	return events
 }

--- a/packages/agent/daemon/runtime/claude_sdk_interactive.go
+++ b/packages/agent/daemon/runtime/claude_sdk_interactive.go
@@ -225,6 +225,21 @@ func (a *ClaudeCodeSDKAdapter) applyClaudeSDKInteractiveAck(
 	response pendingInteractiveResponse,
 	ack claudeSDKInteractiveAck,
 ) {
+	if a == nil || adapterSession == nil || pending == nil {
+		return
+	}
+	// The sidecar response is received without this lock, but its canonical
+	// effects share the exact-session commit axis with reader dispatch and
+	// replacement. A response from E1 cannot settle or publish after E2 wins.
+	adapterSession.dispatchMu.Lock()
+	defer adapterSession.dispatchMu.Unlock()
+	rootAgentSessionID := firstNonEmptyString(
+		strings.TrimSpace(adapterSession.session.AgentSessionID),
+		strings.TrimSpace(session.AgentSessionID),
+	)
+	if !a.sessionMayDispatch(rootAgentSessionID, adapterSession) {
+		return
+	}
 	var state pendingInteractiveRequestState
 	var terminalErr error
 	switch ack.disposition {

--- a/packages/agent/daemon/runtime/claude_sdk_lifecycle.go
+++ b/packages/agent/daemon/runtime/claude_sdk_lifecycle.go
@@ -12,6 +12,31 @@ import (
 const claudeSDKCloseTimeout = 10 * time.Minute
 
 func (a *ClaudeCodeSDKAdapter) Start(ctx context.Context, session Session) ([]activityshared.Event, error) {
+	unlock := a.lockClaudeSDKSessionLifecycle(session.AgentSessionID)
+	defer unlock()
+	if err := a.admitClaudeSDKReplacementLocked(session.AgentSessionID); err != nil {
+		return nil, err
+	}
+	return a.replaceClaudeSDKSessionLocked(ctx, session)
+}
+
+func (a *ClaudeCodeSDKAdapter) replaceClaudeSDKSessionLocked(
+	ctx context.Context,
+	session Session,
+) ([]activityshared.Event, error) {
+	previous := a.getSession(session.AgentSessionID)
+	events, err := a.startClaudeSDKSession(ctx, session)
+	if err != nil && previous != nil {
+		a.restoreOwnedPreviousSession(session.AgentSessionID, previous)
+	}
+	if err == nil && previous != nil {
+		a.removeSession(session.AgentSessionID, previous)
+		a.closeOrRetainClaudeSDKSession(session.AgentSessionID, previous)
+	}
+	return events, err
+}
+
+func (a *ClaudeCodeSDKAdapter) startClaudeSDKSession(ctx context.Context, session Session) ([]activityshared.Event, error) {
 	if a == nil || a.transport == nil {
 		return nil, ErrSessionDisconnected
 	}
@@ -63,8 +88,8 @@ func (a *ClaudeCodeSDKAdapter) Start(ctx context.Context, session Session) ([]ac
 	if processCassetteCaptureOrigin(conn) ==
 		ProcessCassetteCaptureOriginAttachedLiveConnection {
 		if !restore {
-			_ = conn.Close()
 			a.removeSession(session.AgentSessionID, adapterSession)
+			a.closeOrRetainClaudeSDKSession(session.AgentSessionID, adapterSession)
 			return nil, errors.New(
 				"attached live Claude replay requires a restored provider session id",
 			)
@@ -95,16 +120,16 @@ func (a *ClaudeCodeSDKAdapter) Start(ctx context.Context, session Session) ([]ac
 		Type:    "start",
 		Payload: startPayload,
 	}); err != nil {
-		_ = conn.Close()
 		a.removeSession(session.AgentSessionID, adapterSession)
+		a.closeOrRetainClaudeSDKSession(session.AgentSessionID, adapterSession)
 		return nil, err
 	}
 
 	for {
 		event, err := adapterSession.reader.next(ctx)
 		if err != nil {
-			_ = conn.Close()
 			a.removeSession(session.AgentSessionID, adapterSession)
+			a.closeOrRetainClaudeSDKSession(session.AgentSessionID, adapterSession)
 			return nil, err
 		}
 		eventCtx := context.Background()
@@ -142,13 +167,13 @@ func (a *ClaudeCodeSDKAdapter) Start(ctx context.Context, session Session) ([]ac
 			adapterSession.conn,
 			event,
 		); err != nil {
-			_ = conn.Close()
 			a.removeSession(session.AgentSessionID, adapterSession)
+			a.closeOrRetainClaudeSDKSession(session.AgentSessionID, adapterSession)
 			return nil, err
 		}
 		if event.Type == "error" {
-			_ = conn.Close()
 			a.removeSession(session.AgentSessionID, adapterSession)
+			a.closeOrRetainClaudeSDKSession(session.AgentSessionID, adapterSession)
 			return nil, errors.New(payloadString(event.Payload, "error"))
 		}
 	}
@@ -174,15 +199,12 @@ func (a *ClaudeCodeSDKAdapter) Resume(ctx context.Context, session Session) erro
 	if strings.TrimSpace(session.ProviderSessionID) == "" {
 		return ErrSessionDisconnected
 	}
-	previous := a.getSession(session.AgentSessionID)
-	_, err := a.Start(ctx, session)
-	if err != nil && previous != nil {
-		a.restorePreviousSession(session.AgentSessionID, previous)
+	unlock := a.lockClaudeSDKSessionLifecycle(session.AgentSessionID)
+	defer unlock()
+	if err := a.admitClaudeSDKReplacementLocked(session.AgentSessionID); err != nil {
+		return err
 	}
-	if err == nil && previous != nil {
-		a.removeSession(session.AgentSessionID, previous)
-		_ = previous.conn.Close()
-	}
+	_, err := a.replaceClaudeSDKSessionLocked(ctx, session)
 	return classifyClaudeSDKResumeError(session, err)
 }
 
@@ -191,6 +213,12 @@ func (*ClaudeCodeSDKAdapter) CanResume(session Session) bool {
 }
 
 func (a *ClaudeCodeSDKAdapter) Close(ctx context.Context, session Session) error {
+	unlock := a.lockClaudeSDKSessionLifecycle(session.AgentSessionID)
+	defer unlock()
+	return a.closeClaudeSDKSession(ctx, session)
+}
+
+func (a *ClaudeCodeSDKAdapter) closeClaudeSDKSession(ctx context.Context, session Session) error {
 	adapterSession := a.getSession(session.AgentSessionID)
 	if adapterSession == nil {
 		return nil
@@ -201,7 +229,7 @@ func (a *ClaudeCodeSDKAdapter) Close(ctx context.Context, session Session) error
 	if !readerStarted {
 		if err := a.startClaudeSDKReader(session.AgentSessionID, adapterSession); err != nil {
 			a.removeSession(session.AgentSessionID, adapterSession)
-			_ = adapterSession.conn.Close()
+			a.closeOrRetainClaudeSDKSession(session.AgentSessionID, adapterSession)
 			return err
 		}
 	}
@@ -222,14 +250,18 @@ func (a *ClaudeCodeSDKAdapter) Close(ctx context.Context, session Session) error
 		},
 	}); err != nil {
 		a.removeSession(session.AgentSessionID, adapterSession)
-		_ = adapterSession.conn.Close()
+		a.closeOrRetainClaudeSDKSession(session.AgentSessionID, adapterSession)
 		return err
 	}
 	a.removeSession(session.AgentSessionID, adapterSession)
 	if graceful, ok := adapterSession.conn.(GracefulProcessConnection); ok {
 		_ = graceful.CloseInput()
 	}
-	return adapterSession.conn.Close()
+	if err := adapterSession.conn.Close(); err != nil {
+		a.retainRetiredClaudeSDKSession(session.AgentSessionID, adapterSession)
+		return err
+	}
+	return nil
 }
 
 func (a *ClaudeCodeSDKAdapter) HasLiveSession(session Session) bool {
@@ -246,6 +278,8 @@ func (a *ClaudeCodeSDKAdapter) ReleaseLiveSession(ctx context.Context, session S
 // transport. It deliberately does not send the sidecar "close" request,
 // which is the graceful provider-session close contract.
 func (a *ClaudeCodeSDKAdapter) DisconnectLiveSession(_ context.Context, session Session) error {
+	unlock := a.lockClaudeSDKSessionLifecycle(session.AgentSessionID)
+	defer unlock()
 	adapterSession := a.getSession(session.AgentSessionID)
 	if adapterSession == nil {
 		return nil

--- a/packages/agent/daemon/runtime/claude_sdk_resource_ownership.go
+++ b/packages/agent/daemon/runtime/claude_sdk_resource_ownership.go
@@ -1,0 +1,238 @@
+package agentruntime
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"strings"
+
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+)
+
+func (a *ClaudeCodeSDKAdapter) failAllClaudeSDKRootProviderTurns(
+	adapterSession *claudeSDKAdapterSession,
+	session Session,
+	err error,
+) []activityshared.Event {
+	if a == nil || adapterSession == nil {
+		return nil
+	}
+	a.mu.Lock()
+	rootTurnID := strings.TrimSpace(adapterSession.rootTurnID)
+	providerTurnIDs := make([]string, 0, len(adapterSession.rootProviderTurns))
+	for providerTurnID := range adapterSession.rootProviderTurns {
+		providerTurnID = strings.TrimSpace(providerTurnID)
+		if providerTurnID != "" {
+			providerTurnIDs = append(providerTurnIDs, providerTurnID)
+		}
+	}
+	adapterSession.rootProviderTurns = make(map[string]struct{})
+	a.mu.Unlock()
+	if rootTurnID == "" || len(providerTurnIDs) == 0 {
+		return nil
+	}
+	sort.Strings(providerTurnIDs)
+	metadata := map[string]any{"adapter": claudeSDKSidecarAdapterName}
+	if err != nil {
+		metadata["error"] = err.Error()
+	}
+	events := make([]activityshared.Event, 0, len(providerTurnIDs))
+	for _, providerTurnID := range providerTurnIDs {
+		events = append(events, claudeSDKRootProviderTurnCompletedEvent(
+			session,
+			rootTurnID,
+			providerTurnID,
+			activityshared.TurnOutcomeFailed,
+			metadata,
+		))
+	}
+	return events
+}
+
+func (a *ClaudeCodeSDKAdapter) lockClaudeSDKSessionLifecycle(agentSessionID string) func() {
+	if a == nil {
+		return func() {}
+	}
+	key := strings.TrimSpace(agentSessionID)
+	a.lifecycleMu.Lock()
+	lock := a.lifecycleLocks[key]
+	if lock == nil {
+		lock = &claudeSDKSessionLock{}
+		a.lifecycleLocks[key] = lock
+	}
+	lock.refs++
+	a.lifecycleMu.Unlock()
+	lock.mu.Lock()
+	return func() {
+		lock.mu.Unlock()
+		a.lifecycleMu.Lock()
+		lock.refs--
+		if lock.refs == 0 && a.lifecycleLocks[key] == lock {
+			delete(a.lifecycleLocks, key)
+		}
+		a.lifecycleMu.Unlock()
+	}
+}
+
+func claudeSDKProcessCleanupPendingError(cause error) error {
+	debugMessage := "an earlier Claude sidecar process is still shutting down"
+	if cause != nil {
+		debugMessage = cause.Error()
+	}
+	return &AppError{
+		Code:         AppErrorProcessCleanupPending,
+		Message:      "agent process cleanup is still pending",
+		DebugMessage: debugMessage,
+		Cause:        cause,
+	}
+}
+
+func (a *ClaudeCodeSDKAdapter) retainRetiredClaudeSDKSession(agentSessionID string, session *claudeSDKAdapterSession) {
+	if a == nil || session == nil || session.conn == nil {
+		return
+	}
+	agentSessionID = strings.TrimSpace(agentSessionID)
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.retiredSessions == nil {
+		a.retiredSessions = make(map[string][]*claudeSDKAdapterSession)
+	}
+	session.invalid = true
+	for _, retained := range a.retiredSessions[agentSessionID] {
+		if retained == session || (retained != nil && retained.conn == session.conn) {
+			return
+		}
+	}
+	a.retiredSessions[agentSessionID] = append(a.retiredSessions[agentSessionID], session)
+}
+
+func (a *ClaudeCodeSDKAdapter) closeOrRetainClaudeSDKSession(agentSessionID string, session *claudeSDKAdapterSession) {
+	if session == nil || session.conn == nil {
+		return
+	}
+	if err := session.conn.Close(); err != nil {
+		a.retainRetiredClaudeSDKSession(agentSessionID, session)
+	}
+}
+
+func (a *ClaudeCodeSDKAdapter) hasRetiredClaudeSDKSessions(agentSessionID string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.retiredSessions[strings.TrimSpace(agentSessionID)]) > 0
+}
+
+func (a *ClaudeCodeSDKAdapter) admitClaudeSDKReplacementLocked(agentSessionID string) error {
+	if !a.hasRetiredClaudeSDKSessions(agentSessionID) {
+		return nil
+	}
+	_, err := a.retryOneClaudeSDKSessionLocked(agentSessionID)
+	if err != nil {
+		return claudeSDKProcessCleanupPendingError(err)
+	}
+	if a.hasRetiredClaudeSDKSessions(agentSessionID) {
+		return claudeSDKProcessCleanupPendingError(errors.New("multiple earlier Claude sidecar processes still require cleanup"))
+	}
+	return nil
+}
+
+func (a *ClaudeCodeSDKAdapter) retryOneClaudeSDKSession(agentSessionID string) (bool, error) {
+	if a == nil {
+		return false, nil
+	}
+	agentSessionID = strings.TrimSpace(agentSessionID)
+	a.mu.Lock()
+	if agentSessionID == "" {
+		for candidate, current := range a.sessions {
+			if current != nil && current.conn != nil && current.invalid {
+				agentSessionID = candidate
+				break
+			}
+		}
+		if agentSessionID == "" {
+			for candidate, retired := range a.retiredSessions {
+				if len(retired) > 0 {
+					agentSessionID = candidate
+					break
+				}
+			}
+		}
+	}
+	a.mu.Unlock()
+	if agentSessionID == "" {
+		return false, nil
+	}
+	unlock := a.lockClaudeSDKSessionLifecycle(agentSessionID)
+	defer unlock()
+	return a.retryOneClaudeSDKSessionLocked(agentSessionID)
+}
+
+func (a *ClaudeCodeSDKAdapter) retryOneClaudeSDKSessionLocked(agentSessionID string) (bool, error) {
+	a.mu.Lock()
+	current := a.sessions[agentSessionID]
+	if current != nil && current.conn != nil && current.invalid {
+		a.mu.Unlock()
+		if err := current.conn.Close(); err != nil {
+			return true, err
+		}
+		a.removeSession(agentSessionID, current)
+		return true, nil
+	}
+	retired := a.retiredSessions[agentSessionID]
+	var target *claudeSDKAdapterSession
+	for _, candidate := range retired {
+		if candidate != nil {
+			target = candidate
+			break
+		}
+	}
+	a.mu.Unlock()
+	if target == nil {
+		return false, nil
+	}
+	if err := target.conn.Close(); err != nil {
+		return true, err
+	}
+	a.removeRetiredClaudeSDKSession(agentSessionID, target)
+	return true, nil
+}
+
+func (a *ClaudeCodeSDKAdapter) removeRetiredClaudeSDKSession(agentSessionID string, target *claudeSDKAdapterSession) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	retired := a.retiredSessions[agentSessionID]
+	for index, session := range retired {
+		if session != target {
+			continue
+		}
+		retired = append(retired[:index], retired[index+1:]...)
+		if len(retired) == 0 {
+			delete(a.retiredSessions, agentSessionID)
+		} else {
+			a.retiredSessions[agentSessionID] = retired
+		}
+		return
+	}
+}
+
+func (a *ClaudeCodeSDKAdapter) CleanupLiveSessionResources(ctx context.Context, limit int) LiveSessionResourceCleanupResult {
+	var result LiveSessionResourceCleanupResult
+	if limit <= 0 {
+		return result
+	}
+	select {
+	case <-ctx.Done():
+		return result
+	default:
+	}
+	attempted, err := a.retryOneClaudeSDKSession("")
+	if !attempted {
+		return result
+	}
+	result.Attempted = 1
+	if err != nil {
+		result.Failed = 1
+	} else {
+		result.Cleaned = 1
+	}
+	return result
+}

--- a/packages/agent/daemon/runtime/claude_sdk_session.go
+++ b/packages/agent/daemon/runtime/claude_sdk_session.go
@@ -12,12 +12,32 @@ import (
 )
 
 func (a *ClaudeCodeSDKAdapter) storeSession(agentSessionID string, session *claudeSDKAdapterSession) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
 	if session != nil && session.childSessions == nil {
 		session.childSessions = make(map[string]claudeSDKChildSession)
 	}
-	a.sessions[agentSessionID] = session
+	agentSessionID = strings.TrimSpace(agentSessionID)
+	for {
+		a.mu.Lock()
+		previous := a.sessions[agentSessionID]
+		a.mu.Unlock()
+		if previous != nil && previous != session {
+			previous.dispatchMu.Lock()
+		}
+		a.mu.Lock()
+		if a.sessions[agentSessionID] != previous {
+			a.mu.Unlock()
+			if previous != nil && previous != session {
+				previous.dispatchMu.Unlock()
+			}
+			continue
+		}
+		a.sessions[agentSessionID] = session
+		a.mu.Unlock()
+		if previous != nil && previous != session {
+			previous.dispatchMu.Unlock()
+		}
+		return
+	}
 }
 
 func (*ClaudeCodeSDKAdapter) applySidecarSessionEvent(
@@ -57,6 +77,7 @@ func (a *ClaudeCodeSDKAdapter) removeSession(agentSessionID string, expected *cl
 	if a == nil || expected == nil {
 		return false
 	}
+	expected.dispatchMu.Lock()
 	a.mu.Lock()
 	expected.invalid = true
 	pending := make([]*pendingInteractiveRequest, 0, len(expected.pendingRequests))
@@ -65,6 +86,7 @@ func (a *ClaudeCodeSDKAdapter) removeSession(agentSessionID string, expected *cl
 	}
 	if a.sessions[agentSessionID] != expected {
 		a.mu.Unlock()
+		expected.dispatchMu.Unlock()
 		for _, request := range pending {
 			request.finish(pendingInteractiveRequestStateSuperseded)
 		}
@@ -72,25 +94,19 @@ func (a *ClaudeCodeSDKAdapter) removeSession(agentSessionID string, expected *cl
 	}
 	delete(a.sessions, agentSessionID)
 	a.mu.Unlock()
+	expected.dispatchMu.Unlock()
 	for _, request := range pending {
 		request.finish(pendingInteractiveRequestStateSuperseded)
 	}
 	return true
 }
 
-func (a *ClaudeCodeSDKAdapter) markSessionInvalid(session *claudeSDKAdapterSession) {
-	if a == nil || session == nil {
-		return
-	}
-	a.mu.Lock()
-	session.invalid = true
-	a.mu.Unlock()
-}
-
 func (a *ClaudeCodeSDKAdapter) restorePreviousSession(agentSessionID string, previous *claudeSDKAdapterSession) bool {
 	if a == nil || previous == nil {
 		return false
 	}
+	previous.dispatchMu.Lock()
+	defer previous.dispatchMu.Unlock()
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	current := a.sessions[agentSessionID]
@@ -104,6 +120,25 @@ func (a *ClaudeCodeSDKAdapter) restorePreviousSession(agentSessionID string, pre
 	return true
 }
 
+// restoreOwnedPreviousSession is used only when a replacement launch fails.
+// An invalid previous session remains unusable, but restoring it to the owned
+// registry preserves the physical handle for a later close retry.
+func (a *ClaudeCodeSDKAdapter) restoreOwnedPreviousSession(agentSessionID string, previous *claudeSDKAdapterSession) bool {
+	if a == nil || previous == nil {
+		return false
+	}
+	previous.dispatchMu.Lock()
+	defer previous.dispatchMu.Unlock()
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	current := a.sessions[agentSessionID]
+	if current != nil {
+		return current == previous
+	}
+	a.sessions[agentSessionID] = previous
+	return true
+}
+
 func (a *ClaudeCodeSDKAdapter) sessionIsUsable(agentSessionID string, session *claudeSDKAdapterSession) bool {
 	if a == nil || session == nil {
 		return false
@@ -111,6 +146,16 @@ func (a *ClaudeCodeSDKAdapter) sessionIsUsable(agentSessionID string, session *c
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	return a.sessions[agentSessionID] == session && !session.invalid
+}
+
+func (a *ClaudeCodeSDKAdapter) sessionMayDispatch(agentSessionID string, session *claudeSDKAdapterSession) bool {
+	if a == nil || session == nil {
+		return false
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	current := a.sessions[agentSessionID]
+	return !session.invalid && current == session
 }
 
 func (a *ClaudeCodeSDKAdapter) emitCommandSnapshot(snapshot AgentSessionCommandSnapshot) {

--- a/packages/agent/daemon/runtime/claude_sdk_session_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_session_test.go
@@ -2,12 +2,14 @@ package agentruntime
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -170,6 +172,357 @@ func TestClaudeCodeSDKAdapterDisconnectLiveSessionRetriesCloseFailedHandle(t *te
 	conn.mu.Unlock()
 	if closeCalls != 2 {
 		t.Fatalf("transport close calls=%d, want 2", closeCalls)
+	}
+}
+
+type replacementClaudeSDKTransport struct {
+	mu    sync.Mutex
+	conns []*scriptedClaudeSDKConnection
+}
+
+func (t *replacementClaudeSDKTransport) Start(context.Context, ProcessSpec) (ProcessConnection, error) {
+	started, err := json.Marshal(claudeSDKSidecarEvent{
+		Version: claudeSDKSidecarProtocolVersion,
+		Type:    "session_started",
+		Payload: map[string]any{"providerSessionId": "provider-session-replacement"},
+	})
+	if err != nil {
+		return nil, err
+	}
+	conn := &scriptedClaudeSDKConnection{frames: []ProcessFrame{{Stdout: append(started, '\n')}}}
+	t.mu.Lock()
+	t.conns = append(t.conns, conn)
+	t.mu.Unlock()
+	return conn, nil
+}
+
+func (t *replacementClaudeSDKTransport) starts() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.conns)
+}
+
+func TestClaudeCodeSDKAdapterCloseFailureRetainsOwnershipAndBackpressuresFurtherResume(t *testing.T) {
+	t.Parallel()
+
+	transport := &replacementClaudeSDKTransport{}
+	adapter := NewClaudeCodeSDKAdapter(transport)
+	session := standardTestSession(ProviderClaudeCode)
+	session.ProviderSessionID = "provider-session-1"
+	oldConnection := newBlockingClaudeSDKConnection()
+	oldConnection.closeFailures = 4
+	oldSession := &claudeSDKAdapterSession{
+		conn: oldConnection, reader: newClaudeSDKLineReader(oldConnection, false), session: session,
+		pendingRequests: make(map[string]*pendingInteractiveRequest), pendingResponses: make(map[string]chan claudeSDKSidecarEvent),
+		turns: make(map[string]*claudeSDKTurnWaiter), liveState: newClaudeSDKLiveState(),
+	}
+	adapter.storeSession(session.AgentSessionID, oldSession)
+	if err := adapter.DisconnectLiveSession(t.Context(), session); err == nil {
+		t.Fatal("DisconnectLiveSession error=nil, want close failure")
+	}
+	if adapter.HasLiveSession(session) {
+		t.Fatal("close-failed Claude session remained usable")
+	}
+	if err := adapter.Resume(t.Context(), session); err != nil {
+		t.Fatalf("first replacement Resume: %v", err)
+	}
+	if !adapter.HasLiveSession(session) {
+		t.Fatal("replacement Claude session is not usable")
+	}
+	if err := adapter.DisconnectLiveSession(t.Context(), session); err != nil {
+		t.Fatalf("release replacement: %v", err)
+	}
+	startsBefore := transport.starts()
+	err := adapter.Resume(t.Context(), session)
+	if AppErrorCode(err) != AppErrorProcessCleanupPending {
+		t.Fatalf("second Resume error code=%q err=%v", AppErrorCode(err), err)
+	}
+	if startsAfter := transport.starts(); startsAfter != startsBefore {
+		t.Fatalf("replacement spawned behind cleanup backpressure: %d -> %d", startsBefore, startsAfter)
+	}
+	cleanupAdapter, ok := any(adapter).(LiveSessionResourceCleanupAdapter)
+	if !ok {
+		t.Fatal("Claude adapter does not own detached resource cleanup")
+	}
+	cleanup := cleanupAdapter.CleanupLiveSessionResources(t.Context(), 1)
+	if cleanup.Attempted != 1 || cleanup.Failed != 1 {
+		t.Fatalf("failed cleanup=%#v", cleanup)
+	}
+	oldConnection.mu.Lock()
+	oldConnection.closeFailures = 0
+	oldConnection.mu.Unlock()
+	cleanup = cleanupAdapter.CleanupLiveSessionResources(t.Context(), 1)
+	if cleanup.Attempted != 1 || cleanup.Cleaned != 1 || cleanup.Failed != 0 {
+		t.Fatalf("successful cleanup=%#v", cleanup)
+	}
+}
+
+func TestClaudeCodeSDKAdapterDropsLateEventsFromRetiredConnection(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	oldSession := &claudeSDKAdapterSession{session: session, liveState: newClaudeSDKLiveState()}
+	adapter.beginClaudeSDKRootTurn(oldSession, "turn-old", "provider-turn-old")
+	adapter.storeSession(session.AgentSessionID, oldSession)
+	replacement := &claudeSDKAdapterSession{session: session, liveState: newClaudeSDKLiveState()}
+	adapter.storeSession(session.AgentSessionID, replacement)
+	adapter.removeSession(session.AgentSessionID, oldSession)
+
+	var published []activityshared.Event
+	adapter.SetSessionEventSink(func(_ string, events []activityshared.Event) {
+		published = append(published, events...)
+	})
+	if err := adapter.dispatchClaudeSDKEvent(session.AgentSessionID, oldSession, claudeSDKSidecarEvent{
+		Type: "turn_completed",
+		Payload: map[string]any{
+			"turnId": "turn-old", "providerTurnId": "provider-turn-old", "stopReason": "end_turn",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(published) != 0 {
+		t.Fatalf("retired connection published late events: %#v", published)
+	}
+	if adapter.getSession(session.AgentSessionID) != replacement {
+		t.Fatal("late retired event displaced replacement session")
+	}
+}
+
+func TestClaudeCodeSDKAdapterSerializesEventCommitBeforeConcurrentReplacement(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	projectionEntered := make(chan struct{})
+	releaseProjection := make(chan struct{})
+	pending := &pendingInteractiveRequest{
+		agentSessionID: session.AgentSessionID,
+		turnID:         "turn-old",
+		requestID:      "request-old",
+		callID:         "approval:request-old",
+		callType:       "approval",
+		name:           "Bash",
+		onTerminal: func(_ *pendingInteractiveRequest, _ pendingInteractiveRequestState) {
+			close(projectionEntered)
+			<-releaseProjection
+		},
+	}
+	oldSession := &claudeSDKAdapterSession{
+		session: session,
+		pendingRequests: map[string]*pendingInteractiveRequest{
+			claudeSDKPendingRequestKey(pending.turnID, pending.requestID): pending,
+		},
+		pendingResponses: make(map[string]chan claudeSDKSidecarEvent),
+		turns:            make(map[string]*claudeSDKTurnWaiter),
+		liveState:        newClaudeSDKLiveState(),
+	}
+	adapter.storeSession(session.AgentSessionID, oldSession)
+	var published []activityshared.Event
+	adapter.SetSessionEventSink(func(_ string, events []activityshared.Event) {
+		published = append(published, events...)
+	})
+
+	dispatchDone := make(chan error, 1)
+	go func() {
+		dispatchDone <- adapter.dispatchClaudeSDKEvent(session.AgentSessionID, oldSession, claudeSDKSidecarEvent{
+			Type: "approval_resolved",
+			Payload: map[string]any{
+				"turnId": "turn-old", "requestId": "request-old", "optionId": "allow",
+			},
+		})
+	}()
+	<-projectionEntered
+
+	replacementSession := session
+	replacementSession.Status = SessionStatusReady
+	replacement := &claudeSDKAdapterSession{
+		session:          replacementSession,
+		pendingRequests:  make(map[string]*pendingInteractiveRequest),
+		pendingResponses: make(map[string]chan claudeSDKSidecarEvent),
+		turns:            make(map[string]*claudeSDKTurnWaiter),
+		liveState:        newClaudeSDKLiveState(),
+	}
+	replacementDone := make(chan struct{})
+	go func() {
+		adapter.storeSession(session.AgentSessionID, replacement)
+		close(replacementDone)
+	}()
+	select {
+	case <-replacementDone:
+		t.Fatal("replacement crossed an in-flight event commit")
+	default:
+	}
+	close(releaseProjection)
+	if err := <-dispatchDone; err != nil {
+		t.Fatalf("dispatch event: %v", err)
+	}
+	<-replacementDone
+	if len(published) == 0 {
+		t.Fatal("event that won the generation commit axis was not published")
+	}
+	if got := adapter.claudeSDKSessionSnapshot(replacement); got.Status != SessionStatusReady {
+		t.Fatalf("replacement session status=%q, want unchanged ready", got.Status)
+	}
+}
+
+func TestClaudeCodeSDKAdapterReaderFailureCommitsBeforeConcurrentReplacement(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	failureProjectionEntered := make(chan struct{})
+	releaseFailureProjection := make(chan struct{})
+	pending := &pendingInteractiveRequest{
+		agentSessionID: session.AgentSessionID,
+		turnID:         "turn-old",
+		requestID:      "request-old",
+		callID:         "approval:request-old",
+		callType:       "approval",
+		name:           "Bash",
+		onTerminal: func(_ *pendingInteractiveRequest, _ pendingInteractiveRequestState) {
+			close(failureProjectionEntered)
+			<-releaseFailureProjection
+		},
+	}
+	oldSession := &claudeSDKAdapterSession{
+		session: session,
+		pendingRequests: map[string]*pendingInteractiveRequest{
+			claudeSDKPendingRequestKey(pending.turnID, pending.requestID): pending,
+		},
+		pendingResponses: make(map[string]chan claudeSDKSidecarEvent),
+		turns:            make(map[string]*claudeSDKTurnWaiter),
+		liveState:        newClaudeSDKLiveState(),
+	}
+	adapter.storeSession(session.AgentSessionID, oldSession)
+	var published []activityshared.Event
+	adapter.SetSessionEventSink(func(_ string, events []activityshared.Event) {
+		published = append(published, events...)
+	})
+
+	failureDone := make(chan struct{})
+	go func() {
+		adapter.failClaudeSDKReader(session.AgentSessionID, oldSession, errors.New("old reader failed"))
+		close(failureDone)
+	}()
+	<-failureProjectionEntered
+	replacement := &claudeSDKAdapterSession{
+		session:          session,
+		pendingRequests:  make(map[string]*pendingInteractiveRequest),
+		pendingResponses: make(map[string]chan claudeSDKSidecarEvent),
+		turns:            make(map[string]*claudeSDKTurnWaiter),
+		liveState:        newClaudeSDKLiveState(),
+	}
+	replacementDone := make(chan struct{})
+	go func() {
+		adapter.storeSession(session.AgentSessionID, replacement)
+		close(replacementDone)
+	}()
+	select {
+	case <-replacementDone:
+		t.Fatal("replacement crossed an in-flight reader-failure commit")
+	default:
+	}
+	close(releaseFailureProjection)
+	<-failureDone
+	<-replacementDone
+	if len(published) == 0 {
+		t.Fatal("reader failure that won the commit axis published no terminal events")
+	}
+	if got := adapter.getSession(session.AgentSessionID); got != replacement {
+		t.Fatal("replacement did not become current after reader-failure commit")
+	}
+}
+
+func TestClaudeCodeSDKAdapterDropsInteractiveAckAfterReplacement(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	pending := &pendingInteractiveRequest{
+		agentSessionID: session.AgentSessionID,
+		turnID:         "turn-old",
+		requestID:      "request-old",
+		callID:         "approval:request-old",
+		callType:       "approval",
+		name:           "Bash",
+		state:          pendingInteractiveRequestStateResolving,
+	}
+	oldSession := &claudeSDKAdapterSession{
+		session: session,
+		pendingRequests: map[string]*pendingInteractiveRequest{
+			claudeSDKPendingRequestKey(pending.turnID, pending.requestID): pending,
+		},
+		pendingResponses: make(map[string]chan claudeSDKSidecarEvent),
+		turns:            make(map[string]*claudeSDKTurnWaiter),
+		liveState:        newClaudeSDKLiveState(),
+	}
+	adapter.storeSession(session.AgentSessionID, oldSession)
+	replacementSession := session
+	replacementSession.Status = SessionStatusReady
+	replacement := &claudeSDKAdapterSession{
+		session:          replacementSession,
+		pendingRequests:  make(map[string]*pendingInteractiveRequest),
+		pendingResponses: make(map[string]chan claudeSDKSidecarEvent),
+		turns:            make(map[string]*claudeSDKTurnWaiter),
+		liveState:        newClaudeSDKLiveState(),
+	}
+	adapter.storeSession(session.AgentSessionID, replacement)
+	var published []activityshared.Event
+	adapter.SetSessionEventSink(func(_ string, events []activityshared.Event) {
+		published = append(published, events...)
+	})
+
+	adapter.applyClaudeSDKInteractiveAck(
+		oldSession,
+		session,
+		pending,
+		pendingInteractiveResponse{optionID: "allow"},
+		claudeSDKInteractiveAck{disposition: InteractiveDispositionAnswered},
+	)
+	if got := pending.disposition(); got != pendingInteractiveRequestStateResolving {
+		t.Fatalf("old request disposition=%q, want unchanged resolving", got)
+	}
+	if len(published) != 0 {
+		t.Fatalf("old interactive ack published after replacement: %#v", published)
+	}
+	if got := adapter.claudeSDKSessionSnapshot(replacement); got.Status != SessionStatusReady {
+		t.Fatalf("replacement session status=%q, want unchanged ready", got.Status)
+	}
+}
+
+func TestClaudeCodeSDKAdapterExitedConnectionWithPersistentCloseFailureRemainsOwned(t *testing.T) {
+	transport := &replacementClaudeSDKTransport{}
+	adapter := NewClaudeCodeSDKAdapter(transport)
+	session := standardTestSession(ProviderClaudeCode)
+	base := newBlockingClaudeSDKConnection()
+	connection := newDoneClosedCloseFailConnection(base)
+	adapterSession := &claudeSDKAdapterSession{
+		conn: connection, reader: newClaudeSDKLineReader(connection, false), session: session,
+		pendingRequests: make(map[string]*pendingInteractiveRequest), pendingResponses: make(map[string]chan claudeSDKSidecarEvent),
+		turns: make(map[string]*claudeSDKTurnWaiter), liveState: newClaudeSDKLiveState(),
+	}
+	adapter.storeSession(session.AgentSessionID, adapterSession)
+
+	if err := adapter.DisconnectLiveSession(t.Context(), session); err == nil {
+		t.Fatal("DisconnectLiveSession error=nil, want persistent Close failure")
+	}
+	if adapter.HasLiveSession(session) {
+		t.Fatal("close-failed Claude connection reported usable")
+	}
+	if adapter.getSession(session.AgentSessionID) != adapterSession {
+		t.Fatal("Done-closed close-failed Claude handle lost current ownership")
+	}
+	if err := adapter.Resume(t.Context(), session); err != nil {
+		t.Fatalf("Resume after exited close failure: %v", err)
+	}
+	if !adapter.HasLiveSession(session) {
+		t.Fatal("replacement Claude session is not usable")
+	}
+	if adapter.getSession(session.AgentSessionID) == adapterSession {
+		t.Fatal("exited close-failed Claude handle remained current after replacement")
+	}
+	cleanup := adapter.CleanupLiveSessionResources(t.Context(), 1)
+	if cleanup.Attempted != 1 || cleanup.Failed != 1 || cleanup.Cleaned != 0 {
+		t.Fatalf("cleanup=%#v, want one retained failure", cleanup)
+	}
+	connection.mu.Lock()
+	closeCalls := connection.closeCalls
+	connection.mu.Unlock()
+	if closeCalls != 3 {
+		t.Fatalf("Close calls=%d, want disconnect + replacement retirement + bounded cleanup", closeCalls)
 	}
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -151,6 +151,7 @@ type CodexAppServerAdapter struct {
 	commandResolver            ProviderCommandResolver
 	mu                         sync.Mutex
 	sessions                   map[string]*codexAppServerSession
+	retiredSessions            map[string][]*codexAppServerSession
 	terminalInteractions       terminalInteractiveDispositionStore
 	interactiveDispositionSink InteractiveDispositionSink
 	commandSink                CommandSnapshotSink
@@ -207,9 +208,14 @@ type codexAppServerSessionLock struct {
 }
 
 type codexAppServerSession struct {
-	client     *codexAppServerClient
-	threadID   string
-	serverInfo map[string]any
+	client *codexAppServerClient
+	// releaseFailed preserves ownership after a physical Close error while
+	// making the client unavailable to Exec. A successful replacement moves
+	// this handle to retiredSessions until bounded cleanup confirms closure.
+	releasing     bool
+	releaseFailed bool
+	threadID      string
+	serverInfo    map[string]any
 	// resumeRuntimeContext preserves the historical adapter projection only
 	// when replay attaches at an already-initialized connection checkpoint.
 	resumeRuntimeContext map[string]any
@@ -475,6 +481,7 @@ func newAppServerAdapter(
 		config:              config,
 		commandResolver:     commandResolver,
 		sessions:            make(map[string]*codexAppServerSession),
+		retiredSessions:     make(map[string][]*codexAppServerSession),
 		lifecycleLocks:      make(map[string]*codexAppServerSessionLock),
 		cancelGraceWindow:   defaultCodexAppServerCancelGraceWindow,
 		turnStartAckTimeout: defaultCodexAppServerTurnStartAckTimeout,

--- a/packages/agent/daemon/runtime/codex_appserver_lifecycle_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_lifecycle_test.go
@@ -3,9 +3,11 @@ package agentruntime
 import (
 	"context"
 	"errors"
+	"io"
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 )
 
 // --- per-process app-server transport ---
@@ -424,5 +426,142 @@ func TestCodexAppServerClientCloseIsIdempotent(t *testing.T) {
 	conn.mu.Unlock()
 	if closeCount != 1 {
 		t.Fatalf("underlying connection Close calls = %d, want 1 (client Close must be idempotent)", closeCount)
+	}
+}
+
+func TestAppServerCloseFailureRetainsUnusableHandleAndBackpressuresReplacement(t *testing.T) {
+	for _, provider := range []string{ProviderCodex, ProviderTuttiAgent} {
+		provider := provider
+		t.Run(provider, func(t *testing.T) {
+			transport := &multiProcAppServerTransport{}
+			var adapter *CodexAppServerAdapter
+			if provider == ProviderTuttiAgent {
+				adapter = NewTuttiAgentAppServerAdapterWithHostMetadata(transport, LegacyHostMetadata())
+			} else {
+				adapter = NewCodexAppServerAdapter(transport)
+			}
+			session := testAppServerSession()
+			session.Provider = provider
+			session.ProviderSessionID = "codex-thread-1"
+			if _, err := adapter.Start(t.Context(), session); err != nil {
+				t.Fatalf("Start: %v", err)
+			}
+			oldConnection := transport.conn(0)
+			oldConnection.mu.Lock()
+			oldConnection.closeFailures = 4
+			oldConnection.mu.Unlock()
+
+			if err := adapter.ReleaseLiveSession(t.Context(), session); err == nil {
+				t.Fatal("ReleaseLiveSession error=nil, want close failure")
+			}
+			if adapter.HasLiveSession(session) {
+				t.Fatal("close-failed client remained usable")
+			}
+			if err := adapter.Resume(t.Context(), session); err != nil {
+				t.Fatalf("first replacement Resume: %v", err)
+			}
+			if !adapter.HasLiveSession(session) {
+				t.Fatal("replacement client is not usable")
+			}
+			if err := adapter.ReleaseLiveSession(t.Context(), session); err != nil {
+				t.Fatalf("release replacement: %v", err)
+			}
+			spawnedBefore, _ := transport.snapshot()
+			err := adapter.Resume(t.Context(), session)
+			if AppErrorCode(err) != AppErrorProcessCleanupPending {
+				t.Fatalf("second Resume error code=%q err=%v", AppErrorCode(err), err)
+			}
+			spawnedAfter, _ := transport.snapshot()
+			if spawnedAfter != spawnedBefore {
+				t.Fatalf("spawned processes changed behind cleanup backpressure: %d -> %d", spawnedBefore, spawnedAfter)
+			}
+			cleanupAdapter, ok := any(adapter).(LiveSessionResourceCleanupAdapter)
+			if !ok {
+				t.Fatal("app-server adapter does not own detached resource cleanup")
+			}
+			cleanup := cleanupAdapter.CleanupLiveSessionResources(t.Context(), 1)
+			if cleanup.Attempted != 1 || cleanup.Failed != 1 {
+				t.Fatalf("failed cleanup=%#v", cleanup)
+			}
+			oldConnection.mu.Lock()
+			oldConnection.closeFailures = 0
+			oldConnection.mu.Unlock()
+			cleanup = cleanupAdapter.CleanupLiveSessionResources(t.Context(), 1)
+			if cleanup.Attempted != 1 || cleanup.Cleaned != 1 || cleanup.Failed != 0 {
+				t.Fatalf("successful cleanup=%#v", cleanup)
+			}
+		})
+	}
+}
+
+type doneClosedCloseFailConnection struct {
+	ProcessConnection
+	mu         sync.Mutex
+	done       chan struct{}
+	closeCalls int
+}
+
+func newDoneClosedCloseFailConnection(connection ProcessConnection) *doneClosedCloseFailConnection {
+	done := make(chan struct{})
+	close(done)
+	return &doneClosedCloseFailConnection{ProcessConnection: connection, done: done}
+}
+
+func (*doneClosedCloseFailConnection) Recv() (ProcessFrame, error) {
+	return ProcessFrame{}, io.EOF
+}
+
+func (c *doneClosedCloseFailConnection) Close() error {
+	c.mu.Lock()
+	c.closeCalls++
+	c.mu.Unlock()
+	return errors.New("injected persistent close failure after process exit")
+}
+
+func (c *doneClosedCloseFailConnection) Done() <-chan struct{} { return c.done }
+
+func TestAppServerExitedConnectionWithPersistentCloseFailureRemainsOwned(t *testing.T) {
+	base, _ := newScriptedAppServerHarness()
+	connection := newDoneClosedCloseFailConnection(base)
+	client := newCodexAppServerClient(connection)
+	transport := &multiProcAppServerTransport{}
+	adapter := NewCodexAppServerAdapter(transport)
+	session := testAppServerSession()
+	session.ProviderSessionID = "codex-thread-1"
+	appSession := &codexAppServerSession{client: client, pendingRequests: make(map[string]*pendingInteractiveRequest)}
+	adapter.storeSession(session.AgentSessionID, appSession)
+	select {
+	case <-client.Done():
+	case <-time.After(time.Second):
+		t.Fatal("app-server client did not observe the closed process connection")
+	}
+
+	if adapter.HasLiveSession(session) {
+		t.Fatal("Done-closed app-server client reported usable")
+	}
+	if err := adapter.DisconnectLiveSession(t.Context(), session); err == nil {
+		t.Fatal("DisconnectLiveSession error=nil, want persistent Close failure")
+	}
+	if adapter.getSession(session.AgentSessionID) != appSession {
+		t.Fatal("Done-closed close-failed handle lost current ownership")
+	}
+	if err := adapter.Resume(t.Context(), session); err != nil {
+		t.Fatalf("Resume after exited close failure: %v", err)
+	}
+	if !adapter.HasLiveSession(session) {
+		t.Fatal("replacement app-server session is not usable")
+	}
+	if adapter.getSession(session.AgentSessionID) == appSession {
+		t.Fatal("exited close-failed handle remained current after replacement")
+	}
+	cleanup := adapter.CleanupLiveSessionResources(t.Context(), 1)
+	if cleanup.Attempted != 1 || cleanup.Failed != 1 || cleanup.Cleaned != 0 {
+		t.Fatalf("cleanup=%#v, want one retained failure", cleanup)
+	}
+	connection.mu.Lock()
+	closeCalls := connection.closeCalls
+	connection.mu.Unlock()
+	if closeCalls != 3 {
+		t.Fatalf("Close calls=%d, want disconnect + replacement retirement + bounded cleanup", closeCalls)
 	}
 }

--- a/packages/agent/daemon/runtime/codex_appserver_registry.go
+++ b/packages/agent/daemon/runtime/codex_appserver_registry.go
@@ -43,15 +43,17 @@ func (a *CodexAppServerAdapter) storeSession(agentSessionID string, session *cod
 	// Replacing a stored session must never orphan its app-server process:
 	// when the new entry does not carry the existing client forward, that
 	// client (and its OS process) would otherwise leak without an owner.
-	var replacedClient *codexAppServerClient
+	var replaced *codexAppServerSession
 	if existing := a.sessions[key]; existing != nil && existing != session && existing.client != nil &&
 		(session == nil || existing.client != session.client) {
-		replacedClient = existing.client
+		existing.releasing = true
+		existing.client.SetMessageHandler(nil)
+		replaced = existing
 	}
 	a.sessions[key] = session
 	a.mu.Unlock()
-	if replacedClient != nil {
-		_ = replacedClient.Close()
+	if replaced != nil {
+		a.closeOrRetainCodexSession(key, replaced)
 	}
 }
 
@@ -103,7 +105,9 @@ func (a *CodexAppServerAdapter) invalidateSessionClient(
 	for _, request := range pending {
 		request.supersede(errPermissionRequestCanceled)
 	}
-	_ = expectedClient.Close()
+	if err := expectedClient.Close(); err != nil {
+		a.retainRetiredCodexSession(key, appSession)
+	}
 	return true
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_resource_ownership.go
+++ b/packages/agent/daemon/runtime/codex_appserver_resource_ownership.go
@@ -1,0 +1,193 @@
+package agentruntime
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+func codexProcessCleanupPendingError(cause error) error {
+	debugMessage := "an earlier app-server process is still shutting down"
+	if cause != nil {
+		debugMessage = cause.Error()
+	}
+	return &AppError{
+		Code:         AppErrorProcessCleanupPending,
+		Message:      "agent process cleanup is still pending",
+		DebugMessage: debugMessage,
+		Cause:        cause,
+	}
+}
+
+func (a *CodexAppServerAdapter) retainRetiredCodexSession(agentSessionID string, session *codexAppServerSession) {
+	if a == nil || session == nil || session.client == nil {
+		return
+	}
+	agentSessionID = strings.TrimSpace(agentSessionID)
+	session.client.SetMessageHandler(nil)
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.retiredSessions == nil {
+		a.retiredSessions = make(map[string][]*codexAppServerSession)
+	}
+	session.releasing = false
+	session.releaseFailed = true
+	for _, retained := range a.retiredSessions[agentSessionID] {
+		if retained == session || (retained != nil && retained.client == session.client) {
+			return
+		}
+	}
+	a.retiredSessions[agentSessionID] = append(a.retiredSessions[agentSessionID], session)
+}
+
+func (a *CodexAppServerAdapter) closeOrRetainCodexSession(agentSessionID string, session *codexAppServerSession) {
+	if session == nil || session.client == nil {
+		return
+	}
+	session.client.SetMessageHandler(nil)
+	if err := session.client.Close(); err != nil {
+		a.retainRetiredCodexSession(agentSessionID, session)
+	}
+}
+
+func (a *CodexAppServerAdapter) hasRetiredCodexSessions(agentSessionID string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.retiredSessions[strings.TrimSpace(agentSessionID)]) > 0
+}
+
+// One close-failed current handle gets one replacement attempt. Once that
+// replacement succeeds the old handle is retired, and later replacements are
+// backpressured until one bounded cleanup attempt confirms closure.
+func (a *CodexAppServerAdapter) admitCodexReplacementLocked(agentSessionID string) error {
+	if !a.hasRetiredCodexSessions(agentSessionID) {
+		return nil
+	}
+	_, err := a.retryOneCodexSessionLocked(agentSessionID)
+	if err != nil {
+		return codexProcessCleanupPendingError(err)
+	}
+	if a.hasRetiredCodexSessions(agentSessionID) {
+		return codexProcessCleanupPendingError(errors.New("multiple earlier app-server processes still require cleanup"))
+	}
+	return nil
+}
+
+func (a *CodexAppServerAdapter) retryOneCodexSession(agentSessionID string) (bool, error) {
+	if a == nil {
+		return false, nil
+	}
+	agentSessionID = strings.TrimSpace(agentSessionID)
+	a.mu.Lock()
+	if agentSessionID == "" {
+		for candidate, current := range a.sessions {
+			if current != nil && current.client != nil && current.releaseFailed && !current.releasing {
+				agentSessionID = candidate
+				break
+			}
+		}
+		if agentSessionID == "" {
+			for candidate, retired := range a.retiredSessions {
+				if len(retired) > 0 {
+					agentSessionID = candidate
+					break
+				}
+			}
+		}
+	}
+	a.mu.Unlock()
+	if agentSessionID == "" {
+		return false, nil
+	}
+	unlock := a.lockSessionLifecycle(agentSessionID)
+	defer unlock()
+	return a.retryOneCodexSessionLocked(agentSessionID)
+}
+
+func (a *CodexAppServerAdapter) retryOneCodexSessionLocked(agentSessionID string) (bool, error) {
+	a.mu.Lock()
+	current := a.sessions[agentSessionID]
+	if current != nil && current.client != nil && current.releaseFailed && !current.releasing {
+		current.releasing = true
+		current.client.SetMessageHandler(nil)
+		a.mu.Unlock()
+		if err := current.client.Close(); err != nil {
+			a.mu.Lock()
+			if a.sessions[agentSessionID] == current {
+				current.releasing = false
+			}
+			a.mu.Unlock()
+			return true, err
+		}
+		a.mu.Lock()
+		if a.sessions[agentSessionID] == current {
+			delete(a.sessions, agentSessionID)
+		}
+		a.mu.Unlock()
+		return true, nil
+	}
+	retired := a.retiredSessions[agentSessionID]
+	var target *codexAppServerSession
+	for _, candidate := range retired {
+		if candidate != nil && !candidate.releasing {
+			target = candidate
+			break
+		}
+	}
+	if target == nil {
+		a.mu.Unlock()
+		return false, nil
+	}
+	target.releasing = true
+	target.client.SetMessageHandler(nil)
+	a.mu.Unlock()
+	if err := target.client.Close(); err != nil {
+		a.mu.Lock()
+		target.releasing = false
+		a.mu.Unlock()
+		return true, err
+	}
+	a.removeRetiredCodexSession(agentSessionID, target)
+	return true, nil
+}
+
+func (a *CodexAppServerAdapter) removeRetiredCodexSession(agentSessionID string, target *codexAppServerSession) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	retired := a.retiredSessions[agentSessionID]
+	for index, session := range retired {
+		if session != target {
+			continue
+		}
+		retired = append(retired[:index], retired[index+1:]...)
+		if len(retired) == 0 {
+			delete(a.retiredSessions, agentSessionID)
+		} else {
+			a.retiredSessions[agentSessionID] = retired
+		}
+		return
+	}
+}
+
+func (a *CodexAppServerAdapter) CleanupLiveSessionResources(ctx context.Context, limit int) LiveSessionResourceCleanupResult {
+	var result LiveSessionResourceCleanupResult
+	if limit <= 0 {
+		return result
+	}
+	select {
+	case <-ctx.Done():
+		return result
+	default:
+	}
+	attempted, err := a.retryOneCodexSession("")
+	if !attempted {
+		return result
+	}
+	result.Attempted = 1
+	if err != nil {
+		result.Failed = 1
+	} else {
+		result.Cleaned = 1
+	}
+	return result
+}

--- a/packages/agent/daemon/runtime/codex_appserver_session.go
+++ b/packages/agent/daemon/runtime/codex_appserver_session.go
@@ -15,6 +15,9 @@ import (
 func (a *CodexAppServerAdapter) Start(ctx context.Context, session Session) (events []activityshared.Event, err error) {
 	unlockLifecycle := a.lockSessionLifecycle(session.AgentSessionID)
 	defer unlockLifecycle()
+	if err := a.admitCodexReplacementLocked(session.AgentSessionID); err != nil {
+		return nil, err
+	}
 	trace := newCodexAppServerStartupTrace(session)
 	defer func() {
 		trace.Finish(err)
@@ -40,9 +43,13 @@ func (a *CodexAppServerAdapter) Start(ctx context.Context, session Session) (eve
 	}
 	started := false
 	keepSession := false
+	startedSession := &codexAppServerSession{
+		client:          client,
+		pendingRequests: make(map[string]*pendingInteractiveRequest),
+	}
 	defer func() {
 		if !started {
-			_ = client.Close()
+			a.closeOrRetainCodexSession(session.AgentSessionID, startedSession)
 		}
 		if !keepSession {
 			a.removeSession(session.AgentSessionID)
@@ -183,6 +190,9 @@ func (a *CodexAppServerAdapter) Resume(ctx context.Context, session Session) (er
 	}
 	unlockLifecycle := a.lockSessionLifecycle(session.AgentSessionID)
 	defer unlockLifecycle()
+	if err := a.admitCodexReplacementLocked(session.AgentSessionID); err != nil {
+		return err
+	}
 	// Resume may run over a session that still holds a live client. Unlike
 	// Start, the old client is kept alive until the replacement has resumed
 	// successfully (storeSession closes it on replace): if the new spawn or
@@ -209,9 +219,13 @@ func (a *CodexAppServerAdapter) Resume(ctx context.Context, session Session) (er
 	started := false
 	keepSession := false
 	previousSession := a.getSession(session.AgentSessionID)
+	startedSession := &codexAppServerSession{
+		client:          client,
+		pendingRequests: make(map[string]*pendingInteractiveRequest),
+	}
 	defer func() {
 		if !started {
-			_ = client.Close()
+			a.closeOrRetainCodexSession(session.AgentSessionID, startedSession)
 		}
 		if !keepSession {
 			if previousSession != nil {
@@ -374,12 +388,16 @@ func (*CodexAppServerAdapter) CanResume(session Session) bool {
 }
 
 func (a *CodexAppServerAdapter) HasLiveSession(session Session) bool {
-	appSession := a.getSession(session.AgentSessionID)
-	if appSession == nil || appSession.client == nil {
+	a.mu.Lock()
+	appSession := a.sessions[strings.TrimSpace(session.AgentSessionID)]
+	if appSession == nil || appSession.client == nil || appSession.releasing || appSession.releaseFailed {
+		a.mu.Unlock()
 		return false
 	}
+	client := appSession.client
+	a.mu.Unlock()
 	select {
-	case <-appSession.client.Done():
+	case <-client.Done():
 		return false
 	default:
 		return true
@@ -427,9 +445,19 @@ func (a *CodexAppServerAdapter) DisconnectLiveSession(_ context.Context, session
 func (a *CodexAppServerAdapter) closeLiveSession(agentSessionID string) error {
 	a.mu.Lock()
 	appSession := a.sessions[agentSessionID]
+	if appSession != nil && appSession.client != nil {
+		appSession.releasing = true
+		appSession.client.SetMessageHandler(nil)
+	}
 	a.mu.Unlock()
 	if appSession != nil && appSession.client != nil {
 		if err := appSession.client.Close(); err != nil {
+			a.mu.Lock()
+			if a.sessions[agentSessionID] == appSession {
+				appSession.releasing = false
+				appSession.releaseFailed = true
+			}
+			a.mu.Unlock()
 			return err
 		}
 		a.mu.Lock()
@@ -594,7 +622,10 @@ func (a *CodexAppServerAdapter) startClientPrepared(
 	started := false
 	defer func() {
 		if !started {
-			_ = client.Close()
+			a.closeOrRetainCodexSession(session.AgentSessionID, &codexAppServerSession{
+				client:          client,
+				pendingRequests: make(map[string]*pendingInteractiveRequest),
+			})
 		}
 	}()
 	captureOrigin := processCassetteCaptureOrigin(conn)

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -140,6 +140,13 @@ resumes a provider or replays a prompt. Provider adapters terminalize active
 work and pending interactions before dropping the transport, and transport-only
 disconnect must not invoke a destructive provider `session/close`. A later
 user command follows the ordinary just-in-time Resume path.
+Host consumers that perform a provisional runtime mutation use
+`WithWorkspaceRuntimeOperation`; its callback receives the reentrant admitted
+context and must own startup through cleanup. Attachment observers first call
+`AcquireWorkspaceRuntimeDisconnectFence`, which closes admission immediately,
+then retry `Wait` until already-admitted mutations drain. Canceling one Wait
+does not reopen admission; every joined owner must call `Release`, and one
+owner cannot reopen the Workspace while another disconnect remains active.
 `CreateSessionInput.RailPlacement` optionally carries the caller-selected,
 versioned canonical rail identity. Host validates it before provider startup
 and persists its opaque `SectionKey` exactly on first creation. An idempotent

--- a/packages/agent/host/conformance/conformance.go
+++ b/packages/agent/host/conformance/conformance.go
@@ -216,6 +216,37 @@ type WorkspaceRuntimeDisconnectScenario struct {
 	run  func(context.Context, WorkspaceRuntimeDisconnectDriver) error
 }
 
+// WorkspaceRuntimeAdmissionDriver exposes only the Host-owned coordination
+// seam needed to verify admission and durable disconnect fencing.
+type WorkspaceRuntimeAdmissionDriver interface {
+	WithWorkspaceRuntimeOperation(context.Context, string, func(context.Context) error) error
+	AcquireWorkspaceRuntimeDisconnectFence(context.Context, string) (WorkspaceRuntimeDisconnectFenceDriver, error)
+}
+
+type WorkspaceRuntimeDisconnectFenceDriver interface {
+	Wait(context.Context) (context.Context, error)
+	Release()
+}
+
+type WorkspaceRuntimeAdmissionScenario struct {
+	Name string
+	run  func(context.Context, WorkspaceRuntimeAdmissionDriver) error
+}
+
+func RunWorkspaceRuntimeAdmission(
+	ctx context.Context,
+	driver WorkspaceRuntimeAdmissionDriver,
+	scenario WorkspaceRuntimeAdmissionScenario,
+) error {
+	if driver == nil {
+		return fmt.Errorf("workspace runtime admission conformance driver is required")
+	}
+	if scenario.run == nil {
+		return fmt.Errorf("workspace runtime admission scenario %q has no runner", scenario.Name)
+	}
+	return scenario.run(ctx, driver)
+}
+
 func RunWorkspaceRuntimeDisconnect(
 	ctx context.Context,
 	driver WorkspaceRuntimeDisconnectDriver,

--- a/packages/agent/host/conformance/conformance_test.go
+++ b/packages/agent/host/conformance/conformance_test.go
@@ -52,6 +52,20 @@ func TestPublishedWorkspaceRuntimeDisconnectScenarioCatalogHasUniqueNames(t *tes
 	}
 }
 
+func TestPublishedWorkspaceRuntimeAdmissionScenarioCatalogHasUniqueNames(t *testing.T) {
+	scenarios := WorkspaceRuntimeAdmissionScenarios()
+	seen := make(map[string]struct{}, len(scenarios))
+	for _, scenario := range scenarios {
+		if scenario.Name == "" {
+			t.Fatal("workspace runtime admission scenario has empty name")
+		}
+		if _, duplicate := seen[scenario.Name]; duplicate {
+			t.Fatalf("duplicate workspace runtime admission scenario name %q", scenario.Name)
+		}
+		seen[scenario.Name] = struct{}{}
+	}
+}
+
 func TestPublishedInteractionTreeScenarioCatalogHasUniqueNames(t *testing.T) {
 	t.Parallel()
 	scenarios := InteractionTreeScenarios()

--- a/packages/agent/host/conformance/workspace_runtime_admission_scenarios.go
+++ b/packages/agent/host/conformance/workspace_runtime_admission_scenarios.go
@@ -1,0 +1,175 @@
+package conformance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+func WorkspaceRuntimeAdmissionScenarios() []WorkspaceRuntimeAdmissionScenario {
+	return []WorkspaceRuntimeAdmissionScenario{
+		{Name: "disconnect fence survives canceled drain wait", run: runDisconnectFenceSurvivesCanceledDrainWait},
+		{Name: "joined disconnect owners release independently", run: runJoinedDisconnectOwnersReleaseIndependently},
+		{Name: "admitted callback context is reentrant", run: runAdmittedCallbackContextIsReentrant},
+		{Name: "admitted callback releases after panic", run: runAdmittedCallbackReleasesAfterPanic},
+		{Name: "canceled callback does not enter", run: runCanceledCallbackDoesNotEnter},
+		{Name: "release before wait is idempotent", run: runReleaseBeforeWaitIsIdempotent},
+	}
+}
+
+func runDisconnectFenceSurvivesCanceledDrainWait(ctx context.Context, driver WorkspaceRuntimeAdmissionDriver) error {
+	operationEntered := make(chan struct{})
+	releaseOperation := make(chan struct{})
+	operationDone := make(chan error, 1)
+	go func() {
+		operationDone <- driver.WithWorkspaceRuntimeOperation(ctx, "workspace-1", func(context.Context) error {
+			close(operationEntered)
+			<-releaseOperation
+			return nil
+		})
+	}()
+	<-operationEntered
+
+	fence, err := driver.AcquireWorkspaceRuntimeDisconnectFence(ctx, "workspace-1")
+	if err != nil {
+		return fmt.Errorf("acquire disconnect fence: %w", err)
+	}
+	defer fence.Release()
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+	if _, err := fence.Wait(canceled); !errors.Is(err, context.Canceled) {
+		return fmt.Errorf("canceled drain wait error=%v, want context canceled", err)
+	}
+
+	blockedEntered := make(chan struct{})
+	blockedDone := make(chan error, 1)
+	go func() {
+		blockedDone <- driver.WithWorkspaceRuntimeOperation(ctx, "workspace-1", func(context.Context) error {
+			close(blockedEntered)
+			return nil
+		})
+	}()
+	select {
+	case <-blockedEntered:
+		return errors.New("runtime operation entered after canceled fence wait")
+	default:
+	}
+	close(releaseOperation)
+	if err := <-operationDone; err != nil {
+		return fmt.Errorf("release admitted operation: %w", err)
+	}
+	if _, err := fence.Wait(ctx); err != nil {
+		return fmt.Errorf("retry drain wait: %w", err)
+	}
+	select {
+	case <-blockedEntered:
+		return errors.New("runtime operation entered while drained fence remained held")
+	default:
+	}
+	fence.Release()
+	if err := <-blockedDone; err != nil {
+		return fmt.Errorf("blocked operation after release: %w", err)
+	}
+	return nil
+}
+
+func runJoinedDisconnectOwnersReleaseIndependently(ctx context.Context, driver WorkspaceRuntimeAdmissionDriver) error {
+	first, err := driver.AcquireWorkspaceRuntimeDisconnectFence(ctx, "workspace-1")
+	if err != nil {
+		return err
+	}
+	defer first.Release()
+	second, err := driver.AcquireWorkspaceRuntimeDisconnectFence(ctx, "workspace-1")
+	if err != nil {
+		return err
+	}
+	defer second.Release()
+	if _, err := first.Wait(ctx); err != nil {
+		return err
+	}
+	first.Release()
+
+	entered := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- driver.WithWorkspaceRuntimeOperation(ctx, "workspace-1", func(context.Context) error {
+			close(entered)
+			return nil
+		})
+	}()
+	select {
+	case <-entered:
+		return errors.New("one joined owner reopened admission")
+	default:
+	}
+	if _, err := second.Wait(ctx); err != nil {
+		return err
+	}
+	second.Release()
+	return <-done
+}
+
+func runAdmittedCallbackContextIsReentrant(ctx context.Context, driver WorkspaceRuntimeAdmissionDriver) error {
+	return driver.WithWorkspaceRuntimeOperation(ctx, "workspace-1", func(admittedCtx context.Context) error {
+		return driver.WithWorkspaceRuntimeOperation(admittedCtx, "workspace-1", func(context.Context) error {
+			return nil
+		})
+	})
+}
+
+func runAdmittedCallbackReleasesAfterPanic(ctx context.Context, driver WorkspaceRuntimeAdmissionDriver) (err error) {
+	func() {
+		defer func() {
+			if recovered := recover(); recovered == nil {
+				err = errors.New("admitted callback panic was swallowed")
+			}
+		}()
+		_ = driver.WithWorkspaceRuntimeOperation(ctx, "workspace-1", func(context.Context) error {
+			panic("expected admission cleanup panic")
+		})
+	}()
+	if err != nil {
+		return err
+	}
+	fence, err := driver.AcquireWorkspaceRuntimeDisconnectFence(ctx, "workspace-1")
+	if err != nil {
+		return err
+	}
+	defer fence.Release()
+	if _, err := fence.Wait(ctx); err != nil {
+		return fmt.Errorf("panic leaked admitted operation: %w", err)
+	}
+	return nil
+}
+
+func runCanceledCallbackDoesNotEnter(ctx context.Context, driver WorkspaceRuntimeAdmissionDriver) error {
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+	entered := false
+	err := driver.WithWorkspaceRuntimeOperation(canceled, "workspace-1", func(context.Context) error {
+		entered = true
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		return fmt.Errorf("canceled callback error=%v, want context canceled", err)
+	}
+	if entered {
+		return errors.New("canceled callback entered runtime mutation")
+	}
+	return nil
+}
+
+func runReleaseBeforeWaitIsIdempotent(ctx context.Context, driver WorkspaceRuntimeAdmissionDriver) error {
+	fence, err := driver.AcquireWorkspaceRuntimeDisconnectFence(ctx, "workspace-1")
+	if err != nil {
+		return err
+	}
+	fence.Release()
+	fence.Release()
+	if _, err := fence.Wait(ctx); err == nil {
+		return errors.New("released fence granted an exclusive context")
+	}
+	return driver.WithWorkspaceRuntimeOperation(ctx, "workspace-1", func(context.Context) error {
+		return nil
+	})
+}

--- a/packages/agent/host/lifecycle_workspace_disconnect_test.go
+++ b/packages/agent/host/lifecycle_workspace_disconnect_test.go
@@ -129,6 +129,31 @@ func TestWorkspaceRuntimeDisconnectFencesResumeBeforeSessionActor(t *testing.T) 
 	}
 }
 
+func TestDurableWorkspaceRuntimeDisconnectFenceRunsSweepWithExclusiveContext(t *testing.T) {
+	t.Parallel()
+	runtime := &workspaceDisconnectRuntime{
+		sessions:     []ProviderRuntimeSession{{ID: "session-1", WorkspaceID: "workspace-1"}},
+		disconnected: make(map[string]bool),
+	}
+	host := New(Config{Runtime: runtime})
+	fence, err := host.AcquireWorkspaceRuntimeDisconnectFence(t.Context(), "workspace-1")
+	if err != nil {
+		t.Fatalf("AcquireWorkspaceRuntimeDisconnectFence: %v", err)
+	}
+	defer fence.Release()
+	disconnectCtx, err := fence.Wait(t.Context())
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	result, err := host.DisconnectWorkspaceRuntime(disconnectCtx, "workspace-1")
+	if err != nil {
+		t.Fatalf("DisconnectWorkspaceRuntime: %v", err)
+	}
+	if result.Scanned != 1 || result.Disconnected != 1 || !runtime.disconnected["session-1"] {
+		t.Fatalf("disconnect result/state = %#v/%v", result, runtime.disconnected)
+	}
+}
+
 func TestReentrantAttachmentCleanupDoesNotDisconnectNewConnectionAfterOperationLeaves(t *testing.T) {
 	t.Parallel()
 	runtime := &workspaceDisconnectRuntime{
@@ -158,6 +183,44 @@ func TestReentrantAttachmentCleanupDoesNotDisconnectNewConnectionAfterOperationL
 	}
 	if len(runtime.targetCalls) != 1 || len(runtime.calls) != 0 || runtime.disconnected["session-1"] {
 		t.Fatalf("deferred target/broad calls/state = %v/%v/%v", runtime.targetCalls, runtime.calls, runtime.disconnected)
+	}
+}
+
+func TestReentrantDeferredDisconnectPanicDoesNotStrandWorkspaceAdmission(t *testing.T) {
+	t.Parallel()
+	host := New(Config{Runtime: &workspaceDisconnectRuntime{
+		sessions:     []ProviderRuntimeSession{{ID: "session-1", WorkspaceID: "workspace-1"}},
+		disconnected: make(map[string]bool),
+	}})
+	secondRan := false
+	func() {
+		defer func() {
+			if recovered := recover(); recovered == nil {
+				t.Fatal("deferred disconnect panic was swallowed")
+			}
+		}()
+		_ = host.withWorkspaceRuntimeOperation(t.Context(), "workspace-1", func(_ context.Context) error {
+			host.workspaceRuntimeAdmission.deferDisconnect("workspace-1", func(context.Context) {
+				panic("injected deferred disconnect panic")
+			})
+			host.workspaceRuntimeAdmission.deferDisconnect("workspace-1", func(context.Context) {
+				secondRan = true
+			})
+			return nil
+		})
+	}()
+	if secondRan {
+		t.Fatal("deferred callback after panic ran without its predecessor completing")
+	}
+	entered := false
+	if err := host.withWorkspaceRuntimeOperation(t.Context(), "workspace-1", func(context.Context) error {
+		entered = true
+		return nil
+	}); err != nil {
+		t.Fatalf("runtime operation after recovered panic: %v", err)
+	}
+	if !entered {
+		t.Fatal("runtime operation did not enter after recovered panic")
 	}
 }
 

--- a/packages/agent/host/runtime_operations.go
+++ b/packages/agent/host/runtime_operations.go
@@ -141,6 +141,22 @@ func (h *Host) prepareCancelRuntimeOperation(
 }
 
 func (h *Host) processRuntimeOperation(ctx context.Context, operation storesqlite.RuntimeOperation, recovering bool) (storesqlite.RuntimeOperation, error) {
+	if operation.Kind == storesqlite.RuntimeOperationKindPlanDecision {
+		var result storesqlite.RuntimeOperation
+		var processErr error
+		err := h.withWorkspaceRuntimeOperation(ctx, operation.WorkspaceID, func(operationCtx context.Context) error {
+			result, processErr = h.processRuntimeOperationAdmitted(operationCtx, operation, recovering)
+			return processErr
+		})
+		if err != nil {
+			return result, err
+		}
+		return result, processErr
+	}
+	return h.processRuntimeOperationAdmitted(ctx, operation, recovering)
+}
+
+func (h *Host) processRuntimeOperationAdmitted(ctx context.Context, operation storesqlite.RuntimeOperation, recovering bool) (storesqlite.RuntimeOperation, error) {
 	if operation.Status == storesqlite.RuntimeOperationStatusCompleted {
 		return operation, nil
 	}

--- a/packages/agent/host/workspace_runtime_gate.go
+++ b/packages/agent/host/workspace_runtime_gate.go
@@ -8,6 +8,7 @@ import (
 )
 
 var errWorkspaceRuntimeDisconnectReentrant = errors.New("workspace runtime disconnect requested by an admitted operation")
+var errWorkspaceRuntimeDisconnectFenceReleased = errors.New("workspace runtime disconnect fence is released")
 
 type workspaceRuntimeAdmission struct {
 	mu     sync.Mutex
@@ -18,8 +19,24 @@ type workspaceRuntimeAdmissionState struct {
 	changed       chan struct{}
 	operations    int
 	disconnecting bool
+	disconnectors int
+	exclusive     bool
 	refs          int
 	deferred      []func(context.Context)
+}
+
+// WorkspaceRuntimeDisconnectFence closes Workspace runtime admission as soon
+// as it is acquired. Wait may be retried with a new context without reopening
+// admission; Release is idempotent and reopens admission only after every
+// joined owner has released its fence.
+type WorkspaceRuntimeDisconnectFence struct {
+	gate        *workspaceRuntimeAdmission
+	workspaceID string
+	state       *workspaceRuntimeAdmissionState
+
+	mu        sync.Mutex
+	released  bool
+	exclusive bool
 }
 
 type workspaceRuntimeAdmissionContext struct {
@@ -42,6 +59,9 @@ func (g *workspaceRuntimeAdmission) enterOperation(
 	workspaceID = strings.TrimSpace(workspaceID)
 	if g == nil || workspaceID == "" {
 		return ctx, func() {}, ErrInvalidArgument
+	}
+	if err := ctx.Err(); err != nil {
+		return ctx, func() {}, err
 	}
 	if admission, ok := ctx.Value(workspaceRuntimeAdmissionContextKey{}).(workspaceRuntimeAdmissionContext); ok &&
 		admission.gate == g && admission.workspaceID == workspaceID {
@@ -88,55 +108,119 @@ func (g *workspaceRuntimeAdmission) beginDisconnect(
 		}
 		return ctx, func() {}, errWorkspaceRuntimeDisconnectReentrant
 	}
+	fence, err := g.acquireDisconnectFence(ctx, workspaceID)
+	if err != nil {
+		return ctx, func() {}, err
+	}
+	disconnectCtx, err := fence.Wait(ctx)
+	if err != nil {
+		fence.Release()
+		return ctx, func() {}, err
+	}
+	return disconnectCtx, fence.Release, nil
+}
+
+func (g *workspaceRuntimeAdmission) acquireDisconnectFence(
+	ctx context.Context,
+	workspaceID string,
+) (*WorkspaceRuntimeDisconnectFence, error) {
+	workspaceID = strings.TrimSpace(workspaceID)
+	if g == nil || workspaceID == "" {
+		return nil, ErrInvalidArgument
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if admission, ok := ctx.Value(workspaceRuntimeAdmissionContextKey{}).(workspaceRuntimeAdmissionContext); ok &&
+		admission.gate == g && admission.workspaceID == workspaceID {
+		return nil, errWorkspaceRuntimeDisconnectReentrant
+	}
+	g.mu.Lock()
+	state := g.stateLocked(workspaceID)
+	state.disconnectors++
+	if !state.disconnecting {
+		state.disconnecting = true
+		g.notifyLocked(state)
+	}
+	g.mu.Unlock()
+	return &WorkspaceRuntimeDisconnectFence{gate: g, workspaceID: workspaceID, state: state}, nil
+}
+
+// Wait drains already-admitted operations and grants one exclusive disconnect
+// scope. A canceled wait leaves the fence and admission closure intact so the
+// owner can retry without admitting a runtime mutation in between.
+func (f *WorkspaceRuntimeDisconnectFence) Wait(ctx context.Context) (context.Context, error) {
+	if f == nil || f.gate == nil || f.state == nil {
+		return ctx, ErrInvalidArgument
+	}
+	if err := ctx.Err(); err != nil {
+		return ctx, err
+	}
+	f.mu.Lock()
+	if f.released {
+		f.mu.Unlock()
+		return ctx, errWorkspaceRuntimeDisconnectFenceReleased
+	}
+	if f.exclusive {
+		f.mu.Unlock()
+		return context.WithValue(ctx, workspaceRuntimeAdmissionContextKey{}, workspaceRuntimeAdmissionContext{
+			gate: f.gate, workspaceID: f.workspaceID, exclusive: true,
+		}), nil
+	}
+	f.mu.Unlock()
 	for {
-		g.mu.Lock()
-		state := g.stateLocked(workspaceID)
-		if !state.disconnecting {
-			state.disconnecting = true
-			g.notifyLocked(state)
-			g.mu.Unlock()
-			if err := g.waitForOperations(ctx, workspaceID, state); err != nil {
-				g.endDisconnect(workspaceID, state)
-				return ctx, func() {}, err
+		f.gate.mu.Lock()
+		if f.state.operations == 0 && !f.state.exclusive {
+			f.mu.Lock()
+			if f.released {
+				f.mu.Unlock()
+				f.gate.mu.Unlock()
+				return ctx, errWorkspaceRuntimeDisconnectFenceReleased
 			}
-			disconnectCtx := context.WithValue(ctx, workspaceRuntimeAdmissionContextKey{}, workspaceRuntimeAdmissionContext{
-				gate: g, workspaceID: workspaceID, exclusive: true,
-			})
-			var once sync.Once
-			return disconnectCtx, func() {
-				once.Do(func() { g.endDisconnect(workspaceID, state) })
-			}, nil
+			f.state.exclusive = true
+			f.exclusive = true
+			f.mu.Unlock()
+			f.gate.mu.Unlock()
+			return context.WithValue(ctx, workspaceRuntimeAdmissionContextKey{}, workspaceRuntimeAdmissionContext{
+				gate: f.gate, workspaceID: f.workspaceID, exclusive: true,
+			}), nil
 		}
-		changed := state.changed
-		g.mu.Unlock()
+		changed := f.state.changed
+		f.gate.mu.Unlock()
 		select {
 		case <-ctx.Done():
-			g.releaseReference(workspaceID, state)
-			return ctx, func() {}, ctx.Err()
+			return ctx, ctx.Err()
 		case <-changed:
-			g.releaseReference(workspaceID, state)
 		}
 	}
 }
 
-func (g *workspaceRuntimeAdmission) waitForOperations(ctx context.Context, workspaceID string, state *workspaceRuntimeAdmissionState) error {
-	for {
-		g.mu.Lock()
-		if state.operations == 0 {
-			g.mu.Unlock()
-			return nil
-		}
-		changed := state.changed
-		state.refs++
-		g.mu.Unlock()
-		select {
-		case <-ctx.Done():
-			g.releaseReference(workspaceID, state)
-			return ctx.Err()
-		case <-changed:
-			g.releaseReference(workspaceID, state)
-		}
+// Release relinquishes this caller's fence ownership. Admission remains closed
+// while another joined owner exists.
+func (f *WorkspaceRuntimeDisconnectFence) Release() {
+	if f == nil || f.gate == nil || f.state == nil {
+		return
 	}
+	f.gate.mu.Lock()
+	f.mu.Lock()
+	if f.released {
+		f.mu.Unlock()
+		f.gate.mu.Unlock()
+		return
+	}
+	f.released = true
+	if f.exclusive {
+		f.state.exclusive = false
+		f.exclusive = false
+	}
+	f.state.disconnectors--
+	if f.state.disconnectors == 0 && len(f.state.deferred) == 0 {
+		f.state.disconnecting = false
+	}
+	f.gate.notifyLocked(f.state)
+	f.gate.releaseReferenceLocked(f.workspaceID, f.state)
+	f.mu.Unlock()
+	f.gate.mu.Unlock()
 }
 
 func (g *workspaceRuntimeAdmission) stateLocked(workspaceID string) *workspaceRuntimeAdmissionState {
@@ -157,6 +241,7 @@ func (g *workspaceRuntimeAdmission) leaveOperation(workspaceID string, state *wo
 	if state.operations == 0 && len(state.deferred) > 0 {
 		deferred = append(deferred, state.deferred...)
 		state.deferred = nil
+		state.exclusive = true
 	}
 	if len(deferred) == 0 {
 		g.releaseReferenceLocked(workspaceID, state)
@@ -168,10 +253,13 @@ func (g *workspaceRuntimeAdmission) leaveOperation(workspaceID string, state *wo
 	disconnectCtx := context.WithValue(context.Background(), workspaceRuntimeAdmissionContextKey{}, workspaceRuntimeAdmissionContext{
 		gate: g, workspaceID: workspaceID, exclusive: true,
 	})
+	// The deferred sweep is best-effort and ordered. If a callback panics,
+	// propagate the panic but always reopen admission; callbacks after the
+	// panicking callback are not run because their ordering may depend on it.
+	defer g.finishDeferredDisconnect(workspaceID, state)
 	for _, disconnect := range deferred {
 		disconnect(disconnectCtx)
 	}
-	g.endDisconnect(workspaceID, state)
 }
 
 func (g *workspaceRuntimeAdmission) deferDisconnect(
@@ -190,9 +278,12 @@ func (g *workspaceRuntimeAdmission) deferDisconnect(
 	g.mu.Unlock()
 }
 
-func (g *workspaceRuntimeAdmission) endDisconnect(workspaceID string, state *workspaceRuntimeAdmissionState) {
+func (g *workspaceRuntimeAdmission) finishDeferredDisconnect(workspaceID string, state *workspaceRuntimeAdmissionState) {
 	g.mu.Lock()
-	state.disconnecting = false
+	state.exclusive = false
+	if state.disconnectors == 0 {
+		state.disconnecting = false
+	}
 	g.notifyLocked(state)
 	g.releaseReferenceLocked(workspaceID, state)
 	g.mu.Unlock()
@@ -230,6 +321,31 @@ func (h *Host) withWorkspaceRuntimeOperation(
 	}
 	defer release()
 	return fn(operationCtx)
+}
+
+// WithWorkspaceRuntimeOperation runs one caller-owned runtime mutation under
+// Host's Workspace admission. The admitted context is reentrant for Host
+// lifecycle calls in the callback and must cover the complete mutation,
+// including its cleanup.
+func (h *Host) WithWorkspaceRuntimeOperation(
+	ctx context.Context,
+	workspaceID string,
+	fn func(context.Context) error,
+) error {
+	return h.withWorkspaceRuntimeOperation(ctx, workspaceID, fn)
+}
+
+// AcquireWorkspaceRuntimeDisconnectFence synchronously prevents new runtime
+// mutations in one Workspace. Its Wait may be retried after cancellation; the
+// caller must always Release the returned fence.
+func (h *Host) AcquireWorkspaceRuntimeDisconnectFence(
+	ctx context.Context,
+	workspaceID string,
+) (*WorkspaceRuntimeDisconnectFence, error) {
+	if h == nil || h.workspaceRuntimeAdmission == nil {
+		return nil, ErrInvalidArgument
+	}
+	return h.workspaceRuntimeAdmission.acquireDisconnectFence(ctx, workspaceID)
 }
 
 // BeginWorkspaceRuntimeDisconnect prevents new runtime mutations in one

--- a/services/tuttid/service/agent/host_conformance_test.go
+++ b/services/tuttid/service/agent/host_conformance_test.go
@@ -66,6 +66,23 @@ func TestHostWorkspaceRuntimeDisconnectConformance(t *testing.T) {
 	}
 }
 
+func TestHostWorkspaceRuntimeAdmissionConformance(t *testing.T) {
+	for _, scenario := range hostconformance.WorkspaceRuntimeAdmissionScenarios() {
+		scenario := scenario
+		t.Run(scenario.Name, func(t *testing.T) {
+			driver := &legacyHostConformanceDriver{t: t, directHost: true}
+			if err := driver.Reset(context.Background(), hostconformance.Fixture{}); err != nil {
+				t.Fatal(err)
+			}
+			if err := hostconformance.RunWorkspaceRuntimeAdmission(
+				context.Background(), driver, scenario,
+			); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 func TestHostHistoricalStateConformance(t *testing.T) {
 	for _, scenario := range hostconformance.HistoricalStateScenarios() {
 		scenario := scenario
@@ -725,6 +742,21 @@ func (d *legacyHostConformanceDriver) DisconnectWorkspaceRuntime(
 	workspaceID string,
 ) (agenthost.DisconnectWorkspaceRuntimeResult, error) {
 	return d.service.ApplicationHost().DisconnectWorkspaceRuntime(ctx, workspaceID)
+}
+
+func (d *legacyHostConformanceDriver) WithWorkspaceRuntimeOperation(
+	ctx context.Context,
+	workspaceID string,
+	fn func(context.Context) error,
+) error {
+	return d.service.ApplicationHost().WithWorkspaceRuntimeOperation(ctx, workspaceID, fn)
+}
+
+func (d *legacyHostConformanceDriver) AcquireWorkspaceRuntimeDisconnectFence(
+	ctx context.Context,
+	workspaceID string,
+) (hostconformance.WorkspaceRuntimeDisconnectFenceDriver, error) {
+	return d.service.ApplicationHost().AcquireWorkspaceRuntimeDisconnectFence(ctx, workspaceID)
 }
 
 func (d *legacyHostConformanceDriver) Create(

--- a/services/tuttid/service/agent/runtime_operation_plan_decision_test.go
+++ b/services/tuttid/service/agent/runtime_operation_plan_decision_test.go
@@ -196,6 +196,71 @@ func TestPlanDecisionRecoveryResumesDurableSessionBeforeSettings(t *testing.T) {
 	}
 }
 
+func TestPlanDecisionRuntimeMutationWaitsForWorkspaceDisconnectAdmission(t *testing.T) {
+	t.Parallel()
+
+	t.Run("submit", func(t *testing.T) {
+		now := time.UnixMilli(1_000)
+		service, runtime, _ := planDecisionTestService(now)
+		_, releaseFence, err := service.ApplicationHost().BeginWorkspaceRuntimeDisconnect(t.Context(), "ws-1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		canceled, cancel := context.WithCancel(t.Context())
+		cancel()
+		_, err = service.SubmitPlanDecision(canceled, "ws-1", "session-1", "plan-turn", "plan-turn", SubmitPlanDecisionInput{
+			PromptKind: "plan-implementation", Action: "implement", IdempotencyKey: "decision-1",
+		})
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("SubmitPlanDecision error=%v, want context canceled", err)
+		}
+		if len(runtime.resumeCalls) != 0 || len(runtime.updateSettingsCalls) != 0 || len(runtime.execCalls) != 0 {
+			t.Fatalf("runtime mutated behind disconnect fence: resume=%d settings=%d exec=%d", len(runtime.resumeCalls), len(runtime.updateSettingsCalls), len(runtime.execCalls))
+		}
+		releaseFence()
+		if err := service.ApplicationHost().StepRuntimeOperationWorker(t.Context(), false); err != nil {
+			t.Fatal(err)
+		}
+		if len(runtime.updateSettingsCalls) != 1 || len(runtime.execCalls) != 1 {
+			t.Fatalf("runtime did not continue after fence release: settings=%d exec=%d", len(runtime.updateSettingsCalls), len(runtime.execCalls))
+		}
+	})
+
+	t.Run("durable worker", func(t *testing.T) {
+		now := time.UnixMilli(1_000)
+		service, runtime, store := planDecisionTestService(now)
+		operationID := runtimeOperationID("ws-1", "session-1", agentactivitybiz.RuntimeOperationKindPlanDecision, "plan-turn")
+		store.operation = agentactivitybiz.RuntimeOperation{
+			OperationID: operationID, WorkspaceID: "ws-1", AgentSessionID: "session-1",
+			TurnID: "plan-turn", RequestID: "plan-turn", Kind: agentactivitybiz.RuntimeOperationKindPlanDecision,
+			Status: agentactivitybiz.RuntimeOperationStatusPrepared, NextAttemptAtMS: now.UnixMilli(),
+			Payload: map[string]any{
+				"promptKind": "plan-implementation", "action": "implement", "idempotencyKey": "decision-1",
+				"clientSubmitId": "plan-decision:" + operationID, "step": "prepared",
+			},
+		}
+		_, releaseFence, err := service.ApplicationHost().BeginWorkspaceRuntimeDisconnect(t.Context(), "ws-1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		canceled, cancel := context.WithCancel(t.Context())
+		cancel()
+		if err := service.ApplicationHost().StepRuntimeOperationWorker(canceled, false); !errors.Is(err, context.Canceled) {
+			t.Fatalf("StepRuntimeOperationWorker error=%v, want context canceled", err)
+		}
+		if len(runtime.resumeCalls) != 0 || len(runtime.updateSettingsCalls) != 0 || len(runtime.execCalls) != 0 {
+			t.Fatalf("worker mutated runtime behind disconnect fence: resume=%d settings=%d exec=%d", len(runtime.resumeCalls), len(runtime.updateSettingsCalls), len(runtime.execCalls))
+		}
+		releaseFence()
+		if err := service.ApplicationHost().StepRuntimeOperationWorker(t.Context(), false); err != nil {
+			t.Fatal(err)
+		}
+		if len(runtime.updateSettingsCalls) != 1 || len(runtime.execCalls) != 1 {
+			t.Fatalf("worker did not continue after fence release: settings=%d exec=%d", len(runtime.updateSettingsCalls), len(runtime.execCalls))
+		}
+	})
+}
+
 func TestCraftedInvalidPlanDecisionFailsBeforeProviderCalls(t *testing.T) {
 	now := time.UnixMilli(1_000)
 	service, runtime, store := planDecisionTestService(now)


### PR DESCRIPTION
## Summary

- Route durable PlanDecision work and provisional runtime lifecycles through per-workspace runtime admission. Add a durable, joinable disconnect fence for sleep/wake recovery.
- Preserve ownership of Codex/Tutti Agent and Claude physical handles after persistent close failures, with bounded cleanup and replacement backpressure.
- Serialize Claude generation replacement with reader events, reader failures, and interactive acknowledgements so stale generations cannot mutate the active timeline.
- Add Host conformance scenarios and deterministic provider lifecycle tests.

## Root cause

Prepared durable runtime work could create or mutate runtime sessions without entering workspace admission. Provider adapters also removed logical sessions before proving the physical transport was closed, and Claude asynchronous commits were not linearized with session generation replacement. Sleep/resume could therefore race new runtime work, lose ownership of a still-live process, or publish stale events into a replacement session.

## Verification

- `go test ./packages/agent/daemon/runtime -count=1`
- `go test ./packages/agent/host/... -count=1`
- `go test -race ./packages/agent/daemon/runtime -run "ClaudeCodeSDKAdapter|ClaudeSDK|AppServer.*(CloseFailure|Exited|Replacement)|CodexAppServer.*(CloseFailure|Exited|Replacement)" -count=3`
- `pnpm check:changed -- --push-ready` (13/13 lanes)
- No E2E tests were run.

## Fallback Three Questions

- Source: a provider transport `Close` can fail while the physical process or reader may still be live.
- Why can it not be fixed at that source? Provider transports can be interrupted or fail independently of the owning lifecycle manager; a failed `Close` does not prove process death. The owner must retain and retry cleanup.
- Removal condition: remove the retained-handle cleanup path only if every provider connection contract supplies an authoritative terminal signal after a failed `Close`.

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.