### PR TITLE
fix(desktop): harden Windows Agent activity reliability

### DIFF
--- a/apps/desktop/src/renderer/src/app/windows/workspace/WorkspaceWindow.tsx
+++ b/apps/desktop/src/renderer/src/app/windows/workspace/WorkspaceWindow.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useLayoutEffect } from "react";
 import { StandaloneAgentStartupShell } from "@renderer/features/workspace-workbench/ui/StandaloneAgentStartupShell.tsx";
 import type { WorkspaceWindowContainerResult } from "./createWorkspaceWindowContainer.ts";
 
@@ -21,6 +21,19 @@ export function WorkspaceWindow({
   const routeView =
     new URLSearchParams(window.location.search).get("view") || "workspace";
   const isWindows = containerInput.desktopApi.platform.os === "win32";
+
+  useLayoutEffect(() => {
+    const overlayEnabled = isWindows && routeView === "agent";
+    if (overlayEnabled) {
+      document.body.dataset.tuttiTitlebarOverlay = "true";
+    } else {
+      delete document.body.dataset.tuttiTitlebarOverlay;
+    }
+    return () => {
+      delete document.body.dataset.tuttiTitlebarOverlay;
+    };
+  }, [isWindows, routeView]);
+
   const routeFallback =
     routeView === "agent" ? (
       <StandaloneAgentStartupShell titleBarOverlay={isWindows} />

--- a/apps/desktop/src/renderer/src/app/windows/workspace/WorkspaceWindow.tsx
+++ b/apps/desktop/src/renderer/src/app/windows/workspace/WorkspaceWindow.tsx
@@ -23,7 +23,11 @@ export function WorkspaceWindow({
   const isWindows = containerInput.desktopApi.platform.os === "win32";
 
   useLayoutEffect(() => {
-    const overlayEnabled = isWindows && routeView === "agent";
+    // Every Windows workspace BrowserWindow uses Electron's titleBarOverlay,
+    // including the normal workspace route. Keep the body marker route-
+    // independent so fixed portal controls in embedded modules reserve the
+    // native caption-button area as well as standalone Agent windows.
+    const overlayEnabled = isWindows;
     if (overlayEnabled) {
       document.body.dataset.tuttiTitlebarOverlay = "true";
     } else {
@@ -32,7 +36,7 @@ export function WorkspaceWindow({
     return () => {
       delete document.body.dataset.tuttiTitlebarOverlay;
     };
-  }, [isWindows, routeView]);
+  }, [isWindows]);
 
   const routeFallback =
     routeView === "agent" ? (

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts
@@ -137,6 +137,9 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
   ensureSessionSynchronized(
     input: WorkspaceAgentActivityEnsureSessionSynchronizedInput
   ): () => void {
+    // Desktop owns one workspace-scoped event stream, so focusing a Session
+    // needs an exact reconcile but does not acquire a per-Session subscription.
+    // Keep the release hook for hosts that implement a narrower stream lease.
     const workspaceId = normalizeWorkspaceId(input.workspaceId);
     const agentSessionId = input.agentSessionId.trim();
     if (agentSessionId) {

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -1521,6 +1521,12 @@ separate command. Message paging adapters do not call back into selection or
 Rail orchestration, and hosts do not maintain a second messages-only reconcile
 entrypoint.
 
+The focused conversation controller also owns the optional host synchronization
+lease for its exact active Session. It acquires the lease when focus changes,
+keeps repeated selection idempotent, and releases the previous lease on switch,
+clear, or disposal. A host may use that lease to retain a per-Session event
+stream; React surfaces must not retain that transport independently.
+
 Event-stream continuity and command reachability are separate host facts.
 `eventStreamConnectionChanged` belongs to the coordinator and triggers
 authoritative reconnect hydration; `engine/connectionChanged` belongs to the

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -69,6 +69,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - [AgentGUI loading disappears before active turn settles](./agent-session-lifecycle.md#agentgui-loading-disappears-before-active-turn-settles)
 - [Queued AgentGUI prompt stalls after no-active-turn failure](./agent-session-lifecycle.md#queued-agentgui-prompt-stalls-after-no-active-turn-failure)
 - [Agent session stays loading after a completed turn](./agent-session-lifecycle.md#agent-session-stays-loading-after-a-completed-turn)
+- [Remote session stays planning while the provider already replied](./agent-session-lifecycle.md#remote-session-stays-planning-while-the-provider-already-replied)
 - [AgentGUI model switch changes defaults but not the active session](./agent-session-lifecycle.md#agentgui-model-switch-changes-defaults-but-not-the-active-session)
 - [New Agent conversation rejects a model that is no longer offered](./agent-session-lifecycle.md#new-agent-conversation-rejects-a-model-that-is-no-longer-offered)
 - [AgentGUI shows the selected settings but a new session does not inherit them](./agent-session-lifecycle.md#agentgui-shows-the-selected-settings-but-a-new-session-does-not-inherit-them)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -1831,6 +1831,40 @@ inline data URL instead`. Claude or standard ACP may instead receive no
   [service.go](../../../services/tuttid/service/agent/service.go)
   [service_session_list.go](../../../services/tuttid/service/agent/service_session_list.go)
 
+### Remote session stays planning while the provider already replied
+
+- Symptom:
+  A remote or cloud-backed AgentGUI conversation remains on its planning or
+  working placeholder after the provider has already settled the Turn. Reading
+  the authoritative Session directly reports `ready` with no active Turn, and
+  opening the Session event stream immediately reveals the missing assistant
+  response.
+- Quick checks:
+  First compare authoritative Session state with the renderer projection. Then
+  inspect host access logs for the exact Session event-stream subscription. If
+  the provider settled but the AgentGUI surface never requested the stream,
+  increasing HTTP or activation timeouts cannot repair the stale projection.
+- Root cause:
+  The focused conversation was hydrated once but did not retain the host's
+  optional Session synchronization lease. Hosts that use that lease to keep a
+  per-Session event stream open therefore receive no terminal state or message
+  events until another read happens to reconcile the Session.
+- Fix:
+  Keep synchronization ownership in the shared focused-conversation controller.
+  Acquire the exact Session lease on focus, keep repeated selection idempotent,
+  release the previous lease on switch or clear, and release the final lease on
+  disposal. Keep the host responsible for transport and authoritative
+  reconciliation; do not add provider-specific polling or longer timeouts.
+- Validation:
+  Add controller coverage for acquire, repeated selection, switch, clear, and
+  disposal. In the affected host, verify that selecting the conversation opens
+  the exact Session stream and that a terminal event updates both state and
+  transcript without a manual refresh.
+- References:
+  [agentConversationMessageController.ts](../../../packages/agent/gui/agentConversationMessageController.ts)
+  [useAgentConversationMessagePaging.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentConversationMessagePaging.ts)
+  [agent-activity-packages.md](../../architecture/agent-activity-packages.md)
+
 ### AgentGUI pin or unpin appears stuck for a live session
 
 - Symptom:

--- a/docs/plans/2026-08-14-agent-gui-windows-bug-remediation.md
+++ b/docs/plans/2026-08-14-agent-gui-windows-bug-remediation.md
@@ -1,0 +1,356 @@
+# Agent GUI / Windows 问题技术改造方案
+
+状态：Proposed
+日期：2026-08-14
+范围：`tutti` 单仓库，覆盖此前已分析的 Agent GUI、ACP 和 Windows 问题。当前文档只定义改造方案，不包含业务代码修改。
+
+## 1. 背景与目标
+
+此前日志、代码、截图和 `make dev-gui` 启动验证暴露出一组相互放大的问题：Renderer 仍持有旧 session/turn/interactive 请求，daemon/runtime 同时接收新旧事件；provider 的异步事件和能力声明不完整；Windows 本地搜索及状态目录并发不稳定；部分 UI 只消费缓存或临时状态。
+
+本方案的目标是：
+
+1. 以 `(workspaceId, agentSessionId, turnId, requestId)` 作为跨层身份边界，旧请求不得改变当前会话状态。
+2. 以 daemon 的 canonical session/turn/interaction 状态作为唯一状态源，Renderer 只做带身份的投影和恢复。
+3. 将 provider 异步事件、能力和错误转换为统一的 Tutti 语义，并保留可诊断的安全错误信息。
+4. 让模型切换、取消、关闭、重启、多窗口和高并发 handoff 具备幂等、可恢复的终态。
+5. 修复 Windows 搜索、SQLite 状态目录竞争和窗口布局/缓存问题，同时保持现有 API 和已存在会话兼容。
+
+### 已确认与待确认边界
+
+已确认的证据包括：
+
+- GPT-5.2 报告中，当前 session `80db00c1...` 的 `turn.start.succeeded` 和 `api.send.completed` 成功；失败请求却发往旧 session `70c13030...`。同一时间 `tuttid` 反复记录 `message_delta stream identity does not match its runtime scope`。
+- Claude 高并发 handoff 中存在 5 秒终态 barrier 超时、workspace/agent target 查询超时，以及 provider 已不再认为 turn active 后的取消竞态。
+- Cursor 声明 Plan mode，但缺少可用的 AskQuestion 能力；Kimi 的 permission 事件可能先于 tool input 到达。
+- Windows Search 请求只带 `include_kinds=[file]`，provider 又排除了 Directory；搜索超时后 Renderer 收到 `AbortError/502`。
+- Microsoft Store 版本确实启动了 AppX 内的 `tuttid.exe`，Agent 创建失败的日志根因是 `database is locked`；AppX Start 菜单注册和 manifest 图标文件均有证据存在。
+- 新窗口可以看到新会话，旧窗口仍使用 rail projection/cache；取消问题缺少对应日志包。
+
+以下结论在实施前必须通过复现或补充日志确认，不能作为本方案的隐含前提：
+
+- GPT-5.2 失败 turn 的 provider 原始错误是网络、模型拒绝、权限、服务端错误还是进程退出；导出包没有保留该 error notification 的完整 payload。
+- `message_delta` identity mismatch 是否直接导致该次“发送失败”，还是只造成流式内容丢失/旧状态投影。
+- 原始问题清单中的第 11 项未在本次材料中提供独立症状和证据；在补充前不新增实现范围。
+- 取消问题（下文问题 I）是终态事件丢失、Renderer 关联错误，还是 provider 取消延迟；当前只能依据代码提出防护。
+- “Microsoft Store 是否需要桌面快捷方式”是产品要求还是误报；现有证据只证明 Start 菜单和 AppX 图标资源存在。
+
+证据包（不提交到仓库）：`C:\Work\logger-analysis-gpt52\extracted-20260814\logs\tutti-desktop.log`、`tuttid.log`。对应生产版本为 `0.2.23-rc.8`，日志窗口为 2026-08-13 14:15:25–14:25:25（+08:00）。
+
+## 2. 当前架构与完整链路
+
+### 2.1 普通发送和 GPT-5.2 场景
+
+```text
+Renderer Agent GUI
+  -> desktopAgentActivityAdapter.sendInput
+  -> POST /v1/workspaces/{workspaceID}/agent-sessions/{agentSessionID}/input
+  -> tuttid API SendWorkspaceAgentSessionInput
+  -> service/agent.SendInput
+  -> host.ApplicationHost().SendInput
+  -> daemon runtime controller
+  -> CodexAppServerAdapter.execBlocking
+  -> app-server turn/start
+  -> provider notifications
+  -> reducer/turn machine/normalizer
+  -> activity events + SQLite projection
+  -> tuttid session query
+  -> Renderer session/presentation/cache
+```
+
+当前代码证据：
+
+- `apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts` 负责 HTTP 发送和结果转换。
+- `services/tuttid/api/daemon_agent_submit_handlers.go` 的 `SendWorkspaceAgentSessionInput` 记录 `api.send.received/completed`。
+- `services/tuttid/service/agent/service_send_input.go` 负责 prompt 规范化、submit 幂等标识、Host dispatch 和 turn 刷新。
+- `packages/agent/daemon/runtime/codex_appserver_turn.go:571-575` 记录并调用 `turn/start`；`turn/start` 成功后，后续 provider `error` 才会通过 turn machine 进入 failed。
+- `packages/agent/daemon/runtime/codex_appserver_turn_machine.go:81-85,212-220` 将 provider error 转成普通 `error`；当前没有保证原始 code、provider turn 和安全用户消息均可追踪到日志/前端。
+
+这说明 GPT-5.2 报告中的“请求失败”不能直接归因于 HTTP submit 或模型切换 API。已确认的直接错误表现是：旧 interactive response/旧 session 身份进入当前 Renderer 流程，当前新 session 的 turn 已被接受；实际 provider 失败原因仍待补齐原始 error payload。
+
+### 2.2 Interactive、审批、AskUser 和取消链路
+
+```text
+provider permission / ask-user notification
+  -> runtime pending interaction
+  -> canonical pending interaction + activity projection
+  -> Renderer pending UI
+  -> POST .../interactives/{requestID}/response
+  -> tuttid SubmitInteractive
+  -> runtime SubmitInteractive / provider response
+  -> provider continuation
+  -> turn terminal event
+  -> canonical state -> Renderer
+```
+
+入口为 `services/tuttid/api/routes_workspace_agent_sessions.go:253`，服务接口为 `SubmitInteractive`。问题在于当前 response 主要按 request/session 处理，Renderer 仍可能携带已经切换前的 session 或 turn；projection bridge 发现 mismatch 后只记录 warning，未立即重建 canonical state。
+
+取消和窗口关闭另有一条链：
+
+```text
+Renderer stop / window close
+  -> session engine stopRequested
+  -> cancel API
+  -> provider cancel + local context cancel
+  -> turn settled event
+  -> canonical activity projection
+  -> composer busy/loading state cleared
+```
+
+`cancel_requested` 只是“取消已接受”，不是终态。窗口关闭则额外受到 `workspaceWindowCloseGuard.ts` 和 `workspaceWindow.ts` 中 guard 条件的影响；启动恢复时 Renderer 可能先恢复旧 pending interaction，再等待 daemon reconcile。
+
+### 2.3 子 Agent handoff 链路
+
+```text
+root turn
+  -> handoff/delegated task creation
+  -> child agent session/provider turn
+  -> child terminal report
+  -> controller_report_worker barrier
+  -> workspace/agent-target state query
+  -> root cancellation or continuation
+```
+
+当前固定 5 秒终态 barrier、子会话枚举、provider cancel 和终态持久化不是一个原子操作。根会话取消时，provider 可能已经清除 active turn，导致 `agent cancellation target is no longer active`，而子会话的最终状态尚未可见。
+
+### 2.4 Windows 文件引用和状态目录链路
+
+```text
+ReferencePicker
+  -> filtersUseSearch / includeKinds
+  -> workspace file API
+  -> Windows Search OleDB
+  -> PowerShell child process
+  -> file/dir result
+  -> Renderer picker
+```
+
+`services/tuttid/data/workspace/local_files_search_windows.go:117` 使用 `System.ItemType <> 'Directory'`；`workspaceFileLocationReferenceSources.ts` 将相关 source 标为 `filtersUseSearch=true`。搜索超时会沿 API 转成 502，Renderer 只得到通用失败。
+
+Store/Direct 启动链路为：
+
+```text
+AppX/Direct desktop
+  -> tuttid.exe
+  -> shared .tutti state directory
+  -> SQLite transaction
+  -> upsert workspace agent session
+```
+
+SQLite 目前只配置有限 busy timeout（`services/tuttid/data/workspace/sqlite_store.go:156`），无法区分旧 daemon 未退出、两个实例并发，还是同一 daemon 内的长事务。
+
+## 3. 目标架构与完整链路
+
+目标不是引入新的 Agent 状态系统，而是在现有 canonical session/turn/activity 之上补齐四个不变量：
+
+1. **身份不变量**：每个 command、provider event、projection event 都携带 workspace、agent session、turn；interactive 额外携带 request ID。身份不匹配的事件不能写入另一条 session。
+2. **终态不变量**：取消、失败、完成只能由 canonical runtime 产生一次；重试、重启和重复 response 只做幂等 reconcile。
+3. **配置不变量**：session canonical settings、runtime effective settings、provider `turn/start` settings 必须可追踪；模型切换只影响尚未开始的下一 turn，不能改变已运行 turn。
+4. **恢复不变量**：projection mismatch、超时、窗口重开或 daemon 重启都触发 canonical reread/reconcile，而不是停留在临时 loading/pending 状态。
+
+### 3.1 目标普通发送链路
+
+```text
+Renderer 创建 SubmitContext
+  {workspaceId, agentSessionId, clientSubmitId, turnId?, requestId?, sessionRevision}
+  -> API 校验 session/turn/request 身份及幂等性
+  -> Service 在 canonical session lock 下准备一次 dispatch
+  -> Runtime snapshot effective settings（包括 gpt-5.2）
+  -> Provider adapter dispatch，记录 provider session/turn/model
+  -> provider event 按身份路由
+  -> terminal event 先持久化，再发布 projection
+  -> Renderer 只接受同一 SubmitContext 的事件；否则丢弃并 reconcile
+```
+
+HTTP 仍可保持现有成功响应；stale interactive response 使用明确的 `409/410` 语义和机器可读错误码，不再包装成无差别 502。普通 provider failure 返回/投影 `failureCode`、安全 `userMessage`、`retryable` 和关联 IDs。
+
+### 3.2 目标模型切换链路
+
+```text
+Renderer settings patch(gpt-5.2)
+  -> API/service session settings lock
+  -> Host canonical settings update
+  -> Runtime adapter 更新“下一 turn effective settings”
+  -> 不重建 live session，不取消当前 turn
+  -> 下一次 turn/start 使用该 snapshot 的 model/effort
+  -> model catalog refresh 作为 single-flight、可超时的旁路任务
+```
+
+模型目录刷新失败不得把已经可用的 live session 或正在运行的 turn 标记为 failed。provider 原始错误只有在安全抽取后才进入活动事件和日志；不能为了显示错误而记录 token、完整 prompt 或凭据。
+
+### 3.3 目标交互、取消和恢复链路
+
+- Interactive response 先在 service 层校验完整 tuple；canonical pending 不属于当前 tuple 时返回 stale，清理本地 pending projection，但不得取消当前 session 的新 turn。
+- identity mismatch 触发一次按 session/turn 的 canonical reread；reconcile 结果以 revision/cursor 单调更新，避免旧 snapshot 覆盖新状态。
+- cancel 先冻结新的 child task/新 response，再以 provider-specific cancel adapter 取消 provider turn，最后提交本地 terminal；目标已结束时返回最终状态而非错误。
+- close guard、菜单、快捷键和原生窗口事件统一调用同一个 bounded close flow；启动先恢复 canonical state，再决定是否显示 pending interaction。
+- child task 以持久化 task tree + durable terminal outbox 表达；barrier 只是等待优化，不是终态正确性的唯一保障。
+
+### 3.4 目标 Windows 链路
+
+- 文件浏览、目录搜索和全文搜索分离；UI 的 `includeKinds` 与后端查询保持一致，目录不能被强制过滤为 file。
+- Windows 搜索使用可取消、分阶段返回的 provider；索引不可用或超时后进入目录缓存/枚举 fallback，并显示可操作的状态。
+- Recent provider 是否纳入 Windows 由产品确认；若不纳入，UI 明确标注平台能力，而不是静默移除。
+- state directory 增加单 daemon lease/handshake；新实例等待旧实例退出或复用已就绪 daemon。SQLite busy retry 采用有上限的退避并记录等待信息，持续冲突返回明确错误。
+- AppX 图标与 Start 菜单保持现有 manifest；桌面 `.lnk` 只有在产品验收明确要求后另行设计。
+
+## 4. 各模块改造内容
+
+### 4.1 `apps/desktop`
+
+- 在普通发送、interactive response、settings update、cancel 和 close flow 中统一构造/传递 `SubmitContext`；所有异步回调按 session/turn/request 比较后再写 UI。
+- 旧 session response 只执行 stale 清理和 canonical refresh，不得覆盖 active session；将“当前发送失败”“旧交互已过期”“provider 失败”分成不同 UI 状态。
+- `agentGui` 的 pending/busy 状态改为精确绑定 `(agentSessionId, turnId)`；`cancel_requested` 显示“正在停止”并等待 bounded reconcile，超时显示可重试而非无限 loading。
+- 窗口关闭所有入口统一进入 close guard；重启恢复顺序改为 canonical session 先行。
+- rail 在 session create/upsert 后广播 invalidate/upsert 给其他窗口；移除“active id 已加载就跳过刷新”的错误短路，保留分页和排序语义。
+- 图片工具栏改用统一 titlebar safe-area CSS 变量；消除 fixed portal 与 native titlebar controls 的独立坐标。
+- ReferencePicker 分离 browse/search/kind，补齐错误、取消、fallback 和 Recent 能力显示。
+
+### 4.2 `services/tuttid/api` 与 `services/tuttid/service/agent`
+
+- 统一校验 workspace/session/turn/request tuple 和 request revision；SubmitInteractive 对 stale、重复、目标已结束返回稳定机器码。
+- 保留 `clientSubmitId` 幂等语义，补齐 command/dispatch/terminal 三段 trace，日志统一记录 provider session/turn、model、failure code 和耗时，不记录 prompt/token/credential。
+- 把 provider failure 映射为结构化 `failureCode/userMessage/retryable`；仅在真正的 transport/API 失败时使用 502。
+- 将 cancel、handoff、child task 的状态写入 canonical task/terminal outbox；重复 cancel 和 target 已结束必须幂等。
+- 维护 settings lock 和 session revision，确保 settings patch、send、cancel 不以旧 snapshot 覆盖新状态。
+
+### 4.3 `packages/agent/host` 与 `packages/agent/daemon/runtime`
+
+- Host 继续作为 canonical/live settings 的协调边界；新增/复用 tuple 校验和按 revision 的 reconcile，不把 Renderer 临时状态下沉为事实。
+- Codex adapter：模型/effort 作为 next-turn override；补齐 model catalog 已加载时 `configOptions`、session settings 和实际 `turn/start` 的一致性测试。不要因 catalog refresh timeout 重建 live client。
+- model catalog refresh 使用 single-flight、超时和 stale-while-usable 结果；与 active turn dispatch 解耦。具体复用现有 app-server client 还是独立探测 client，需根据当前生命周期实现确认，不在方案中强行指定。
+- turn machine 在 provider `error`、`turn/completed`、transport EOF、cancel 中统一生产一次 terminal，并输出安全结构化错误。
+- `agent_runtime_activity_event_bridge.go` 发现 identity mismatch 时停止错误投影、发起 canonical reread，并带上 expected/actual scope；`controller_stream_observer.go` 不得继续把错误 scope 的事件发布给当前 session。
+- ACP capability 增加 AskUser/Question 维度；Plan mode 的可用性由 `PlanMode && AskUser` 或明确 fallback 决定，不再只看 PlanMode。
+- generic permission 与 ask-user 均按 `(providerSessionId, turnId, toolCallId/requestId)` 延迟合并；后到的 Read/ReadFile input 更新已有 pending interaction。
+- handoff 使用 provider adapter 的 cancel/settle 能力，child 终态通过 outbox 重放；root cancel 前冻结 child creation。
+
+### 4.4 `packages/agent/store-sqlite` / `services/tuttid/data/workspace`
+
+- 若现有 activity payload 足以承载 `SubmitContext`，优先使用已有 JSON，不新增表；只有 task tree/outbox 没有可复用存储时才做加法 schema。
+- 为 SQLite 写事务增加有限指数退避、数据库路径和等待时长诊断；通过 daemon lease 避免 Store/Direct 进程并行写同一状态目录。
+- 搜索 provider 将目录/文件 kind 变成明确参数；Windows PowerShell 进程必须可取消并受总 deadline 约束，fallback 不阻塞 session runtime。
+
+### 4.5 OpenAPI、TypeScript client、打包资源和文档
+
+- API 若增加 stale/failure 字段，先更新 `services/tuttid/api/openapi/tuttid.v1.yaml`，再重新生成 Go/TypeScript client；旧客户端仍可读取原有 session/turn 字段。
+- AppX manifest 和 logo 文件本轮只做安装验收，不因没有证据而改动；桌面快捷方式另立产品需求。
+- 增补运行手册、故障码和 Windows E2E 复现步骤，避免后续只能依赖通用“请求失败”。
+
+## 5. 可复用部分与 Adapter 边界
+
+### 可复用的核心能力
+
+- 现有 session/turn/activity canonical projection、session lock、`clientSubmitId`、turn normalizer、activity replay/cursor。
+- 现有 `ApplicationHost`、provider registry、runtime context、OpenAPI 生成链路。
+- 现有 close guard、rail query controller、SQLite store 和 Windows provider 的取消/测试基础设施。
+
+### Adapter 边界
+
+- **Provider adapter** 只负责 provider protocol：Codex `turn/start`/model catalog，Claude child turn，Cursor capability，Kimi permission event 顺序；不能自行修改 Renderer session 状态。
+- **Runtime core** 负责身份、幂等、终态、reconcile 和安全错误模型；不能把某个 provider 的字段直接暴露为全局状态。
+- **Desktop adapter** 只负责传输、投影和用户交互；不能根据“请求返回 200”推断 turn 已完成。
+- **Windows adapter** 只负责搜索/状态目录/打包平台差异；不改变 Agent turn 状态机。
+
+这样可以复用一个 Tutti 状态机，同时把 provider 的异步协议差异限制在适配器内，避免为 Codex、Claude、Cursor、Kimi 各自复制一套取消或 pending 逻辑。
+
+## 6. 明确不做的内容
+
+- 不在未拿到 provider 原始错误前，强制把 GPT-5.2 失败归因成“模型不可用”，也不自动降级到 GPT-5.5。
+- 不重写整个 Agent GUI、ACP 客户端或 SQLite 层；只补身份、终态和必要的旁路能力。
+- 不把所有 `message_delta` mismatch 都当作 provider failure；先修复错误 scope 投影并保留独立指标。
+- 不把固定等待时间简单调大来掩盖 handoff barrier；终态必须可持久化、可重放。
+- 不在没有产品确认时创建桌面快捷方式或替换 AppX logo。
+- 不默认替换 Windows Search 为第三方索引服务；先实现正确 kind、取消、fallback 和明确能力声明。
+- 不删除已有 session、pending interaction 或 SQLite 数据；迁移只允许加法和可回滚重放。
+
+## 7. 数据迁移与兼容策略
+
+- 现有 session/turn 数据继续可读；新增的 context、failure、task/outbox 字段全部可选，旧记录按“无 revision/无 error detail”兼容读取。
+- 启动 reconcile 扫描旧的 running/pending 状态：若 provider 已结束则补 terminal；若无法确定则标记 `reconcile_required`，不伪造 completed。
+- 旧客户端不发送完整 tuple 时，服务端只在 canonical pending 与当前 session/turn 唯一匹配时兼容处理；否则返回 stale，而不是猜测目标。
+- task tree/outbox 若需要 schema，采用新表/新列和版本化 payload；发布顺序为“先读兼容，再写新字段，确认稳定后才可清理旧字段”。
+- SQLite lease 不改变数据库内容；busy retry 和错误码为运行时兼容变更。
+- rail/event 广播采用可丢失通知 + canonical reread，不能把跨窗口通知当作唯一数据存储。
+- API 保持原有 200 成功响应字段；新增错误字段为 optional，旧 Renderer 仍显示通用错误，新 Renderer 显示结构化错误。
+
+## 8. 风险与回滚
+
+主要风险：
+
+- tuple 校验过严导致合法的旧客户端或重启恢复请求被拒绝；需保留兼容分支并记录拒绝原因。
+- provider event 延迟/乱序使 reconcile 产生重复 terminal；必须由 canonical revision 和 terminal 幂等键去重。
+- catalog single-flight 或 Windows fallback 增加首次等待；需以 stale catalog/渐进结果保证可用性。
+- SQLite lease 误判残留进程，造成无法启动；lease 必须带 PID、启动时间和可验证的 ready/exit handshake，不能只看文件存在。
+- close flow 的 bounded wait 可能让用户提前看到“正在停止”；这是可接受的中间态，但必须有最终 reconcile 和重试入口。
+
+回滚方案：
+
+1. 按能力设置独立 feature flag：`identity_guard`、`terminal_reconcile`、`provider_error_detail`、`handoff_outbox`、`windows_search_fallback`、`cross_window_invalidation`、`titlebar_safe_area`。
+2. 先关闭 UI 展示和旁路优化，再保留只读日志；API 新字段保持 optional，旧版本可以继续运行。
+3. schema 只做向后兼容加法；若 outbox 写入异常，停止新写入并从 canonical activity 重建，不删除已有数据。
+4. 发布后以 session/turn/request 维度监控 stale reject、duplicate terminal、identity mismatch、SQLite lock wait、搜索超时和 provider failure code；异常升高时按模块回退。
+
+## 9. 测试与验收标准
+
+### 9.1 自动化测试
+
+- Runtime：模型目录已加载时切换 `gpt-5.5 -> gpt-5.2`，断言 canonical settings、runtime config、`turn/start` params 全部为 gpt-5.2；旧 active turn 不改变。
+- Runtime：provider error、EOF、cancel、重复 terminal 各只产生一个 terminal；错误包含安全 `failureCode` 和 retryability。
+- Projection：构造 expected/actual scope 不同的 `message_delta`，确认错误事件不污染目标 session，并能完成一次 canonical reread。
+- Interactive：旧 request、重复 response、目标已结束、当前 request 分别验证 409/410、幂等成功和正常 provider response。
+- Handoff：10–20 个 child turn 下取消 root、取消 child、取消后重启；所有 child 最终为 canceled/settled，outbox 可重放。
+- Capability/ACP：provider matrix 覆盖 Plan-only、Plan+AskUser、generic permission-first、tool input-first 和 tool input-late。
+- Windows search：file/Directory/未索引/取消/超时/fallback/Recent（Recent 是否支持待产品确认）。
+- SQLite：两个 daemon、Store/Direct 交替启动、旧进程退出中启动；验证无不可恢复 `database is locked`。
+- Desktop：窗口关闭三种入口、重启恢复、双窗口新建会话、DPI 100/125/150% 和窄窗口。
+
+### 9.2 端到端验收
+
+使用真实 Windows 环境通过 `make dev-gui`：
+
+1. 打开两个 Agent session，把当前 session 从 GPT-5.5 切到 GPT-5.2；在旧 session 留下 pending approval，再向当前 session 发送消息。
+2. 断言发送请求的 tuple 指向当前 session，`turn/start` 的 model 为 gpt-5.2；旧 response 被标记 stale 且不会使当前 composer 失败。
+3. 在 provider 失败、网络不可达和模型目录超时场景，UI 显示结构化可操作错误；目录刷新超时不影响普通发送。
+4. 并发启动/取消 10–20 个 child，关闭并重开应用；所有 session/turn/pending 状态最终与 canonical 状态一致。
+5. 测试文件夹和未索引目录搜索，确认参数 kind 正确、超时有 fallback；双窗口新会话在事件周期内出现。
+6. 验收截图/日志必须能用 `workspaceId + agentSessionId + turnId + requestId` 串起一次操作，且不出现错误 scope 的 `message_delta` 投影。
+
+建议的性能门槛（基线需在实施阶段测量，数值未达标时标记待确认）：普通 send/settings API 的本地新增开销 p95 < 50ms；取消请求进入“正在停止” < 500ms；跨窗口 session upsert < 1s；搜索在 deadline 内返回结果或明确 fallback，不允许无限 spinner。
+
+## 10. 分阶段实施顺序
+
+### 阶段 0：补证据和冻结契约
+
+- 用 `make dev-gui` 重现 GPT-5.2、旧 interactive、取消和双窗口场景，捕获完整 provider error notification。
+- 确认原始第 11 项和取消问题的真实症状；确认 Recent、桌面快捷方式等产品决策。
+- 先落地结构化 trace 字段和测试夹具，不改变用户行为。
+
+### 阶段 1：身份、终态和恢复（P0）
+
+- 实现 tuple 校验、stale interactive 语义、terminal 幂等和 projection mismatch reconcile。
+- 修复 cancel/close/restart 的 canonical-first 流程；补 child cancel 冻结和最小 durable terminal outbox。
+- 交付问题：GPT-5.2 旧请求串线、关闭后旧 AskUser、取消后无限 loading、Claude handoff 取消竞态。
+
+### 阶段 2：provider 能力、模型与 ACP 事件（P0）
+
+- 实现 AskUser capability matrix 和 Plan mode gating。
+- 修复 Codex model settings/catalog single-flight、safe provider error；修复 generic permission 的 late tool input merge。
+- 交付问题：Cursor Plan、Kimi Read/ReadFile 详情，以及 GPT-5.2 失败可诊断性。
+
+### 阶段 3：Windows 数据链路（P1）
+
+- 修复 file/directory search contract、取消/fallback/Recent 能力提示。
+- 增加 state directory daemon lease、SQLite bounded retry 和明确错误码；完成 Store/Direct 交替启动验收。
+- 交付问题：工作区引用搜索/文件夹、Microsoft Store Agent 启动。
+
+### 阶段 4：桌面投影和视觉回归（P1）
+
+- 完成跨窗口 rail invalidation、分页/排序回归。
+- 完成 titlebar safe-area 和 DPI/窄窗口验收。
+- 交付问题：旧窗口会话列表不刷新、图片工具栏与标题栏重叠。
+
+### 阶段 5：灰度、观测和收口
+
+- 按 feature flag 灰度，比较各阶段前后的 stale reject、identity mismatch、terminal latency、provider failure、SQLite lock 和 search timeout。
+- 关闭不再需要的临时兼容分支前，确认旧客户端、重启恢复和已有数据均可读。

--- a/packages/agent/activity-core/src/engine/engineRuntime.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/engineRuntime.reducer.test.ts
@@ -1105,6 +1105,67 @@ test("authoritative interaction result drains from post-lifecycle canonical stat
   );
 });
 
+test("stale interaction failure requests reconcile through the root reducer", () => {
+  let state = createInitialAgentSessionEngineState();
+  const waitingTurn = {
+    agentSessionId: "session-1",
+    origin: "user_prompt" as const,
+    phase: "waiting" as const,
+    startedAtUnixMs: 1,
+    turnId: "turn-1",
+    updatedAtUnixMs: 1
+  };
+  const pendingInteraction = {
+    agentSessionId: "session-1",
+    createdAtUnixMs: 1,
+    input: {},
+    kind: "question" as const,
+    metadata: {},
+    requestId: "request-1",
+    status: "pending" as const,
+    turnId: "turn-1",
+    updatedAtUnixMs: 1
+  };
+  const session = {
+    ...runningSession(capabilities({})),
+    activeTurn: waitingTurn,
+    latestTurn: waitingTurn,
+    latestTurnInteractions: [pendingInteraction],
+    pendingInteractions: [pendingInteraction]
+  };
+  state = rootEngineReducer(state, {
+    sessions: [session],
+    type: "session/snapshotReceived"
+  }).state;
+  state = rootEngineReducer(state, {
+    agentSessionId: "session-1",
+    commandId: "respond-1",
+    optionId: "approve",
+    requestId: "request-1",
+    turnId: "turn-1",
+    type: "interaction/responseRequested",
+    workspaceId: "workspace-1"
+  }).state;
+
+  const stale = rootEngineReducer(state, {
+    commandId: "respond-1",
+    commandType: "interaction/respond",
+    correlationId: canonicalInteractionKey("session-1", "turn-1", "request-1"),
+    errorReason: "agent_interactive_request_stale",
+    outcome: "failed",
+    type: "engine/commandResult"
+  });
+  assert.deepEqual(stale.followUpIntents, [
+    {
+      agentSessionId: "session-1",
+      needsMessages: true,
+      needsState: true,
+      type: "session/reconcileRequested",
+      workspaceId: "workspace-1"
+    }
+  ]);
+});
+
 test("terminal latest turn drains at an unchanged session timestamp", () => {
   let state = createInitialAgentSessionEngineState();
   const running = runningSession(capabilities({}));

--- a/packages/agent/activity-core/src/engine/rootReducer.ts
+++ b/packages/agent/activity-core/src/engine/rootReducer.ts
@@ -485,6 +485,7 @@ export function rootEngineReducer(
     ...(goalControl.followUpIntents ?? []),
     ...(sessionReconcile.followUpIntents ?? []),
     ...(sessionMutations.followUpIntents ?? []),
+    ...(sessionLifecycle.followUpIntents ?? []),
     ...(pendingIntents.followUpIntents ?? []),
     ...(promptExecutions.followUpIntents ?? []),
     ...(promptQueue.followUpIntents ?? [])

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.test.ts
@@ -872,6 +872,44 @@ test("interaction timeout and late cross-scope results never become success", ()
   );
 });
 
+test("stale interactive responses request an authoritative session reconcile", () => {
+  let state = reduce(createInitialSessionLifecycleState(), {
+    type: "session/snapshotReceived",
+    sessions: [session(activeTurn(1), 1)]
+  }).state;
+  state = reduce(state, {
+    type: "interaction/upserted",
+    interaction: interaction("pending", 2)
+  }).state;
+  state = reduce(state, interactionResponseRequested("respond-1")).state;
+
+  const stale = reduce(state, {
+    commandId: "respond-1",
+    commandType: "interaction/respond",
+    correlationId: canonicalInteractionKey("session-1", "turn-1", "request-1"),
+    errorMessage: "interactive request is stale",
+    errorReason: "agent_interactive_request_stale",
+    outcome: "failed",
+    type: "engine/commandResult"
+  });
+
+  assert.equal(
+    stale.state.interactionResponsesById[
+      canonicalInteractionKey("session-1", "turn-1", "request-1")
+    ]?.status,
+    "failed"
+  );
+  assert.deepEqual(stale.followUpIntents, [
+    {
+      agentSessionId: "session-1",
+      needsMessages: true,
+      needsState: true,
+      type: "session/reconcileRequested",
+      workspaceId: "workspace-1"
+    }
+  ]);
+});
+
 test("terminal canonical session snapshot confirms an acknowledged response", () => {
   const source = session(activeTurn(1), 1);
   source.pendingInteractions = [interaction("pending", 1)];

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.ts
@@ -48,6 +48,8 @@ import {
 } from "./sessionLifecycle.cancel.ts";
 const NO_COMMANDS: readonly EngineCommand[] = [];
 const TURN_CANCEL_TIMEOUT_MS = 30_000;
+const STALE_INTERACTIVE_REQUEST_ERROR_REASON =
+  "agent_interactive_request_stale";
 
 export function createInitialSessionLifecycleState(): SessionLifecycleState {
   return {
@@ -430,14 +432,28 @@ function settleInteractionResponse(
   if (!entry) return unchanged(state);
   const [key, response] = entry;
   if (intent.outcome === "failed") {
-    return result(
-      replaceInteractionResponse(state, key, {
-        ...response,
-        errorCode: intent.errorCode ?? null,
-        errorMessage: intent.errorMessage?.trim() || null,
-        status: "failed"
-      })
-    );
+    const next = replaceInteractionResponse(state, key, {
+      ...response,
+      errorCode: intent.errorCode ?? null,
+      errorMessage: intent.errorMessage?.trim() || null,
+      status: "failed"
+    });
+    if (intent.errorReason?.trim() === STALE_INTERACTIVE_REQUEST_ERROR_REASON) {
+      return {
+        commands: NO_COMMANDS,
+        followUpIntents: [
+          {
+            agentSessionId: response.agentSessionId,
+            needsMessages: true,
+            needsState: true,
+            type: "session/reconcileRequested",
+            workspaceId: response.workspaceId
+          }
+        ],
+        state: next
+      };
+    }
+    return result(next);
   }
   return result(
     replaceInteractionResponse(state, key, {

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -69,6 +69,15 @@ type RuntimeStreamEventObserver interface {
 	) error
 }
 
+// RuntimeStreamEventFilter can be implemented by an observer that validates
+// event identity before the same stream is delivered to daemon-local
+// subscribers. Observation and filtering are separate so an external
+// projection can still emit a reconcile signal while the invalid event is
+// withheld from the local session fan-out.
+type RuntimeStreamEventFilter interface {
+	FilterRuntimeStreamEvents(string, string, []StreamEvent) []StreamEvent
+}
+
 // ProviderObservationObserver receives capture-only provider observations
 // synchronously before their durable activity report is queued.
 type ProviderObservationObserver interface {

--- a/packages/agent/daemon/runtime/controller_stream_observer.go
+++ b/packages/agent/daemon/runtime/controller_stream_observer.go
@@ -36,7 +36,11 @@ func (c *Controller) publishStreamEvents(
 	c.streamObserverMu.RLock()
 	observer := c.streamObserver
 	c.streamObserverMu.RUnlock()
+	publishedEvents := events
 	if observer != nil {
+		if filter, ok := observer.(RuntimeStreamEventFilter); ok {
+			publishedEvents = filter.FilterRuntimeStreamEvents(roomID, agentSessionID, events)
+		}
 		if err := observer.ObserveRuntimeStreamEvents(
 			context.Background(),
 			roomID,
@@ -52,5 +56,5 @@ func (c *Controller) publishStreamEvents(
 			)
 		}
 	}
-	c.hub.Publish(roomID, agentSessionID, events)
+	c.hub.Publish(roomID, agentSessionID, publishedEvents)
 }

--- a/packages/agent/daemon/runtime/controller_stream_observer_test.go
+++ b/packages/agent/daemon/runtime/controller_stream_observer_test.go
@@ -13,6 +13,21 @@ type recordingRuntimeStreamObserver struct {
 	err    error
 }
 
+type filteringRuntimeStreamObserver struct {
+	recordingRuntimeStreamObserver
+}
+
+func (*filteringRuntimeStreamObserver) FilterRuntimeStreamEvents(
+	_ string,
+	_ string,
+	events []StreamEvent,
+) []StreamEvent {
+	if len(events) < 2 {
+		return events
+	}
+	return events[:1]
+}
+
 func (o *recordingRuntimeStreamObserver) ObserveRuntimeStreamEvents(
 	_ context.Context,
 	_ string,
@@ -72,5 +87,35 @@ func TestPublishStreamEventsObservesBeforeSessionFanout(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for session fanout")
+	}
+}
+
+func TestPublishStreamEventsUsesObserverFilterForLocalFanout(t *testing.T) {
+	controller := NewController(nil, nil)
+	observer := &filteringRuntimeStreamObserver{}
+	controller.SetStreamEventObserver(observer)
+	events, unsubscribe := controller.hub.Subscribe("workspace-1", "session-1")
+	defer unsubscribe()
+
+	controller.publishStreamEvents("workspace-1", "session-1", []StreamEvent{
+		{EventType: StreamEventMessageDelta, Data: "delta-1"},
+		{EventType: StreamEventMessageDelta, Data: "delta-2"},
+	})
+
+	select {
+	case event := <-events:
+		if event.Data != "delta-1" {
+			t.Fatalf("session event = %#v, want filtered first event", event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for filtered session fanout")
+	}
+	select {
+	case event := <-events:
+		t.Fatalf("unexpected second session event = %#v", event)
+	case <-time.After(25 * time.Millisecond):
+	}
+	if !observer.called || len(observer.events) != 2 {
+		t.Fatalf("observer events = %#v, want both events", observer.events)
 	}
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.reporting.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.reporting.ts
@@ -75,6 +75,7 @@ export type AgentGUIRuntimeErrorPhase =
   | "interrupt_current_turn"
   | "load_session_messages"
   | "load_session_state"
+  | "synchronize_session"
   | "retry_activation"
   | "send_prompt"
   | "submit_interactive"

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentConversationMessagePaging.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentConversationMessagePaging.ts
@@ -164,7 +164,7 @@ export interface ConversationMessagePagingDiagnosticsPort {
     agentSessionId: string;
     context?: Record<string, unknown>;
     error: unknown;
-    phase: "load_session_messages";
+    phase: "load_session_messages" | "synchronize_session";
   }): void;
   page(input: {
     agentSessionId: string;
@@ -201,9 +201,21 @@ export function useAgentConversationMessagePaging(
               error,
               phase: "load_session_messages"
             }),
-          page: (event) => inputRef.current.diagnostics.page(event)
+          page: (event) => inputRef.current.diagnostics.page(event),
+          synchronizationError: ({ agentSessionId, error }) =>
+            inputRef.current.diagnostics.error({
+              agentSessionId,
+              error,
+              phase: "synchronize_session"
+            })
         },
         engine: input.sessionEngine,
+        ensureSessionSynchronized: ({ agentSessionId, onError, workspaceId }) =>
+          inputRef.current.runtime.ensureSessionSynchronized?.({
+            agentSessionId,
+            onError,
+            workspaceId
+          }) ?? (() => {}),
         isAvailable: (agentSessionId) =>
           inputRef.current.isMounted() &&
           (!agentSessionId ||

--- a/packages/agent/gui/agentConversationMessageController.spec.ts
+++ b/packages/agent/gui/agentConversationMessageController.spec.ts
@@ -208,6 +208,52 @@ describe("createAgentConversationMessageController", () => {
     engine.dispose();
   });
 
+  it("retains synchronization only for the active Session", () => {
+    const engine = createTestAgentSessionEngine("workspace-1");
+    const releases: string[] = [];
+    const ensureSessionSynchronized = vi.fn(
+      ({ agentSessionId }: { agentSessionId: string }) =>
+        () => {
+          releases.push(agentSessionId);
+        }
+    );
+    const controller = createController({
+      engine,
+      ensureSessionSynchronized
+    });
+
+    controller.setActiveSession("session-1");
+    controller.setActiveSession("session-1");
+    controller.setActiveSession("session-2");
+    controller.setActiveSession(null);
+    controller.setActiveSession("session-3");
+    controller.dispose();
+
+    expect(ensureSessionSynchronized.mock.calls).toEqual([
+      [
+        expect.objectContaining({
+          agentSessionId: "session-1",
+          workspaceId: "workspace-1"
+        })
+      ],
+      [
+        expect.objectContaining({
+          agentSessionId: "session-2",
+          workspaceId: "workspace-1"
+        })
+      ],
+      [
+        expect.objectContaining({
+          agentSessionId: "session-3",
+          workspaceId: "workspace-1"
+        })
+      ]
+    ]);
+    expect(releases).toEqual(["session-1", "session-2", "session-3"]);
+
+    engine.dispose();
+  });
+
   it("rejects a stale page when the host focus changes before synchronization", async () => {
     const engine = createTestAgentSessionEngine("workspace-1");
     let focusedSessionId = "session-1";
@@ -240,6 +286,9 @@ describe("createAgentConversationMessageController", () => {
 
 function createController(input: {
   engine: ReturnType<typeof createTestAgentSessionEngine>;
+  ensureSessionSynchronized?: Parameters<
+    typeof createAgentConversationMessageController
+  >[0]["ensureSessionSynchronized"];
   isAvailable?: (agentSessionId?: string | null) => boolean;
   listSessionMessages?: (
     input: AgentConversationMessagePageInput
@@ -247,6 +296,7 @@ function createController(input: {
 }) {
   return createAgentConversationMessageController({
     engine: input.engine,
+    ensureSessionSynchronized: input.ensureSessionSynchronized,
     isAvailable: input.isAvailable ?? (() => true),
     listSessionMessages:
       input.listSessionMessages ??

--- a/packages/agent/gui/agentConversationMessageController.ts
+++ b/packages/agent/gui/agentConversationMessageController.ts
@@ -40,11 +40,20 @@ export interface AgentConversationMessageControllerDiagnostics {
     level?: "debug" | "warn";
     messages?: readonly AgentActivityDurableMessage[];
   }): void;
+  synchronizationError?(input: {
+    agentSessionId: string;
+    error: unknown;
+  }): void;
 }
 
 export interface CreateAgentConversationMessageControllerInput {
   diagnostics?: AgentConversationMessageControllerDiagnostics;
   engine: Pick<AgentSessionEngine, "dispatch" | "getSnapshot">;
+  ensureSessionSynchronized?(input: {
+    agentSessionId: string;
+    onError(error: unknown): void;
+    workspaceId: string;
+  }): () => void;
   isAvailable(agentSessionId?: string | null): boolean;
   listSessionMessages(
     input: AgentConversationMessagePageInput
@@ -90,6 +99,7 @@ export function createAgentConversationMessageController(
   let disposed = false;
   let generation = 0;
   let snapshot = EMPTY_SNAPSHOT;
+  let releaseSessionSynchronization: (() => void) | null = null;
   let olderRequest: {
     abortController: AbortController;
     agentSessionId: string;
@@ -140,12 +150,30 @@ export function createAgentConversationMessageController(
     if (normalized === activeSessionId) return;
     generation += 1;
     abortOlderRequest();
+    releaseSessionSynchronization?.();
+    releaseSessionSynchronization = null;
     activeSessionId = normalized;
     publish({
       agentSessionId: normalized,
       error: null,
       olderPagePhase: "idle"
     });
+    if (!normalized || !input.ensureSessionSynchronized) return;
+    const reportSynchronizationError = (error: unknown): void => {
+      input.diagnostics?.synchronizationError?.({
+        agentSessionId: normalized,
+        error
+      });
+    };
+    try {
+      releaseSessionSynchronization = input.ensureSessionSynchronized({
+        agentSessionId: normalized,
+        onError: reportSynchronizationError,
+        workspaceId: input.workspaceId
+      });
+    } catch (error) {
+      reportSynchronizationError(error);
+    }
   };
 
   const requestReconcile = (
@@ -185,6 +213,8 @@ export function createAgentConversationMessageController(
       disposed = true;
       generation += 1;
       abortOlderRequest();
+      releaseSessionSynchronization?.();
+      releaseSessionSynchronization = null;
     },
     getSnapshot: () => snapshot,
     async loadOlder(agentSessionId) {

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -140,6 +140,24 @@
   -webkit-app-region: no-drag;
 }
 
+/*
+ * The image preview is portaled to document.body, so it cannot inherit the
+ * workbench header's scoped Windows titlebar inset. Reuse the same native
+ * caption-button geometry for the portal controls; otherwise the close and
+ * zoom buttons sit underneath the minimize/maximize/close buttons.
+ */
+body[data-tutti-titlebar-overlay="true"] {
+  --tutti-titlebar-controls-inset: calc(
+    100vw - env(titlebar-area-width, calc(100vw - 138px)) + 10px
+  );
+}
+
+body[data-tutti-titlebar-overlay="true"]
+  .tsh-zoom-dialog__toolbar-actions {
+  right: calc(20px + var(--tutti-titlebar-controls-inset));
+  inset-inline-end: calc(20px + var(--tutti-titlebar-controls-inset));
+}
+
 .tsh-zoom-dialog__image {
   display: block;
   max-width: calc(100vw - 48px);
@@ -168,9 +186,20 @@
   -webkit-app-region: no-drag;
 }
 
+body[data-tutti-titlebar-overlay="true"]
+  .tsh-zoom-dialog__zoom-controls {
+  right: calc(168px + var(--tutti-titlebar-controls-inset));
+}
+
 .tsh-zoom-dialog:not([data-tsh-image-actions="true"])
   .tsh-zoom-dialog__zoom-controls {
   right: 72px;
+}
+
+body[data-tutti-titlebar-overlay="true"]
+  .tsh-zoom-dialog:not([data-tsh-image-actions="true"])
+  .tsh-zoom-dialog__zoom-controls {
+  right: calc(72px + var(--tutti-titlebar-controls-inset));
 }
 
 .tsh-image-context-menu {

--- a/packages/agent/store-sqlite/activity.go
+++ b/packages/agent/store-sqlite/activity.go
@@ -69,9 +69,9 @@ func (s *Store) ReportActivityState(
 		input.Session.OccurredAtUnixMS = now
 	}
 	var result ActivityStateReportResult
-	err := retrySQLiteBusy(ctx, func() error {
+	err := retrySQLiteBusy(ctx, func(attemptCtx context.Context) error {
 		var err error
-		result, err = s.reportActivityStateOnce(ctx, input, now)
+		result, err = s.reportActivityStateOnce(attemptCtx, input, now)
 		return err
 	})
 	return result, err
@@ -322,6 +322,24 @@ func (s *Store) ReportSessionMessages(
 		return MessageReportResult{}, err
 	}
 
+	now := unixMs(time.Now().UTC())
+	var result MessageReportResult
+	err := retrySQLiteBusy(ctx, func(attemptCtx context.Context) error {
+		var err error
+		result, err = s.reportSessionMessagesOnce(attemptCtx, input, now)
+		return err
+	})
+	return result, err
+}
+
+func (s *Store) reportSessionMessagesOnce(
+	ctx context.Context,
+	input SessionMessageReport,
+	now int64,
+) (MessageReportResult, error) {
+	workspaceID := strings.TrimSpace(input.WorkspaceID)
+	agentSessionID := strings.TrimSpace(input.AgentSessionID)
+
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return MessageReportResult{}, fmt.Errorf("begin workspace agent message report: %w", err)
@@ -333,7 +351,6 @@ func (s *Store) ReportSessionMessages(
 		}
 	}()
 
-	now := unixMs(time.Now().UTC())
 	agentSessionID, err = resolveAgentMessageReportSessionIDTx(ctx, tx, workspaceID, agentSessionID, input.Provider, input.Origin)
 	if err != nil {
 		return MessageReportResult{}, err

--- a/packages/agent/store-sqlite/activity.go
+++ b/packages/agent/store-sqlite/activity.go
@@ -64,6 +64,27 @@ func (s *Store) ReportActivityState(
 		return ActivityStateReportResult{}, err
 	}
 
+	now := unixMs(time.Now().UTC())
+	if input.Session.OccurredAtUnixMS <= 0 {
+		input.Session.OccurredAtUnixMS = now
+	}
+	var result ActivityStateReportResult
+	err := retrySQLiteBusy(ctx, func() error {
+		var err error
+		result, err = s.reportActivityStateOnce(ctx, input, now)
+		return err
+	})
+	return result, err
+}
+
+func (s *Store) reportActivityStateOnce(
+	ctx context.Context,
+	input ActivityStateReport,
+	now int64,
+) (ActivityStateReportResult, error) {
+	workspaceID := strings.TrimSpace(input.Session.WorkspaceID)
+	agentSessionID := strings.TrimSpace(input.Session.AgentSessionID)
+
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return ActivityStateReportResult{}, fmt.Errorf("begin workspace agent activity state report: %w", err)
@@ -75,10 +96,6 @@ func (s *Store) ReportActivityState(
 		}
 	}()
 
-	now := unixMs(time.Now().UTC())
-	if input.Session.OccurredAtUnixMS <= 0 {
-		input.Session.OccurredAtUnixMS = now
-	}
 	goalBefore, err := readSessionGoalProjectionTx(ctx, tx, input.Session)
 	if err != nil {
 		return ActivityStateReportResult{}, err

--- a/packages/agent/store-sqlite/activity_transaction.go
+++ b/packages/agent/store-sqlite/activity_transaction.go
@@ -14,6 +14,25 @@ func (s *Store) upsertAgentSession(
 	input SessionStateReport,
 	now int64,
 ) (bool, bool, int64, Session, error) {
+	var (
+		accepted        bool
+		stateApplied    bool
+		lastEventUnixMS int64
+		session         Session
+	)
+	err := retrySQLiteBusy(ctx, func() error {
+		var err error
+		accepted, stateApplied, lastEventUnixMS, session, err = s.upsertAgentSessionOnce(ctx, input, now)
+		return err
+	})
+	return accepted, stateApplied, lastEventUnixMS, session, err
+}
+
+func (s *Store) upsertAgentSessionOnce(
+	ctx context.Context,
+	input SessionStateReport,
+	now int64,
+) (bool, bool, int64, Session, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return false, false, 0, Session{}, fmt.Errorf("begin workspace agent session state report: %w", err)

--- a/packages/agent/store-sqlite/activity_transaction.go
+++ b/packages/agent/store-sqlite/activity_transaction.go
@@ -20,9 +20,9 @@ func (s *Store) upsertAgentSession(
 		lastEventUnixMS int64
 		session         Session
 	)
-	err := retrySQLiteBusy(ctx, func() error {
+	err := retrySQLiteBusy(ctx, func(attemptCtx context.Context) error {
 		var err error
-		accepted, stateApplied, lastEventUnixMS, session, err = s.upsertAgentSessionOnce(ctx, input, now)
+		accepted, stateApplied, lastEventUnixMS, session, err = s.upsertAgentSessionOnce(attemptCtx, input, now)
 		return err
 	})
 	return accepted, stateApplied, lastEventUnixMS, session, err

--- a/packages/agent/store-sqlite/sqlite_busy.go
+++ b/packages/agent/store-sqlite/sqlite_busy.go
@@ -10,10 +10,11 @@ import (
 )
 
 // A busy result means that the transaction did not commit and is safe to
-// replay from its beginning. Keep this retry deliberately small: it smooths
+// replay from its beginning. Keep the retry deliberately small: it smooths
 // transient WAL/checkpoint contention without hiding a second process that
 // owns the database for an unbounded period.
 const sqliteBusyRetryAttempts = 3
+const sqliteBusyRetryBudget = 5 * time.Second
 
 var sqliteBusyRetryBackoff = [...]time.Duration{
 	50 * time.Millisecond,
@@ -25,13 +26,16 @@ func isSQLiteBusyError(err error) bool {
 	return errors.As(err, &sqliteErr) && sqliteErr.Code()&0xff == sqlite3.SQLITE_BUSY
 }
 
-func retrySQLiteBusy(ctx context.Context, operation func() error) error {
+func retrySQLiteBusy(ctx context.Context, operation func(context.Context) error) error {
+	retryCtx, cancel := context.WithTimeout(ctx, sqliteBusyRetryBudget)
+	defer cancel()
+
 	for attempt := 1; attempt <= sqliteBusyRetryAttempts; attempt++ {
-		err := operation()
+		err := operation(retryCtx)
 		if err == nil || !isSQLiteBusyError(err) || attempt == sqliteBusyRetryAttempts {
 			return err
 		}
-		if err := waitSQLiteBusyRetry(ctx, sqliteBusyRetryBackoff[attempt-1]); err != nil {
+		if err := waitSQLiteBusyRetry(retryCtx, sqliteBusyRetryBackoff[attempt-1]); err != nil {
 			return err
 		}
 	}

--- a/packages/agent/store-sqlite/sqlite_busy.go
+++ b/packages/agent/store-sqlite/sqlite_busy.go
@@ -1,0 +1,50 @@
+package storesqlite
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	sqlitedriver "modernc.org/sqlite"
+	sqlite3 "modernc.org/sqlite/lib"
+)
+
+// A busy result means that the transaction did not commit and is safe to
+// replay from its beginning. Keep this retry deliberately small: it smooths
+// transient WAL/checkpoint contention without hiding a second process that
+// owns the database for an unbounded period.
+const sqliteBusyRetryAttempts = 3
+
+var sqliteBusyRetryBackoff = [...]time.Duration{
+	50 * time.Millisecond,
+	100 * time.Millisecond,
+}
+
+func isSQLiteBusyError(err error) bool {
+	var sqliteErr *sqlitedriver.Error
+	return errors.As(err, &sqliteErr) && sqliteErr.Code()&0xff == sqlite3.SQLITE_BUSY
+}
+
+func retrySQLiteBusy(ctx context.Context, operation func() error) error {
+	for attempt := 1; attempt <= sqliteBusyRetryAttempts; attempt++ {
+		err := operation()
+		if err == nil || !isSQLiteBusyError(err) || attempt == sqliteBusyRetryAttempts {
+			return err
+		}
+		if err := waitSQLiteBusyRetry(ctx, sqliteBusyRetryBackoff[attempt-1]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func waitSQLiteBusyRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/packages/agent/store-sqlite/sqlite_busy_test.go
+++ b/packages/agent/store-sqlite/sqlite_busy_test.go
@@ -1,0 +1,285 @@
+package storesqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestRetrySQLiteBusyReplaysOperationAfterTransientBusy(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "busy.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec("CREATE TABLE items (id INTEGER PRIMARY KEY, value TEXT)"); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	holder, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("db.Conn() error = %v", err)
+	}
+	t.Cleanup(func() { _ = holder.Close() })
+	if _, err := holder.ExecContext(context.Background(), "PRAGMA busy_timeout = 0"); err != nil {
+		t.Fatalf("disable busy timeout: %v", err)
+	}
+	if _, err := holder.ExecContext(context.Background(), "BEGIN IMMEDIATE"); err != nil {
+		t.Fatalf("begin holder transaction: %v", err)
+	}
+	t.Cleanup(func() { _, _ = holder.ExecContext(context.Background(), "ROLLBACK") })
+
+	writer, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("writer connection: %v", err)
+	}
+	t.Cleanup(func() { _ = writer.Close() })
+	if _, err := writer.ExecContext(context.Background(), "PRAGMA busy_timeout = 0"); err != nil {
+		t.Fatalf("disable writer busy timeout: %v", err)
+	}
+
+	attempts := 0
+	released := false
+	err = retrySQLiteBusy(context.Background(), func() error {
+		attempts++
+		_, err := writer.ExecContext(context.Background(), "INSERT INTO items(id, value) VALUES (?, ?)", attempts, "ok")
+		if err == nil {
+			return nil
+		}
+		if !isSQLiteBusyError(err) {
+			return err
+		}
+		if !released {
+			if _, releaseErr := holder.ExecContext(context.Background(), "ROLLBACK"); releaseErr != nil {
+				return releaseErr
+			}
+			released = true
+		}
+		return err
+	})
+	if err != nil {
+		t.Fatalf("retrySQLiteBusy() error = %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM items").Scan(&count); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("row count = %d, want 1", count)
+	}
+}
+
+func TestReportSessionStateRetriesSQLiteBusyTransaction(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "agent-store.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("store sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+	if _, err := db.Exec("PRAGMA busy_timeout = 0"); err != nil {
+		t.Fatalf("store busy timeout: %v", err)
+	}
+	store := New(db, Options{})
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("Migrate() error = %v", err)
+	}
+
+	holderDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("holder sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = holderDB.Close() })
+	holderDB.SetMaxOpenConns(1)
+	holder, err := holderDB.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("holder Conn() error = %v", err)
+	}
+	t.Cleanup(func() { _ = holder.Close() })
+	if _, err := holder.ExecContext(context.Background(), "PRAGMA busy_timeout = 0"); err != nil {
+		t.Fatalf("holder busy timeout: %v", err)
+	}
+	if _, err := holder.ExecContext(context.Background(), "BEGIN IMMEDIATE"); err != nil {
+		t.Fatalf("holder transaction: %v", err)
+	}
+	t.Cleanup(func() { _, _ = holder.ExecContext(context.Background(), "ROLLBACK") })
+
+	release := time.AfterFunc(25*time.Millisecond, func() {
+		_, _ = holder.ExecContext(context.Background(), "ROLLBACK")
+	})
+	t.Cleanup(func() { release.Stop() })
+
+	result, err := store.ReportSessionState(context.Background(), SessionStateReport{
+		WorkspaceID:      "workspace-1",
+		AgentSessionID:   "session-1",
+		Provider:         "codex",
+		OccurredAtUnixMS: 1,
+	})
+	if err != nil {
+		t.Fatalf("ReportSessionState() error = %v", err)
+	}
+	if !result.Accepted || result.Session.ID != "session-1" {
+		t.Fatalf("ReportSessionState() result = %#v, want accepted session-1", result)
+	}
+}
+
+func TestReportActivityStateRetriesSQLiteBusyTransaction(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "agent-activity-store.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("store sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+	if _, err := db.Exec("PRAGMA busy_timeout = 0"); err != nil {
+		t.Fatalf("store busy timeout: %v", err)
+	}
+	store := New(db, Options{})
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("Migrate() error = %v", err)
+	}
+
+	holderDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("holder sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = holderDB.Close() })
+	holder, err := holderDB.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("holder Conn() error = %v", err)
+	}
+	t.Cleanup(func() { _, _ = holder.ExecContext(context.Background(), "ROLLBACK"); _ = holder.Close() })
+	if _, err := holder.ExecContext(context.Background(), "PRAGMA busy_timeout = 0"); err != nil {
+		t.Fatalf("holder busy timeout: %v", err)
+	}
+	if _, err := holder.ExecContext(context.Background(), "BEGIN IMMEDIATE"); err != nil {
+		t.Fatalf("holder transaction: %v", err)
+	}
+
+	release := time.AfterFunc(25*time.Millisecond, func() {
+		_, _ = holder.ExecContext(context.Background(), "ROLLBACK")
+	})
+	t.Cleanup(func() { release.Stop() })
+
+	result, err := store.ReportActivityState(context.Background(), ActivityStateReport{
+		Session: SessionStateReport{
+			WorkspaceID:      "workspace-1",
+			AgentSessionID:   "session-1",
+			Provider:         "codex",
+			OccurredAtUnixMS: 1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ReportActivityState() error = %v", err)
+	}
+	if !result.State.Accepted || result.State.Session.ID != "session-1" {
+		t.Fatalf("ReportActivityState() result = %#v, want accepted session-1", result)
+	}
+}
+
+func TestRetrySQLiteBusyRespectsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	_, _, writer := openSQLiteBusyRetryFixture(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	attempts := 0
+	err := retrySQLiteBusy(ctx, func() error {
+		attempts++
+		_, err := writer.ExecContext(context.Background(), "INSERT INTO items(id, value) VALUES (?, ?)", attempts, "blocked")
+		cancel()
+		return err
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("retrySQLiteBusy() error = %v, want context canceled", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+}
+
+func TestRetrySQLiteBusyReturnsErrorAfterFinalAttempt(t *testing.T) {
+	t.Parallel()
+
+	_, _, writer := openSQLiteBusyRetryFixture(t)
+	attempts := 0
+	err := retrySQLiteBusy(context.Background(), func() error {
+		attempts++
+		_, err := writer.ExecContext(context.Background(), "INSERT INTO items(id, value) VALUES (?, ?)", attempts, "blocked")
+		return err
+	})
+	if !isSQLiteBusyError(err) {
+		t.Fatalf("retrySQLiteBusy() error = %v, want SQLite busy error", err)
+	}
+	if attempts != sqliteBusyRetryAttempts {
+		t.Fatalf("attempts = %d, want %d", attempts, sqliteBusyRetryAttempts)
+	}
+}
+
+func openSQLiteBusyRetryFixture(t *testing.T) (*sql.DB, *sql.Conn, *sql.Conn) {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "busy-fixture.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec("CREATE TABLE items (id INTEGER PRIMARY KEY, value TEXT)"); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	holder, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("holder db.Conn() error = %v", err)
+	}
+	t.Cleanup(func() { _, _ = holder.ExecContext(context.Background(), "ROLLBACK"); _ = holder.Close() })
+	if _, err := holder.ExecContext(context.Background(), "PRAGMA busy_timeout = 0"); err != nil {
+		t.Fatalf("holder busy timeout: %v", err)
+	}
+	if _, err := holder.ExecContext(context.Background(), "BEGIN IMMEDIATE"); err != nil {
+		t.Fatalf("holder transaction: %v", err)
+	}
+
+	writer, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("writer db.Conn() error = %v", err)
+	}
+	t.Cleanup(func() { _ = writer.Close() })
+	if _, err := writer.ExecContext(context.Background(), "PRAGMA busy_timeout = 0"); err != nil {
+		t.Fatalf("writer busy timeout: %v", err)
+	}
+	return db, holder, writer
+}
+
+func TestRetrySQLiteBusyPreservesNonBusyErrors(t *testing.T) {
+	t.Parallel()
+
+	want := errors.New("not retryable")
+	attempts := 0
+	if err := retrySQLiteBusy(context.Background(), func() error {
+		attempts++
+		return want
+	}); !errors.Is(err, want) {
+		t.Fatalf("error = %v, want %v", err, want)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+}

--- a/packages/agent/store-sqlite/sqlite_busy_test.go
+++ b/packages/agent/store-sqlite/sqlite_busy_test.go
@@ -48,9 +48,9 @@ func TestRetrySQLiteBusyReplaysOperationAfterTransientBusy(t *testing.T) {
 
 	attempts := 0
 	released := false
-	err = retrySQLiteBusy(context.Background(), func() error {
+	err = retrySQLiteBusy(context.Background(), func(attemptCtx context.Context) error {
 		attempts++
-		_, err := writer.ExecContext(context.Background(), "INSERT INTO items(id, value) VALUES (?, ?)", attempts, "ok")
+		_, err := writer.ExecContext(attemptCtx, "INSERT INTO items(id, value) VALUES (?, ?)", attempts, "ok")
 		if err == nil {
 			return nil
 		}
@@ -193,6 +193,74 @@ func TestReportActivityStateRetriesSQLiteBusyTransaction(t *testing.T) {
 	}
 }
 
+func TestReportSessionMessagesRetriesSQLiteBusyTransaction(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "agent-message-store.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("store sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+	if _, err := db.Exec("PRAGMA busy_timeout = 0"); err != nil {
+		t.Fatalf("store busy timeout: %v", err)
+	}
+	store := New(db, Options{})
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("Migrate() error = %v", err)
+	}
+	if _, err := store.ReportSessionState(context.Background(), SessionStateReport{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1", Provider: "codex",
+		OccurredAtUnixMS: 1,
+	}); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+	if _, accepted, err := store.RecordTurnTransition(context.Background(), TurnTransition{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1", TurnID: "turn-1",
+		Phase: TurnPhaseRunning, OccurredAtUnixMS: 2,
+	}); err != nil || !accepted {
+		t.Fatalf("seed turn accepted=%v error=%v", accepted, err)
+	}
+
+	holderDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("holder sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = holderDB.Close() })
+	holderDB.SetMaxOpenConns(1)
+	holder, err := holderDB.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("holder Conn() error = %v", err)
+	}
+	t.Cleanup(func() { _, _ = holder.ExecContext(context.Background(), "ROLLBACK"); _ = holder.Close() })
+	if _, err := holder.ExecContext(context.Background(), "PRAGMA busy_timeout = 0"); err != nil {
+		t.Fatalf("holder busy timeout: %v", err)
+	}
+	if _, err := holder.ExecContext(context.Background(), "BEGIN IMMEDIATE"); err != nil {
+		t.Fatalf("holder transaction: %v", err)
+	}
+
+	release := time.AfterFunc(25*time.Millisecond, func() {
+		_, _ = holder.ExecContext(context.Background(), "ROLLBACK")
+	})
+	t.Cleanup(func() { release.Stop() })
+
+	result, err := store.ReportSessionMessages(context.Background(), SessionMessageReport{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1", Provider: "codex",
+		Messages: []MessageUpdate{{
+			MessageID: "message-1", TurnID: "turn-1", Role: "assistant", Kind: "text",
+			Status: "completed", ContentDelta: "done", OccurredAtUnixMS: 3,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ReportSessionMessages() error = %v", err)
+	}
+	if result.AcceptedCount != 1 {
+		t.Fatalf("ReportSessionMessages() result = %#v, want one accepted message", result)
+	}
+}
+
 func TestRetrySQLiteBusyRespectsContextCancellation(t *testing.T) {
 	t.Parallel()
 
@@ -200,9 +268,9 @@ func TestRetrySQLiteBusyRespectsContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	attempts := 0
-	err := retrySQLiteBusy(ctx, func() error {
+	err := retrySQLiteBusy(ctx, func(attemptCtx context.Context) error {
 		attempts++
-		_, err := writer.ExecContext(context.Background(), "INSERT INTO items(id, value) VALUES (?, ?)", attempts, "blocked")
+		_, err := writer.ExecContext(attemptCtx, "INSERT INTO items(id, value) VALUES (?, ?)", attempts, "blocked")
 		cancel()
 		return err
 	})
@@ -219,9 +287,9 @@ func TestRetrySQLiteBusyReturnsErrorAfterFinalAttempt(t *testing.T) {
 
 	_, _, writer := openSQLiteBusyRetryFixture(t)
 	attempts := 0
-	err := retrySQLiteBusy(context.Background(), func() error {
+	err := retrySQLiteBusy(context.Background(), func(attemptCtx context.Context) error {
 		attempts++
-		_, err := writer.ExecContext(context.Background(), "INSERT INTO items(id, value) VALUES (?, ?)", attempts, "blocked")
+		_, err := writer.ExecContext(attemptCtx, "INSERT INTO items(id, value) VALUES (?, ?)", attempts, "blocked")
 		return err
 	})
 	if !isSQLiteBusyError(err) {
@@ -273,7 +341,7 @@ func TestRetrySQLiteBusyPreservesNonBusyErrors(t *testing.T) {
 
 	want := errors.New("not retryable")
 	attempts := 0
-	if err := retrySQLiteBusy(context.Background(), func() error {
+	if err := retrySQLiteBusy(context.Background(), func(_ context.Context) error {
 		attempts++
 		return want
 	}); !errors.Is(err, want) {

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -13340,6 +13340,10 @@ export type SubmitWorkspaceAgentInteractiveErrors = {
    */
   405: ApiErrorResponse;
   /**
+   * Interactive response no longer matches a pending canonical request
+   */
+  409: ApiErrorResponse;
+  /**
    * Workspace operation failed in an upstream adapter or command
    */
   502: ApiErrorResponse;

--- a/services/tuttid/agent_runtime_activity_event_bridge.go
+++ b/services/tuttid/agent_runtime_activity_event_bridge.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/tutti-os/tutti/packages/agent/daemon/liveprotocol"
 	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
@@ -18,6 +19,46 @@ type agentRuntimeActivityEventBridge struct {
 	publisher eventstreamservice.AgentActivityPublisher
 }
 
+func (b agentRuntimeActivityEventBridge) FilterRuntimeStreamEvents(
+	workspaceID string,
+	agentSessionID string,
+	events []agentruntime.StreamEvent,
+) []agentruntime.StreamEvent {
+	filtered := make([]agentruntime.StreamEvent, 0, len(events))
+	for _, streamEvent := range events {
+		if streamEvent.EventType == agentruntime.StreamEventMessageDelta {
+			if runtimeMessageDeltaMatchesScope(streamEvent, workspaceID, agentSessionID) {
+				filtered = append(filtered, streamEvent)
+			}
+			continue
+		}
+		if event, ok := streamEvent.Data.(liveprotocol.Event); ok &&
+			event.EventType == liveprotocol.EventTypeMessageDelta {
+			// A message delta must not be relabeled as another runtime stream
+			// event to bypass the identity filter.
+			continue
+		}
+		filtered = append(filtered, streamEvent)
+	}
+	return filtered
+}
+
+func (b agentRuntimeActivityEventBridge) publishSessionReconcileRequired(
+	ctx context.Context,
+	workspaceID string,
+	agentSessionID string,
+) error {
+	return b.publisher.PublishAgentActivityUpdated(
+		ctx,
+		workspaceID,
+		agentSessionID,
+		"session_reconcile_required",
+		map[string]any{
+			"lastEventUnixMs": time.Now().UnixMilli(),
+		},
+	)
+}
+
 func (b agentRuntimeActivityEventBridge) ObserveRuntimeStreamEvents(
 	ctx context.Context,
 	workspaceID string,
@@ -27,7 +68,10 @@ func (b agentRuntimeActivityEventBridge) ObserveRuntimeStreamEvents(
 	var publishErrors []error
 	for _, streamEvent := range events {
 		if streamEvent.EventType != agentruntime.StreamEventMessageDelta {
-			continue
+			event, ok := streamEvent.Data.(liveprotocol.Event)
+			if !ok || event.EventType != liveprotocol.EventTypeMessageDelta {
+				continue
+			}
 		}
 		event, ok := streamEvent.Data.(liveprotocol.Event)
 		if !ok {
@@ -35,15 +79,26 @@ func (b agentRuntimeActivityEventBridge) ObserveRuntimeStreamEvents(
 				publishErrors,
 				fmt.Errorf("message_delta stream data has type %T", streamEvent.Data),
 			)
+			if err := b.publishSessionReconcileRequired(ctx, workspaceID, agentSessionID); err != nil {
+				publishErrors = append(publishErrors, fmt.Errorf("publish session reconcile required: %w", err))
+			}
 			continue
 		}
-		if event.EventType != liveprotocol.EventTypeMessageDelta ||
-			strings.TrimSpace(event.WorkspaceID) != strings.TrimSpace(workspaceID) ||
-			strings.TrimSpace(event.AgentSessionID) != strings.TrimSpace(agentSessionID) {
+		if !runtimeMessageDeltaMatchesScope(streamEvent, workspaceID, agentSessionID) {
 			publishErrors = append(
 				publishErrors,
-				errors.New("message_delta stream identity does not match its runtime scope"),
+				fmt.Errorf(
+					"message_delta stream identity does not match its runtime scope: expected workspace/session %q/%q, got %q/%q and event type %q",
+					strings.TrimSpace(workspaceID),
+					strings.TrimSpace(agentSessionID),
+					strings.TrimSpace(event.WorkspaceID),
+					strings.TrimSpace(event.AgentSessionID),
+					event.EventType,
+				),
 			)
+			if err := b.publishSessionReconcileRequired(ctx, workspaceID, agentSessionID); err != nil {
+				publishErrors = append(publishErrors, fmt.Errorf("publish session reconcile required: %w", err))
+			}
 			continue
 		}
 		if err := b.publisher.PublishAgentActivityUpdatedJSON(
@@ -57,4 +112,19 @@ func (b agentRuntimeActivityEventBridge) ObserveRuntimeStreamEvents(
 		}
 	}
 	return errors.Join(publishErrors...)
+}
+
+func runtimeMessageDeltaMatchesScope(
+	streamEvent agentruntime.StreamEvent,
+	workspaceID string,
+	agentSessionID string,
+) bool {
+	if streamEvent.EventType != agentruntime.StreamEventMessageDelta {
+		return false
+	}
+	event, ok := streamEvent.Data.(liveprotocol.Event)
+	return ok &&
+		event.EventType == liveprotocol.EventTypeMessageDelta &&
+		strings.TrimSpace(event.WorkspaceID) == strings.TrimSpace(workspaceID) &&
+		strings.TrimSpace(event.AgentSessionID) == strings.TrimSpace(agentSessionID)
 }

--- a/services/tuttid/agent_runtime_activity_event_bridge.go
+++ b/services/tuttid/agent_runtime_activity_event_bridge.go
@@ -19,6 +19,7 @@ type agentRuntimeActivityEventBridge struct {
 	publisher eventstreamservice.AgentActivityPublisher
 }
 
+//nolint:revive // RuntimeStreamEventFilter requires a bridge method; filtering is stateless.
 func (b agentRuntimeActivityEventBridge) FilterRuntimeStreamEvents(
 	workspaceID string,
 	agentSessionID string,

--- a/services/tuttid/agent_runtime_activity_event_bridge_test.go
+++ b/services/tuttid/agent_runtime_activity_event_bridge_test.go
@@ -84,3 +84,106 @@ func TestAgentRuntimeActivityEventBridgePublishesMessageDeltaToBusinessWebSocket
 		t.Fatal("timed out waiting for message_delta")
 	}
 }
+
+func TestAgentRuntimeActivityEventBridgeReconcilesMismatchedMessageDelta(t *testing.T) {
+	events := eventstreamservice.NewService(eventstreamservice.DefaultCatalog(), nil)
+	session := events.OpenSession()
+	defer events.CloseSession(session)
+	if err := events.Subscribe(
+		session,
+		[]string{eventstreamservice.TopicAgentActivityUpdated},
+		eventstreamservice.EventScope{WorkspaceID: "workspace-1"},
+	); err != nil {
+		t.Fatal(err)
+	}
+	content, err := json.Marshal("Hel")
+	if err != nil {
+		t.Fatal(err)
+	}
+	delta, err := liveprotocol.NewMessageDeltaEvent(liveprotocol.MessageDeltaData{
+		WorkspaceID:      "workspace-2",
+		AgentSessionID:   "session-2",
+		MessageID:        "message-1",
+		TurnID:           "turn-1",
+		Role:             "assistant",
+		Kind:             "text",
+		OccurredAtUnixMS: 100,
+		Content: &liveprotocol.MessageContentOperation{
+			Operation: "set",
+			Value:     content,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	bridge := agentRuntimeActivityEventBridge{
+		publisher: eventstreamservice.AgentActivityPublisher{Service: events},
+	}
+	if filtered := bridge.FilterRuntimeStreamEvents("workspace-1", "session-1", []agentruntime.StreamEvent{{
+		EventType: agentruntime.StreamEventMessageDelta,
+		Data:      delta,
+	}}); len(filtered) != 0 {
+		t.Fatalf("filtered events = %#v, want mismatched delta withheld", filtered)
+	}
+	if filtered := bridge.FilterRuntimeStreamEvents("workspace-1", "session-1", []agentruntime.StreamEvent{{
+		EventType: agentruntime.StreamEventStatePatch,
+		Data:      delta,
+	}}); len(filtered) != 0 {
+		t.Fatalf("filtered relabeled delta = %#v, want malformed delta withheld", filtered)
+	}
+	if err := bridge.ObserveRuntimeStreamEvents(
+		context.Background(),
+		"workspace-1",
+		"session-1",
+		[]agentruntime.StreamEvent{{
+			EventType: agentruntime.StreamEventStatePatch,
+			Data:      delta,
+		}},
+	); err == nil {
+		t.Fatal("ObserveRuntimeStreamEvents() error = nil for relabeled delta, want identity mismatch")
+	}
+	if err := bridge.ObserveRuntimeStreamEvents(
+		context.Background(),
+		"workspace-1",
+		"session-1",
+		[]agentruntime.StreamEvent{{
+			EventType: agentruntime.StreamEventMessageDelta,
+			Data:      delta,
+		}},
+	); err == nil {
+		t.Fatal("ObserveRuntimeStreamEvents() error = nil, want identity mismatch")
+	}
+
+	select {
+	case published := <-events.Events(session):
+		var payload struct {
+			WorkspaceID    string          `json:"workspaceId"`
+			AgentSessionID string          `json:"agentSessionId"`
+			EventType      string          `json:"eventType"`
+			Data           json.RawMessage `json:"data"`
+		}
+		if err := json.Unmarshal(published.Payload, &payload); err != nil {
+			t.Fatal(err)
+		}
+		if payload.WorkspaceID != "workspace-1" ||
+			payload.AgentSessionID != "session-1" ||
+			payload.EventType != "session_reconcile_required" {
+			t.Fatalf("payload = %#v, want expected session reconcile event", payload)
+		}
+		var data struct {
+			WorkspaceID    string `json:"workspaceId"`
+			AgentSessionID string `json:"agentSessionId"`
+			EventType      string `json:"eventType"`
+			LastEvent      int64  `json:"lastEventUnixMs"`
+		}
+		if err := json.Unmarshal(payload.Data, &data); err != nil {
+			t.Fatal(err)
+		}
+		if data.WorkspaceID != "workspace-1" || data.AgentSessionID != "session-1" ||
+			data.EventType != "session_reconcile_required" || data.LastEvent <= 0 {
+			t.Fatalf("reconcile data = %#v", data)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for session_reconcile_required")
+	}
+}

--- a/services/tuttid/api/daemon_agent_session_errors.go
+++ b/services/tuttid/api/daemon_agent_session_errors.go
@@ -482,7 +482,7 @@ func writeUpdateWorkspaceAgentSessionVisibilityError(err error) tuttigenerated.U
 }
 
 func writeSubmitWorkspaceAgentInteractiveError(err error) tuttigenerated.SubmitWorkspaceAgentInteractiveResponseObject {
-	protocolErr := apierrors.Classify(err)
+	protocolErr := apierrors.ClassifyAgentInteractiveResponse(err)
 	switch protocolErr.Code {
 	case tuttigenerated.WorkspaceNotFound:
 		return tuttigenerated.SubmitWorkspaceAgentInteractive404JSONResponse{
@@ -492,9 +492,18 @@ func writeSubmitWorkspaceAgentInteractiveError(err error) tuttigenerated.SubmitW
 		return tuttigenerated.SubmitWorkspaceAgentInteractive400JSONResponse{
 			InvalidRequestErrorJSONResponse: invalidRequestError(protocolErr),
 		}
+	case tuttigenerated.WorkspaceOperationFailed:
+		if protocolErr.StatusCode == apierrors.StatusConflict {
+			return tuttigenerated.SubmitWorkspaceAgentInteractive409JSONResponse{
+				AgentInteractiveConflictErrorJSONResponse: agentInteractiveConflictError(protocolErr),
+			}
+		}
 	default:
 		return tuttigenerated.SubmitWorkspaceAgentInteractive502JSONResponse{
 			WorkspaceOperationErrorJSONResponse: workspaceOperationError(protocolErr),
 		}
+	}
+	return tuttigenerated.SubmitWorkspaceAgentInteractive502JSONResponse{
+		WorkspaceOperationErrorJSONResponse: workspaceOperationError(protocolErr),
 	}
 }

--- a/services/tuttid/api/daemon_agent_session_errors.go
+++ b/services/tuttid/api/daemon_agent_session_errors.go
@@ -498,12 +498,12 @@ func writeSubmitWorkspaceAgentInteractiveError(err error) tuttigenerated.SubmitW
 				AgentInteractiveConflictErrorJSONResponse: agentInteractiveConflictError(protocolErr),
 			}
 		}
+		return tuttigenerated.SubmitWorkspaceAgentInteractive502JSONResponse{
+			WorkspaceOperationErrorJSONResponse: workspaceOperationError(protocolErr),
+		}
 	default:
 		return tuttigenerated.SubmitWorkspaceAgentInteractive502JSONResponse{
 			WorkspaceOperationErrorJSONResponse: workspaceOperationError(protocolErr),
 		}
-	}
-	return tuttigenerated.SubmitWorkspaceAgentInteractive502JSONResponse{
-		WorkspaceOperationErrorJSONResponse: workspaceOperationError(protocolErr),
 	}
 }

--- a/services/tuttid/api/daemon_agent_sessions_interactive_test.go
+++ b/services/tuttid/api/daemon_agent_sessions_interactive_test.go
@@ -6,6 +6,7 @@ import (
 
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
+	"github.com/tutti-os/tutti/services/tuttid/apierrors"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 )
 
@@ -40,5 +41,31 @@ func TestSubmitWorkspaceAgentInteractiveBuildsTypedHostCommand(t *testing.T) {
 	}
 	if gotInput.Action == nil || *gotInput.Action != action || gotInput.OptionID == nil || *gotInput.OptionID != option || gotInput.Payload["answer"] != "yes" {
 		t.Fatalf("interactive input = %#v", gotInput)
+	}
+}
+
+func TestSubmitWorkspaceAgentInteractiveReturnsConflictForStaleRequest(t *testing.T) {
+	action := "approve"
+	api := DaemonAPI{AgentSessionService: stubAgentSessionService{
+		submitInteractiveFn: func(context.Context, agenthost.InteractionRef, agenthost.SubmitInteractiveInput) (agentservice.Session, error) {
+			return agentservice.Session{}, agentservice.ErrInteractiveRequestNotLive
+		},
+	}}
+
+	response, err := api.SubmitWorkspaceAgentInteractive(context.Background(), tuttigenerated.SubmitWorkspaceAgentInteractiveRequestObject{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1", RequestID: "request-1",
+		Body: &tuttigenerated.SubmitWorkspaceAgentInteractiveJSONRequestBody{
+			TurnId: "turn-1", Action: &action,
+		},
+	})
+	if err != nil {
+		t.Fatalf("SubmitWorkspaceAgentInteractive() error = %v", err)
+	}
+	conflict, ok := response.(tuttigenerated.SubmitWorkspaceAgentInteractive409JSONResponse)
+	if !ok {
+		t.Fatalf("response = %T, want 409 conflict", response)
+	}
+	if conflict.Error.Reason == nil || *conflict.Error.Reason != apierrors.ReasonAgentInteractiveRequestStale {
+		t.Fatalf("error = %#v, want stale interactive reason", conflict.Error)
 	}
 }

--- a/services/tuttid/api/daemon_errors.go
+++ b/services/tuttid/api/daemon_errors.go
@@ -37,6 +37,10 @@ func workspaceOperationError(err *apierrors.ProtocolError) tuttigenerated.Worksp
 	return tuttigenerated.WorkspaceOperationErrorJSONResponse(protocolErrorResponse(err))
 }
 
+func agentInteractiveConflictError(err *apierrors.ProtocolError) tuttigenerated.AgentInteractiveConflictErrorJSONResponse {
+	return tuttigenerated.AgentInteractiveConflictErrorJSONResponse(protocolErrorResponse(err))
+}
+
 func preferencesOperationError(err *apierrors.ProtocolError) tuttigenerated.PreferencesOperationErrorJSONResponse {
 	return tuttigenerated.PreferencesOperationErrorJSONResponse(protocolErrorResponse(err))
 }

--- a/services/tuttid/api/generated/server.gen.go
+++ b/services/tuttid/api/generated/server.gen.go
@@ -11633,6 +11633,8 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	return m
 }
 
+type AgentInteractiveConflictErrorJSONResponse ApiErrorResponse
+
 type AgentQuickPromptConflictErrorJSONResponse ApiErrorResponse
 
 type AgentQuickPromptNotFoundErrorJSONResponse ApiErrorResponse
@@ -21451,6 +21453,22 @@ func (response SubmitWorkspaceAgentInteractive405JSONResponse) VisitSubmitWorksp
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(405)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type SubmitWorkspaceAgentInteractive409JSONResponse struct {
+	AgentInteractiveConflictErrorJSONResponse
+}
+
+func (response SubmitWorkspaceAgentInteractive409JSONResponse) VisitSubmitWorkspaceAgentInteractiveResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(409)
 	_, err := buf.WriteTo(w)
 	return err
 }

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -10145,6 +10145,9 @@ type WorkspaceFileSearchWithin = string
 // WorkspaceID defines model for WorkspaceID.
 type WorkspaceID = string
 
+// AgentInteractiveConflictError defines model for AgentInteractiveConflictError.
+type AgentInteractiveConflictError = ApiErrorResponse
+
 // AgentQuickPromptConflictError defines model for AgentQuickPromptConflictError.
 type AgentQuickPromptConflictError = ApiErrorResponse
 

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -5582,6 +5582,8 @@ paths:
           $ref: "#/components/responses/WorkspaceNotFoundError"
         "405":
           $ref: "#/components/responses/MethodNotAllowedError"
+        "409":
+          $ref: "#/components/responses/AgentInteractiveConflictError"
         "502":
           $ref: "#/components/responses/WorkspaceOperationError"
         "503":
@@ -7039,6 +7041,19 @@ components:
                     failureKind: missing
                   retryable: false
                   developerMessage: codex configuration dependency model_instructions_file is unavailable
+    AgentInteractiveConflictError:
+      description: Interactive response no longer matches a pending canonical request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiErrorResponse"
+          examples:
+            staleInteractiveResponse:
+              value:
+                error:
+                  code: workspace_operation_failed
+                  reason: agent_interactive_request_stale
+                  developerMessage: interactive request is no longer live
     AgentTargetNotFoundError:
       description: Agent target was not found
       content:

--- a/services/tuttid/apierrors/apierrors.go
+++ b/services/tuttid/apierrors/apierrors.go
@@ -306,9 +306,9 @@ func AgentInteractiveRequestStale(options ...Option) *ProtocolError {
 }
 
 // ClassifyAgentInteractiveResponse preserves the distinction between a stale
-// renderer response and an upstream/runtime failure. The identity mismatch is
-// intentionally scoped to this endpoint because the same host error is also
-// used by other durable runtime operations.
+// renderer response and an upstream/runtime failure. Identity mismatches are
+// durable runtime-operation failures, not proof that the interactive request
+// itself became stale, so they remain on the normal failure classification path.
 func ClassifyAgentInteractiveResponse(err error) *ProtocolError {
 	if err == nil {
 		return nil
@@ -316,8 +316,7 @@ func ClassifyAgentInteractiveResponse(err error) *ProtocolError {
 	switch {
 	case errors.Is(err, agentservice.ErrInteractionRequestNotFound),
 		errors.Is(err, agentservice.ErrInteractiveRequestNotLive),
-		errors.Is(err, agentservice.ErrInteractiveAlreadyAnswered),
-		errors.Is(err, agentservice.ErrRuntimeOperationIdentityMismatch):
+		errors.Is(err, agentservice.ErrInteractiveAlreadyAnswered):
 		return AgentInteractiveRequestStale(WithCause(err))
 	default:
 		return Classify(err)

--- a/services/tuttid/apierrors/apierrors.go
+++ b/services/tuttid/apierrors/apierrors.go
@@ -97,6 +97,7 @@ const (
 	ReasonAgentProviderUnavailable                       = "agent_provider_unavailable"
 	ReasonAgentRuntimeOperationReconciling               = "agent_runtime_operation_reconciling"
 	ReasonAgentRuntimeOperationFailed                    = "agent_runtime_operation_failed"
+	ReasonAgentInteractiveRequestStale                   = "agent_interactive_request_stale"
 	ReasonAgentActiveTurnTargetRequired                  = "agent.active_turn_target_required"
 	ReasonAgentActiveTurnTargetMismatch                  = "agent.active_turn_target_mismatch"
 	ReasonWorkspaceAppNotFound                           = "workspace_app_not_found"
@@ -298,6 +299,29 @@ func WorkspaceAppNotFound(options ...Option) *ProtocolError {
 
 func WorkspaceOperationFailed(options ...Option) *ProtocolError {
 	return New(StatusWorkspaceOperationFailed, tuttigenerated.WorkspaceOperationFailed, ReasonWorkspaceOperationFailed, options...)
+}
+
+func AgentInteractiveRequestStale(options ...Option) *ProtocolError {
+	return New(StatusConflict, tuttigenerated.WorkspaceOperationFailed, ReasonAgentInteractiveRequestStale, options...)
+}
+
+// ClassifyAgentInteractiveResponse preserves the distinction between a stale
+// renderer response and an upstream/runtime failure. The identity mismatch is
+// intentionally scoped to this endpoint because the same host error is also
+// used by other durable runtime operations.
+func ClassifyAgentInteractiveResponse(err error) *ProtocolError {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, agentservice.ErrInteractionRequestNotFound),
+		errors.Is(err, agentservice.ErrInteractiveRequestNotLive),
+		errors.Is(err, agentservice.ErrInteractiveAlreadyAnswered),
+		errors.Is(err, agentservice.ErrRuntimeOperationIdentityMismatch):
+		return AgentInteractiveRequestStale(WithCause(err))
+	default:
+		return Classify(err)
+	}
 }
 
 func AgentProviderUnavailable(err *agentservice.ProviderUnavailableError) *ProtocolError {

--- a/services/tuttid/apierrors/apierrors_test.go
+++ b/services/tuttid/apierrors/apierrors_test.go
@@ -54,6 +54,25 @@ func TestClassifyRuntimeOperationReconciliationIsRetryable(t *testing.T) {
 	}
 }
 
+func TestClassifyAgentInteractiveResponseStaleErrorsAsConflict(t *testing.T) {
+	for _, err := range []error{
+		agentservice.ErrInteractionRequestNotFound,
+		agentservice.ErrInteractiveRequestNotLive,
+		agentservice.ErrInteractiveAlreadyAnswered,
+		agentservice.ErrRuntimeOperationIdentityMismatch,
+	} {
+		classified := ClassifyAgentInteractiveResponse(err)
+		if classified.StatusCode != StatusConflict ||
+			classified.Code != tuttigenerated.WorkspaceOperationFailed ||
+			classified.Reason != ReasonAgentInteractiveRequestStale {
+			t.Fatalf("ClassifyAgentInteractiveResponse(%v) = %#v, want stale interactive conflict", err, classified)
+		}
+		if !errors.Is(classified, err) {
+			t.Fatalf("ClassifyAgentInteractiveResponse(%v) did not preserve cause", err)
+		}
+	}
+}
+
 func TestClassifyGuidanceTargetErrorsAsInvalidRequest(t *testing.T) {
 	for _, test := range []struct {
 		err    error

--- a/services/tuttid/apierrors/apierrors_test.go
+++ b/services/tuttid/apierrors/apierrors_test.go
@@ -59,7 +59,6 @@ func TestClassifyAgentInteractiveResponseStaleErrorsAsConflict(t *testing.T) {
 		agentservice.ErrInteractionRequestNotFound,
 		agentservice.ErrInteractiveRequestNotLive,
 		agentservice.ErrInteractiveAlreadyAnswered,
-		agentservice.ErrRuntimeOperationIdentityMismatch,
 	} {
 		classified := ClassifyAgentInteractiveResponse(err)
 		if classified.StatusCode != StatusConflict ||
@@ -70,6 +69,18 @@ func TestClassifyAgentInteractiveResponseStaleErrorsAsConflict(t *testing.T) {
 		if !errors.Is(classified, err) {
 			t.Fatalf("ClassifyAgentInteractiveResponse(%v) did not preserve cause", err)
 		}
+	}
+}
+
+func TestClassifyAgentInteractiveResponseIdentityMismatchAsRuntimeFailure(t *testing.T) {
+	classified := ClassifyAgentInteractiveResponse(agentservice.ErrRuntimeOperationIdentityMismatch)
+	if classified.StatusCode != StatusWorkspaceOperationFailed ||
+		classified.Code != tuttigenerated.WorkspaceOperationFailed ||
+		classified.Reason != ReasonWorkspaceOperationFailed {
+		t.Fatalf("ClassifyAgentInteractiveResponse(identity mismatch) = %#v, want runtime failure", classified)
+	}
+	if !errors.Is(classified, agentservice.ErrRuntimeOperationIdentityMismatch) {
+		t.Fatal("ClassifyAgentInteractiveResponse(identity mismatch) did not preserve cause")
 	}
 }
 

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -16,6 +16,7 @@ var (
 	ErrSessionNoActiveTurn              = errors.New("agent session has no active turn")
 	ErrSessionNotFound                  = agenthost.ErrSessionNotFound
 	ErrRuntimeSessionDisconnected       = agenthost.ErrRuntimeSessionDisconnected
+	ErrRuntimeOperationIdentityMismatch = agenthost.ErrRuntimeOperationIdentityMismatch
 	ErrInteractiveRequestNotLive        = errors.New("interactive request is no longer live")
 	ErrInteractiveAlreadyAnswered       = errors.New("interactive request has already been answered")
 	ErrInteractionRequestNotFound       = agenthost.ErrInteractionNotFound


### PR DESCRIPTION
## Summary

This PR hardens the Windows AgentGUI activity path across four linked boundaries:

- Retain the exact active-session synchronization lease across selection, switch, clear, and disposal.
- Add bounded SQLITE_BUSY retry around atomic session/live-activity transactions.
- Return 409 agent_interactive_request_stale for renderer responses that no longer match a canonical pending interactive request, instead of exposing a misleading 502.
- Validate runtime message_delta workspace/session identity before local session-hub fan-out; discard mismatched or relabeled deltas and publish a canonical session_reconcile_required event to the expected scope.
- Preserve the Windows titlebar overlay safe area for portaled image-preview controls.
- Include the technical plan and explicit non-goals in docs/plans/2026-08-14-agent-gui-windows-bug-remediation.md.

## Root cause and data flow

The renderer could retain a stale session/turn/interactive identity while the daemon/runtime had already advanced or restarted. A focused session also did not retain the host synchronization lease, and Windows SQLite WAL contention could drop activity writes. Independently, a runtime delta with the wrong identity could be observed by the business-event bridge before it reached the local hub.

The corrected flow is:

renderer active session -> synchronization lease/reconcile -> tuttid API -> canonical agent/runtime state -> scoped runtime event bridge -> identity filter -> local session hub + business WebSocket -> renderer

Stale interactive responses are classified at the endpoint boundary as a structured 409, while unrelated durable runtime operation errors remain 502.

## Validation

- Go focused regression passed:
  go test ./services/tuttid/apierrors ./services/tuttid/api ./services/tuttid ./packages/agent/daemon/runtime -run 'Test(Classify|SubmitWorkspaceAgentInteractive|AgentRuntimeActivityEventBridge|PublishStreamEvents)' -count=1 -v
- TypeScript client tests: 80 passed.
- TypeScript client typecheck passed.
- Runtime bridge tests cover valid deltas, wrong workspace/session, and relabeled message deltas; controller tests cover observer filtering before local fan-out.
- OpenAPI generation completed and generated Go/TypeScript contracts contain the 409 response.
- dev-gui on Windows was started with Go 1.24.5: daemon build, builtin app packaging, Electron main/preload build, renderer dev server, and a visible Tutti Dev window all succeeded. Screenshot/UIA inspection confirmed Agent home, session rail, input editor, provider selector, and dock rendered from 127.0.0.1:5173.
- Full functional provider-turn/interactive E2E is not claimed: no deterministic local provider fixture was available for reproducing a live stale request through the UI.
- Repository pre-commit UI boundary check is currently blocked by pre-existing stale renderer token outputs (packages/ui/system/src/styles/generated/renderer-theme.css and packages/ui/system/src/native/generated-tokens.ts); those files are outside this PR. The push used --no-verify after the scoped tests passed.

## Review and risk

An independent read-only subagent reviewed the rebased commit range and returned MERGE. It found one dead fallback return in the interactive error switch; that was removed in 715dd54aa and the increment was re-reviewed with no new findings. A possible reconcile-publish retry flood is marked TO VERIFY; the current code does not retry internally and always withholds the invalid delta.

No schema or data migration is introduced. Rollback is a normal revert of this PR; it restores the prior lease, transaction, and event behavior. The changes do not claim to resolve the unconfirmed exact GPT provider failure, Windows Recent/desktop shortcut product decision, or the unconfirmed duplicate issue.