### PR TITLE
fix(connector): preserve pending remote authorization

### DIFF
--- a/docs/architecture/connector-market.md
+++ b/docs/architecture/connector-market.md
@@ -351,7 +351,12 @@ Remote Connector authorization uses that account projection for Start,
 observation, presentation, and route publication; the device Connector's
 authorization field is not remote authorization truth. A completed Start
 operation may retain a private authorization-session receipt while provider
-work is pending. Each receipt has a terminal resolution, and only unresolved
+work is pending. The Start response preserves the current session's `pending`
+state when the durable account projection is still missing, disconnected,
+expired, or failed; this ephemeral response state lets the caller continue the
+same idempotent session and does not replace the projection as durable truth.
+An already connected projection wins a race with a stale pending session. Each
+receipt has a terminal resolution, and only unresolved
 receipts for the daemon's current account are polled. Applying an authoritative
 connected Snapshot atomically writes its monotonic Projection and surfaces all
 matching account-and-Connector receipts. The daemon holds the account lifecycle

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -135,6 +135,12 @@ App Center, workspace-app lifecycle, App Factory, file references, and File Mana
 - [FileManager home-relative paths break only the list pane](./workspace-apps-files.md#filemanager-home-relative-paths-break-only-the-list-pane)
 - [Windows FileManager paths exist but fail validation or selection](./workspace-apps-files.md#windows-filemanager-paths-exist-but-fail-validation-or-selection)
 
+## [Connector Market](./connector-market.md)
+
+Connector catalog, installation, account authorization, and runtime convergence.
+
+- [OAuth opens once, then the desktop stays disconnected or a second attempt supersedes the first](./connector-market.md#oauth-opens-once-then-the-desktop-stays-disconnected-or-a-second-attempt-supersedes-the-first)
+
 ## [Toolchain, Browser, And Terminal](./toolchain-browser-terminal.md)
 
 CLI behavior, CI, package assets, skills, Browser Node, and terminal input.

--- a/docs/conventions/troubleshooting/connector-market.md
+++ b/docs/conventions/troubleshooting/connector-market.md
@@ -1,0 +1,31 @@
+# Connector Market Troubleshooting
+
+### OAuth opens once, then the desktop stays disconnected or a second attempt supersedes the first
+
+**Symptoms**
+
+- the browser receives a valid OAuth redirect on the first authorization click
+- the local Start operation is already `completed` while its private session
+  receipt is still unresolved
+- the account authorization projection remains `disconnected` until the OAuth
+  callback is observed
+- the renderer stops waiting, and a later click creates a new session that may
+  supersede the first one
+
+**Check**
+
+Trace the three states separately: the durable Start operation, its private
+authorization-session receipt, and the account authorization projection. A
+completed Start operation means the external session was created; it does not
+mean the provider authorization is terminal. Confirm that a redirect session
+returns `pending` to the caller even when the durable projection has not changed
+yet, then confirm the same client request identity is reused until the projection
+becomes connected or failed.
+
+**Rule**
+
+Keep the account projection as durable authorization truth. Preserve the
+current session's `pending` state only in the Start command result so shared
+clients continue that idempotent session. Do not persist a synthetic connected
+projection, infer success from the Start operation's terminal state, or create a
+second external session to refresh the UI.

--- a/packages/connector/host/application.go
+++ b/packages/connector/host/application.go
@@ -416,6 +416,14 @@ func (application *Application) BeginAuthorization(
 		} else {
 			connector.Authorization = Authorization{State: projection.State, FailureCode: projection.FailureCode}
 		}
+		// The account projection remains the durable authorization truth, but a
+		// redirect session can be pending before the control plane publishes its
+		// first changed projection. Preserve that in-flight state in this command
+		// result so callers keep following the same idempotent session instead of
+		// treating the initial disconnected projection as terminal.
+		if session.State == AuthorizationStatePending && connector.Authorization.State != AuthorizationStateConnected {
+			connector.Authorization = Authorization{State: AuthorizationStatePending}
+		}
 	}
 	return AuthorizationResult{
 		Connector:        connector,

--- a/packages/connector/host/application_test.go
+++ b/packages/connector/host/application_test.go
@@ -719,7 +719,7 @@ func TestApplicationLocalUninstallKeepsRemoteProjectionAndReusesItAfterReinstall
 	}
 }
 
-func TestApplicationRemoteAuthorizationStartUsesAccountProjectionInsteadOfDeviceState(t *testing.T) {
+func TestApplicationRemoteAuthorizationStartPreservesPendingBeforeProjectionConverges(t *testing.T) {
 	connector := testConnector("tencent-docs")
 	connector.Release.Manifest.AuthorizationKind = "oauth2"
 	connector.Release.Manifest.RequiredCapabilities = []string{"tools"}
@@ -746,7 +746,8 @@ func TestApplicationRemoteAuthorizationStartUsesAccountProjectionInsteadOfDevice
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.AuthorizationURL == "" || repository.connectors[connector.Key].Authorization.State != AuthorizationStateConnected {
+	if result.AuthorizationURL == "" || result.Connector.Authorization.State != AuthorizationStatePending ||
+		repository.connectors[connector.Key].Authorization.State != AuthorizationStateConnected {
 		t.Fatalf("result=%#v device authorization=%#v", result, repository.connectors[connector.Key].Authorization)
 	}
 	receipt := repository.operations[result.Operation.OperationID].Execution.AuthorizationSession


### PR DESCRIPTION
## 问题

远端 OAuth 启动成功后，控制面的账户授权投影在回调完成前仍可能是 `disconnected`。Connector Host 使用该旧投影覆盖了本次授权会话返回的 `pending`，导致共享前端提前停止轮询、关闭弹窗，并允许第二次点击创建新会话。第二个会话会 supersede 第一个；即使 OAuth 稍后完成，页面也不会自动收敛到 `connected`。

## 修改

- 账户投影继续作为持久授权真相
- 当本次授权会话仍为 `pending` 且投影尚未连接时，仅在 Start 命令结果中保留 `pending`
- 已连接投影仍优先于竞态中的旧 pending 会话
- 补充远端授权回归断言、架构说明和排障条目

## 验证

- `go test -count=1 ./...`（`packages/connector/host`）
- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready`

均通过。