### PR TITLE
fix(agent): preserve terminal turn error codes

### DIFF
--- a/packages/agent/daemon/runtime/activity_projection_test.go
+++ b/packages/agent/daemon/runtime/activity_projection_test.go
@@ -719,6 +719,29 @@ func TestRootProviderTurnFailurePersistsVisibleErrorCode(t *testing.T) {
 	}
 }
 
+func TestRootProviderTurnFailurePersistsUnknownCodeWithoutDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	session := reportTestSession()
+	ctx, ok := activityEventContext(session, "root-provider-turn-failed", "root-turn-1")
+	if !ok {
+		t.Fatal("activityEventContext() returned !ok")
+	}
+	failed := activityshared.NewRootProviderTurnCompleted(ctx, "root-turn-1", "provider-turn-1", activityshared.TurnOutcomeFailed)
+
+	report := reportActivityInput(session, []activityshared.Event{failed})
+	if len(report.StatePatches) != 1 {
+		t.Fatalf("state patches = %#v, want one root provider failure", report.StatePatches)
+	}
+	completed := report.StatePatches[0].RootProviderTurn
+	if completed == nil {
+		t.Fatal("root provider turn transition is nil")
+	}
+	if completed.ErrorCode != "unknown" || completed.ErrorMessage != "" {
+		t.Fatalf("root provider turn error = %q/%q, want unknown/empty", completed.ErrorCode, completed.ErrorMessage)
+	}
+}
+
 func TestSessionStatusFromActivityPreservesWaiting(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/controller_turn_state_test.go
+++ b/packages/agent/daemon/runtime/controller_turn_state_test.go
@@ -84,6 +84,33 @@ func TestFailedTurnActivityEventProjectsProviderStopReason(t *testing.T) {
 	}
 }
 
+func TestFailedTurnActivityEventProjectsUnknownCodeWithoutDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	session := Session{Provider: ProviderCodex, AgentSessionID: "agent-1", RoomID: "room-1"}
+	event := newTurnActivityEvent(
+		session,
+		EventTurnFailed,
+		"turn-1",
+		SessionStatusFailed,
+		"",
+		"",
+		nil,
+	)
+	patch, ok := statePatchFromSessionEvent(
+		canonical.EventSource{Provider: ProviderCodex},
+		event,
+		"agent-1",
+		200,
+	)
+	if !ok || patch.Turn == nil {
+		t.Fatalf("failed turn patch = %#v ok=%v", patch, ok)
+	}
+	if patch.Turn.ErrorCode != "unknown" || patch.Turn.ErrorMessage != "" {
+		t.Fatalf("failed turn error = %q/%q, want unknown/empty", patch.Turn.ErrorCode, patch.Turn.ErrorMessage)
+	}
+}
+
 func TestProviderStopFailureCodeUsesClosedVocabulary(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/reporter_state.go
+++ b/packages/agent/daemon/runtime/reporter_state.go
@@ -167,7 +167,7 @@ func statePatchFromSessionEvent(source canonical.EventSource, event activityshar
 			strings.TrimSpace(event.Payload.TurnOutcome) == string(activityshared.TurnOutcomeFailed) &&
 			strings.TrimSpace(errorCode) == "" {
 			errorCode = providerStopFailureCode(payloadString(event.Payload.Metadata, "stopReason"))
-			if errorCode == "" && strings.TrimSpace(errorMessage) != "" {
+			if errorCode == "" {
 				errorCode = visibleFailureCode(errorMessage)
 			}
 		}
@@ -196,7 +196,7 @@ func turnFailureDetails(event activityshared.Event) (string, string) {
 	if code == "" {
 		code = providerStopFailureCode(payloadString(event.Payload.Metadata, "stopReason"))
 	}
-	if code == "" && message != "" {
+	if code == "" {
 		code = visibleFailureCode(message)
 	}
 	return code, message


### PR DESCRIPTION
## Summary
- Ensure failed Turn projections always persist a stable `error_code`.
- Preserve existing structured and classified codes; use `unknown` only when no diagnostic is available.
- Cover both ordinary `turn_failed` and root-provider terminal failure paths.

## Tests
- `pnpm check:changed -- --failed-only` (passed: 8 lanes, 3 rerun, 5 reused)

## Notes
- Provider identity handling is unchanged; this PR is limited to terminal error-code completeness.