### PR TITLE
fix(connector): settle authorization loading

### DIFF
--- a/.changeset/connector-authorization-ui-terminal-race.md
+++ b/.changeset/connector-authorization-ui-terminal-race.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/connector-market": patch
+---
+
+Keep OAuth authorization loading active until its durable operation reaches a terminal state, and prevent a late accepted response from overwriting that terminal result in connector cards.

--- a/packages/connector/market/src/services/connectorMarketService.test.ts
+++ b/packages/connector/market/src/services/connectorMarketService.test.ts
@@ -1186,6 +1186,85 @@ test("continues one authorization session, opens each URL once, and clears loadi
   service.dispose();
 });
 
+test("waits for terminal authorization reconciliation before clearing loading", async () => {
+  const terminalConnector = deferred<Connector>();
+  const reconciliationStarted = deferred<void>();
+  let authorizationCalls = 0;
+  const initial = connector("notion", 1);
+  initial.authorization = { state: "disconnected" };
+  const pending = connector("notion", 2);
+  pending.authorization = { state: "pending" };
+  const connected = connector("notion", 3);
+  connected.authorization = { state: "connected" };
+  const acceptedOperation = {
+    ...operation("start_authorization", 2),
+    connectorKey: "notion",
+    operationId: "notion-authorization",
+    stage: "accepted" as const
+  };
+  const completedOperation = {
+    ...acceptedOperation,
+    state: "completed" as const,
+    stage: "completed" as const,
+    updatedAt: "2026-08-03T00:00:01Z"
+  };
+  const service = new ConnectorMarketService({
+    backend: backendWith({
+      getSnapshot: async () => snapshot(1, [initial]),
+      beginAuthorization: async () => {
+        authorizationCalls += 1;
+        if (authorizationCalls === 1) {
+          return {
+            connector: pending,
+            operation: acceptedOperation,
+            authorizationUrl: "https://authorization.example/notion",
+            revision: 2
+          };
+        }
+        await reconciliationStarted.promise;
+        return {
+          connector: connected,
+          operation: acceptedOperation,
+          revision: 3
+        };
+      },
+      getOperation: async () => completedOperation,
+      getConnector: async () => {
+        reconciliationStarted.resolve();
+        return terminalConnector.promise;
+      }
+    }),
+    openAuthorizationUrl: async () => undefined
+  });
+  await service.ensureLoaded();
+
+  let settled = false;
+  const authorization = service.beginAuthorization("notion").finally(() => {
+    settled = true;
+  });
+  await waitFor(
+    () =>
+      service.dataStore.connectorsByKey.notion?.authorization.state ===
+      "connected"
+  );
+
+  assert.equal(settled, false);
+  assert.equal(
+    service.dataStore.operationsByConnectorKey.notion?.stage,
+    "accepted"
+  );
+
+  terminalConnector.resolve(connected);
+  await authorization;
+
+  assert.equal(
+    service.dataStore.operationsByConnectorKey.notion?.stage,
+    "completed"
+  );
+  assert.deepEqual(service.dataStore.authorizingConnectorKeys, {});
+  service.dispose();
+});
+
 test("late event subscription reconciles the authoritative snapshot and disposes once", async () => {
   const events = new TestEventSource();
   let revision = 1;

--- a/packages/connector/market/src/services/connectorMarketService.ts
+++ b/packages/connector/market/src/services/connectorMarketService.ts
@@ -300,6 +300,7 @@ export class ConnectorMarketService implements IConnectorMarketService {
           openedAuthorizationUrls.size > 0 &&
           this.authorizationState(connectorKey) === "connected"
         ) {
+          await this.waitForAuthorizationOperation(connectorKey);
           return;
         }
         let result: ConnectorAuthorizationResult;
@@ -332,6 +333,7 @@ export class ConnectorMarketService implements IConnectorMarketService {
           this.reconcileUninstallNotificationStates(next.operations);
           expectedRevision = this.dataStore.revision;
           if (this.authorizationState(connectorKey) === "connected") {
+            await this.waitForAuthorizationOperation(connectorKey);
             return;
           }
           if (canRecoverBusyContinuation) {
@@ -343,7 +345,7 @@ export class ConnectorMarketService implements IConnectorMarketService {
           return;
         }
         applyConnectorMutationResult(this.dataStore, result);
-        this.trackOperation(result.operation);
+        const operationTrack = this.trackOperation(result.operation);
         const authorizationUrl = result.authorizationUrl;
         const discoveredNextStep =
           authorizationUrl !== undefined &&
@@ -355,6 +357,7 @@ export class ConnectorMarketService implements IConnectorMarketService {
           }
         }
         if (this.authorizationState(connectorKey) === "connected") {
+          await operationTrack;
           return;
         }
         if (result.connector.authorization.state !== "pending") {
@@ -744,14 +747,19 @@ export class ConnectorMarketService implements IConnectorMarketService {
     }
   }
 
-  private trackOperation(operation: ConnectorOperation): void {
+  private trackOperation(
+    operation: ConnectorOperation
+  ): Promise<void> | undefined {
     if (
       this.disposed ||
       operation.state === "completed" ||
-      operation.state === "failed" ||
-      this.operationTracks.has(operation.operationId)
+      operation.state === "failed"
     ) {
       return;
+    }
+    const existing = this.operationTracks.get(operation.operationId);
+    if (existing) {
+      return existing;
     }
     const generation = this.dataGeneration;
     let promise!: Promise<void>;
@@ -770,6 +778,7 @@ export class ConnectorMarketService implements IConnectorMarketService {
         }
       });
     this.operationTracks.set(operation.operationId, promise);
+    return promise;
   }
 
   private async runOperationTrack(
@@ -817,6 +826,14 @@ export class ConnectorMarketService implements IConnectorMarketService {
       if (operation.state === "completed" || operation.state === "failed") {
         try {
           await this.reconcileTerminalOperation(operation, generation);
+          if (this.isCurrent(generation)) {
+            // A continuation response for the same idempotent mutation may
+            // arrive while terminal connector reconciliation is in flight.
+            // Re-assert the authoritative terminal receipt after that await so
+            // the older accepted response cannot leave the card permanently
+            // busy until a later background refresh.
+            this.applyTrackedOperation(operation);
+          }
           return;
         } catch (error) {
           if (this.isRetryableOperationError(error)) {
@@ -926,6 +943,14 @@ export class ConnectorMarketService implements IConnectorMarketService {
 
   private authorizationState(connectorKey: string) {
     return this.dataStore.connectorsByKey[connectorKey]?.authorization.state;
+  }
+
+  private waitForAuthorizationOperation(connectorKey: string): Promise<void> {
+    const operation = this.dataStore.operationsByConnectorKey[connectorKey];
+    if (!operation || operation.kind !== "start_authorization") {
+      return Promise.resolve();
+    }
+    return this.trackOperation(operation) ?? Promise.resolve();
   }
 
   private waitForAuthorizationContinuation(): Promise<void> {


### PR DESCRIPTION
## Summary
- keep OAuth authorization loading active until its durable operation reaches a terminal state
- return the existing operation tracker to concurrent continuation responses
- re-assert terminal operation state after connector reconciliation so stale accepted responses cannot leave cards busy

## Root cause
The account projection can become connected before the durable `start_authorization` operation reaches `completed`. A continuation response could overwrite the tracked terminal operation with its older `accepted` payload while terminal connector reconciliation was awaiting. The authorization command then returned and the card interpreted the stale generic `accepted` stage as installation work until a later background refresh.

## Verification
- `pnpm --dir packages/connector/market test` (57 passed)
- `pnpm --dir packages/connector/market typecheck`
- `pnpm --dir packages/connector/market build`
- `pnpm exec oxlint packages/connector/market/src/services/connectorMarketService.ts packages/connector/market/src/services/connectorMarketService.test.ts --deny-warnings`
- `pnpm exec oxfmt --check packages/connector/market/src/services/connectorMarketService.ts packages/connector/market/src/services/connectorMarketService.test.ts`
- `pnpm check:changed`
