### PR TITLE
fix(store): make Windows MSIX submission compatible

### DIFF
--- a/.github/workflows/desktop-store-submit.yml
+++ b/.github/workflows/desktop-store-submit.yml
@@ -15,6 +15,10 @@ on:
       target_commit:
         required: true
         type: string
+      verify_release_tag:
+        default: true
+        required: false
+        type: boolean
   workflow_dispatch:
     inputs:
       release_tag:
@@ -35,6 +39,11 @@ on:
       submit:
         default: false
         description: Submit the validated package to Partner Center
+        required: true
+        type: boolean
+      verify_release_tag:
+        default: true
+        description: Require the release tag to resolve to the target commit
         required: true
         type: boolean
 
@@ -63,6 +72,7 @@ jobs:
       TUTTI_STORE_IDENTITY_NAME: ${{ vars.TUTTI_STORE_IDENTITY_NAME }}
       TUTTI_STORE_PUBLISHER: ${{ vars.TUTTI_STORE_PUBLISHER }}
       TUTTI_STORE_PUBLISHER_DISPLAY_NAME: ${{ vars.TUTTI_STORE_PUBLISHER_DISPLAY_NAME }}
+      TUTTI_STORE_MSIX_MIN_VERSION: 10.0.17763.0
 
     steps:
       - name: Validate stable submission request
@@ -98,6 +108,7 @@ jobs:
           ref: ${{ inputs.target_commit }}
 
       - name: Verify stable tag points to release target
+        if: ${{ inputs.verify_release_tag }}
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
@@ -170,7 +181,16 @@ jobs:
           $publisher = $identity.GetAttribute('Publisher')
           $version = $identity.GetAttribute('Version')
           $architecture = $identity.GetAttribute('ProcessorArchitecture')
+          $minVersion = $manifest.SelectSingleNode("/*[local-name()='Package']/*[local-name()='Dependencies']/*[local-name()='TargetDeviceFamily']").GetAttribute('MinVersion')
+          $maxVersionTested = $manifest.SelectSingleNode("/*[local-name()='Package']/*[local-name()='Dependencies']/*[local-name()='TargetDeviceFamily']").GetAttribute('MaxVersionTested')
           $expectedVersion = "$env:TUTTI_DESKTOP_BUILD_VERSION.0"
+          try {
+            $parsedMinVersion = [version]$minVersion
+            $parsedMaxVersionTested = [version]$maxVersionTested
+            $requiredMinVersion = [version]$env:TUTTI_STORE_MSIX_MIN_VERSION
+          } catch {
+            throw "Invalid Store package Windows version metadata: MinVersion=$minVersion, MaxVersionTested=$maxVersionTested"
+          }
           $packageDisplayName = $manifest.SelectSingleNode("/*[local-name()='Package']/*[local-name()='Properties']/*[local-name()='DisplayName']").InnerText
           $application = $manifest.SelectSingleNode("/*[local-name()='Package']/*[local-name()='Applications']/*[local-name()='Application']")
           $applicationId = $application.GetAttribute('Id')
@@ -190,6 +210,12 @@ jobs:
           }
           if ($architecture -ne 'x64') {
             throw "Store architecture mismatch: $architecture"
+          }
+          if ($parsedMinVersion -lt $requiredMinVersion) {
+            throw "Store package MinVersion $minVersion is below the Microsoft Store MSIX floor $env:TUTTI_STORE_MSIX_MIN_VERSION"
+          }
+          if ($parsedMaxVersionTested -lt $parsedMinVersion) {
+            throw "Store package MaxVersionTested $maxVersionTested is below MinVersion $minVersion"
           }
           if ($packageDisplayName -ne $env:TUTTI_STORE_DISPLAY_NAME) {
             throw "Store package display name mismatch: $packageDisplayName"
@@ -245,6 +271,9 @@ jobs:
             packageDisplayName = $packageDisplayName
             productId = $env:TUTTI_MICROSOFT_STORE_PRODUCT_ID
             publisher = $publisher
+            minVersion = $minVersion
+            maxVersionTested = $maxVersionTested
+            submissionPackage = [System.IO.Path]::ChangeExtension($package.Name, '.msix')
             sha256 = $sha256
             tag = $env:TUTTI_DESKTOP_RELEASE_TAG
             version = $version
@@ -253,6 +282,24 @@ jobs:
           "path=$($package.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "sha256=$sha256" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "minVersion=$minVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "maxVersionTested=$maxVersionTested" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - id: submission
+        name: Prepare MSIX Store submission package
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $appxPath = '${{ steps.package.outputs.path }}'
+          $msixPath = [System.IO.Path]::ChangeExtension($appxPath, '.msix')
+          Copy-Item -LiteralPath $appxPath -Destination $msixPath -Force
+          $appxSha256 = (Get-FileHash -LiteralPath $appxPath -Algorithm SHA256).Hash.ToLowerInvariant()
+          $msixSha256 = (Get-FileHash -LiteralPath $msixPath -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($appxSha256 -ne $msixSha256) {
+            throw "MSIX submission alias changed the validated package bytes"
+          }
+          "path=$msixPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "sha256=$msixSha256" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
       - name: Upload validated Store submission artifact
         uses: actions/upload-artifact@v7
@@ -260,6 +307,7 @@ jobs:
           name: tutti-desktop-store-${{ inputs.release_tag }}
           path: |
             apps/desktop/dist/*.appx
+            apps/desktop/dist/*.msix
             apps/desktop/dist/store-submission.json
           if-no-files-found: error
           retention-days: 30
@@ -297,9 +345,7 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $appxPath = '${{ steps.package.outputs.path }}'
-          $msixPath = [System.IO.Path]::ChangeExtension($appxPath, '.msix')
-          Copy-Item -LiteralPath $appxPath -Destination $msixPath -Force
+          $msixPath = '${{ steps.submission.outputs.path }}'
           msstore publish $msixPath -id "$env:TUTTI_MICROSOFT_STORE_PRODUCT_ID"
 
       - name: Record submission summary
@@ -313,7 +359,10 @@ jobs:
           - Tag: `$env:TUTTI_DESKTOP_RELEASE_TAG`
           - Commit: `$(git rev-parse HEAD)`
           - Store version: `${{ steps.package.outputs.version }}`
+          - Windows MinVersion: `${{ steps.package.outputs.minVersion }}`
+          - MaxVersionTested: `${{ steps.package.outputs.maxVersionTested }}`
           - SHA-256: `${{ steps.package.outputs.sha256 }}`
+          - MSIX SHA-256: `${{ steps.submission.outputs.sha256 }}`
           - Submitted: `${{ inputs.submit }}`
 
           The workflow stops after Partner Center accepts the submission request; it does not wait for certification.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@tutti-os/desktop",
   "version": "0.0.0",
   "productName": "Tutti",
-  "description": "Tutti local-first desktop shell.",
+  "description": "Where people and agents build in tune.",
   "author": "Tutti",
   "private": true,
   "packageManager": "pnpm@10.11.0",
@@ -120,7 +120,9 @@
       "languages": [
         "en-US",
         "zh-CN"
-      ]
+      ],
+      "minVersion": "10.0.17763.0",
+      "maxVersionTested": "10.0.26100.0"
     },
     "linux": {
       "target": [

--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -57,8 +57,7 @@ export const en = {
     syncingStatus: "syncing",
     uiSystemNote:
       "The new UI system now owns tokens, icons, and shared primitives in one place.",
-    welcomeDescription:
-      "A local-first intelligent productivity platform that brings control and focus to your workflow.",
+    welcomeDescription: "Where people and agents build in tune.",
     welcomeTitle: "Welcome to Tutti",
     featureLocalTitle: "Local data storage",
     featureLocalDescription: "Privacy and safety stay under your control",

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -175,19 +175,39 @@ name come from the selected GitHub Environment. It must not add AppX files to
 the Direct GitHub Release, S3 mirror, CloudFront updater metadata, or
 `SHA256SUMS.txt`.
 
+The Store manifest explicitly targets Windows `10.0.17763.0` or later and
+declares `10.0.26100.0` as `MaxVersionTested`. The minimum is the Windows 10
+1809 floor required by the current Microsoft Store MSIX submission path. This
+is higher than the legacy AppX package that was previously accepted for the
+product, so a Store package built from this configuration may not be offered as
+an update to devices below that OS version.
+
+The desktop package description is the product tagline
+`Where people and agents build in tune.`. Electron-builder injects this value
+into the Store manifest description and the desktop package metadata. The
+English welcome copy uses the same tagline; technical `local-first` terms in
+architecture docs, tests, and catalog strategy values are intentionally not
+rewritten as product copy.
+
 `.github/workflows/desktop-store-submit.yml` supports two modes:
 
 - a manual test run can build and validate the package with `submit=false`;
 - a stable release can submit the package to Partner Center with `submit=true`.
+
+Manual validation may set `verify_release_tag=false` when the target is an
+untagged branch commit. Production and release-triggered calls keep the default
+`verify_release_tag=true` guard.
 
 The Microsoft Store Developer CLI cannot complete an application's first
 submission from a loose MSIX file. Complete the first submission once in
 Partner Center by uploading the validated AppX artifact and filling the Store
 listing, properties, age rating, pricing, and availability. After that first
 submission exists, the workflow can publish later package updates
-automatically. The workflow presents electron-builder's AppX payload to the
-CLI with an `.msix` extension because the CLI recognizes loose MSIX inputs but
-does not recognize the equivalent `.appx` extension.
+automatically. Electron-builder produces the validated AppX payload; the
+workflow creates a byte-identical `.msix` submission alias because the CLI
+recognizes loose MSIX inputs but does not recognize the equivalent `.appx`
+extension. The alias is created and hash-checked before any Partner Center
+submission.
 
 The automatic stable call is enabled only when the repository variable below
 is true:

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -189,10 +189,16 @@ test("desktop Store packaging reuses the Windows payload and emits AppX only", a
   const storeManifest = await readFile(desktopStoreManifestPath, "utf8");
 
   assert.equal(
+    packageJson.description,
+    "Where people and agents build in tune."
+  );
+  assert.equal(
     packageJson.scripts["build:win:store"],
     "bash ../../tools/scripts/build-desktop-package.sh win-store"
   );
   assert.equal(packageJson.build.appx.electronUpdaterAware, false);
+  assert.equal(packageJson.build.appx.minVersion, "10.0.17763.0");
+  assert.equal(packageJson.build.appx.maxVersionTested, "10.0.26100.0");
   assert.equal(
     packageJson.build.appx.customManifestPath,
     "build/appxmanifest.xml"


### PR DESCRIPTION
## Summary
- raise the Windows Store package MinVersion above the Partner Center MSIX rejection floor
- validate MinVersion/MaxVersionTested and hash-check the byte-identical .msix submission alias in CI
- use Where people and agents build in tune. as the desktop package and English welcome description

## Validation
- node --test tools/scripts/desktop-release-config.test.mjs
- pnpm --filter @tutti-os/desktop typecheck
- pnpm --filter @tutti-os/desktop test
- pnpm check:changed -- --push-ready

The live Partner Center package is v0.2.24.0; the next stable release must be v0.2.25. No production submission was triggered by this PR.