### PR TITLE
fix(agent-gui): preserve unread for unfocused sessions

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -2058,8 +2058,8 @@ test("WorkspaceAgentActivityService preserves realtime turn provenance for atten
       historical.getSessionEngine("ws-2").getSnapshot(),
       "local",
       "session-1"
-    )?.isUnread,
-    false
+    ),
+    null
   );
 });
 

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2896,9 +2896,20 @@ such as TSH may persist their own Rail state without adopting Desktop behavior.
 
 Attention state preserves explicit user intent: marking the currently selected
 Session unread keeps its unread indicator while that selection remains open.
-Selecting the Session again marks it read. A new live completion or a durable
-unread completion discovered by hydration is still marked read immediately when
-its Session is already selected.
+Selecting the Session again marks it read. Selection is node-local while
+attention state is shared, so an active Session may mark its completion read
+only while that AgentGUI surface is both host-focused and host-visible. A
+retained hidden, occluded, or unfocused node must preserve unread attention even
+when its local `activeConversationId` still names the Session. A new live
+completion or a durable unread completion discovered by hydration is marked
+read immediately only when its selected surface satisfies those exposure
+conditions. The read-decision diagnostic records the exact node, completion,
+focus, visibility, and decision reason without logging on stream updates.
+An older historical completion must not replace a newer completion observed
+live. Authoritative history reconciliation may remove a completion that is
+absent from its effective Turn set, but it must retain the durable marker for a
+completion observed live in this run. Otherwise a later historical snapshot can
+recreate that same completion as read and discard its live unread provenance.
 
 Read-only host surfaces reuse the complete workbench header and declare the
 session actions they support. Omitting that capability list preserves the full

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2894,22 +2894,23 @@ Rail state writer because it has no Workbench node-state source. The callback
 contract contains no Tutti Desktop preference or product policy, so other hosts
 such as TSH may persist their own Rail state without adopting Desktop behavior.
 
-Attention state preserves explicit user intent: marking the currently selected
-Session unread keeps its unread indicator while that selection remains open.
-Selecting the Session again marks it read. Selection is node-local while
-attention state is shared, so an active Session may mark its completion read
-only while that AgentGUI surface is both host-focused and host-visible. A
-retained hidden, occluded, or unfocused node must preserve unread attention even
-when its local `activeConversationId` still names the Session. A new live
-completion or a durable unread completion discovered by hydration is marked
-read immediately only when its selected surface satisfies those exposure
-conditions. The read-decision diagnostic records the exact node, completion,
-focus, visibility, and decision reason without logging on stream updates.
-An older historical completion must not replace a newer completion observed
-live. Authoritative history reconciliation may remove a completion that is
-absent from its effective Turn set, but it must retain the durable marker for a
-completion observed live in this run. Otherwise a later historical snapshot can
-recreate that same completion as read and discard its live unread provenance.
+Attention state is unread-only: a live completion or explicit user unread
+request creates a durable unread completion, and real user exposure removes it.
+Absence of an unread completion means read; no separate durable read marker is
+authoritative. Historical list/detail reads own canonical content but never
+create, remove, or reconcile attention. Hydration restores only
+`completed.unreadIds` and `failed.unreadIds`; legacy `readIds` are ignored on
+read and every write payload explicitly empties both read buckets so stale read
+markers cannot survive migration.
+
+Selection is node-local while attention state is shared. An active Session may
+remove unread attention only while its AgentGUI surface is host-focused,
+host-visible, and the renderer document is visible and focused. A retained
+hidden, occluded, unfocused, or backgrounded node must preserve unread
+attention even when its local `activeConversationId` still names the Session.
+The read-decision diagnostic records the exact node, completion, host focus,
+document exposure, visibility, and decision reason without logging on stream
+updates.
 
 Read-only host surfaces reuse the complete workbench header and declare the
 session actions they support. Omitting that capability list preserves the full

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -3304,6 +3304,43 @@ inline data URL instead`. Claude or standard ACP may instead receive no
   [workspaceAgentActivityService.test.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts)
   [attentionReadState.reducer.ts](../../../packages/agent/activity-core/src/engine/attentionReadState.reducer.ts)
 
+### Unfocused AgentGUI Session completion becomes read
+
+- Symptom:
+  A running Session settles after the user focuses another AgentGUI node or
+  window, but the original Session immediately loses its unread-completion lamp.
+- Quick checks:
+  Inspect `agent.gui.attention_read.decision`. The diagnostic identifies the
+  node, completion key, host focus and visibility, and whether the completion
+  was read or preserved. A retained node with `isSurfaceActive=false` or
+  `isSurfaceVisible=false` must report `decision=preserve_unread`; its local
+  `activeConversationId` is not evidence that the user is reading it.
+- Root cause:
+  AgentGUI selection is local to each mounted controller, while attention/read
+  state is shared by the workspace engine. Treating every controller's active
+  Session as visually selected allowed a hidden or unfocused retained node to
+  dispatch the shared `attention/read` intent. A second race can occur when an
+  authoritative history read starts before the live completion, then applies
+  its older detail afterward: attention first writes the completion unread,
+  the stale history removes it, and a later historical Session snapshot
+  recreates the same completion as read.
+- Fix:
+  Pass host-projected focus and visibility into the selection controller and
+  require both before dispatching `attention/read`. Keep the existing manual
+  unread provenance rule so a user-marked unread completion stays unread until
+  the Session is selected again. Do not let an older historical completion
+  replace a newer live attention record. When authoritative history temporarily
+  omits a live completion, remove its active attention record but retain its
+  bounded durable marker so a later historical restore cannot downgrade unread
+  to read.
+- Validation:
+  Keep two AgentGUI nodes mounted, run a Turn in the unfocused node's active
+  Session, and verify its completion key remains in `completed.unreadIds`.
+  Focusing that node should then move the exact key to `completed.readIds`.
+- References:
+  [AgentGUINode.tsx](../../../packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx)
+  [useAgentGUIConversationSelectionController.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.ts)
+
 ### Completed agent session stays activating and disables the composer
 
 - Symptom:

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -3298,7 +3298,7 @@ inline data URL instead`. Claude or standard ACP may instead receive no
   Run
   `pnpm --filter @tutti-os/desktop test -- workspaceAgentActivityService.test.ts`
   and verify the service integration coverage proves that realtime completion
-  becomes unread while a settled historical load remains read.
+  becomes unread while a settled historical load creates no attention record.
 - References:
   [workspaceAgentActivityReconcileBridge.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts)
   [workspaceAgentActivityService.test.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts)
@@ -3311,32 +3311,34 @@ inline data URL instead`. Claude or standard ACP may instead receive no
   window, but the original Session immediately loses its unread-completion lamp.
 - Quick checks:
   Inspect `agent.gui.attention_read.decision`. The diagnostic identifies the
-  node, completion key, host focus and visibility, and whether the completion
-  was read or preserved. A retained node with `isSurfaceActive=false` or
-  `isSurfaceVisible=false` must report `decision=preserve_unread`; its local
-  `activeConversationId` is not evidence that the user is reading it.
+  node, completion key, host focus, document exposure, visibility, and whether
+  the completion was read or preserved. A retained node with
+  `isSurfaceActive=false`, `isSurfaceVisible=false`, or
+  `isSurfaceDocumentExposed=false` must report `decision=preserve_unread`; its
+  local `activeConversationId` is not evidence that the user is reading it.
 - Root cause:
   AgentGUI selection is local to each mounted controller, while attention/read
   state is shared by the workspace engine. Treating every controller's active
   Session as visually selected allowed a hidden or unfocused retained node to
-  dispatch the shared `attention/read` intent. A second race can occur when an
-  authoritative history read starts before the live completion, then applies
-  its older detail afterward: attention first writes the completion unread,
-  the stale history removes it, and a later historical Session snapshot
-  recreates the same completion as read.
+  dispatch the shared `attention/read` intent. Separately, historical Turns
+  without a durable marker were assigned `isUnread=false` and persisted into
+  `readIds`; a stale list/detail response could therefore turn an unseen live
+  completion into durable read state.
 - Fix:
-  Pass host-projected focus and visibility into the selection controller and
-  require both before dispatching `attention/read`. Keep the existing manual
-  unread provenance rule so a user-marked unread completion stays unread until
-  the Session is selected again. Do not let an older historical completion
-  replace a newer live attention record. When authoritative history temporarily
-  omits a live completion, remove its active attention record but retain its
-  bounded durable marker so a later historical restore cannot downgrade unread
-  to read.
+  Use unread-only attention state. Only a live completion transition or an
+  explicit unread request creates an unread record; `attention/read` removes
+  that record, and historical snapshots never mutate attention. Hydration
+  ignores legacy `readIds` and the next write clears those buckets. Pass
+  host-projected focus, host visibility, and renderer document focus/visibility
+  into the selection controller, and require all three before dispatching
+  `attention/read`. Keep the existing manual unread provenance rule so a
+  user-marked unread completion stays unread until the Session is selected
+  again.
 - Validation:
   Keep two AgentGUI nodes mounted, run a Turn in the unfocused node's active
   Session, and verify its completion key remains in `completed.unreadIds`.
-  Focusing that node should then move the exact key to `completed.readIds`.
+  Focusing and exposing that node should remove the exact key while leaving
+  `completed.readIds` empty.
 - References:
   [AgentGUINode.tsx](../../../packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx)
   [useAgentGUIConversationSelectionController.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.ts)

--- a/packages/agent/activity-core/src/engine/attentionReadState.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/attentionReadState.reducer.test.ts
@@ -18,11 +18,26 @@ const turn = {
   updatedAtUnixMs: 2
 };
 
-function acceptedTurnContext(...turns: readonly AgentActivityTurn[]) {
+function acceptedTurnContext(
+  turns: readonly AgentActivityTurn[],
+  options: { includePrevious?: boolean; latest?: boolean } = {}
+) {
   return {
     previousSessionsById: {},
-    previousTurnsById: {},
-    sessionsById: { "session-1": { userId: "user-1" } },
+    previousTurnsById: Object.fromEntries(
+      options.includePrevious === false
+        ? []
+        : turns.map((item) => [
+            canonicalTurnKey(item.agentSessionId, item.turnId),
+            item
+          ])
+    ),
+    sessionsById: {
+      "session-1": {
+        userId: "user-1",
+        latestTurn: options.latest === false ? null : (turns.at(-1) ?? null)
+      }
+    },
     turnsById: Object.fromEntries(
       turns.map((item) => [
         canonicalTurnKey(item.agentSessionId, item.turnId),
@@ -32,133 +47,140 @@ function acceptedTurnContext(...turns: readonly AgentActivityTurn[]) {
   };
 }
 
-test("a live canonical completion becomes unread and read intent clears it", () => {
-  let state = attentionReadStateReducer(
-    createInitialAttentionReadState(),
-    {
-      live: true,
-      type: "turn/upserted",
-      turn
+function liveTurn(turns: readonly AgentActivityTurn[]) {
+  return acceptedTurnContext(turns, { includePrevious: false });
+}
+
+function hydrate(
+  state: ReturnType<typeof createInitialAttentionReadState>,
+  value: {
+    completed?: { readIds?: string[]; unreadIds?: string[] };
+    failed?: { readIds?: string[]; unreadIds?: string[] };
+  } = {}
+) {
+  return attentionReadStateReducer(state, {
+    type: "attention/readStateHydrated",
+    userId: "user-1",
+    completed: {
+      readIds: value.completed?.readIds ?? [],
+      unreadIds: value.completed?.unreadIds ?? []
     },
-    acceptedTurnContext(turn)
-  ).state;
-  assert.deepEqual(
-    state.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"],
-    {
-      completionKey: "turn:session-1:turn-1:completed",
-      isUnread: true,
-      kind: "completed",
-      markedUnreadByUser: false,
-      observationProvenance: "live",
-      readStateProvenance: "live"
+    failed: {
+      readIds: value.failed?.readIds ?? [],
+      unreadIds: value.failed?.unreadIds ?? []
     }
-  );
-  state = attentionReadStateReducer(state, {
+  }).state;
+}
+
+function read(state: ReturnType<typeof createInitialAttentionReadState>) {
+  return attentionReadStateReducer(state, {
     type: "attention/read",
     agentSessionId: "session-1",
     userId: "user-1"
   }).state;
-  assert.equal(
-    state.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"]
-      ?.isUnread,
-    false
-  );
-  assert.equal(
-    state.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"]
-      ?.observationProvenance,
-    "live"
-  );
+}
 
+function unread(state: ReturnType<typeof createInitialAttentionReadState>) {
+  return attentionReadStateReducer(
+    state,
+    {
+      type: "attention/unreadRequested",
+      agentSessionId: "session-1",
+      userId: "user-1"
+    },
+    acceptedTurnContext([turn])
+  ).state;
+}
+
+function hydrateThroughCommand(value: Parameters<typeof hydrate>[1] = {}) {
+  let result = attentionReadStateReducer(createInitialAttentionReadState(), {
+    commandId: "read-1",
+    type: "attention/hydrateRequested",
+    userId: "user-1",
+    workspaceId: "workspace-1"
+  });
+  const commandResult = {
+    commandId: "read-1",
+    commandType: "attention/readState/read",
+    correlationId: "user-1",
+    outcome: "succeeded",
+    type: "engine/commandResult",
+    value: {
+      completed: {
+        readIds: value.completed?.readIds ?? [],
+        unreadIds: value.completed?.unreadIds ?? []
+      },
+      failed: {
+        readIds: value.failed?.readIds ?? [],
+        unreadIds: value.failed?.unreadIds ?? []
+      }
+    }
+  } as const;
+  result = attentionReadStateReducer(result.state, commandResult);
+  return result;
+}
+
+function record(state: ReturnType<typeof createInitialAttentionReadState>) {
+  return state.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"];
+}
+
+test("a live completion creates unread and read removes the unread record", () => {
+  let state = attentionReadStateReducer(
+    createInitialAttentionReadState(),
+    { live: true, type: "turn/upserted", turn },
+    liveTurn([turn])
+  ).state;
+  assert.deepEqual(record(state), {
+    completionKey: "turn:session-1:turn-1:completed",
+    isUnread: true,
+    kind: "completed",
+    markedUnreadByUser: false,
+    observationProvenance: "live",
+    readStateProvenance: "live"
+  });
+
+  state = read(state);
+  assert.equal(record(state), undefined);
+
+  // A replay of an already settled canonical Turn is not a new completion.
   state = attentionReadStateReducer(
     state,
     { live: true, type: "turn/upserted", turn },
-    acceptedTurnContext(turn)
+    acceptedTurnContext([turn])
   ).state;
-  assert.equal(
-    state.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"]
-      ?.isUnread,
-    false
-  );
-  assert.equal(
-    state.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"]
-      ?.markedUnreadByUser,
-    false
-  );
+  assert.equal(record(state), undefined);
 });
 
-test("an omitted live flag remains a live turn upsert for older hosts", () => {
+test("an omitted live flag remains live for older hosts", () => {
   const state = attentionReadStateReducer(
     createInitialAttentionReadState(),
     { type: "turn/upserted", turn },
-    acceptedTurnContext(turn)
+    liveTurn([turn])
   ).state;
-
-  assert.equal(
-    state.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"]
-      ?.isUnread,
-    true
-  );
-  assert.equal(
-    state.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"]
-      ?.observationProvenance,
-    "live"
-  );
+  assert.equal(record(state)?.isUnread, true);
 });
 
-test("a historical canonical completion does not create unread attention", () => {
-  let state = attentionReadStateReducer(createInitialAttentionReadState(), {
-    type: "attention/readStateHydrated",
-    userId: "user-1",
-    completed: { readIds: [], unreadIds: [] },
-    failed: { readIds: [], unreadIds: [] }
-  }).state;
+test("historical turns never create or mutate attention state", () => {
+  let state = hydrate(createInitialAttentionReadState());
   state = attentionReadStateReducer(
     state,
-    {
-      live: false,
-      turn,
-      type: "turn/upserted"
-    },
-    acceptedTurnContext(turn)
+    { live: false, type: "turn/upserted", turn },
+    acceptedTurnContext([turn], { includePrevious: false })
   ).state;
-
-  assert.equal(
-    state.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"]
-      ?.isUnread,
-    false
-  );
-  assert.equal(
-    state.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"]
-      ?.observationProvenance,
-    "historical"
-  );
-
-  const liveState = attentionReadStateReducer(
-    state,
-    { live: true, type: "turn/upserted", turn },
-    acceptedTurnContext(turn)
-  ).state;
-  assert.equal(
-    liveState.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"]
-      ?.isUnread,
-    true
-  );
-  assert.equal(
-    liveState.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"]
-      ?.observationProvenance,
-    "live"
+  assert.equal(record(state), undefined);
+  assert.deepEqual(
+    state.partitionsByUserId["user-1"]?.hydrated?.completedReadIds,
+    []
   );
 });
 
-test("an accepted older historical completion cannot replace newer live attention", () => {
-  const liveTurn = { ...turn, turnId: "turn-live", updatedAtUnixMs: 4 };
-  const oldTurn = { ...turn, turnId: "turn-old", updatedAtUnixMs: 2 };
+test("a stale list snapshot cannot remove a live unread completion", () => {
   let state = attentionReadStateReducer(
     createInitialAttentionReadState(),
-    { live: true, type: "turn/upserted", turn: liveTurn },
-    acceptedTurnContext(liveTurn)
+    { live: true, type: "turn/upserted", turn },
+    liveTurn([turn])
   ).state;
-
+  const oldTurn = { ...turn, turnId: "turn-old", updatedAtUnixMs: 1 };
   state = attentionReadStateReducer(
     state,
     {
@@ -168,211 +190,21 @@ test("an accepted older historical completion cannot replace newer live attentio
     {
       previousSessionsById: { "session-1": {} as never },
       previousTurnsById: {
-        [canonicalTurnKey("session-1", liveTurn.turnId)]: liveTurn
+        [canonicalTurnKey("session-1", turn.turnId)]: turn
       },
       sessionsById: { "session-1": { userId: "user-1" } },
-      turnsById: {
-        [canonicalTurnKey("session-1", oldTurn.turnId)]: oldTurn
-      }
+      turnsById: { [canonicalTurnKey("session-1", oldTurn.turnId)]: oldTurn }
     }
   ).state;
-
-  assert.deepEqual(
-    state.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"],
-    {
-      completionKey: "turn:session-1:turn-live:completed",
-      isUnread: true,
-      kind: "completed",
-      markedUnreadByUser: false,
-      observationProvenance: "live",
-      readStateProvenance: "live"
-    }
-  );
+  assert.equal(record(state)?.completionKey, "turn:session-1:turn-1:completed");
 });
 
-test("manual unread provenance survives until the completion is read or replaced", () => {
+test("authoritative history omission preserves live unread attention", () => {
   let state = attentionReadStateReducer(
     createInitialAttentionReadState(),
     { live: true, type: "turn/upserted", turn },
-    acceptedTurnContext(turn)
+    liveTurn([turn])
   ).state;
-  state = attentionReadStateReducer(state, {
-    type: "attention/read",
-    agentSessionId: "session-1",
-    userId: "user-1"
-  }).state;
-  state = attentionReadStateReducer(state, {
-    type: "attention/unreadRequested",
-    agentSessionId: "session-1",
-    userId: "user-1"
-  }).state;
-  assert.deepEqual(
-    state.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"],
-    {
-      completionKey: "turn:session-1:turn-1:completed",
-      isUnread: true,
-      kind: "completed",
-      markedUnreadByUser: true,
-      observationProvenance: "live",
-      readStateProvenance: "durable"
-    }
-  );
-
-  const replacementTurn = {
-    ...turn,
-    turnId: "turn-2",
-    updatedAtUnixMs: 3
-  };
-  state = attentionReadStateReducer(
-    state,
-    {
-      live: true,
-      type: "turn/upserted",
-      turn: replacementTurn
-    },
-    acceptedTurnContext(replacementTurn)
-  ).state;
-  assert.equal(
-    state.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"]
-      ?.markedUnreadByUser,
-    false
-  );
-});
-
-test("a new completion re-lights a session that was already read", () => {
-  const turn2 = {
-    ...turn,
-    turnId: "turn-2",
-    settledAtUnixMs: 4,
-    updatedAtUnixMs: 4
-  };
-  // Hydrate empty so the durable read set is active for this run.
-  let state = attentionReadStateReducer(createInitialAttentionReadState(), {
-    type: "attention/readStateHydrated",
-    userId: "user-1",
-    completed: { readIds: [], unreadIds: [] },
-    failed: { readIds: [], unreadIds: [] }
-  }).state;
-  // First completion lights, user reads it.
-  state = attentionReadStateReducer(
-    state,
-    { live: true, type: "turn/upserted", turn },
-    acceptedTurnContext(turn)
-  ).state;
-  state = attentionReadStateReducer(state, {
-    type: "attention/read",
-    agentSessionId: "session-1",
-    userId: "user-1"
-  }).state;
-  assert.equal(
-    state.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"]
-      ?.isUnread,
-    false
-  );
-  // A brand new completion on the same session must re-light the lamp.
-  state = attentionReadStateReducer(
-    state,
-    { live: true, type: "turn/upserted", turn: turn2 },
-    acceptedTurnContext(turn2)
-  ).state;
-  assert.equal(
-    state.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"]
-      ?.isUnread,
-    true
-  );
-  // The durable set keeps only the latest completion key for the session.
-  const hydrated = state.partitionsByUserId["user-1"]?.hydrated;
-  assert.deepEqual(hydrated?.completedUnreadIds, [
-    "turn:session-1:turn-2:completed"
-  ]);
-  assert.deepEqual(hydrated?.completedReadIds, []);
-});
-
-test("historical snapshot completion stays read unless persistence says unread", () => {
-  const snapshot = {
-    type: "session/snapshotReceived" as const,
-    sessions: [
-      {
-        ...{
-          activeTurnId: null,
-          latestTurnInteractions: [],
-          pendingInteractions: []
-        },
-        workspaceId: "workspace-1",
-        agentSessionId: "session-1",
-        provider: "codex",
-        cwd: "/workspace",
-        title: "Session",
-        userId: "user-1",
-        activeTurnId: null,
-        activeTurn: null,
-        latestTurn: turn
-      }
-    ]
-  };
-  const initial = attentionReadStateReducer(
-    createInitialAttentionReadState(),
-    snapshot,
-    acceptedTurnContext(turn)
-  ).state;
-  assert.equal(
-    initial.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"]
-      ?.isUnread,
-    false
-  );
-  let hydrated = attentionReadStateReducer(createInitialAttentionReadState(), {
-    type: "attention/readStateHydrated",
-    userId: "user-1",
-    completed: { readIds: [], unreadIds: ["turn:session-1:turn-1:completed"] },
-    failed: { readIds: [], unreadIds: [] }
-  }).state;
-  hydrated = attentionReadStateReducer(
-    hydrated,
-    snapshot,
-    acceptedTurnContext(turn)
-  ).state;
-  assert.equal(
-    hydrated.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"]
-      ?.isUnread,
-    true
-  );
-
-  let readHydrated = attentionReadStateReducer(
-    createInitialAttentionReadState(),
-    {
-      type: "attention/readStateHydrated",
-      userId: "user-1",
-      completed: {
-        readIds: ["turn:session-1:turn-1:completed"],
-        unreadIds: []
-      },
-      failed: { readIds: [], unreadIds: [] }
-    }
-  ).state;
-  readHydrated = attentionReadStateReducer(
-    readHydrated,
-    snapshot,
-    acceptedTurnContext(turn)
-  ).state;
-  readHydrated = attentionReadStateReducer(
-    readHydrated,
-    { live: true, type: "turn/upserted", turn },
-    acceptedTurnContext(turn)
-  ).state;
-  assert.equal(
-    readHydrated.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"]
-      ?.isUnread,
-    false
-  );
-});
-
-test("authoritative turn history removes attention for a retracted completion", () => {
-  let state = attentionReadStateReducer(
-    createInitialAttentionReadState(),
-    { live: true, type: "turn/upserted", turn },
-    acceptedTurnContext(turn)
-  ).state;
-
   state = attentionReadStateReducer(state, {
     agentSessionId: "session-1",
     childSessions: [],
@@ -383,89 +215,327 @@ test("authoritative turn history removes attention for a retracted completion", 
     type: "session/historyAuthoritativeSnapshotReceived",
     workspaceId: "workspace-1"
   }).state;
-
-  assert.equal(
-    state.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"],
-    undefined
-  );
-});
-
-test("historical restore preserves unread provenance after a live completion is temporarily omitted", () => {
-  const oldTurn = { ...turn, turnId: "turn-old", updatedAtUnixMs: 1 };
-  const liveTurn = { ...turn, turnId: "turn-live", updatedAtUnixMs: 4 };
-  let state = attentionReadStateReducer(createInitialAttentionReadState(), {
-    type: "attention/readStateHydrated",
-    userId: "user-1",
-    completed: {
-      readIds: ["turn:session-1:turn-old:completed"],
-      unreadIds: []
-    },
-    failed: { readIds: [], unreadIds: [] }
-  }).state;
-  state = attentionReadStateReducer(
-    state,
-    { live: true, type: "turn/upserted", turn: liveTurn },
-    acceptedTurnContext(liveTurn)
-  ).state;
-
-  state = attentionReadStateReducer(state, {
-    agentSessionId: "session-1",
-    childSessions: [],
-    historyRevision: 1,
-    messages: [],
-    session: { ...authoritativeSession(), latestTurn: oldTurn },
-    turns: [oldTurn],
-    type: "session/historyAuthoritativeSnapshotReceived",
-    workspaceId: "workspace-1"
-  }).state;
-
-  assert.equal(
-    state.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"],
-    undefined
-  );
-  assert.deepEqual(
-    state.partitionsByUserId["user-1"]?.hydrated?.completedUnreadIds,
-    ["turn:session-1:turn-live:completed"]
-  );
+  assert.equal(record(state)?.isUnread, true);
 
   state = attentionReadStateReducer(
     state,
     {
-      sessions: [{ ...authoritativeSession(), latestTurn: liveTurn }],
+      sessions: [{ ...authoritativeSession(), latestTurn: turn }],
       type: "session/snapshotReceived"
     },
-    acceptedTurnContext(liveTurn)
+    acceptedTurnContext([turn])
   ).state;
-
-  assert.equal(
-    state.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"]
-      ?.isUnread,
-    true
-  );
+  assert.equal(record(state)?.isUnread, true);
 });
 
-test("authoritative history preserves live completion provenance atomically", () => {
+test("a live detail snapshot can replay a completion once identity arrives", () => {
   const state = attentionReadStateReducer(
     createInitialAttentionReadState(),
     {
-      agentSessionId: "session-1",
-      childSessions: [],
-      historyRevision: 1,
-      liveTurnId: turn.turnId,
-      messages: [],
-      session: { ...authoritativeSession(), latestTurn: turn },
-      turns: [turn],
-      type: "session/historyAuthoritativeSnapshotReceived",
-      workspaceId: "workspace-1"
+      live: true,
+      replayAcceptedLiveCompletion: true,
+      turn,
+      type: "turn/upserted"
     },
-    acceptedTurnContext(turn)
+    acceptedTurnContext([turn], { includePrevious: false })
   ).state;
+  assert.equal(record(state)?.isUnread, true);
+});
 
+test("an authoritative history live turn marker creates unread atomically", () => {
+  const state = attentionReadStateReducer(
+    createInitialAttentionReadState(),
+    {
+      live: true,
+      replayAcceptedLiveCompletion: true,
+      turn,
+      type: "turn/upserted"
+    },
+    acceptedTurnContext([turn], { includePrevious: false })
+  ).state;
+  assert.equal(record(state)?.isUnread, true);
+});
+
+test("a historical session can be manually marked unread", () => {
+  const state = unread(createInitialAttentionReadState());
+  assert.deepEqual(record(state), {
+    completionKey: "turn:session-1:turn-1:completed",
+    isUnread: true,
+    kind: "completed",
+    markedUnreadByUser: true,
+    observationProvenance: "live",
+    readStateProvenance: "durable"
+  });
+});
+
+test("a new live completion re-lights an already read session", () => {
+  const turn2 = { ...turn, turnId: "turn-2", updatedAtUnixMs: 4 };
+  let state = hydrate(createInitialAttentionReadState());
+  state = attentionReadStateReducer(
+    state,
+    { live: true, type: "turn/upserted", turn },
+    liveTurn([turn])
+  ).state;
+  state = read(state);
+  assert.equal(record(state), undefined);
+  state = attentionReadStateReducer(
+    state,
+    { live: true, type: "turn/upserted", turn: turn2 },
+    acceptedTurnContext([turn, turn2], { includePrevious: false })
+  ).state;
+  assert.equal(record(state)?.completionKey, "turn:session-1:turn-2:completed");
+});
+
+test("a live completion outcome change replaces the unread completion", () => {
+  const failedTurn = { ...turn, outcome: "failed" as const };
+  let state = attentionReadStateReducer(
+    createInitialAttentionReadState(),
+    { live: true, type: "turn/upserted", turn },
+    liveTurn([turn])
+  ).state;
+  assert.equal(record(state)?.kind, "completed");
+
+  state = attentionReadStateReducer(
+    state,
+    { live: true, type: "turn/upserted", turn: failedTurn },
+    {
+      previousSessionsById: {},
+      previousTurnsById: {
+        [canonicalTurnKey("session-1", turn.turnId)]: turn
+      },
+      sessionsById: {
+        "session-1": { userId: "user-1", latestTurn: failedTurn }
+      },
+      turnsById: { [canonicalTurnKey("session-1", turn.turnId)]: failedTurn }
+    }
+  ).state;
+  assert.deepEqual(record(state), {
+    completionKey: "turn:session-1:turn-1:failed",
+    isUnread: true,
+    kind: "failed",
+    markedUnreadByUser: false,
+    observationProvenance: "live",
+    readStateProvenance: "live"
+  });
+});
+
+test("hydration restores persisted unread records and ignores legacy read markers", () => {
+  let state = hydrate(createInitialAttentionReadState(), {
+    completed: {
+      readIds: [
+        "turn:other-read:turn-read:completed",
+        "turn:session-1:turn-1:completed"
+      ],
+      unreadIds: ["turn:session-1:turn-1:completed"]
+    },
+    failed: { readIds: ["turn:other-failed:turn-9:failed"] }
+  });
+  assert.equal(record(state)?.isUnread, true);
   assert.equal(
-    state.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"]
-      ?.isUnread,
-    true
+    state.partitionsByUserId["user-1"]?.hydrated?.completedReadIds.length,
+    0
   );
+  assert.deepEqual(
+    state.partitionsByUserId["user-1"]?.hydrated?.completedUnreadIds,
+    ["turn:session-1:turn-1:completed"]
+  );
+
+  state = read(state);
+  assert.equal(record(state), undefined);
+  assert.deepEqual(
+    state.partitionsByUserId["user-1"]?.hydrated?.completedUnreadIds,
+    []
+  );
+});
+
+test("late legacy read hydration cannot clear a live unread completion", () => {
+  let state = attentionReadStateReducer(
+    createInitialAttentionReadState(),
+    { live: true, type: "turn/upserted", turn },
+    liveTurn([turn])
+  ).state;
+  state = hydrate(state, {
+    completed: { readIds: ["turn:session-1:turn-1:completed"] }
+  });
+  assert.deepEqual(record(state), {
+    completionKey: "turn:session-1:turn-1:completed",
+    isUnread: true,
+    kind: "completed",
+    markedUnreadByUser: false,
+    observationProvenance: "live",
+    readStateProvenance: "live"
+  });
+});
+
+test("a completion observed before empty hydration remains unread", () => {
+  let state = attentionReadStateReducer(
+    createInitialAttentionReadState(),
+    { live: true, type: "turn/upserted", turn },
+    liveTurn([turn])
+  ).state;
+  state = hydrate(state);
+  assert.equal(record(state)?.isUnread, true);
+  assert.deepEqual(
+    state.partitionsByUserId["user-1"]?.hydrated?.completedUnreadIds,
+    ["turn:session-1:turn-1:completed"]
+  );
+});
+
+test("session removal deletes its durable unread key", () => {
+  let state = hydrate(createInitialAttentionReadState(), {
+    completed: { unreadIds: ["turn:session-1:turn-1:completed"] },
+    failed: { unreadIds: ["turn:other:turn-8:failed"] }
+  });
+  state = attentionReadStateReducer(state, {
+    agentSessionId: "session-1",
+    type: "session/removed"
+  }).state;
+  assert.equal(record(state), undefined);
+  assert.deepEqual(
+    state.partitionsByUserId["user-1"]?.hydrated?.completedUnreadIds,
+    []
+  );
+  assert.deepEqual(
+    state.partitionsByUserId["user-1"]?.hydrated?.failedUnreadIds,
+    ["turn:other:turn-8:failed"]
+  );
+});
+
+test("unread request for a removed session is ignored", () => {
+  let state = hydrate(createInitialAttentionReadState(), {
+    completed: { unreadIds: ["turn:session-1:turn-1:completed"] }
+  });
+  state = attentionReadStateReducer(state, {
+    agentSessionId: "session-1",
+    type: "session/removed"
+  }).state;
+  state = attentionReadStateReducer(
+    state,
+    {
+      type: "attention/unreadRequested",
+      agentSessionId: "session-1",
+      userId: "user-1"
+    },
+    acceptedTurnContext([turn], { latest: false })
+  ).state;
+  assert.equal(record(state), undefined);
+});
+
+test("persistence preserves unrelated unread keys and clears read buckets", () => {
+  let result = hydrateThroughCommand({
+    completed: { unreadIds: ["turn:other:turn-9:completed"] },
+    failed: { unreadIds: ["turn:other-b:turn-8:failed"] }
+  });
+  result = attentionReadStateReducer(
+    result.state,
+    { live: true, type: "turn/upserted", turn },
+    liveTurn([turn])
+  );
+  assert.equal(result.commands[0]?.type, "attention/readState/write");
+  assert.deepEqual(result.commands[0], {
+    type: "attention/readState/write",
+    commandId: "attention-write:user-1:1",
+    correlationId: "user-1",
+    userId: "user-1",
+    workspaceId: "workspace-1",
+    completed: {
+      readIds: [],
+      unreadIds: [
+        "turn:other:turn-9:completed",
+        "turn:session-1:turn-1:completed"
+      ]
+    },
+    failed: {
+      readIds: [],
+      unreadIds: ["turn:other-b:turn-8:failed"]
+    }
+  });
+
+  result = attentionReadStateReducer(result.state, {
+    type: "attention/read",
+    agentSessionId: "session-1",
+    userId: "user-1"
+  });
+  assert.deepEqual(result.commands, []);
+  const hydrated = result.state.partitionsByUserId["user-1"]?.hydrated;
+  assert.deepEqual(hydrated?.completedUnreadIds, [
+    "turn:other:turn-9:completed"
+  ]);
+});
+
+test("rapid attention changes serialize full snapshot writes", () => {
+  let result = hydrateThroughCommand();
+  result = attentionReadStateReducer(
+    result.state,
+    { live: true, type: "turn/upserted", turn },
+    liveTurn([turn])
+  );
+  assert.deepEqual(
+    result.commands.map((command) => command.type),
+    ["attention/readState/write"]
+  );
+  result = attentionReadStateReducer(result.state, {
+    type: "attention/read",
+    agentSessionId: "session-1",
+    userId: "user-1"
+  });
+  assert.deepEqual(result.commands, []);
+  result = attentionReadStateReducer(result.state, {
+    commandId: "attention-write:user-1:1",
+    commandType: "attention/readState/write",
+    correlationId: "user-1",
+    outcome: "succeeded",
+    type: "engine/commandResult"
+  });
+  assert.deepEqual(
+    result.commands.map((command) => command.type),
+    ["attention/readState/write"]
+  );
+  assert.deepEqual(result.commands[0], {
+    type: "attention/readState/write",
+    commandId: "attention-write:user-1:2",
+    correlationId: "user-1",
+    userId: "user-1",
+    workspaceId: "workspace-1",
+    completed: { readIds: [], unreadIds: [] },
+    failed: { readIds: [], unreadIds: [] }
+  });
+});
+
+test("write failure is visible and retry emits the latest unread-only snapshot", () => {
+  let result = hydrateThroughCommand();
+  result = attentionReadStateReducer(
+    result.state,
+    { live: true, type: "turn/upserted", turn },
+    liveTurn([turn])
+  );
+  result = attentionReadStateReducer(result.state, {
+    commandId: "attention-write:user-1:1",
+    commandType: "attention/readState/write",
+    correlationId: "user-1",
+    errorMessage: "disk full",
+    outcome: "failed",
+    type: "engine/commandResult"
+  });
+  assert.equal(
+    result.state.partitionsByUserId["user-1"]?.lastError,
+    "disk full"
+  );
+  result = attentionReadStateReducer(result.state, {
+    type: "attention/persistRetryRequested",
+    userId: "user-1"
+  });
+  assert.deepEqual(
+    result.commands.map((command) => command.type),
+    ["attention/readState/write"]
+  );
+  const writeCommand = result.commands[0];
+  assert.equal(writeCommand?.type, "attention/readState/write");
+  if (writeCommand?.type !== "attention/readState/write") return;
+  assert.deepEqual(writeCommand.completed, {
+    readIds: [],
+    unreadIds: ["turn:session-1:turn-1:completed"]
+  });
 });
 
 function authoritativeSession() {
@@ -506,344 +576,3 @@ function authoritativeSession() {
     workspaceId: "workspace-1"
   };
 }
-
-test("late hydration authoritatively clears an already observed unread completion", () => {
-  let state = attentionReadStateReducer(
-    createInitialAttentionReadState(),
-    {
-      live: true,
-      type: "turn/upserted",
-      turn
-    },
-    acceptedTurnContext(turn)
-  ).state;
-  state = attentionReadStateReducer(state, {
-    type: "attention/readStateHydrated",
-    userId: "user-1",
-    completed: { readIds: ["turn:session-1:turn-1:completed"], unreadIds: [] },
-    failed: { readIds: [], unreadIds: [] }
-  }).state;
-  assert.equal(
-    state.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"]
-      ?.isUnread,
-    false
-  );
-});
-
-test("read intent without an observed completion does not invent attention", () => {
-  const state = attentionReadStateReducer(createInitialAttentionReadState(), {
-    type: "attention/read",
-    agentSessionId: "session-1",
-    userId: "user-1"
-  }).state;
-  assert.equal(state.partitionsByUserId["user-1"], undefined);
-});
-
-test("read state is isolated between users in one workspace engine", () => {
-  let state = attentionReadStateReducer(
-    createInitialAttentionReadState(),
-    { live: true, type: "turn/upserted", turn },
-    acceptedTurnContext(turn)
-  ).state;
-  state = attentionReadStateReducer(state, {
-    type: "attention/read",
-    agentSessionId: "session-1",
-    userId: "user-1"
-  }).state;
-  state = attentionReadStateReducer(state, {
-    type: "attention/readStateHydrated",
-    userId: "user-2",
-    completed: { readIds: [], unreadIds: ["turn:session-1:turn-1:completed"] },
-    failed: { readIds: [], unreadIds: [] }
-  }).state;
-  assert.equal(
-    state.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"]
-      ?.isUnread,
-    false
-  );
-  assert.equal(
-    state.partitionsByUserId["user-2"]?.recordsBySessionId["session-1"],
-    undefined
-  );
-});
-
-test("reading one observed session preserves hydrated ids for unloaded sessions", () => {
-  let state = attentionReadStateReducer(createInitialAttentionReadState(), {
-    type: "attention/readStateHydrated",
-    userId: "user-1",
-    completed: {
-      readIds: ["turn:other-a:turn-9:completed"],
-      unreadIds: ["turn:session-1:turn-1:completed"]
-    },
-    failed: { readIds: [], unreadIds: ["turn:other-b:turn-8:failed"] }
-  }).state;
-  state = attentionReadStateReducer(
-    state,
-    { live: true, type: "turn/upserted", turn },
-    acceptedTurnContext(turn)
-  ).state;
-  state = attentionReadStateReducer(state, {
-    type: "attention/read",
-    agentSessionId: "session-1",
-    userId: "user-1"
-  }).state;
-  const hydrated = state.partitionsByUserId["user-1"]?.hydrated;
-  assert.deepEqual(hydrated?.completedReadIds, [
-    "turn:other-a:turn-9:completed",
-    "turn:session-1:turn-1:completed"
-  ]);
-  assert.deepEqual(hydrated?.failedUnreadIds, ["turn:other-b:turn-8:failed"]);
-});
-
-test("session upserts do not drive attention; the turn signal does", () => {
-  // Attention is driven by turn provenance (`turn/upserted` = live realtime,
-  // `session/snapshotReceived` = historical), not by session metadata upserts.
-  // A `session/upserted` carrying a settled latest turn is metadata only and
-  // must not create an attention record on its own.
-  const upserted = attentionReadStateReducer(
-    createInitialAttentionReadState(),
-    {
-      type: "session/upserted",
-      session: {
-        workspaceId: "workspace-1",
-        agentSessionId: "session-1",
-        userId: "user-1",
-        provider: "codex",
-        cwd: "/workspace",
-        title: "Session",
-        activeTurnId: null,
-        activeTurn: null,
-        latestTurnInteractions: [],
-        latestTurn: turn,
-        pendingInteractions: []
-      }
-    }
-  ).state;
-  assert.deepEqual(upserted.partitionsByUserId, {});
-  // Once the session identity is known, the live turn signal lights it.
-  const lit = attentionReadStateReducer(
-    upserted,
-    { live: true, type: "turn/upserted", turn },
-    acceptedTurnContext(turn)
-  ).state;
-  assert.equal(
-    lit.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"]?.isUnread,
-    true
-  );
-});
-
-test("hydration and writes cross the engine command port without dropping unloaded ids", () => {
-  let result = attentionReadStateReducer(createInitialAttentionReadState(), {
-    type: "attention/hydrateRequested",
-    commandId: "read-1",
-    userId: "user-1",
-    workspaceId: "workspace-1"
-  });
-  assert.deepEqual(result.commands, [
-    {
-      type: "attention/readState/read",
-      commandId: "read-1",
-      correlationId: "user-1",
-      userId: "user-1",
-      workspaceId: "workspace-1"
-    }
-  ]);
-  result = attentionReadStateReducer(result.state, {
-    type: "engine/commandResult",
-    commandId: "read-1",
-    commandType: "attention/readState/read",
-    correlationId: "user-1",
-    outcome: "succeeded",
-    value: {
-      completed: {
-        readIds: ["turn:other:turn-9:completed"],
-        unreadIds: ["turn:session-1:turn-1:completed"]
-      },
-      failed: { readIds: [], unreadIds: ["turn:other:turn-8:failed"] }
-    }
-  });
-  result = attentionReadStateReducer(
-    result.state,
-    { live: true, type: "turn/upserted", turn },
-    acceptedTurnContext(turn)
-  );
-  assert.equal(result.commands[0]?.type, "attention/readState/write");
-  result = attentionReadStateReducer(result.state, {
-    type: "engine/commandResult",
-    commandId: "attention-write:user-1:1",
-    commandType: "attention/readState/write",
-    correlationId: "user-1",
-    outcome: "succeeded"
-  });
-  result = attentionReadStateReducer(result.state, {
-    type: "attention/read",
-    agentSessionId: "session-1",
-    userId: "user-1"
-  });
-  assert.deepEqual(result.commands, [
-    {
-      type: "attention/readState/write",
-      commandId: "attention-write:user-1:2",
-      correlationId: "user-1",
-      userId: "user-1",
-      workspaceId: "workspace-1",
-      completed: {
-        readIds: [
-          "turn:other:turn-9:completed",
-          "turn:session-1:turn-1:completed"
-        ],
-        unreadIds: []
-      },
-      failed: { readIds: [], unreadIds: ["turn:other:turn-8:failed"] }
-    }
-  ]);
-});
-
-test("a completion observed before empty hydration is merged and persisted", () => {
-  let result = attentionReadStateReducer(
-    createInitialAttentionReadState(),
-    { live: true, type: "turn/upserted", turn },
-    acceptedTurnContext(turn)
-  );
-  result = attentionReadStateReducer(result.state, {
-    type: "attention/hydrateRequested",
-    commandId: "read-1",
-    userId: "user-1",
-    workspaceId: "workspace-1"
-  });
-  result = attentionReadStateReducer(result.state, {
-    type: "engine/commandResult",
-    commandId: "read-1",
-    commandType: "attention/readState/read",
-    correlationId: "user-1",
-    outcome: "succeeded",
-    value: {
-      completed: { readIds: [], unreadIds: [] },
-      failed: { readIds: [], unreadIds: [] }
-    }
-  });
-  assert.deepEqual(result.commands, [
-    {
-      type: "attention/readState/write",
-      commandId: "attention-write:user-1:1",
-      correlationId: "user-1",
-      userId: "user-1",
-      workspaceId: "workspace-1",
-      completed: {
-        readIds: [],
-        unreadIds: ["turn:session-1:turn-1:completed"]
-      },
-      failed: { readIds: [], unreadIds: [] }
-    }
-  ]);
-});
-
-test("rapid attention changes serialize full snapshot writes", () => {
-  let result = attentionReadStateReducer(createInitialAttentionReadState(), {
-    type: "attention/hydrateRequested",
-    commandId: "read-1",
-    userId: "user-1",
-    workspaceId: "workspace-1"
-  });
-  result = attentionReadStateReducer(result.state, {
-    type: "engine/commandResult",
-    commandId: "read-1",
-    commandType: "attention/readState/read",
-    correlationId: "user-1",
-    outcome: "succeeded",
-    value: {
-      completed: { readIds: [], unreadIds: [] },
-      failed: { readIds: [], unreadIds: [] }
-    }
-  });
-  result = attentionReadStateReducer(
-    result.state,
-    { live: true, type: "turn/upserted", turn },
-    acceptedTurnContext(turn)
-  );
-  assert.deepEqual(
-    result.commands.map((command) => command.type),
-    ["attention/readState/write"]
-  );
-  result = attentionReadStateReducer(result.state, {
-    type: "attention/read",
-    agentSessionId: "session-1",
-    userId: "user-1"
-  });
-  assert.deepEqual(result.commands, []);
-  result = attentionReadStateReducer(result.state, {
-    type: "engine/commandResult",
-    commandId: "attention-write:user-1:1",
-    commandType: "attention/readState/write",
-    correlationId: "user-1",
-    outcome: "succeeded"
-  });
-  assert.deepEqual(result.commands, [
-    {
-      type: "attention/readState/write",
-      commandId: "attention-write:user-1:2",
-      correlationId: "user-1",
-      userId: "user-1",
-      workspaceId: "workspace-1",
-      completed: {
-        readIds: ["turn:session-1:turn-1:completed"],
-        unreadIds: []
-      },
-      failed: { readIds: [], unreadIds: [] }
-    }
-  ]);
-  const stateBeforeLateResult = result.state;
-  result = attentionReadStateReducer(result.state, {
-    type: "engine/commandResult",
-    commandId: "attention-write:user-1:1",
-    commandType: "attention/readState/write",
-    correlationId: "user-1",
-    outcome: "succeeded"
-  });
-  assert.equal(result.state, stateBeforeLateResult);
-});
-
-test("write failure is visible and an explicit retry emits the latest snapshot", () => {
-  let result = attentionReadStateReducer(createInitialAttentionReadState(), {
-    type: "attention/hydrateRequested",
-    commandId: "read-1",
-    userId: "user-1",
-    workspaceId: "workspace-1"
-  });
-  result = attentionReadStateReducer(result.state, {
-    type: "engine/commandResult",
-    commandId: "read-1",
-    commandType: "attention/readState/read",
-    correlationId: "user-1",
-    outcome: "succeeded",
-    value: {
-      completed: { readIds: [], unreadIds: [] },
-      failed: { readIds: [], unreadIds: [] }
-    }
-  });
-  result = attentionReadStateReducer(
-    result.state,
-    { live: true, type: "turn/upserted", turn },
-    acceptedTurnContext(turn)
-  );
-  result = attentionReadStateReducer(result.state, {
-    type: "engine/commandResult",
-    commandId: "attention-write:user-1:1",
-    commandType: "attention/readState/write",
-    correlationId: "user-1",
-    errorMessage: "disk full",
-    outcome: "failed"
-  });
-  assert.equal(
-    result.state.partitionsByUserId["user-1"]?.lastError,
-    "disk full"
-  );
-  result = attentionReadStateReducer(result.state, {
-    type: "attention/persistRetryRequested",
-    userId: "user-1"
-  });
-  assert.deepEqual(
-    result.commands.map((command) => command.type),
-    ["attention/readState/write"]
-  );
-});

--- a/packages/agent/activity-core/src/engine/attentionReadState.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/attentionReadState.reducer.test.ts
@@ -150,6 +150,46 @@ test("a historical canonical completion does not create unread attention", () =>
   );
 });
 
+test("an accepted older historical completion cannot replace newer live attention", () => {
+  const liveTurn = { ...turn, turnId: "turn-live", updatedAtUnixMs: 4 };
+  const oldTurn = { ...turn, turnId: "turn-old", updatedAtUnixMs: 2 };
+  let state = attentionReadStateReducer(
+    createInitialAttentionReadState(),
+    { live: true, type: "turn/upserted", turn: liveTurn },
+    acceptedTurnContext(liveTurn)
+  ).state;
+
+  state = attentionReadStateReducer(
+    state,
+    {
+      sessions: [{ ...authoritativeSession(), latestTurn: oldTurn }],
+      type: "session/snapshotReceived"
+    },
+    {
+      previousSessionsById: { "session-1": {} as never },
+      previousTurnsById: {
+        [canonicalTurnKey("session-1", liveTurn.turnId)]: liveTurn
+      },
+      sessionsById: { "session-1": { userId: "user-1" } },
+      turnsById: {
+        [canonicalTurnKey("session-1", oldTurn.turnId)]: oldTurn
+      }
+    }
+  ).state;
+
+  assert.deepEqual(
+    state.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"],
+    {
+      completionKey: "turn:session-1:turn-live:completed",
+      isUnread: true,
+      kind: "completed",
+      markedUnreadByUser: false,
+      observationProvenance: "live",
+      readStateProvenance: "live"
+    }
+  );
+});
+
 test("manual unread provenance survives until the completion is read or replaced", () => {
   let state = attentionReadStateReducer(
     createInitialAttentionReadState(),
@@ -347,6 +387,60 @@ test("authoritative turn history removes attention for a retracted completion", 
   assert.equal(
     state.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"],
     undefined
+  );
+});
+
+test("historical restore preserves unread provenance after a live completion is temporarily omitted", () => {
+  const oldTurn = { ...turn, turnId: "turn-old", updatedAtUnixMs: 1 };
+  const liveTurn = { ...turn, turnId: "turn-live", updatedAtUnixMs: 4 };
+  let state = attentionReadStateReducer(createInitialAttentionReadState(), {
+    type: "attention/readStateHydrated",
+    userId: "user-1",
+    completed: {
+      readIds: ["turn:session-1:turn-old:completed"],
+      unreadIds: []
+    },
+    failed: { readIds: [], unreadIds: [] }
+  }).state;
+  state = attentionReadStateReducer(
+    state,
+    { live: true, type: "turn/upserted", turn: liveTurn },
+    acceptedTurnContext(liveTurn)
+  ).state;
+
+  state = attentionReadStateReducer(state, {
+    agentSessionId: "session-1",
+    childSessions: [],
+    historyRevision: 1,
+    messages: [],
+    session: { ...authoritativeSession(), latestTurn: oldTurn },
+    turns: [oldTurn],
+    type: "session/historyAuthoritativeSnapshotReceived",
+    workspaceId: "workspace-1"
+  }).state;
+
+  assert.equal(
+    state.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"],
+    undefined
+  );
+  assert.deepEqual(
+    state.partitionsByUserId["user-1"]?.hydrated?.completedUnreadIds,
+    ["turn:session-1:turn-live:completed"]
+  );
+
+  state = attentionReadStateReducer(
+    state,
+    {
+      sessions: [{ ...authoritativeSession(), latestTurn: liveTurn }],
+      type: "session/snapshotReceived"
+    },
+    acceptedTurnContext(liveTurn)
+  ).state;
+
+  assert.equal(
+    state.partitionsByUserId["user-1"]?.recordsBySessionId["session-1"]
+      ?.isUnread,
+    true
   );
 });
 

--- a/packages/agent/activity-core/src/engine/attentionReadState.reducer.ts
+++ b/packages/agent/activity-core/src/engine/attentionReadState.reducer.ts
@@ -6,22 +6,29 @@ import type {
 } from "./types.ts";
 import type {
   AttentionCompletionKind,
-  AttentionObservationProvenance,
-  AttentionReadStateProvenance,
   AttentionReadRecord,
   AttentionReadPartition,
   AttentionReadState
 } from "./attentionReadState.types.ts";
-import type { CanonicalAgentSession } from "./sessionLifecycle.types.ts";
 import { canonicalTurnKey } from "./sessionEntityKeys.ts";
 
 const NO_COMMANDS: readonly EngineCommand[] = [];
 
 interface AttentionReadStateContext {
-  previousSessionsById: Readonly<Record<string, CanonicalAgentSession>>;
+  previousSessionsById: Readonly<
+    Record<string, { userId?: string; latestTurn?: AgentActivityTurn | null }>
+  >;
   previousTurnsById: Readonly<Record<string, AgentActivityTurn>>;
-  sessionsById: Readonly<Record<string, { userId?: string }>>;
+  sessionsById: Readonly<
+    Record<string, { userId?: string; latestTurn?: AgentActivityTurn | null }>
+  >;
   turnsById: Readonly<Record<string, AgentActivityTurn>>;
+}
+
+interface CompletionKeyParts {
+  agentSessionId: string;
+  completionKey: string;
+  kind: AttentionCompletionKind;
 }
 
 export function createInitialAttentionReadState(): AttentionReadState {
@@ -44,15 +51,14 @@ export function attentionReadStateReducer(
     case "attention/readStateHydrated":
       return hydrate(state, intent);
     case "attention/read":
-      return setUnread(
+      return removeUnread(state, intent.userId, intent.agentSessionId);
+    case "attention/unreadRequested":
+      return requestUnread(
         state,
         intent.userId,
         intent.agentSessionId,
-        false,
-        false
+        context
       );
-    case "attention/unreadRequested":
-      return setUnread(state, intent.userId, intent.agentSessionId, true, true);
     case "attention/persistRetryRequested":
       return retryPersistence(state, intent.userId);
     case "engine/commandResult":
@@ -67,56 +73,35 @@ export function attentionReadStateReducer(
       return unchanged(state);
     case "turn/projectionReceived":
     case "turn/upserted": {
+      if (intent.type === "turn/upserted" && intent.live === false) {
+        return unchanged(state);
+      }
       const turn = acceptedCanonicalTurn(intent.turn, context);
-      if (!turn) return unchanged(state);
-      return observeTurn(
-        state,
-        context.sessionsById[turn.agentSessionId]?.userId ?? "",
-        turn,
-        intent.type === "turn/projectionReceived" || intent.live !== false,
-        context.previousTurnsById
-      );
+      const userId = context.sessionsById[turn?.agentSessionId ?? ""]?.userId;
+      const replayAcceptedLiveCompletion =
+        intent.type === "turn/upserted" &&
+        intent.replayAcceptedLiveCompletion === true;
+      if (
+        !turn ||
+        userId === undefined ||
+        (!replayAcceptedLiveCompletion &&
+          !isLiveCompletionTransition(turn, context))
+      ) {
+        return unchanged(state);
+      }
+      return observeLiveUnread(state, userId, turn);
     }
+    case "session/detailSnapshotReceived":
     case "session/historyAuthoritativeSnapshotReceived":
-      return reconcileAuthoritativeHistoryAttention(state, intent, context);
-    case "session/snapshotReceived": {
-      let next = state;
-      for (const session of intent.sessions) {
-        if (session.latestTurn) {
-          const turn = acceptedCanonicalTurn(session.latestTurn, context);
-          const id = session.agentSessionId.trim();
-          const key = canonicalTurnKey(id, session.latestTurn.turnId);
-          const snapshotAccepted =
-            context.sessionsById[id] !== context.previousSessionsById[id] ||
-            turn !== context.previousTurnsById[key];
-          if (!turn || !snapshotAccepted) continue;
-          next = observeTurn(
-            next,
-            context.sessionsById[turn.agentSessionId]?.userId ?? "",
-            turn,
-            false,
-            context.previousTurnsById
-          ).state;
-        }
-      }
-      return next === state ? unchanged(state) : changed(next);
-    }
-    case "session/removed": {
-      const id = intent.agentSessionId.trim();
-      let next = state;
-      for (const [userId, partition] of Object.entries(
-        state.partitionsByUserId
-      )) {
-        if (!partition.recordsBySessionId[id]) continue;
-        const recordsBySessionId = { ...partition.recordsBySessionId };
-        delete recordsBySessionId[id];
-        next = replacePartition(next, userId, {
-          ...partition,
-          recordsBySessionId
-        });
-      }
-      return next === state ? unchanged(state) : changed(next);
-    }
+      // Historical reads own canonical content. Their accepted live completion
+      // is replayed explicitly by sessionReconcile as a marked turn upsert.
+      return unchanged(state);
+    case "session/snapshotReceived":
+      // A list snapshot is historical content. It must not create a read
+      // marker, create an unread marker, or remove an existing unread marker.
+      return unchanged(state);
+    case "session/removed":
+      return removeSession(state, intent.agentSessionId);
     default:
       return unchanged(state);
   }
@@ -136,229 +121,122 @@ function acceptedCanonicalTurn(
     : null;
 }
 
-function reconcileAuthoritativeTurns(
-  state: AttentionReadState,
-  rawSessionId: string,
-  turns: readonly AgentActivityTurn[]
-): EngineReducerResult<AttentionReadState> {
-  const sessionId = rawSessionId.trim();
-  if (!sessionId) return unchanged(state);
-  const authoritativeCompletionKeys = new Set<string>();
-  for (const turn of turns) {
-    if (turn.agentSessionId.trim() !== sessionId) continue;
-    const turnId = turn.turnId.trim();
-    const kind = completionKind(turn);
-    if (turnId && kind) {
-      authoritativeCompletionKeys.add(`turn:${sessionId}:${turnId}:${kind}`);
-    }
-  }
-
-  let next = state;
-  const commands: EngineCommand[] = [];
-  for (const [userId, partition] of Object.entries(state.partitionsByUserId)) {
-    const current = partition.recordsBySessionId[sessionId];
-    const removeRecord =
-      current !== undefined &&
-      !authoritativeCompletionKeys.has(current.completionKey);
-    const hydrated = partition.hydrated;
-    let nextHydrated = hydrated;
-    if (hydrated) {
-      const completedReadIds = retainAuthoritativeCompletionKeys(
-        hydrated.completedReadIds,
-        sessionId,
-        authoritativeCompletionKeys
-      );
-      const completedUnreadIds = retainAuthoritativeCompletionKeys(
-        hydrated.completedUnreadIds,
-        sessionId,
-        authoritativeCompletionKeys
-      );
-      const failedReadIds = retainAuthoritativeCompletionKeys(
-        hydrated.failedReadIds,
-        sessionId,
-        authoritativeCompletionKeys
-      );
-      const failedUnreadIds = retainAuthoritativeCompletionKeys(
-        hydrated.failedUnreadIds,
-        sessionId,
-        authoritativeCompletionKeys
-      );
-      const filteredHydrated = {
-        completedReadIds,
-        completedUnreadIds,
-        failedReadIds,
-        failedUnreadIds
-      };
-      if (removeRecord && current?.observationProvenance === "live") {
-        // A detail read can be internally consistent yet still have started
-        // before this live completion. Remove the non-authoritative record so
-        // genuine retractions stop driving the lamp, but retain its durable
-        // marker. If a later historical snapshot restores the same completion,
-        // it must not silently downgrade the live unread observation to read.
-        nextHydrated = updateDurableMarker(
-          { ...partition, hydrated: filteredHydrated },
-          sessionId,
-          current.completionKey,
-          current.kind,
-          current.isUnread
-        ).hydrated;
-      } else if (
-        completedReadIds !== hydrated.completedReadIds ||
-        completedUnreadIds !== hydrated.completedUnreadIds ||
-        failedReadIds !== hydrated.failedReadIds ||
-        failedUnreadIds !== hydrated.failedUnreadIds
-      ) {
-        nextHydrated = filteredHydrated;
-      }
-    }
-    if (!removeRecord && nextHydrated === hydrated) continue;
-
-    let recordsBySessionId = partition.recordsBySessionId;
-    if (removeRecord) {
-      const mutableRecords: Record<string, AttentionReadRecord> = {
-        ...partition.recordsBySessionId
-      };
-      delete mutableRecords[sessionId];
-      recordsBySessionId = mutableRecords;
-    }
-    const reconciledPartition: AttentionReadPartition = {
-      ...partition,
-      hydrated: nextHydrated,
-      recordsBySessionId
-    };
-    const persistence =
-      nextHydrated !== hydrated
-        ? queuePersistence(reconciledPartition, userId)
-        : { commands: NO_COMMANDS, partition: reconciledPartition };
-    commands.push(...persistence.commands);
-    next = replacePartition(next, userId, persistence.partition);
-  }
-  return next === state ? unchanged(state) : changed(next, commands);
-}
-
-function reconcileAuthoritativeHistoryAttention(
-  state: AttentionReadState,
-  intent: Extract<
-    EngineIntent,
-    { type: "session/historyAuthoritativeSnapshotReceived" }
-  >,
+function isLiveCompletionTransition(
+  turn: AgentActivityTurn,
   context: AttentionReadStateContext
-): EngineReducerResult<AttentionReadState> {
-  const reconciled = reconcileAuthoritativeTurns(
-    state,
-    intent.agentSessionId,
-    intent.turns
+): boolean {
+  if (!completionKind(turn)) return false;
+  const previous =
+    context.previousTurnsById[
+      canonicalTurnKey(turn.agentSessionId, turn.turnId)
+    ];
+  return (
+    previous === undefined ||
+    previous.phase !== "settled" ||
+    previous.outcome !== turn.outcome
   );
-  const liveTurnId = intent.liveTurnId?.trim() ?? "";
-  const incomingLiveTurn = liveTurnId
-    ? intent.turns.find((turn) => turn.turnId.trim() === liveTurnId)
-    : undefined;
-  const liveTurn = incomingLiveTurn
-    ? acceptedCanonicalTurn(incomingLiveTurn, context)
-    : null;
-  if (!liveTurn) return reconciled;
-  const observed = observeTurn(
-    reconciled.state,
-    context.sessionsById[intent.agentSessionId]?.userId ?? "",
-    liveTurn,
-    true,
-    context.previousTurnsById
-  );
-  return {
-    commands: [...reconciled.commands, ...observed.commands],
-    state: observed.state
-  };
 }
 
-function retainAuthoritativeCompletionKeys(
-  keys: readonly string[],
-  sessionId: string,
-  authoritativeCompletionKeys: ReadonlySet<string>
-): readonly string[] {
-  const prefix = `turn:${sessionId}:`;
-  const filtered = keys.filter(
-    (key) => !key.startsWith(prefix) || authoritativeCompletionKeys.has(key)
-  );
-  return filtered.length === keys.length ? keys : filtered;
-}
-
-function observeTurn(
+function observeLiveUnread(
   state: AttentionReadState,
   rawUserId: string,
-  turn: AgentActivityTurn,
-  live: boolean,
-  previousTurnsById: Readonly<Record<string, AgentActivityTurn>> = {}
+  turn: AgentActivityTurn
 ): EngineReducerResult<AttentionReadState> {
-  const id = turn.agentSessionId.trim();
+  const parts = completionKeyParts(turn);
   const userId = rawUserId.trim();
-  const turnId = turn.turnId.trim();
-  const kind = completionKind(turn);
-  if (!id || !userId || !turnId || !kind) return unchanged(state);
+  if (!parts || !userId) return unchanged(state);
   const partition = partitionFor(state, userId);
-  const completionKey = `turn:${id}:${turnId}:${kind}`;
+  const current = partition.recordsBySessionId[parts.agentSessionId];
+  if (current?.completionKey === parts.completionKey) return unchanged(state);
+
+  return upsertUnread(state, userId, parts, false);
+}
+
+function requestUnread(
+  state: AttentionReadState,
+  rawUserId: string,
+  rawId: string,
+  context: AttentionReadStateContext
+): EngineReducerResult<AttentionReadState> {
+  const id = rawId.trim();
+  const userId = rawUserId.trim();
+  if (!id || !userId) return unchanged(state);
+  const partition = partitionFor(state, userId);
   const current = partition.recordsBySessionId[id];
-  if (
-    !live &&
-    current?.observationProvenance === "live" &&
-    current.completionKey !== completionKey
-  ) {
-    const currentLiveTurn = Object.values(previousTurnsById).find(
-      (candidate) =>
-        candidate.agentSessionId === id &&
-        completionKeyForTurn(candidate) === current.completionKey
+  if (current) {
+    if (current.markedUnreadByUser) return unchanged(state);
+    return upsertUnread(
+      state,
+      userId,
+      {
+        agentSessionId: id,
+        completionKey: current.completionKey,
+        kind: current.kind
+      },
+      true
     );
-    if (
-      currentLiveTurn &&
-      currentLiveTurn.updatedAtUnixMs >= turn.updatedAtUnixMs
-    ) {
-      return unchanged(state);
-    }
   }
+
+  const latestTurn = context.sessionsById[id]?.latestTurn;
+  const turn = latestTurn ? acceptedCanonicalTurn(latestTurn, context) : null;
+  const parts = turn ? completionKeyParts(turn) : null;
+  if (!parts) return unchanged(state);
+  return upsertUnread(state, userId, parts, true);
+}
+
+function upsertUnread(
+  state: AttentionReadState,
+  userId: string,
+  parts: CompletionKeyParts,
+  markedUnreadByUser: boolean
+): EngineReducerResult<AttentionReadState> {
+  const partition = partitionFor(state, userId);
+  const current = partition.recordsBySessionId[parts.agentSessionId];
+  const nextPartition: AttentionReadPartition = {
+    ...replaceDurableUnread(partition, parts),
+    recordsBySessionId: {
+      ...partition.recordsBySessionId,
+      [parts.agentSessionId]: {
+        completionKey: parts.completionKey,
+        isUnread: true,
+        kind: parts.kind,
+        markedUnreadByUser,
+        observationProvenance: "live",
+        readStateProvenance: markedUnreadByUser ? "durable" : "live"
+      }
+    }
+  };
   if (
-    current?.completionKey === completionKey &&
-    (current.observationProvenance === "live" || !live)
+    current?.completionKey === parts.completionKey &&
+    current.markedUnreadByUser === markedUnreadByUser
   ) {
     return unchanged(state);
   }
-  const sameCompletion = current?.completionKey === completionKey;
-  const hydratedIsUnread = hydratedUnread(partition, completionKey, kind);
-  const liveUpgradeMustIgnoreHistoricalMarker =
-    live && sameCompletion && current?.readStateProvenance === "historical";
-  const isUnread = liveUpgradeMustIgnoreHistoricalMarker
-    ? true
-    : (hydratedIsUnread ?? live);
-  const observationProvenance: AttentionObservationProvenance = live
-    ? "live"
-    : "historical";
-  const readStateProvenance: AttentionReadStateProvenance =
-    liveUpgradeMustIgnoreHistoricalMarker
-      ? "live"
-      : hydratedIsUnread !== null
-        ? "durable"
-        : live
-          ? "live"
-          : "historical";
-  const durablePartition = updateDurableMarker(
-    partition,
-    id,
-    completionKey,
-    kind,
-    isUnread
+  const persistence = queuePersistence(nextPartition, userId);
+  return changed(
+    replacePartition(state, userId, persistence.partition),
+    persistence.commands
   );
-  const nextPartition = {
-    ...durablePartition,
-    recordsBySessionId: {
-      ...durablePartition.recordsBySessionId,
-      [id]: {
-        completionKey,
-        isUnread,
-        kind,
-        markedUnreadByUser:
-          sameCompletion && current ? current.markedUnreadByUser : false,
-        observationProvenance,
-        readStateProvenance
-      }
-    }
+}
+
+function removeUnread(
+  state: AttentionReadState,
+  rawUserId: string,
+  rawId: string
+): EngineReducerResult<AttentionReadState> {
+  const id = rawId.trim();
+  const userId = rawUserId.trim();
+  if (!id || !userId) return unchanged(state);
+  const partition = partitionFor(state, userId);
+  const current = partition.recordsBySessionId[id];
+  if (!current) return unchanged(state);
+
+  const recordsBySessionId = { ...partition.recordsBySessionId };
+  delete recordsBySessionId[id];
+  const nextPartition: AttentionReadPartition = {
+    ...partition,
+    hydrated: removeDurableSessionKeys(partition, id),
+    recordsBySessionId
   };
   const persistence = queuePersistence(nextPartition, userId);
   return changed(
@@ -367,13 +245,84 @@ function observeTurn(
   );
 }
 
-function completionKeyForTurn(turn: AgentActivityTurn): string | null {
-  const kind = completionKind(turn);
-  const sessionId = turn.agentSessionId.trim();
+function removeSession(
+  state: AttentionReadState,
+  rawId: string
+): EngineReducerResult<AttentionReadState> {
+  const id = rawId.trim();
+  if (!id) return unchanged(state);
+  let next = state;
+  const commands: EngineCommand[] = [];
+  for (const [userId, partition] of Object.entries(state.partitionsByUserId)) {
+    if (!partition.recordsBySessionId[id]) continue;
+    const recordsBySessionId = { ...partition.recordsBySessionId };
+    delete recordsBySessionId[id];
+    const hydrated = removeDurableSessionKeys(partition, id);
+    const nextPartition: AttentionReadPartition = {
+      ...partition,
+      hydrated,
+      recordsBySessionId
+    };
+    const persistence = queuePersistence(nextPartition, userId);
+    commands.push(...persistence.commands);
+    next = replacePartition(next, userId, persistence.partition);
+  }
+  return next === state ? unchanged(state) : changed(next, commands);
+}
+
+function replaceDurableUnread(
+  partition: AttentionReadPartition,
+  parts: CompletionKeyParts
+): AttentionReadPartition {
+  if (!partition.hydrated) return partition;
+  const completedUnreadIds = new Set(partition.hydrated.completedUnreadIds);
+  const failedUnreadIds = new Set(partition.hydrated.failedUnreadIds);
+  evictSessionCompletionKeys(parts.agentSessionId, [
+    completedUnreadIds,
+    failedUnreadIds
+  ]);
+  (parts.kind === "completed" ? completedUnreadIds : failedUnreadIds).add(
+    parts.completionKey
+  );
+  return {
+    ...partition,
+    hydrated: {
+      completedReadIds: [],
+      completedUnreadIds: [...completedUnreadIds],
+      failedReadIds: [],
+      failedUnreadIds: [...failedUnreadIds]
+    }
+  };
+}
+
+function removeDurableSessionKeys(
+  partition: AttentionReadPartition,
+  sessionId: string
+): AttentionReadPartition["hydrated"] {
+  if (!partition.hydrated) return partition.hydrated;
+  const completedUnreadIds = new Set(partition.hydrated.completedUnreadIds);
+  const failedUnreadIds = new Set(partition.hydrated.failedUnreadIds);
+  evictSessionCompletionKeys(sessionId, [completedUnreadIds, failedUnreadIds]);
+  return {
+    completedReadIds: [],
+    completedUnreadIds: [...completedUnreadIds],
+    failedReadIds: [],
+    failedUnreadIds: [...failedUnreadIds]
+  };
+}
+
+function completionKeyParts(
+  turn: AgentActivityTurn
+): CompletionKeyParts | null {
+  const agentSessionId = turn.agentSessionId.trim();
   const turnId = turn.turnId.trim();
-  return sessionId && turnId && kind
-    ? `turn:${sessionId}:${turnId}:${kind}`
-    : null;
+  const kind = completionKind(turn);
+  if (!agentSessionId || !turnId || !kind) return null;
+  return {
+    agentSessionId,
+    completionKey: `turn:${agentSessionId}:${turnId}:${kind}`,
+    kind
+  };
 }
 
 function completionKind(
@@ -387,103 +336,115 @@ function completionKind(
       : null;
 }
 
-function hydratedUnread(
-  state: AttentionReadPartition,
-  completionKey: string,
-  kind: AttentionCompletionKind
-): boolean | null {
-  const hydrated = state.hydrated;
-  if (!hydrated) return null;
-  const unread =
-    kind === "completed"
-      ? hydrated.completedUnreadIds
-      : hydrated.failedUnreadIds;
-  const read =
-    kind === "completed" ? hydrated.completedReadIds : hydrated.failedReadIds;
-  if (unread.includes(completionKey)) return true;
-  if (read.includes(completionKey)) return false;
-  return null;
-}
-
-function setUnread(
+function hydrate(
   state: AttentionReadState,
-  rawUserId: string,
-  rawId: string,
-  isUnread: boolean,
-  markedUnreadByUser: boolean
+  intent: Extract<EngineIntent, { type: "attention/readStateHydrated" }>
 ): EngineReducerResult<AttentionReadState> {
-  const id = rawId.trim();
-  const userId = rawUserId.trim();
-  if (!id || !userId) return unchanged(state);
+  const userId = intent.userId.trim();
+  if (!userId) return unchanged(state);
   const partition = partitionFor(state, userId);
-  const current = partition.recordsBySessionId[id];
-  if (!current) return unchanged(state);
-  const next: AttentionReadRecord = current;
-  if (
-    current.isUnread === isUnread &&
-    current.markedUnreadByUser === markedUnreadByUser
-  ) {
+  const persistedCompletedUnread = sanitizeCompletionKeys(
+    intent.completed.unreadIds
+  );
+  const persistedFailedUnread = sanitizeCompletionKeys(intent.failed.unreadIds);
+  const persistedRecords: Record<string, AttentionReadRecord> = {};
+  for (const key of persistedCompletedUnread) {
+    const parts = parseCompletionKey(key, "completed");
+    if (parts)
+      persistedRecords[parts.agentSessionId] = unreadRecord(parts, false);
+  }
+  for (const key of persistedFailedUnread) {
+    const parts = parseCompletionKey(key, "failed");
+    if (parts && !persistedRecords[parts.agentSessionId]) {
+      persistedRecords[parts.agentSessionId] = unreadRecord(parts, false);
+    }
+  }
+
+  const recordsBySessionId: Record<string, AttentionReadRecord> = {
+    ...persistedRecords,
+    ...partition.recordsBySessionId
+  };
+  const completedUnreadIds = new Set(persistedCompletedUnread);
+  const failedUnreadIds = new Set(persistedFailedUnread);
+  for (const [sessionId, record] of Object.entries(recordsBySessionId)) {
+    evictSessionCompletionKeys(sessionId, [
+      completedUnreadIds,
+      failedUnreadIds
+    ]);
+    (record.kind === "completed" ? completedUnreadIds : failedUnreadIds).add(
+      record.completionKey
+    );
+  }
+
+  const hydrated = {
+    completedReadIds: [],
+    completedUnreadIds: [...completedUnreadIds],
+    failedReadIds: [],
+    failedUnreadIds: [...failedUnreadIds]
+  };
+  const recordsChanged = !sameRecords(
+    partition.recordsBySessionId,
+    recordsBySessionId
+  );
+  const firstHydration = partition.hydrated === null;
+  const hydratedChanged =
+    !firstHydration &&
+    (partition.hydrated?.completedReadIds.length !== 0 ||
+      partition.hydrated?.failedReadIds.length !== 0 ||
+      !sameStrings(
+        partition.hydrated?.completedUnreadIds ?? [],
+        hydrated.completedUnreadIds
+      ) ||
+      !sameStrings(
+        partition.hydrated?.failedUnreadIds ?? [],
+        hydrated.failedUnreadIds
+      ));
+  const nextPartition: AttentionReadPartition = {
+    ...partition,
+    hydrated,
+    lastError: null,
+    recordsBySessionId
+  };
+  if (!recordsChanged && !firstHydration && !hydratedChanged) {
     return unchanged(state);
   }
-  const durablePartition = updateDurableMarker(
-    partition,
-    id,
-    current.completionKey,
-    current.kind,
-    isUnread
-  );
-  const nextPartition = {
-    ...durablePartition,
-    recordsBySessionId: {
-      ...durablePartition.recordsBySessionId,
-      [id]: {
-        ...next,
-        isUnread,
-        markedUnreadByUser,
-        readStateProvenance: "durable" as const
-      }
-    }
-  };
-  const persistence = queuePersistence(nextPartition, userId);
+  const persistence = hydratedChanged
+    ? queuePersistence(nextPartition, userId)
+    : { commands: NO_COMMANDS, partition: nextPartition };
   return changed(
     replacePartition(state, userId, persistence.partition),
     persistence.commands
   );
 }
 
-function updateDurableMarker(
-  partition: AttentionReadPartition,
-  sessionId: string,
-  completionKey: string,
-  kind: AttentionCompletionKind,
-  isUnread: boolean
-): AttentionReadPartition {
-  if (!partition.hydrated) return partition;
-  const completedReadIds = new Set(partition.hydrated.completedReadIds);
-  const completedUnreadIds = new Set(partition.hydrated.completedUnreadIds);
-  const failedReadIds = new Set(partition.hydrated.failedReadIds);
-  const failedUnreadIds = new Set(partition.hydrated.failedUnreadIds);
-  // Only the latest completion per session drives the lamp, so evict any prior
-  // completion key for this session across every bucket before recording the new
-  // one. This keeps the durable set bounded to one key per session (per kind)
-  // while still keying on the exact completion so a new turn re-lights.
-  evictSessionCompletionKeys(sessionId, [
-    completedReadIds,
-    completedUnreadIds,
-    failedReadIds,
-    failedUnreadIds
-  ]);
-  const read = kind === "completed" ? completedReadIds : failedReadIds;
-  const unread = kind === "completed" ? completedUnreadIds : failedUnreadIds;
-  (isUnread ? unread : read).add(completionKey);
+function unreadRecord(
+  parts: CompletionKeyParts,
+  markedUnreadByUser: boolean
+): AttentionReadRecord {
   return {
-    ...partition,
-    hydrated: {
-      completedReadIds: [...completedReadIds],
-      completedUnreadIds: [...completedUnreadIds],
-      failedReadIds: [...failedReadIds],
-      failedUnreadIds: [...failedUnreadIds]
-    }
+    completionKey: parts.completionKey,
+    isUnread: true,
+    kind: parts.kind,
+    markedUnreadByUser,
+    observationProvenance: "live",
+    readStateProvenance: "durable"
+  };
+}
+
+function parseCompletionKey(
+  key: string,
+  expectedKind: AttentionCompletionKind
+): CompletionKeyParts | null {
+  const match = /^turn:([^:]+):([^:]+):(completed|failed)$/.exec(key);
+  if (!match) return null;
+  const kind = match[3] as AttentionCompletionKind;
+  if (kind !== expectedKind) return null;
+  const agentSessionId = match[1];
+  if (!agentSessionId) return null;
+  return {
+    agentSessionId,
+    completionKey: key,
+    kind
   };
 }
 
@@ -500,76 +461,41 @@ function evictSessionCompletionKeys(
 }
 
 function sanitizeCompletionKeys(ids: readonly string[]): string[] {
-  // Durable buckets hold completion keys (`turn:<session>:<turn>:<kind>`). Drop
-  // any legacy per-session id left by older builds so it cannot linger; a stale
-  // session id never matches a completion-key lookup anyway, and dropping it now
-  // keeps the persisted set clean without a bespoke migration.
-  return ids.filter((id) => id.startsWith("turn:"));
+  return ids.filter((id) => /^turn:[^:]+:[^:]+:(?:completed|failed)$/.test(id));
 }
 
-function hydrate(
-  state: AttentionReadState,
-  intent: Extract<EngineIntent, { type: "attention/readStateHydrated" }>
-): EngineReducerResult<AttentionReadState> {
-  const userId = intent.userId.trim();
-  if (!userId) return unchanged(state);
-  const partition = partitionFor(state, userId);
-  const completedReadIds = new Set(
-    sanitizeCompletionKeys(intent.completed.readIds)
+function sameRecords(
+  left: Readonly<Record<string, AttentionReadRecord>>,
+  right: Readonly<Record<string, AttentionReadRecord>>
+): boolean {
+  const leftIds = Object.keys(left);
+  const rightIds = Object.keys(right);
+  return (
+    leftIds.length === rightIds.length &&
+    leftIds.every((id) => {
+      const a = left[id];
+      const b = right[id];
+      return (
+        a !== undefined &&
+        b !== undefined &&
+        a.completionKey === b.completionKey &&
+        a.isUnread === b.isUnread &&
+        a.kind === b.kind &&
+        a.markedUnreadByUser === b.markedUnreadByUser &&
+        a.observationProvenance === b.observationProvenance &&
+        a.readStateProvenance === b.readStateProvenance
+      );
+    })
   );
-  const completedUnreadIds = new Set(
-    sanitizeCompletionKeys(intent.completed.unreadIds)
-  );
-  const failedReadIds = new Set(sanitizeCompletionKeys(intent.failed.readIds));
-  const failedUnreadIds = new Set(
-    sanitizeCompletionKeys(intent.failed.unreadIds)
-  );
-  const recordsBySessionId = { ...partition.recordsBySessionId };
-  let mergedObservedRecord = false;
-  for (const [id, record] of Object.entries(recordsBySessionId)) {
-    const key = record.completionKey;
-    const unread =
-      record.kind === "completed" ? completedUnreadIds : failedUnreadIds;
-    const read = record.kind === "completed" ? completedReadIds : failedReadIds;
-    if (unread.has(key)) {
-      recordsBySessionId[id] = { ...record, isUnread: true };
-    } else if (read.has(key)) {
-      recordsBySessionId[id] = {
-        ...record,
-        isUnread: false,
-        markedUnreadByUser: false
-      };
-    } else {
-      // The durable store predates this session's current completion. Evict any
-      // prior key for the session so the set stays bounded, then persist the
-      // observed provenance on the next write.
-      evictSessionCompletionKeys(id, [
-        completedReadIds,
-        completedUnreadIds,
-        failedReadIds,
-        failedUnreadIds
-      ]);
-      (record.isUnread ? unread : read).add(key);
-      mergedObservedRecord = true;
-    }
-  }
-  const nextPartition = {
-    ...partition,
-    hydrated: {
-      completedReadIds: [...completedReadIds],
-      completedUnreadIds: [...completedUnreadIds],
-      failedReadIds: [...failedReadIds],
-      failedUnreadIds: [...failedUnreadIds]
-    },
-    lastError: null,
-    recordsBySessionId
-  };
-  const persistence = mergedObservedRecord
-    ? queuePersistence(nextPartition, userId)
-    : { commands: NO_COMMANDS, partition: nextPartition };
-  return changed(
-    replacePartition(state, userId, persistence.partition),
-    persistence.commands
+}
+
+function sameStrings(
+  left: readonly string[],
+  right: readonly string[]
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
   );
 }
 
@@ -737,11 +663,11 @@ function queuePersistence(
         userId,
         workspaceId: partition.workspaceId,
         completed: {
-          readIds: partition.hydrated.completedReadIds,
+          readIds: [],
           unreadIds: partition.hydrated.completedUnreadIds
         },
         failed: {
-          readIds: partition.hydrated.failedReadIds,
+          readIds: [],
           unreadIds: partition.hydrated.failedUnreadIds
         }
       }
@@ -792,6 +718,7 @@ function changed(
 ): EngineReducerResult<AttentionReadState> {
   return { commands, state };
 }
+
 function unchanged(
   state: AttentionReadState
 ): EngineReducerResult<AttentionReadState> {

--- a/packages/agent/activity-core/src/engine/attentionReadState.reducer.ts
+++ b/packages/agent/activity-core/src/engine/attentionReadState.reducer.ts
@@ -73,7 +73,8 @@ export function attentionReadStateReducer(
         state,
         context.sessionsById[turn.agentSessionId]?.userId ?? "",
         turn,
-        intent.type === "turn/projectionReceived" || intent.live !== false
+        intent.type === "turn/projectionReceived" || intent.live !== false,
+        context.previousTurnsById
       );
     }
     case "session/historyAuthoritativeSnapshotReceived":
@@ -93,7 +94,8 @@ export function attentionReadStateReducer(
             next,
             context.sessionsById[turn.agentSessionId]?.userId ?? "",
             turn,
-            false
+            false,
+            context.previousTurnsById
           ).state;
         }
       }
@@ -181,18 +183,32 @@ function reconcileAuthoritativeTurns(
         sessionId,
         authoritativeCompletionKeys
       );
-      if (
+      const filteredHydrated = {
+        completedReadIds,
+        completedUnreadIds,
+        failedReadIds,
+        failedUnreadIds
+      };
+      if (removeRecord && current?.observationProvenance === "live") {
+        // A detail read can be internally consistent yet still have started
+        // before this live completion. Remove the non-authoritative record so
+        // genuine retractions stop driving the lamp, but retain its durable
+        // marker. If a later historical snapshot restores the same completion,
+        // it must not silently downgrade the live unread observation to read.
+        nextHydrated = updateDurableMarker(
+          { ...partition, hydrated: filteredHydrated },
+          sessionId,
+          current.completionKey,
+          current.kind,
+          current.isUnread
+        ).hydrated;
+      } else if (
         completedReadIds !== hydrated.completedReadIds ||
         completedUnreadIds !== hydrated.completedUnreadIds ||
         failedReadIds !== hydrated.failedReadIds ||
         failedUnreadIds !== hydrated.failedUnreadIds
       ) {
-        nextHydrated = {
-          completedReadIds,
-          completedUnreadIds,
-          failedReadIds,
-          failedUnreadIds
-        };
+        nextHydrated = filteredHydrated;
       }
     }
     if (!removeRecord && nextHydrated === hydrated) continue;
@@ -245,7 +261,8 @@ function reconcileAuthoritativeHistoryAttention(
     reconciled.state,
     context.sessionsById[intent.agentSessionId]?.userId ?? "",
     liveTurn,
-    true
+    true,
+    context.previousTurnsById
   );
   return {
     commands: [...reconciled.commands, ...observed.commands],
@@ -269,7 +286,8 @@ function observeTurn(
   state: AttentionReadState,
   rawUserId: string,
   turn: AgentActivityTurn,
-  live: boolean
+  live: boolean,
+  previousTurnsById: Readonly<Record<string, AgentActivityTurn>> = {}
 ): EngineReducerResult<AttentionReadState> {
   const id = turn.agentSessionId.trim();
   const userId = rawUserId.trim();
@@ -279,6 +297,23 @@ function observeTurn(
   const partition = partitionFor(state, userId);
   const completionKey = `turn:${id}:${turnId}:${kind}`;
   const current = partition.recordsBySessionId[id];
+  if (
+    !live &&
+    current?.observationProvenance === "live" &&
+    current.completionKey !== completionKey
+  ) {
+    const currentLiveTurn = Object.values(previousTurnsById).find(
+      (candidate) =>
+        candidate.agentSessionId === id &&
+        completionKeyForTurn(candidate) === current.completionKey
+    );
+    if (
+      currentLiveTurn &&
+      currentLiveTurn.updatedAtUnixMs >= turn.updatedAtUnixMs
+    ) {
+      return unchanged(state);
+    }
+  }
   if (
     current?.completionKey === completionKey &&
     (current.observationProvenance === "live" || !live)
@@ -330,6 +365,15 @@ function observeTurn(
     replacePartition(state, userId, persistence.partition),
     persistence.commands
   );
+}
+
+function completionKeyForTurn(turn: AgentActivityTurn): string | null {
+  const kind = completionKind(turn);
+  const sessionId = turn.agentSessionId.trim();
+  const turnId = turn.turnId.trim();
+  return sessionId && turnId && kind
+    ? `turn:${sessionId}:${turnId}:${kind}`
+    : null;
 }
 
 function completionKind(

--- a/packages/agent/activity-core/src/engine/attentionReadState.types.ts
+++ b/packages/agent/activity-core/src/engine/attentionReadState.types.ts
@@ -4,15 +4,15 @@ export type AttentionReadStateProvenance = "durable" | "historical" | "live";
 
 export interface AttentionReadRecord {
   completionKey: string;
+  /** Compatibility projection: every stored attention record is unread. */
   isUnread: boolean;
   kind: AttentionCompletionKind;
   markedUnreadByUser: boolean;
-  /** Whether this completion has been observed from a live event in this run. */
+  /** Whether this completion has live/manual rather than historical provenance. */
   observationProvenance: AttentionObservationProvenance;
   /**
-   * Whether the current read state came from durable state or this observation.
-   * Older host-created snapshots may omit this field and are treated as
-   * having no historical-only marker.
+   * Compatibility projection. Historical reads no longer create records, so
+   * this field no longer participates in read/unread decisions.
    */
   readStateProvenance?: AttentionReadStateProvenance;
 }
@@ -24,11 +24,12 @@ export interface AttentionReadPartition {
   writeDirty: boolean;
   writeInFlightCommandId: string | null;
   writeRevision: number;
-  // Durable read state, keyed by completion key (`turn:<session>:<turn>:<kind>`)
-  // rather than bare session id, so a new turn on an already-read session is a
-  // distinct entry and re-lights the lamp. Kept bounded to the latest completion
-  // per session. The `*Ids` naming is retained only because it is the serialized
-  // persistence field name; the values are completion keys, not session ids.
+  // Durable unread state, keyed by completion key
+  // (`turn:<session>:<turn>:<kind>`) rather than bare session id. Only live
+  // completions and user unread requests create entries; read removes the
+  // entry. The legacy `readIds` fields remain in the serialized schema for
+  // backward compatibility, but are ignored on hydration and cleared on the
+  // next successful write.
   hydrated: {
     completedReadIds: readonly string[];
     completedUnreadIds: readonly string[];

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.types.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.types.ts
@@ -162,6 +162,12 @@ export interface TurnUpsertedIntent {
    * and is treated as a live observation.
    */
   live?: boolean;
+  /**
+   * Internal replay of an already accepted live completion after reconcile
+   * supplied Session identity. It may create attention even though canonical
+   * state already contains the settled Turn.
+   */
+  replayAcceptedLiveCompletion?: true;
   turn: AgentActivityTurn;
 }
 

--- a/packages/agent/activity-core/src/engine/sessionReconcile.reducer.ts
+++ b/packages/agent/activity-core/src/engine/sessionReconcile.reducer.ts
@@ -111,7 +111,8 @@ export function sessionReconcileReducer(
 
 function receiveDetailSnapshot(
   state: SessionReconcileState,
-  intent: Extract<EngineIntent, { type: "session/detailSnapshotReceived" }>
+  intent: Extract<EngineIntent, { type: "session/detailSnapshotReceived" }>,
+  liveTurnId?: string
 ): EngineReducerResult<SessionReconcileState> {
   const followUpIntents: EngineIntent[] = [
     {
@@ -131,8 +132,13 @@ function receiveDetailSnapshot(
     });
   }
   if (intent.live && intent.session.latestTurn) {
+    const replayAcceptedLiveCompletion =
+      !liveTurnId || intent.session.latestTurn.turnId === liveTurnId;
     followUpIntents.push({
       live: true,
+      ...(replayAcceptedLiveCompletion
+        ? { replayAcceptedLiveCompletion: true as const }
+        : {}),
       turn: intent.session.latestTurn,
       type: "turn/upserted"
     });
@@ -165,16 +171,20 @@ function receiveAuthoritativeHistorySnapshot(
     { type: "session/historyAuthoritativeSnapshotReceived" }
   >
 ): EngineReducerResult<SessionReconcileState> {
-  const detail = receiveDetailSnapshot(state, {
-    childSessions: intent.childSessions,
-    editRetry: intent.editRetry,
-    messages: intent.messages,
-    session: intent.session,
-    sessionMessageWindows: intent.sessionMessageWindows,
-    turns: intent.turns,
-    type: "session/detailSnapshotReceived",
-    workspaceId: intent.workspaceId
-  });
+  const detail = receiveDetailSnapshot(
+    state,
+    {
+      childSessions: intent.childSessions,
+      editRetry: intent.editRetry,
+      messages: intent.messages,
+      session: intent.session,
+      sessionMessageWindows: intent.sessionMessageWindows,
+      turns: intent.turns,
+      type: "session/detailSnapshotReceived",
+      workspaceId: intent.workspaceId
+    },
+    intent.liveTurnId
+  );
   const checkpoint = applyHistoryCheckpoint(
     state,
     {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -282,6 +282,8 @@ export const AgentGUINode = memo(function AgentGUINode({
   ]);
   const { viewModel, actions } = useAgentGUINodeController({
     nodeId,
+    isSurfaceActive: isActive,
+    isSurfaceVisible: isVisible,
     workspaceId,
     currentUserId,
     workspacePath,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.reporting.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.reporting.ts
@@ -381,6 +381,57 @@ export function reportAgentGUIActiveConversationCleared(input: {
   }
 }
 
+export function reportAgentGUIAttentionReadDecision(input: {
+  agentSessionId: string;
+  completionKey: string;
+  decision: "preserve_unread" | "read";
+  isSurfaceActive: boolean;
+  isSurfaceVisible: boolean;
+  markedUnreadByUser: boolean;
+  nodeId?: string;
+  previousActiveConversationId: string | null;
+  reason:
+    | "active_selection"
+    | "manual_unread_current_selection"
+    | "reselected"
+    | "surface_hidden"
+    | "surface_inactive";
+  runtime: AgentGUIRuntime;
+  workspaceId: string;
+}): void {
+  const reportDiagnostic = input.runtime.reportDiagnostic;
+  if (!reportDiagnostic) {
+    return;
+  }
+  try {
+    void Promise.resolve(
+      reportDiagnostic.call(input.runtime, {
+        details: {
+          agentSessionId: input.agentSessionId,
+          completionKey: input.completionKey,
+          decision: input.decision,
+          isSurfaceActive: input.isSurfaceActive,
+          isSurfaceVisible: input.isSurfaceVisible,
+          markedUnreadByUser: input.markedUnreadByUser,
+          nodeId: input.nodeId ?? null,
+          previousActiveConversationId: input.previousActiveConversationId,
+          reason: input.reason
+        },
+        event: "agent.gui.attention_read.decision",
+        level: "info",
+        source: "agent-gui",
+        workspaceId: input.workspaceId
+      })
+    ).catch(() => {});
+  } catch (reportError) {
+    // Diagnostic logging must never affect attention/read decisions.
+    console.error(
+      "[agent-gui] reportAgentGUIAttentionReadDecision failed",
+      reportError
+    );
+  }
+}
+
 export function reportAgentGUIConversationListProjectionSkipped(input: {
   activeConversationId: string | null;
   currentUserIdPresent: boolean;

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.reporting.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.reporting.ts
@@ -386,6 +386,7 @@ export function reportAgentGUIAttentionReadDecision(input: {
   completionKey: string;
   decision: "preserve_unread" | "read";
   isSurfaceActive: boolean;
+  isSurfaceDocumentExposed: boolean;
   isSurfaceVisible: boolean;
   markedUnreadByUser: boolean;
   nodeId?: string;
@@ -395,7 +396,8 @@ export function reportAgentGUIAttentionReadDecision(input: {
     | "manual_unread_current_selection"
     | "reselected"
     | "surface_hidden"
-    | "surface_inactive";
+    | "surface_inactive"
+    | "document_not_exposed";
   runtime: AgentGUIRuntime;
   workspaceId: string;
 }): void {
@@ -411,6 +413,7 @@ export function reportAgentGUIAttentionReadDecision(input: {
           completionKey: input.completionKey,
           decision: input.decision,
           isSurfaceActive: input.isSurfaceActive,
+          isSurfaceDocumentExposed: input.isSurfaceDocumentExposed,
           isSurfaceVisible: input.isSurfaceVisible,
           markedUnreadByUser: input.markedUnreadByUser,
           nodeId: input.nodeId ?? null,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.types.ts
@@ -49,6 +49,8 @@ export interface ACPConfigOptionSelection {
 }
 export interface UseAgentGUINodeControllerInput {
   nodeId?: string;
+  isSurfaceActive: boolean;
+  isSurfaceVisible: boolean;
   workspaceId: string;
   currentUserId?: string | null;
   workspacePath: string;

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/readAgentGUISurfaceDocumentExposure.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/readAgentGUISurfaceDocumentExposure.ts
@@ -1,0 +1,11 @@
+/**
+ * Reads whether this renderer document is both visible and focused. Host node
+ * focus/visibility is not enough: a Workbench node can remain focused in host
+ * state while the OS window or browser document is backgrounded.
+ */
+export function readAgentGUISurfaceDocumentExposure(): boolean {
+  return (
+    typeof document === "undefined" ||
+    (document.visibilityState === "visible" && document.hasFocus())
+  );
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.spec.ts
@@ -82,10 +82,13 @@ describe("clearRolledBackAgentGUISelection", () => {
         intent,
         isComposerHomeRef,
         isMountedRef: { current: true },
+        isSurfaceActive: true,
+        isSurfaceVisible: true,
         loadDraftComposerOptions: vi.fn(),
         loadSelectedConversationMessages: vi.fn(async () => undefined),
         loadSessionState: vi.fn(),
         markSelectedConversationDetailPending: vi.fn(() => null),
+        nodeId: "node-1",
         onDataChangeRef: { current: onDataChange },
         sessionEngine: {
           dispatch: vi.fn(),
@@ -193,10 +196,13 @@ describe("clearRolledBackAgentGUISelection", () => {
         intent,
         isComposerHomeRef,
         isMountedRef: { current: true },
+        isSurfaceActive: true,
+        isSurfaceVisible: true,
         loadDraftComposerOptions: vi.fn(),
         loadSelectedConversationMessages: vi.fn(async () => undefined),
         loadSessionState: vi.fn(),
         markSelectedConversationDetailPending: vi.fn(() => null),
+        nodeId: "node-1",
         onDataChangeRef: { current: onDataChange },
         sessionEngine: {
           dispatch: vi.fn(),
@@ -336,10 +342,13 @@ describe("clearRolledBackAgentGUISelection", () => {
         intent,
         isComposerHomeRef,
         isMountedRef: { current: true },
+        isSurfaceActive: true,
+        isSurfaceVisible: true,
         loadDraftComposerOptions: vi.fn(),
         loadSelectedConversationMessages: vi.fn(async () => undefined),
         loadSessionState: vi.fn(),
         markSelectedConversationDetailPending: vi.fn(() => null),
+        nodeId: "node-1",
         onDataChangeRef: { current: onDataChange },
         sessionEngine: {
           dispatch: vi.fn(),
@@ -440,11 +449,14 @@ describe("conversation reload ownership", () => {
         intent,
         isComposerHomeRef,
         isMountedRef: { current: true },
+        isSurfaceActive: true,
+        isSurfaceVisible: true,
         loadDraftComposerOptions: vi.fn(),
         loadSelectedConversationMessages,
         loadSessionState: vi.fn(),
         markSelectedConversationDetailPending: (agentSessionId) =>
           agentSessionId,
+        nodeId: "node-1",
         onDataChangeRef: {
           current: (updater) => {
             dataRef.current = updater(dataRef.current);
@@ -486,6 +498,8 @@ describe("shouldMarkActiveConversationRead", () => {
     expect(
       shouldMarkActiveConversationRead({
         activeConversationId: "session-1",
+        isSurfaceActive: true,
+        isSurfaceVisible: true,
         previousActiveConversationId: "session-1",
         record: { ...record, markedUnreadByUser: true }
       })
@@ -496,6 +510,8 @@ describe("shouldMarkActiveConversationRead", () => {
     expect(
       shouldMarkActiveConversationRead({
         activeConversationId: "session-1",
+        isSurfaceActive: true,
+        isSurfaceVisible: true,
         previousActiveConversationId: "session-2",
         record: { ...record, markedUnreadByUser: true }
       })
@@ -506,9 +522,35 @@ describe("shouldMarkActiveConversationRead", () => {
     expect(
       shouldMarkActiveConversationRead({
         activeConversationId: "session-1",
+        isSurfaceActive: true,
+        isSurfaceVisible: true,
         previousActiveConversationId: "session-1",
         record
       })
     ).toBe(true);
+  });
+
+  it("keeps unread attention when the selected Session belongs to an inactive surface", () => {
+    expect(
+      shouldMarkActiveConversationRead({
+        activeConversationId: "session-1",
+        isSurfaceActive: false,
+        isSurfaceVisible: true,
+        previousActiveConversationId: "session-1",
+        record
+      })
+    ).toBe(false);
+  });
+
+  it("keeps unread attention when the selected Session belongs to a hidden surface", () => {
+    expect(
+      shouldMarkActiveConversationRead({
+        activeConversationId: "session-1",
+        isSurfaceActive: true,
+        isSurfaceVisible: false,
+        previousActiveConversationId: "session-1",
+        record
+      })
+    ).toBe(false);
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.spec.ts
@@ -499,6 +499,7 @@ describe("shouldMarkActiveConversationRead", () => {
       shouldMarkActiveConversationRead({
         activeConversationId: "session-1",
         isSurfaceActive: true,
+        isSurfaceDocumentExposed: true,
         isSurfaceVisible: true,
         previousActiveConversationId: "session-1",
         record: { ...record, markedUnreadByUser: true }
@@ -511,6 +512,7 @@ describe("shouldMarkActiveConversationRead", () => {
       shouldMarkActiveConversationRead({
         activeConversationId: "session-1",
         isSurfaceActive: true,
+        isSurfaceDocumentExposed: true,
         isSurfaceVisible: true,
         previousActiveConversationId: "session-2",
         record: { ...record, markedUnreadByUser: true }
@@ -523,6 +525,7 @@ describe("shouldMarkActiveConversationRead", () => {
       shouldMarkActiveConversationRead({
         activeConversationId: "session-1",
         isSurfaceActive: true,
+        isSurfaceDocumentExposed: true,
         isSurfaceVisible: true,
         previousActiveConversationId: "session-1",
         record
@@ -535,6 +538,7 @@ describe("shouldMarkActiveConversationRead", () => {
       shouldMarkActiveConversationRead({
         activeConversationId: "session-1",
         isSurfaceActive: false,
+        isSurfaceDocumentExposed: true,
         isSurfaceVisible: true,
         previousActiveConversationId: "session-1",
         record
@@ -547,7 +551,21 @@ describe("shouldMarkActiveConversationRead", () => {
       shouldMarkActiveConversationRead({
         activeConversationId: "session-1",
         isSurfaceActive: true,
+        isSurfaceDocumentExposed: true,
         isSurfaceVisible: false,
+        previousActiveConversationId: "session-1",
+        record
+      })
+    ).toBe(false);
+  });
+
+  it("keeps unread attention when the document is hidden or unfocused", () => {
+    expect(
+      shouldMarkActiveConversationRead({
+        activeConversationId: "session-1",
+        isSurfaceActive: true,
+        isSurfaceDocumentExposed: false,
+        isSurfaceVisible: true,
         previousActiveConversationId: "session-1",
         record
       })

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.ts
@@ -22,6 +22,7 @@ import {
 } from "../model/agentGuiSessionNavigationMemory";
 import { AGENT_SESSION_NOT_FOUND_ERROR } from "./agentGuiController.errors";
 import {
+  reportAgentGUIAttentionReadDecision,
   reportAgentGUIActiveConversationCleared,
   reportAgentGUIConversationListProjectionSkipped
 } from "./agentGuiController.reporting";
@@ -66,6 +67,8 @@ interface UseAgentGUIConversationSelectionControllerInput {
   intent: ConversationIntent;
   isComposerHomeRef: RefObject<boolean>;
   isMountedRef: RefObject<boolean>;
+  isSurfaceActive: boolean;
+  isSurfaceVisible: boolean;
   loadDraftComposerOptions(): void;
   loadSelectedConversationMessages(
     agentSessionId: string,
@@ -73,6 +76,7 @@ interface UseAgentGUIConversationSelectionControllerInput {
   ): Promise<void>;
   loadSessionState(agentSessionId: string): void;
   markSelectedConversationDetailPending(agentSessionId: string): string | null;
+  nodeId?: string;
   onDataChangeRef: RefObject<
     (updater: (current: AgentGUINodeData) => AgentGUINodeData) => void
   >;
@@ -104,15 +108,49 @@ export function clearRolledBackAgentGUISelection(
 
 export function shouldMarkActiveConversationRead(input: {
   activeConversationId: string;
+  isSurfaceActive: boolean;
+  isSurfaceVisible: boolean;
   previousActiveConversationId: string | null;
   record: AttentionReadRecord | undefined;
 }): boolean {
-  const { activeConversationId, previousActiveConversationId, record } = input;
+  const {
+    activeConversationId,
+    isSurfaceActive,
+    isSurfaceVisible,
+    previousActiveConversationId,
+    record
+  } = input;
   if (!record?.isUnread) return false;
+  if (!isSurfaceActive || !isSurfaceVisible) return false;
   return (
     !record.markedUnreadByUser ||
     previousActiveConversationId !== activeConversationId
   );
+}
+
+export function activeConversationReadDecisionReason(input: {
+  activeConversationId: string;
+  isSurfaceActive: boolean;
+  isSurfaceVisible: boolean;
+  previousActiveConversationId: string | null;
+  record: AttentionReadRecord;
+}):
+  | "active_selection"
+  | "manual_unread_current_selection"
+  | "reselected"
+  | "surface_hidden"
+  | "surface_inactive" {
+  if (!input.isSurfaceVisible) return "surface_hidden";
+  if (!input.isSurfaceActive) return "surface_inactive";
+  if (
+    input.record.markedUnreadByUser &&
+    input.previousActiveConversationId === input.activeConversationId
+  ) {
+    return "manual_unread_current_selection";
+  }
+  return input.previousActiveConversationId === input.activeConversationId
+    ? "active_selection"
+    : "reselected";
 }
 
 export function shouldClearMissingAgentGUISelection(input: {
@@ -149,10 +187,13 @@ export function useAgentGUIConversationSelectionController(
     intent,
     isComposerHomeRef,
     isMountedRef,
+    isSurfaceActive,
+    isSurfaceVisible,
     loadDraftComposerOptions,
     loadSelectedConversationMessages,
     loadSessionState,
     markSelectedConversationDetailPending,
+    nodeId,
     onDataChangeRef,
     sessionEngine,
     setActiveConversationId,
@@ -167,6 +208,7 @@ export function useAgentGUIConversationSelectionController(
     workspaceId
   } = input;
   const previousAttentionActiveConversationIdRef = useRef<string | null>(null);
+  const attentionReadDiagnosticKeyRef = useRef<string | null>(null);
   const rolledBackSelectionSessionIdRef = useRef<string | null>(null);
   const persistedConfirmedActivationRequestIdRef = useRef<string | null>(null);
   const attentionHydrationRef = useRef<{
@@ -279,13 +321,51 @@ export function useAgentGUIConversationSelectionController(
     const previousActiveConversationId =
       previousAttentionActiveConversationIdRef.current;
     previousAttentionActiveConversationIdRef.current = activeConversationId;
-    if (
-      shouldMarkActiveConversationRead({
+    const attentionRecord =
+      attentionReadRecordsBySessionId[activeConversationId];
+    const shouldMarkRead = shouldMarkActiveConversationRead({
+      activeConversationId,
+      isSurfaceActive,
+      isSurfaceVisible,
+      previousActiveConversationId,
+      record: attentionRecord
+    });
+    if (attentionRecord?.isUnread) {
+      const reason = activeConversationReadDecisionReason({
         activeConversationId,
+        isSurfaceActive,
+        isSurfaceVisible,
         previousActiveConversationId,
-        record: attentionReadRecordsBySessionId[activeConversationId]
-      })
-    ) {
+        record: attentionRecord
+      });
+      const diagnosticKey = [
+        attentionRecord.completionKey,
+        isSurfaceActive,
+        isSurfaceVisible,
+        previousActiveConversationId,
+        attentionRecord.markedUnreadByUser,
+        shouldMarkRead
+      ].join(":");
+      if (attentionReadDiagnosticKeyRef.current !== diagnosticKey) {
+        attentionReadDiagnosticKeyRef.current = diagnosticKey;
+        reportAgentGUIAttentionReadDecision({
+          agentSessionId: activeConversationId,
+          completionKey: attentionRecord.completionKey,
+          decision: shouldMarkRead ? "read" : "preserve_unread",
+          isSurfaceActive,
+          isSurfaceVisible,
+          markedUnreadByUser: attentionRecord.markedUnreadByUser,
+          nodeId,
+          previousActiveConversationId,
+          reason,
+          runtime: agentActivityRuntime,
+          workspaceId
+        });
+      }
+    } else {
+      attentionReadDiagnosticKeyRef.current = null;
+    }
+    if (shouldMarkRead) {
       sessionEngine.dispatch({
         type: "attention/read",
         agentSessionId: activeConversationId,
@@ -299,6 +379,8 @@ export function useAgentGUIConversationSelectionController(
     attentionReadRecordsBySessionId,
     clearRailRevealRequest,
     currentUserId,
+    isSurfaceActive,
+    isSurfaceVisible,
     sessionEngine,
     setActiveMessageSession,
     workspaceId

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.ts
@@ -21,6 +21,7 @@ import {
   rememberAgentGUIActiveConversation
 } from "../model/agentGuiSessionNavigationMemory";
 import { AGENT_SESSION_NOT_FOUND_ERROR } from "./agentGuiController.errors";
+import { readAgentGUISurfaceDocumentExposure } from "./readAgentGUISurfaceDocumentExposure";
 import {
   reportAgentGUIAttentionReadDecision,
   reportAgentGUIActiveConversationCleared,
@@ -109,6 +110,7 @@ export function clearRolledBackAgentGUISelection(
 export function shouldMarkActiveConversationRead(input: {
   activeConversationId: string;
   isSurfaceActive: boolean;
+  isSurfaceDocumentExposed: boolean;
   isSurfaceVisible: boolean;
   previousActiveConversationId: string | null;
   record: AttentionReadRecord | undefined;
@@ -116,12 +118,15 @@ export function shouldMarkActiveConversationRead(input: {
   const {
     activeConversationId,
     isSurfaceActive,
+    isSurfaceDocumentExposed,
     isSurfaceVisible,
     previousActiveConversationId,
     record
   } = input;
   if (!record?.isUnread) return false;
-  if (!isSurfaceActive || !isSurfaceVisible) return false;
+  if (!isSurfaceActive || !isSurfaceVisible || !isSurfaceDocumentExposed) {
+    return false;
+  }
   return (
     !record.markedUnreadByUser ||
     previousActiveConversationId !== activeConversationId
@@ -131,6 +136,7 @@ export function shouldMarkActiveConversationRead(input: {
 export function activeConversationReadDecisionReason(input: {
   activeConversationId: string;
   isSurfaceActive: boolean;
+  isSurfaceDocumentExposed: boolean;
   isSurfaceVisible: boolean;
   previousActiveConversationId: string | null;
   record: AttentionReadRecord;
@@ -139,9 +145,11 @@ export function activeConversationReadDecisionReason(input: {
   | "manual_unread_current_selection"
   | "reselected"
   | "surface_hidden"
-  | "surface_inactive" {
+  | "surface_inactive"
+  | "document_not_exposed" {
   if (!input.isSurfaceVisible) return "surface_hidden";
   if (!input.isSurfaceActive) return "surface_inactive";
+  if (!input.isSurfaceDocumentExposed) return "document_not_exposed";
   if (
     input.record.markedUnreadByUser &&
     input.previousActiveConversationId === input.activeConversationId
@@ -318,60 +326,77 @@ export function useAgentGUIConversationSelectionController(
       previousAttentionActiveConversationIdRef.current = null;
       return;
     }
-    const previousActiveConversationId =
-      previousAttentionActiveConversationIdRef.current;
-    previousAttentionActiveConversationIdRef.current = activeConversationId;
-    const attentionRecord =
-      attentionReadRecordsBySessionId[activeConversationId];
-    const shouldMarkRead = shouldMarkActiveConversationRead({
-      activeConversationId,
-      isSurfaceActive,
-      isSurfaceVisible,
-      previousActiveConversationId,
-      record: attentionRecord
-    });
-    if (attentionRecord?.isUnread) {
-      const reason = activeConversationReadDecisionReason({
+    const evaluateAttentionRead = () => {
+      const previousActiveConversationId =
+        previousAttentionActiveConversationIdRef.current;
+      previousAttentionActiveConversationIdRef.current = activeConversationId;
+      const attentionRecord =
+        attentionReadRecordsBySessionId[activeConversationId];
+      const isSurfaceDocumentExposed = readAgentGUISurfaceDocumentExposure();
+      const shouldMarkRead = shouldMarkActiveConversationRead({
         activeConversationId,
         isSurfaceActive,
+        isSurfaceDocumentExposed,
         isSurfaceVisible,
         previousActiveConversationId,
         record: attentionRecord
       });
-      const diagnosticKey = [
-        attentionRecord.completionKey,
-        isSurfaceActive,
-        isSurfaceVisible,
-        previousActiveConversationId,
-        attentionRecord.markedUnreadByUser,
-        shouldMarkRead
-      ].join(":");
-      if (attentionReadDiagnosticKeyRef.current !== diagnosticKey) {
-        attentionReadDiagnosticKeyRef.current = diagnosticKey;
-        reportAgentGUIAttentionReadDecision({
-          agentSessionId: activeConversationId,
-          completionKey: attentionRecord.completionKey,
-          decision: shouldMarkRead ? "read" : "preserve_unread",
+      if (attentionRecord?.isUnread) {
+        const reason = activeConversationReadDecisionReason({
+          activeConversationId,
           isSurfaceActive,
+          isSurfaceDocumentExposed,
           isSurfaceVisible,
-          markedUnreadByUser: attentionRecord.markedUnreadByUser,
-          nodeId,
           previousActiveConversationId,
-          reason,
-          runtime: agentActivityRuntime,
-          workspaceId
+          record: attentionRecord
+        });
+        const diagnosticKey = [
+          attentionRecord.completionKey,
+          isSurfaceActive,
+          isSurfaceDocumentExposed,
+          isSurfaceVisible,
+          previousActiveConversationId,
+          attentionRecord.markedUnreadByUser,
+          shouldMarkRead
+        ].join(":");
+        if (attentionReadDiagnosticKeyRef.current !== diagnosticKey) {
+          attentionReadDiagnosticKeyRef.current = diagnosticKey;
+          reportAgentGUIAttentionReadDecision({
+            agentSessionId: activeConversationId,
+            completionKey: attentionRecord.completionKey,
+            decision: shouldMarkRead ? "read" : "preserve_unread",
+            isSurfaceActive,
+            isSurfaceDocumentExposed,
+            isSurfaceVisible,
+            markedUnreadByUser: attentionRecord.markedUnreadByUser,
+            nodeId,
+            previousActiveConversationId,
+            reason,
+            runtime: agentActivityRuntime,
+            workspaceId
+          });
+        }
+      } else {
+        attentionReadDiagnosticKeyRef.current = null;
+      }
+      if (shouldMarkRead) {
+        sessionEngine.dispatch({
+          type: "attention/read",
+          agentSessionId: activeConversationId,
+          userId: currentUserId?.trim() ?? ""
         });
       }
-    } else {
-      attentionReadDiagnosticKeyRef.current = null;
-    }
-    if (shouldMarkRead) {
-      sessionEngine.dispatch({
-        type: "attention/read",
-        agentSessionId: activeConversationId,
-        userId: currentUserId?.trim() ?? ""
-      });
-    }
+    };
+    const handleExposureChange = () => evaluateAttentionRead();
+    document.addEventListener("visibilitychange", handleExposureChange);
+    window.addEventListener("blur", handleExposureChange);
+    window.addEventListener("focus", handleExposureChange);
+    evaluateAttentionRead();
+    return () => {
+      document.removeEventListener("visibilitychange", handleExposureChange);
+      window.removeEventListener("blur", handleExposureChange);
+      window.removeEventListener("focus", handleExposureChange);
+    };
   }, [
     activeConversationId,
     activePendingActivation,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -113,6 +113,8 @@ export type {
 
 export function useAgentGUINodeController({
   nodeId,
+  isSurfaceActive,
+  isSurfaceVisible,
   workspaceId,
   currentUserId,
   workspacePath,
@@ -505,10 +507,13 @@ export function useAgentGUINodeController({
     intent,
     isComposerHomeRef,
     isMountedRef,
+    isSurfaceActive,
+    isSurfaceVisible,
     loadDraftComposerOptions: () => loadDraftComposerOptionsRef.current(),
     loadSelectedConversationMessages,
     loadSessionState,
     markSelectedConversationDetailPending,
+    nodeId,
     onDataChangeRef,
     sessionEngine,
     requestRailReveal,


### PR DESCRIPTION
## Summary
- gate AgentGUI automatic read decisions on host-projected focus and visibility
- preserve newer live attention provenance across stale historical reconciliation
- add decision diagnostics, regression tests, and lifecycle documentation

## Root cause
Each retained AgentGUI controller treated its local activeConversationId as user-visible selection and dispatched shared attention/read even while its surface was unfocused or hidden. Independently, a stale authoritative history snapshot could remove a newer live unread marker and later restore the completion as historical/read.

## Validation
- pnpm test:ts -- --packages-json '["@tutti-os/agent-gui","@tutti-os/agent-activity-core"]'\n- pnpm check:changed (13 lanes)\n- pre-push pnpm check:changed -- --push-ready (14 lanes)\n- make dev-gui E2E: completion in an unfocused AgentGUI surface remained unread for 5 seconds; focusing that surface moved the same completion key to read\n- independent review: Architecture, Performance, and Consumer Compatibility lanes passed