### PR TITLE
fix(runtime): use signed Python on Windows

### DIFF
--- a/.github/workflows/publish-tutti-app-runtime.yml
+++ b/.github/workflows/publish-tutti-app-runtime.yml
@@ -79,10 +79,14 @@ jobs:
           if (!lock.platforms?.[platform]) {
             throw new Error(`runtime lock does not contain ${platform}`);
           }
+          const pythonVersion =
+            platform === "windows-amd64"
+              ? lock.python?.windows?.version
+              : lock.python?.version;
           for (const [name, value] of [
             ["runtime_version", lock.runtimeVersion],
             ["uv_version", lock.uv?.version],
-            ["python_version", lock.python?.version],
+            ["python_version", pythonVersion],
             ["python_windows_archive_url", lock.python?.windows?.archiveUrl],
             ["python_windows_archive_sha256", lock.python?.windows?.archiveSha256],
             ["python_windows_archive_root", lock.python?.windows?.archiveRoot],
@@ -286,10 +290,9 @@ jobs:
           PYTHON_WINDOWS_ARCHIVE_SHA256: ${{ steps.lock.outputs.python_windows_archive_sha256 }}
           PYTHON_WINDOWS_ARCHIVE_ROOT: ${{ steps.lock.outputs.python_windows_archive_root }}
         run: |
-          # The official CPython release may be source-only for a patch
-          # release. Use the pinned relocatable build instead of silently
-          # substituting another Python version.
-          $archive = "python-$env:PYTHON_VERSION-windows.tar.gz"
+          # Windows uses the last official CPython 3.12 embeddable release so
+          # every executable module carries the PSF Authenticode signature.
+          $archive = "python-$env:PYTHON_VERSION-embed-amd64.zip"
           $archivePath = Join-Path $env:RUNNER_TEMP $archive
           Invoke-WebRequest -Uri $env:PYTHON_WINDOWS_ARCHIVE_URL -OutFile $archivePath
           $actual = (Get-FileHash -Algorithm SHA256 $archivePath).Hash.ToLowerInvariant()
@@ -300,12 +303,29 @@ jobs:
           $target = Join-Path $env:RUNNER_TEMP 'tutti-runtime-python'
           Remove-Item $expanded, $target -Recurse -Force -ErrorAction SilentlyContinue
           New-Item -ItemType Directory -Path $expanded -Force | Out-Null
-          tar -xzf $archivePath -C $expanded
+          Expand-Archive -LiteralPath $archivePath -DestinationPath $expanded
           $pythonRoot = Join-Path $target 'python/bin'
           New-Item -ItemType Directory -Path $pythonRoot -Force | Out-Null
           $sourceRoot = Join-Path $expanded $env:PYTHON_WINDOWS_ARCHIVE_ROOT
           if (-not (Test-Path (Join-Path $sourceRoot 'python.exe'))) {
             throw "Managed Python archive root does not contain python.exe"
+          }
+          $peFiles = Get-ChildItem -LiteralPath $sourceRoot -Recurse -File | Where-Object {
+            $_.Extension -in '.exe', '.dll', '.pyd'
+          }
+          if (-not $peFiles) {
+            throw "Managed Python archive contains no Windows executable files"
+          }
+          $invalidSignatures = @($peFiles | Where-Object {
+            (Get-AuthenticodeSignature -LiteralPath $_.FullName).Status -ne 'Valid'
+          })
+          if ($invalidSignatures.Count -gt 0) {
+            $invalidNames = ($invalidSignatures.Name | Sort-Object) -join ', '
+            throw "Managed Python archive contains invalid or unsigned files: $invalidNames"
+          }
+          $pythonSignature = Get-AuthenticodeSignature -LiteralPath (Join-Path $sourceRoot 'python.exe')
+          if ($pythonSignature.SignerCertificate.Subject -notmatch 'O=Python Software Foundation') {
+            throw "Managed Python executable is not signed by the Python Software Foundation"
           }
           Copy-Item (Join-Path $sourceRoot '*') $pythonRoot -Recurse
           $python = Join-Path $pythonRoot 'python.exe'

--- a/config/tutti.app-runtime.lock.json
+++ b/config/tutti.app-runtime.lock.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "tutti.app.runtime-lock.v1",
-  "runtimeVersion": "2026.07.1",
+  "runtimeVersion": "2026.08.0",
   "uv": {
     "version": "0.11.19"
   },
@@ -9,9 +9,10 @@
     "sourceUrl": "https://www.python.org/ftp/python/3.12.13/Python-3.12.13.tgz",
     "sourceSha256": "0816c4761c97ecdb3f50a3924de0a93fd78cb63ee8e6c04201ddfaedca500b0b",
     "windows": {
-      "archiveUrl": "https://github.com/astral-sh/python-build-standalone/releases/download/20260728/cpython-3.12.13%2B20260728-x86_64-pc-windows-msvc-install_only.tar.gz",
-      "archiveSha256": "8a0e1ded37e11f4c72b9671bf134bb478b1b2d55efe53a3d6e589b166f1bf2e1",
-      "archiveRoot": "python"
+      "version": "3.12.10",
+      "archiveUrl": "https://www.python.org/ftp/python/3.12.10/python-3.12.10-embed-amd64.zip",
+      "archiveSha256": "4acbed6dd1c744b0376e3b1cf57ce906f9dc9e95e68824584c8099a63025a3c3",
+      "archiveRoot": "."
     }
   },
   "node": {

--- a/docs/conventions/workspace-app-runtime.md
+++ b/docs/conventions/workspace-app-runtime.md
@@ -94,13 +94,14 @@ The workflow is:
 
 The workflow:
 
-1. Installs the pinned uv version.
-2. Uses uv to install the pinned Python baseline.
-3. Downloads the pinned Node release for each platform and verifies it against Node's `SHASUMS256.txt`.
-4. Assembles separate Python and Node zips per platform.
-5. Writes metadata for each platform's runtime components.
-6. Uploads immutable component zips to S3.
-7. Builds and uploads `catalog.json`.
+1. Installs the pinned uv version on macOS and Linux.
+2. Uses uv to install the pinned macOS/Linux Python baseline.
+3. Downloads the pinned official CPython embeddable package on Windows, verifies its SHA-256, and requires valid Authenticode signatures on every `.exe`, `.dll`, and `.pyd` file.
+4. Downloads the pinned Node release for each platform and verifies it against Node's `SHASUMS256.txt`.
+5. Assembles separate Python and Node zips per platform.
+6. Writes metadata for each platform's runtime components.
+7. Uploads immutable component zips to S3.
+8. Builds and uploads `catalog.json`.
 
 Runtime artifacts should be uploaded under a dedicated S3 prefix, normally:
 
@@ -176,10 +177,21 @@ remain portable. Apps that only need Node may declare
 `runtime.profile: "connector-node-static"` so launch does not require the Python
 component. If runtime requirements need to become more selective later, add a
 capability list such as runtime component requirements rather than restoring a
-single-kind manifest field. The Windows Python component is built from the
-version-pinned relocatable archive in config/tutti.app-runtime.lock.json;
-the archive URL and SHA-256 are locked separately because some CPython patch
-releases are source-only on python.org.
+single-kind manifest field. macOS and Linux currently use Python 3.12.13 from
+the pinned uv-managed distribution. Windows uses python.org's official signed
+Python 3.12.10 embeddable package because Python 3.12.10 is the last 3.12 patch
+release with official Windows binaries; later 3.12 security releases are
+source-only. The Windows version, archive URL, and SHA-256 are pinned separately
+in `config/tutti.app-runtime.lock.json`, and platform metadata must report the
+effective version rather than the cross-platform default.
+
+The Windows embeddable package is intentionally minimal and isolated. It does
+not include `pip`, `venv`, or `ensurepip`. Windows workspace apps using the
+baseline profile must ship their dependencies in the app package and must not
+install packages into the managed runtime. Moving Windows to a later Python
+patch requires either an official signed binary distribution or Authenticode
+signing of every shipped `.exe`, `.dll`, and `.pyd` file with an approved Tutti
+publisher identity. SHA-256 verification alone is not a code-signing substitute.
 
 ## Runtime Overrides
 

--- a/tools/scripts/build-tutti-app-runtime-catalog.test.mjs
+++ b/tools/scripts/build-tutti-app-runtime-catalog.test.mjs
@@ -7,7 +7,11 @@ import { buildTuttiAppRuntimeCatalog } from "./build-tutti-app-runtime-catalog.m
 
 const runtimeWorkflowPath = new URL(
   "../../.github/workflows/publish-tutti-app-runtime.yml",
-  import.meta.url
+  import.meta.url,
+);
+const runtimeLockPath = new URL(
+  "../../config/tutti.app-runtime.lock.json",
+  import.meta.url,
 );
 
 test("buildTuttiAppRuntimeCatalog writes runtime catalog from artifact metadata", async () => {
@@ -18,12 +22,12 @@ test("buildTuttiAppRuntimeCatalog writes runtime catalog from artifact metadata"
       python: {
         artifactPath:
           "2026.06.0/darwin-arm64/python/tutti-app-runtime-python-darwin-arm64-2026.06.0.zip",
-        artifactSha256: "a".repeat(64)
-      }
+        artifactSha256: "a".repeat(64),
+      },
     },
     profiles: {
-      baseline: ["python"]
-    }
+      baseline: ["python"],
+    },
   });
   const linux = await runtimeMetadataFile(tempDir, {
     platform: "linux-amd64",
@@ -31,36 +35,36 @@ test("buildTuttiAppRuntimeCatalog writes runtime catalog from artifact metadata"
       node: {
         artifactPath:
           "2026.06.0/linux-amd64/node/tutti-app-runtime-node-linux-amd64-2026.06.0.zip",
-        artifactSha256: "b".repeat(64)
-      }
+        artifactSha256: "b".repeat(64),
+      },
     },
     profiles: {
       baseline: ["node"],
-      "node-static": ["node"]
-    }
+      "node-static": ["node"],
+    },
   });
   const output = path.join(tempDir, "catalog.json");
 
   const catalog = await buildTuttiAppRuntimeCatalog({
     artifactBaseUrl: "https://cdn.example.test/app-runtimes/",
     metadataFiles: [linux, darwin],
-    output
+    output,
   });
 
   assert.deepEqual(Object.keys(catalog.runtimes), [
     "darwin-arm64",
-    "linux-amd64"
+    "linux-amd64",
   ]);
   assert.deepEqual(JSON.parse(await readFile(output, "utf8")), catalog);
   assert.equal(
     catalog.runtimes["darwin-arm64"].components.python.artifactUrl,
-    "https://cdn.example.test/app-runtimes/2026.06.0/darwin-arm64/python/tutti-app-runtime-python-darwin-arm64-2026.06.0.zip"
+    "https://cdn.example.test/app-runtimes/2026.06.0/darwin-arm64/python/tutti-app-runtime-python-darwin-arm64-2026.06.0.zip",
   );
   assert.deepEqual(catalog.runtimes["darwin-arm64"].profiles.baseline, [
-    "python"
+    "python",
   ]);
   assert.deepEqual(catalog.runtimes["linux-amd64"].profiles["node-static"], [
-    "node"
+    "node",
   ]);
 });
 
@@ -71,24 +75,24 @@ test("buildTuttiAppRuntimeCatalog rejects duplicate platforms", async () => {
     components: {
       python: {
         artifactPath: "2026.06.0/darwin-arm64/python/first.zip",
-        artifactSha256: "a".repeat(64)
-      }
+        artifactSha256: "a".repeat(64),
+      },
     },
     profiles: {
-      baseline: ["python"]
-    }
+      baseline: ["python"],
+    },
   });
   const second = await runtimeMetadataFile(tempDir, {
     platform: "darwin-arm64",
     components: {
       python: {
         artifactPath: "2026.06.0/darwin-arm64/python/second.zip",
-        artifactSha256: "b".repeat(64)
-      }
+        artifactSha256: "b".repeat(64),
+      },
     },
     profiles: {
-      baseline: ["python"]
-    }
+      baseline: ["python"],
+    },
   });
 
   await assert.rejects(
@@ -96,9 +100,9 @@ test("buildTuttiAppRuntimeCatalog rejects duplicate platforms", async () => {
       buildTuttiAppRuntimeCatalog({
         artifactBaseUrl: "https://cdn.example.test/app-runtimes",
         metadataFiles: [first, second],
-        output: path.join(tempDir, "catalog.json")
+        output: path.join(tempDir, "catalog.json"),
       }),
-    /duplicate runtime platform darwin-arm64/
+    /duplicate runtime platform darwin-arm64/,
   );
 });
 
@@ -107,18 +111,23 @@ test("Tutti app runtime workflow publishes immutable artifacts and mutable catal
 
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /config\/tutti\.app-runtime\.lock\.json/);
+  assert.match(workflow, /platform === "windows-amd64"/);
+  assert.match(workflow, /lock\.python\?\.windows\?\.version/);
   assert.match(workflow, /uv python install --no-bin "\$\{PYTHON_VERSION\}"/);
-  assert.match(workflow, /python-\$env:PYTHON_VERSION-windows\.tar\.gz/);
+  assert.match(workflow, /python-\$env:PYTHON_VERSION-embed-amd64\.zip/);
   assert.match(workflow, /PYTHON_WINDOWS_ARCHIVE_SHA256/);
-  assert.match(workflow, /tar -xzf \$archivePath/);
+  assert.match(workflow, /Expand-Archive -LiteralPath \$archivePath/);
+  assert.match(workflow, /Get-AuthenticodeSignature/);
+  assert.match(workflow, /O=Python Software Foundation/);
+  assert.match(workflow, /\.Extension -in '\.exe', '\.dll', '\.pyd'/);
   assert.match(workflow, /SHASUMS256\.txt/);
   assert.match(
     workflow,
-    /tutti-app-runtime-python-\$\{PLATFORM\}-\$\{RUNTIME_VERSION\}\.zip/
+    /tutti-app-runtime-python-\$\{PLATFORM\}-\$\{RUNTIME_VERSION\}\.zip/,
   );
   assert.match(
     workflow,
-    /tutti-app-runtime-node-\$\{PLATFORM\}-\$\{RUNTIME_VERSION\}\.zip/
+    /tutti-app-runtime-node-\$\{PLATFORM\}-\$\{RUNTIME_VERSION\}\.zip/,
   );
   assert.match(workflow, /node\/bin\/npm/);
   assert.match(workflow, /npm-cli\.js/);
@@ -136,17 +145,32 @@ test("Tutti app runtime workflow publishes immutable artifacts and mutable catal
   assert.match(workflow, /Restore runtime artifact layout/);
   assert.match(
     workflow,
-    /target_dir="tutti-app-runtime\/\$\{runtime_version\}\/\$\{platform\}"/
+    /target_dir="tutti-app-runtime\/\$\{runtime_version\}\/\$\{platform\}"/,
   );
   assertAwsValidationBeforeConfigure(workflow, [
     "AWS_REGION_VALUE",
     "AWS_ROLE_ARN_VALUE",
     "S3_BUCKET_VALUE",
-    "ARTIFACT_BASE_URL_VALUE"
+    "ARTIFACT_BASE_URL_VALUE",
   ]);
   assert.match(workflow, /build-tutti-app-runtime-catalog\.mjs/);
   assert.match(workflow, /max-age=31536000, immutable/);
   assert.match(workflow, /max-age=60/);
+});
+
+test("Windows runtime pins the official signed CPython 3.12.10 embeddable package", async () => {
+  const lock = JSON.parse(await readFile(runtimeLockPath, "utf8"));
+
+  assert.equal(lock.python.version, "3.12.13");
+  assert.equal(lock.python.windows.version, "3.12.10");
+  assert.equal(
+    lock.python.windows.archiveUrl,
+    "https://www.python.org/ftp/python/3.12.10/python-3.12.10-embed-amd64.zip",
+  );
+  assert.equal(
+    lock.python.windows.archiveSha256,
+    "4acbed6dd1c744b0376e3b1cf57ce906f9dc9e95e68824584c8099a63025a3c3",
+  );
 });
 
 function assertAwsValidationBeforeConfigure(workflow, names) {
@@ -156,7 +180,7 @@ function assertAwsValidationBeforeConfigure(workflow, names) {
   assert.notEqual(configureIndex, -1, "workflow should configure AWS");
   assert.ok(
     validationIndex < configureIndex,
-    "AWS validation must run before credentials configuration"
+    "AWS validation must run before credentials configuration",
   );
   for (const name of names) {
     assert.match(workflow, new RegExp(`for name in[\\s\\S]*${name}`));
@@ -177,23 +201,23 @@ async function runtimeMetadataFile(tempDir, overrides) {
         artifactPath:
           "2026.06.0/darwin-arm64/python/tutti-app-runtime-python-darwin-arm64-2026.06.0.zip",
         artifactSha256: "a".repeat(64),
-        artifactSizeBytes: 123
+        artifactSizeBytes: 123,
       },
       node: {
         version: "22.22.3",
         artifactPath:
           "2026.06.0/darwin-arm64/node/tutti-app-runtime-node-darwin-arm64-2026.06.0.zip",
         artifactSha256: "b".repeat(64),
-        artifactSizeBytes: 456
-      }
+        artifactSizeBytes: 456,
+      },
     },
     profiles: {
-      baseline: ["python", "node"]
-    }
+      baseline: ["python", "node"],
+    },
   };
   const metadata = {
     ...baseMetadata,
-    ...overrides
+    ...overrides,
   };
   if (overrides.components) {
     metadata.components = Object.fromEntries(
@@ -207,14 +231,14 @@ async function runtimeMetadataFile(tempDir, overrides) {
               ? baseMetadata.nodeVersion
               : baseMetadata.pythonVersion),
           artifactSizeBytes: component.artifactSizeBytes ?? 123,
-          ...component
-        }
-      ])
+          ...component,
+        },
+      ]),
     );
   }
   const filePath = path.join(
     tempDir,
-    `${metadata.platform}-${Math.random()}.json`
+    `${metadata.platform}-${Math.random()}.json`,
   );
   await writeFile(filePath, `${JSON.stringify(metadata, null, 2)}\n`);
   return filePath;


### PR DESCRIPTION
## 背景

Windows Smart App Control 强制执行时，当前托管 Python 3.12.13 来自 `python-build-standalone`，其中 `python.exe`、DLL 和 `.pyd` 没有 Authenticode 签名，会被 Windows Code Integrity 拦截，导致 Automation 等 Python Workspace App 无法启动。

## 改动

- Windows 托管运行时改用 python.org 官方 Python 3.12.10 embeddable x64 包
- macOS/Linux 继续使用 Python 3.12.13，运行时元数据按平台记录实际 Python 版本
- 运行时版本提升为 `2026.08.0`
- 保留 SHA-256 校验，并新增所有 `.exe`、`.dll`、`.pyd` 的 Authenticode 校验
- 强制验证 `python.exe` 的签名发布者为 Python Software Foundation
- 更新运行时规范，记录 Windows embeddable 包不含 `pip`、`venv` 和 `ensurepip`，应用必须自带依赖
- 增加发布工作流与版本锁定测试

## 影响

Automation 当前只依赖 Python 标准库，可以使用官方 3.12.10 运行时。新的签名发布门禁会阻止无签名或签名无效的 Windows Python 进入运行时目录。

## 验证

- `node --test ./tools/scripts/build-tutti-app-runtime-catalog.test.mjs`：4/4 通过
- Prettier 检查通过
- `git diff --check` 通过
- 本地核验官方包 SHA-256
- 31 个 Windows PE 文件 Authenticode 状态全部为 `Valid`
- `python.exe` 发布者确认为 Python Software Foundation
- 打包后的 Python 3.12.10 标准库加载及 Automation 后端加载验证通过
