### PR TITLE
fix(agent): classify provider start timeouts

### DIFF
--- a/packages/agent/daemon/hostadapter/runtime.go
+++ b/packages/agent/daemon/hostadapter/runtime.go
@@ -674,6 +674,9 @@ func mapRuntimeError(err error) error {
 	}
 	var appErr *agentruntime.AppError
 	if errors.As(err, &appErr) && appErr != nil {
+		if appErr.Code == agentruntime.AppErrorProviderStartTimeout {
+			return host.NewProviderStartTimeoutError(appErr.Message, appErr.DebugMessage, appErr)
+		}
 		if errors.Is(appErr, context.Canceled) || errors.Is(appErr, context.DeadlineExceeded) {
 			return err
 		}

--- a/packages/agent/daemon/hostadapter/runtime.go
+++ b/packages/agent/daemon/hostadapter/runtime.go
@@ -672,11 +672,15 @@ func mapRuntimeError(err error) error {
 	if errors.Is(err, agentruntime.ErrEffectiveHistoryUnsupported) {
 		return host.ErrRuntimeHistoryUnsupported
 	}
+	if errors.Is(err, agentruntime.ErrProviderStartTimeout) {
+		var appErr *agentruntime.AppError
+		if errors.As(err, &appErr) && appErr != nil {
+			return host.NewProviderStartTimeoutError(appErr.Message, appErr.DebugMessage, err)
+		}
+		return host.NewProviderStartTimeoutError("", "", err)
+	}
 	var appErr *agentruntime.AppError
 	if errors.As(err, &appErr) && appErr != nil {
-		if appErr.Code == agentruntime.AppErrorProviderStartTimeout {
-			return host.NewProviderStartTimeoutError(appErr.Message, appErr.DebugMessage, appErr)
-		}
 		if errors.Is(appErr, context.Canceled) || errors.Is(appErr, context.DeadlineExceeded) {
 			return err
 		}

--- a/packages/agent/daemon/hostadapter/runtime_test.go
+++ b/packages/agent/daemon/hostadapter/runtime_test.go
@@ -217,8 +217,12 @@ func TestMapRuntimeErrorPreservesProviderDiagnostics(t *testing.T) {
 func TestMapRuntimeErrorKeepsTransportOutcomeUnknown(t *testing.T) {
 	for _, target := range []error{context.Canceled, context.DeadlineExceeded} {
 		t.Run(target.Error(), func(t *testing.T) {
+			code := "request_failed"
+			if errors.Is(target, context.DeadlineExceeded) {
+				code = "request_timed_out"
+			}
 			runtimeErr := &agentruntime.AppError{
-				Code:  "request_failed",
+				Code:  code,
 				Cause: fmt.Errorf("provider response: %w", target),
 			}
 			mapped := mapRuntimeError(runtimeErr)
@@ -235,10 +239,13 @@ func TestMapRuntimeErrorKeepsTransportOutcomeUnknown(t *testing.T) {
 
 func TestMapRuntimeErrorPreservesProviderStartTimeoutVerdict(t *testing.T) {
 	runtimeErr := &agentruntime.AppError{
-		Code:         agentruntime.AppErrorProviderStartTimeout,
-		Message:      "Agent provider took too long to start",
+		Code:         "request_timed_out",
+		Message:      "Agent could not start before the request timed out.",
 		DebugMessage: "provider startup exceeded its deadline",
-		Cause:        fmt.Errorf("provider start: %w", context.DeadlineExceeded),
+		Cause: errors.Join(
+			agentruntime.ErrProviderStartTimeout,
+			fmt.Errorf("provider start: %w", context.DeadlineExceeded),
+		),
 	}
 	mapped := mapRuntimeError(fmt.Errorf("daemon runtime: %w", runtimeErr))
 	var providerErr *host.ProviderError
@@ -247,6 +254,9 @@ func TestMapRuntimeErrorPreservesProviderStartTimeoutVerdict(t *testing.T) {
 	}
 	if providerErr.Code != host.ProviderErrorCodeStartTimeout {
 		t.Fatalf("ProviderError code = %q, want %q", providerErr.Code, host.ProviderErrorCodeStartTimeout)
+	}
+	if providerErr.Message != runtimeErr.Message || providerErr.DebugMessage != runtimeErr.DebugMessage {
+		t.Fatalf("ProviderError = %#v, want presentation diagnostics from %#v", providerErr, runtimeErr)
 	}
 	if !errors.Is(mapped, context.DeadlineExceeded) || !errors.Is(mapped, runtimeErr) {
 		t.Fatalf("mapped error did not preserve runtime deadline chain: %v", mapped)

--- a/packages/agent/daemon/hostadapter/runtime_test.go
+++ b/packages/agent/daemon/hostadapter/runtime_test.go
@@ -233,6 +233,26 @@ func TestMapRuntimeErrorKeepsTransportOutcomeUnknown(t *testing.T) {
 	}
 }
 
+func TestMapRuntimeErrorPreservesProviderStartTimeoutVerdict(t *testing.T) {
+	runtimeErr := &agentruntime.AppError{
+		Code:         agentruntime.AppErrorProviderStartTimeout,
+		Message:      "Agent provider took too long to start",
+		DebugMessage: "provider startup exceeded its deadline",
+		Cause:        fmt.Errorf("provider start: %w", context.DeadlineExceeded),
+	}
+	mapped := mapRuntimeError(fmt.Errorf("daemon runtime: %w", runtimeErr))
+	var providerErr *host.ProviderError
+	if !errors.As(mapped, &providerErr) {
+		t.Fatalf("mapped error = %v, want ProviderError", mapped)
+	}
+	if providerErr.Code != host.ProviderErrorCodeStartTimeout {
+		t.Fatalf("ProviderError code = %q, want %q", providerErr.Code, host.ProviderErrorCodeStartTimeout)
+	}
+	if !errors.Is(mapped, context.DeadlineExceeded) || !errors.Is(mapped, runtimeErr) {
+		t.Fatalf("mapped error did not preserve runtime deadline chain: %v", mapped)
+	}
+}
+
 func TestMapRuntimeErrorMapsDisconnectedSessionAcrossHostBoundary(t *testing.T) {
 	runtimeErr := fmt.Errorf("fence requires live provider: %w", agentruntime.ErrSessionDisconnected)
 	mapped := mapRuntimeError(runtimeErr)

--- a/packages/agent/daemon/runtime/claude_sdk_lifecycle.go
+++ b/packages/agent/daemon/runtime/claude_sdk_lifecycle.go
@@ -130,6 +130,13 @@ func (a *ClaudeCodeSDKAdapter) startClaudeSDKSession(ctx context.Context, sessio
 		if err != nil {
 			a.removeSession(session.AgentSessionID, adapterSession)
 			a.closeOrRetainClaudeSDKSession(session.AgentSessionID, adapterSession)
+			if errors.Is(err, context.DeadlineExceeded) {
+				// The process is already launched and the start request has been
+				// sent. A deadline at this boundary means the provider never
+				// established its runtime Session, rather than preparation or
+				// delivery timing out before provider readiness was observable.
+				err = errors.Join(ErrProviderStartTimeout, err)
+			}
 			return nil, err
 		}
 		eventCtx := context.Background()

--- a/packages/agent/daemon/runtime/claude_sdk_session_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_session_test.go
@@ -29,6 +29,49 @@ func TestClaudeCodeSDKAdapterCanResumeRequiresProviderSessionID(t *testing.T) {
 	}
 }
 
+func TestClaudeCodeSDKAdapterMarksProviderReadinessDeadline(t *testing.T) {
+	t.Parallel()
+
+	conn := &recordingClaudeSDKConnection{}
+	adapter := NewClaudeCodeSDKAdapter(&recordingClaudeSDKTransport{conn: conn})
+	session := standardTestSession(ProviderClaudeCode)
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	_, err := adapter.Start(ctx, session)
+	if !errors.Is(err, ErrProviderStartTimeout) || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Start() error = %v, want provider-start marker and deadline cause", err)
+	}
+	if adapter.getSession(session.AgentSessionID) != nil {
+		t.Fatal("timed-out provider readiness retained adapter session")
+	}
+	requests := conn.sentRequests()
+	if len(requests) != 1 || requests[0].Type != "start" {
+		t.Fatalf("sent requests = %#v, want one provider start before timeout", requests)
+	}
+}
+
+func TestClaudeCodeSDKAdapterLeavesPreparationDeadlineUnclassified(t *testing.T) {
+	t.Parallel()
+
+	transport := &recordingClaudeSDKTransport{conn: &recordingClaudeSDKConnection{}}
+	adapter := NewClaudeCodeSDKAdapter(transport)
+	adapter.SetProviderLaunchPreparer(func(context.Context, ProviderLaunchPrepareInput) (ProviderLaunchPrepareResult, error) {
+		return ProviderLaunchPrepareResult{}, context.DeadlineExceeded
+	})
+
+	_, err := adapter.Start(context.Background(), standardTestSession(ProviderClaudeCode))
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Start() error = %v, want preparation deadline", err)
+	}
+	if errors.Is(err, ErrProviderStartTimeout) {
+		t.Fatalf("Start() error = %v, preparation deadline gained provider-start verdict", err)
+	}
+	if len(transport.spec.Command) != 0 {
+		t.Fatalf("process spec = %#v, preparation failure must not start provider", transport.spec)
+	}
+}
+
 func TestClaudeCodeSDKAdapterCloseHonorsCallerDeadlineAndForcesTeardown(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/controller_session_lifecycle.go
+++ b/packages/agent/daemon/runtime/controller_session_lifecycle.go
@@ -83,8 +83,10 @@ func (c *Controller) Start(ctx context.Context, input StartInput) (StartResult, 
 		if AppErrorCode(err) == "" {
 			detail := cleanVisibleErrorText(err.Error())
 			code := visibleFailureCode(detail)
-			if errors.Is(err, context.DeadlineExceeded) {
-				code = AppErrorProviderStartTimeout
+			if errors.Is(err, ErrProviderStartTimeout) {
+				// Provider-start ownership is carried separately in the error
+				// chain. Keep the established presentation/API vocabulary here.
+				code = "request_timed_out"
 			}
 			startError = &AppError{
 				Code:         code,

--- a/packages/agent/daemon/runtime/controller_session_lifecycle.go
+++ b/packages/agent/daemon/runtime/controller_session_lifecycle.go
@@ -83,6 +83,9 @@ func (c *Controller) Start(ctx context.Context, input StartInput) (StartResult, 
 		if AppErrorCode(err) == "" {
 			detail := cleanVisibleErrorText(err.Error())
 			code := visibleFailureCode(detail)
+			if errors.Is(err, context.DeadlineExceeded) {
+				code = AppErrorProviderStartTimeout
+			}
 			startError = &AppError{
 				Code:         code,
 				Message:      visibleFailureContent(provider, "start", code),

--- a/packages/agent/daemon/runtime/controller_start_test.go
+++ b/packages/agent/daemon/runtime/controller_start_test.go
@@ -52,6 +52,27 @@ func TestControllerStartFailureDoesNotCreateCanonicalSessionOrTurnlessMessage(t 
 	}
 }
 
+func TestControllerStartClassifiesAdapterDeadlineBeforeSessionRegistration(t *testing.T) {
+	t.Parallel()
+
+	controller := NewController([]Adapter{providerStartTimeoutAdapter{}}, nil)
+	_, err := controller.Start(context.Background(), StartInput{
+		RoomID:         "room-timeout",
+		AgentSessionID: "agent-timeout",
+		Provider:       hermesExtensionTestProvider,
+		CWD:            "/workspace",
+	})
+	if code := AppErrorCode(err); code != AppErrorProviderStartTimeout {
+		t.Fatalf("Start error code = %q (err=%v), want %q", code, err, AppErrorProviderStartTimeout)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Start error = %v, want deadline cause preserved", err)
+	}
+	if stored, ok := controller.get("room-timeout", "agent-timeout"); ok {
+		t.Fatalf("stored session = %#v, want no runtime session after start timeout", stored)
+	}
+}
+
 func TestControllerStartPreservesStructuredCleanupBackpressureError(t *testing.T) {
 	t.Parallel()
 
@@ -734,6 +755,12 @@ func (a *recordingPromptAdapter) ValidatePromptContent(_ Session, content []Prom
 }
 
 type failingStartAdapter struct{}
+
+type providerStartTimeoutAdapter struct{ failingStartAdapter }
+
+func (providerStartTimeoutAdapter) Start(context.Context, Session) ([]activityshared.Event, error) {
+	return nil, fmt.Errorf("provider start: %w", context.DeadlineExceeded)
+}
 
 type cleanupPendingStartAdapter struct{ failingStartAdapter }
 

--- a/packages/agent/daemon/runtime/controller_start_test.go
+++ b/packages/agent/daemon/runtime/controller_start_test.go
@@ -62,8 +62,8 @@ func TestControllerStartClassifiesAdapterDeadlineBeforeSessionRegistration(t *te
 		Provider:       hermesExtensionTestProvider,
 		CWD:            "/workspace",
 	})
-	if code := AppErrorCode(err); code != AppErrorProviderStartTimeout {
-		t.Fatalf("Start error code = %q (err=%v), want %q", code, err, AppErrorProviderStartTimeout)
+	if code := AppErrorCode(err); code != "agent.provider_start_timeout" {
+		t.Fatalf("Start error code = %q (err=%v), want agent.provider_start_timeout", code, err)
 	}
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("Start error = %v, want deadline cause preserved", err)

--- a/packages/agent/daemon/runtime/controller_start_test.go
+++ b/packages/agent/daemon/runtime/controller_start_test.go
@@ -52,24 +52,45 @@ func TestControllerStartFailureDoesNotCreateCanonicalSessionOrTurnlessMessage(t 
 	}
 }
 
-func TestControllerStartClassifiesAdapterDeadlineBeforeSessionRegistration(t *testing.T) {
+func TestControllerStartPreservesTypedProviderTimeoutWithoutChangingPresentationCode(t *testing.T) {
 	t.Parallel()
 
-	controller := NewController([]Adapter{providerStartTimeoutAdapter{}}, nil)
+	controller := NewController([]Adapter{typedProviderStartTimeoutAdapter{}}, nil)
 	_, err := controller.Start(context.Background(), StartInput{
 		RoomID:         "room-timeout",
 		AgentSessionID: "agent-timeout",
 		Provider:       hermesExtensionTestProvider,
 		CWD:            "/workspace",
 	})
-	if code := AppErrorCode(err); code != "agent.provider_start_timeout" {
-		t.Fatalf("Start error code = %q (err=%v), want agent.provider_start_timeout", code, err)
+	if code := AppErrorCode(err); code != "request_timed_out" {
+		t.Fatalf("Start error code = %q (err=%v), want request_timed_out", code, err)
 	}
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("Start error = %v, want deadline cause preserved", err)
+	if !errors.Is(err, ErrProviderStartTimeout) || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Start error = %v, want typed provider-start timeout and deadline cause", err)
 	}
 	if stored, ok := controller.get("room-timeout", "agent-timeout"); ok {
 		t.Fatalf("stored session = %#v, want no runtime session after start timeout", stored)
+	}
+}
+
+func TestControllerStartDoesNotInferProviderTimeoutFromCallerDeadline(t *testing.T) {
+	t.Parallel()
+
+	controller := NewController([]Adapter{callerDeadlineStartAdapter{}}, nil)
+	_, err := controller.Start(context.Background(), StartInput{
+		RoomID:         "room-caller-timeout",
+		AgentSessionID: "agent-caller-timeout",
+		Provider:       hermesExtensionTestProvider,
+		CWD:            "/workspace",
+	})
+	if code := AppErrorCode(err); code != "request_timed_out" {
+		t.Fatalf("Start error code = %q (err=%v), want request_timed_out", code, err)
+	}
+	if errors.Is(err, ErrProviderStartTimeout) {
+		t.Fatalf("Start error = %v, arbitrary caller deadline gained provider-start verdict", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Start error = %v, want caller deadline preserved", err)
 	}
 }
 
@@ -756,10 +777,16 @@ func (a *recordingPromptAdapter) ValidatePromptContent(_ Session, content []Prom
 
 type failingStartAdapter struct{}
 
-type providerStartTimeoutAdapter struct{ failingStartAdapter }
+type typedProviderStartTimeoutAdapter struct{ failingStartAdapter }
 
-func (providerStartTimeoutAdapter) Start(context.Context, Session) ([]activityshared.Event, error) {
-	return nil, fmt.Errorf("provider start: %w", context.DeadlineExceeded)
+func (typedProviderStartTimeoutAdapter) Start(context.Context, Session) ([]activityshared.Event, error) {
+	return nil, errors.Join(ErrProviderStartTimeout, fmt.Errorf("provider start: %w", context.DeadlineExceeded))
+}
+
+type callerDeadlineStartAdapter struct{ failingStartAdapter }
+
+func (callerDeadlineStartAdapter) Start(context.Context, Session) ([]activityshared.Event, error) {
+	return nil, fmt.Errorf("caller request: %w", context.DeadlineExceeded)
 }
 
 type cleanupPendingStartAdapter struct{ failingStartAdapter }

--- a/packages/agent/daemon/runtime/errors.go
+++ b/packages/agent/daemon/runtime/errors.go
@@ -4,12 +4,16 @@ import "errors"
 
 const (
 	AppErrorProviderSessionNotFound = "agent.provider_session_not_found"
-	AppErrorProviderStartTimeout    = "agent.provider_start_timeout"
 	AppErrorProcessCleanupPending   = "agent.process_cleanup_pending"
 	AppErrorResumeSessionNotLocal   = "agent.resume_session_not_local"
 )
 
 var (
+	// ErrProviderStartTimeout is attached only by a provider adapter that has
+	// reached its provider-readiness boundary and observed the start deadline
+	// before a runtime Session was established. Callers must not infer this
+	// verdict from an arbitrary context deadline.
+	ErrProviderStartTimeout          = errors.New("agent provider start timed out")
 	ErrSessionDisconnected           = errors.New("agent session is not connected")
 	ErrInteractiveRequestNotLive     = errors.New("interactive request is no longer live")
 	ErrInteractiveAlreadyAnswered    = errors.New("interactive request has already been answered")

--- a/packages/agent/daemon/runtime/errors.go
+++ b/packages/agent/daemon/runtime/errors.go
@@ -4,7 +4,7 @@ import "errors"
 
 const (
 	AppErrorProviderSessionNotFound = "agent.provider_session_not_found"
-	AppErrorProviderStartTimeout    = "provider_start_timeout"
+	AppErrorProviderStartTimeout    = "agent.provider_start_timeout"
 	AppErrorProcessCleanupPending   = "agent.process_cleanup_pending"
 	AppErrorResumeSessionNotLocal   = "agent.resume_session_not_local"
 )

--- a/packages/agent/daemon/runtime/errors.go
+++ b/packages/agent/daemon/runtime/errors.go
@@ -4,6 +4,7 @@ import "errors"
 
 const (
 	AppErrorProviderSessionNotFound = "agent.provider_session_not_found"
+	AppErrorProviderStartTimeout    = "provider_start_timeout"
 	AppErrorProcessCleanupPending   = "agent.process_cleanup_pending"
 	AppErrorResumeSessionNotLocal   = "agent.resume_session_not_local"
 )

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -366,7 +366,12 @@ provider code and diagnostic text remain local observations rather than a
 stable cross-service taxonomy; coordination layers persist only their own
 coarse product reason when needed. `NewProviderError` deliberately leaves
 cancellation and deadline failures unclassified because their delivery result
-is unknown and must remain recoverable.
+is unknown and must remain recoverable. The narrow
+`NewProviderStartTimeoutError` exception is used only after the runtime owner
+has observed the provider adapter's Start stage time out before establishing a
+runtime Session. It preserves the deadline cause while exposing
+`provider_start_timeout` as a typed Provider failure; callers must not infer
+that verdict from an arbitrary context deadline.
 `UpdateSettings` serializes with runtime resume:
 historical sessions persist settings only, while live sessions update the
 runtime first and persist the resulting settings only after the runtime

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -369,9 +369,11 @@ cancellation and deadline failures unclassified because their delivery result
 is unknown and must remain recoverable. The narrow
 `NewProviderStartTimeoutError` exception is used only after the runtime owner
 has observed the provider adapter's Start stage time out before establishing a
-runtime Session. It preserves the deadline cause while exposing
-`provider_start_timeout` as a typed Provider failure; callers must not infer
-that verdict from an arbitrary context deadline.
+runtime Session. The daemon keeps the existing `request_timed_out` AppError
+code for API and presentation behavior and carries that narrow verdict as
+`ErrProviderStartTimeout` in the error chain. The Host runtime adapter maps the
+marker to `provider_start_timeout` while preserving the deadline cause; callers
+must not infer that verdict from an arbitrary context deadline.
 `UpdateSettings` serializes with runtime resume:
 historical sessions persist settings only, while live sessions update the
 runtime first and persist the resulting settings only after the runtime

--- a/packages/agent/host/errors.go
+++ b/packages/agent/host/errors.go
@@ -58,6 +58,8 @@ type ProviderError struct {
 	Cause        error
 }
 
+const ProviderErrorCodeStartTimeout = "provider_start_timeout"
+
 // NewProviderError converts an adapter's structured provider observation into
 // the Host contract. Cancellation and deadline errors remain unclassified
 // because their delivery result is unknown and consumers must keep them
@@ -71,6 +73,23 @@ func NewProviderError(code, message, debugMessage string, cause error) error {
 	}
 	return &ProviderError{
 		Code:         code,
+		Message:      message,
+		DebugMessage: debugMessage,
+		Cause:        cause,
+	}
+}
+
+// NewProviderStartTimeoutError preserves the narrow runtime verdict that a
+// provider adapter timed out while starting, before a runtime Session was
+// established. Unlike an arbitrary deadline, this verdict is safe to expose as
+// a ProviderError because the runtime owner has already identified the failed
+// lifecycle stage.
+func NewProviderStartTimeoutError(message, debugMessage string, cause error) error {
+	if cause == nil {
+		return nil
+	}
+	return &ProviderError{
+		Code:         ProviderErrorCodeStartTimeout,
 		Message:      message,
 		DebugMessage: debugMessage,
 		Cause:        cause,

--- a/packages/agent/host/errors_test.go
+++ b/packages/agent/host/errors_test.go
@@ -58,3 +58,25 @@ func TestNewProviderErrorLeavesDeliveryUnknownContextErrorsRecoverable(t *testin
 		t.Fatalf("NewProviderError(nil) = %v, want nil", mapped)
 	}
 }
+
+func TestNewProviderStartTimeoutErrorPreservesTypedVerdictAndDeadlineCause(t *testing.T) {
+	cause := fmt.Errorf("provider start: %w", context.DeadlineExceeded)
+	mapped := NewProviderStartTimeoutError(
+		"Agent provider took too long to start",
+		"provider startup exceeded its deadline",
+		cause,
+	)
+	var providerErr *ProviderError
+	if !errors.As(mapped, &providerErr) {
+		t.Fatalf("NewProviderStartTimeoutError() = %v, want ProviderError", mapped)
+	}
+	if providerErr.Code != ProviderErrorCodeStartTimeout {
+		t.Fatalf("ProviderError code = %q, want %q", providerErr.Code, ProviderErrorCodeStartTimeout)
+	}
+	if !errors.Is(mapped, context.DeadlineExceeded) {
+		t.Fatalf("mapped error = %v, want deadline cause preserved", mapped)
+	}
+	if mapped := NewProviderStartTimeoutError("", "", nil); mapped != nil {
+		t.Fatalf("NewProviderStartTimeoutError(nil) = %v, want nil", mapped)
+	}
+}


### PR DESCRIPTION
## Summary

- classify only provider-process start deadlines as `provider_start_timeout` at the runtime-owned start boundary
- preserve that explicit verdict as a typed `agenthost.ProviderError` through the Host adapter while leaving ordinary cancellation and deadline errors unclassified
- add regression tests and document the downstream classification contract

## Motivation

A raw `context deadline exceeded` does not identify which phase failed and can also be joined from cleanup or delivery-unknown paths. Downstream consumers need a narrow typed signal before treating a failed provider start as terminal. This change creates that signal at the component that owns the provider process start and preserves it without widening generic timeout handling.

## Verification

- `go test ./packages/agent/host ./packages/agent/daemon/runtime ./packages/agent/daemon/hostadapter -count=1`
- `pnpm check:changed -- --push-ready` (10/10 lanes passed)
- staged formatting and repository boundary hooks

## Windows impact

This is platform-neutral error classification only. It does not change Windows paths, process creation, signals, permissions, or executable discovery.

## Follow-up

TSH will consume the typed error after this change is released and the Tutti dependency cohort is upgraded. The TSH retry and durable handoff changes are intentionally not coupled to an unpublished dependency version in this PR.

## Checklist

- [x] The change is focused on one concern.
- [x] The Host contract and adapter behavior have direct regression coverage.
- [x] Behavior documentation is updated.
- [x] The lowest meaningful local checks passed.
- [x] The commit includes DCO sign-off.