### PR TITLE
fix(agent): separate model probes from skill preparation

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1785,6 +1785,13 @@ requests only `skills/list` and retains the ordinary Skill projection through
 the shared app-server transport, capability contract, cache, and structured
 prompt-item submission path.
 
+Model-only app-server catalog probes are a separate read path: they request
+`model/list` without `skills/list` and pass the runtime launch preparation
+contract's `SkipSkills` flag. These probes do not create a live Session and
+must not resolve or materialize provider Skill directories. A Composer-options
+read that returns both models and Skills keeps the normal Skill preparation
+path.
+
 Tutti Desktop's slash connector section is a local catalog projection,
 not a Provider connector catalog. `services/tuttid/service/agent` reads the
 daemon-owned connector-market application through its read-only snapshot port;

--- a/packages/agent/daemon/runtime/provider_launch_prepare.go
+++ b/packages/agent/daemon/runtime/provider_launch_prepare.go
@@ -30,6 +30,9 @@ type ProviderLaunchPrepareInput struct {
 	Env         []string
 	CWD         string
 	DirectStart bool
+	// SkipSkills is used by model-only probes that do not start a live Agent
+	// Session and therefore do not need provider Skill materialization.
+	SkipSkills bool
 }
 
 type ProviderLaunchPrepareResult struct {

--- a/packages/agent/gui/agentGUIPerformanceMonitor.spec.ts
+++ b/packages/agent/gui/agentGUIPerformanceMonitor.spec.ts
@@ -171,6 +171,35 @@ describe("createAgentGUIPerformanceMonitor", () => {
     }
   });
 
+  it("does not report expected Composer options cancellation as a failure", async () => {
+    const harness = createEngineHarness(engineState({}));
+    const onEvent = vi.fn();
+    const monitor = createAgentGUIPerformanceMonitor({
+      engine: harness.engine,
+      onEvent,
+      subscribeSessionEvents: harness.subscribeSessionEvents
+    });
+
+    const pending = monitor.trackComposerOptionsLoad({
+      agentTargetId: "codex-target",
+      load: () => Promise.reject(new Error("composer_options_load_superseded")),
+      provider: "codex",
+      source: "session-engine"
+    });
+
+    await expect(pending).rejects.toThrow("composer_options_load_superseded");
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "composer_options_load_started" })
+    );
+    expect(onEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        outcome: "failed",
+        type: "composer_options_load_settled"
+      })
+    );
+    monitor.dispose();
+  });
+
   it("does not let a Composer options event sink change the load result", async () => {
     const eventSinkFailure = new Error("event sink failed");
     const consoleError = vi

--- a/packages/agent/gui/agentGUIPerformanceMonitor.ts
+++ b/packages/agent/gui/agentGUIPerformanceMonitor.ts
@@ -524,22 +524,24 @@ export async function trackAgentGUIComposerOptionsLoad(
     options = await input.load();
   } catch (error) {
     const observedAtUnixMs = safeNowUnixMs(nowUnixMs);
-    emitPerformanceEvent(input.onEvent, {
-      agentTargetId,
-      ...agentGUIPerformanceDuration(observedAtUnixMs - startedAtUnixMs),
-      ...performanceErrorFieldsFromError(error),
-      failureStage: "options_load",
-      force,
-      hasDirectory,
-      observedAtUnixMs,
-      operationId,
-      outcome: "failed",
-      provider,
-      source: input.source,
-      startedAtUnixMs,
-      type: "composer_options_load_settled",
-      workspaceId: input.workspaceId
-    });
+    if (!isExpectedComposerOptionsCancellation(error)) {
+      emitPerformanceEvent(input.onEvent, {
+        agentTargetId,
+        ...agentGUIPerformanceDuration(observedAtUnixMs - startedAtUnixMs),
+        ...performanceErrorFieldsFromError(error),
+        failureStage: "options_load",
+        force,
+        hasDirectory,
+        observedAtUnixMs,
+        operationId,
+        outcome: "failed",
+        provider,
+        source: input.source,
+        startedAtUnixMs,
+        type: "composer_options_load_settled",
+        workspaceId: input.workspaceId
+      });
+    }
     throw error;
   }
 
@@ -698,6 +700,24 @@ function normalizePerformanceErrorCode(value: unknown): string {
     .replace(/^_+|_+$/g, "")
     .slice(0, 120);
   return normalized || "unknown";
+}
+
+function isExpectedComposerOptionsCancellation(error: unknown): boolean {
+  const record = asRecord(error);
+  const candidates = [
+    stringField(record, "code"),
+    error instanceof Error ? error.name : undefined,
+    error instanceof Error ? error.message : undefined
+  ]
+    .map((value) => value?.trim().toLowerCase())
+    .filter((value): value is string => Boolean(value));
+  return candidates.some((value) =>
+    [
+      "composer_options_load_aborted",
+      "composer_options_load_superseded",
+      "agent_session_engine_disposed"
+    ].includes(value)
+  );
 }
 
 function composerOptionsOperationId(

--- a/packages/agent/runtimeprep/capability.go
+++ b/packages/agent/runtimeprep/capability.go
@@ -410,26 +410,30 @@ func resolveCapabilities(ctx context.Context, input PrepareInput, profile Deploy
 			section.Body = renderedBody
 			section.Key = name + "/" + section.Key
 		}
-		resolved.Skills = append(resolved.Skills, contribution.Skills...)
+		if !input.SkipSkills {
+			resolved.Skills = append(resolved.Skills, contribution.Skills...)
+		}
 		resolved.PolicySections = append(resolved.PolicySections, contribution.PolicySections...)
 		resolved.EnvOverlay = append(resolved.EnvOverlay, contribution.EnvOverlay...)
 	}
-	for _, source := range sources {
-		if source == nil {
-			continue
-		}
-		skills, err := source.Skills(ctx, SkillContext{WorkspaceID: input.WorkspaceID, AgentSessionID: input.AgentSessionID, Provider: input.Provider, Cwd: input.Cwd})
-		if err != nil {
-			return nil, fmt.Errorf("resolve runtime preparation skill source: %w", err)
-		}
-		for index := range skills {
-			if skills[index].Source == "" {
-				skills[index].Source = "host"
+	if !input.SkipSkills {
+		for _, source := range sources {
+			if source == nil {
+				continue
 			}
+			skills, err := source.Skills(ctx, SkillContext{WorkspaceID: input.WorkspaceID, AgentSessionID: input.AgentSessionID, Provider: input.Provider, Cwd: input.Cwd})
+			if err != nil {
+				return nil, fmt.Errorf("resolve runtime preparation skill source: %w", err)
+			}
+			for index := range skills {
+				if skills[index].Source == "" {
+					skills[index].Source = "host"
+				}
+			}
+			resolved.Skills = append(resolved.Skills, skills...)
 		}
-		resolved.Skills = append(resolved.Skills, skills...)
+		resolved.Skills = append(resolved.Skills, input.ExtraSkills...)
 	}
-	resolved.Skills = append(resolved.Skills, input.ExtraSkills...)
 	if err := validateResolvedSkills(resolved.Skills, input.Provider); err != nil {
 		return nil, err
 	}

--- a/packages/agent/runtimeprep/capability_test.go
+++ b/packages/agent/runtimeprep/capability_test.go
@@ -267,6 +267,20 @@ func TestDefaultPreparerIncludesHostSkillSources(t *testing.T) {
 	}
 }
 
+func TestResolveCapabilitiesSkipsSkillSourcesForModelProbe(t *testing.T) {
+	called := false
+	_, err := resolveCapabilities(t.Context(), PrepareInput{
+		Provider:   "codex",
+		SkipSkills: true,
+	}, StandardProfile(), []SkillSource{countingSkillSource{called: &called}})
+	if err != nil {
+		t.Fatalf("resolveCapabilities() error = %v", err)
+	}
+	if called {
+		t.Fatal("model-only capability resolution called a Skill source")
+	}
+}
+
 func TestResolveCapabilitiesRejectsSkillPathTraversal(t *testing.T) {
 	profile := DeploymentProfile{Name: "test", Packs: []CapabilityPack{{
 		Name: "unsafe", Resolve: staticCapability(SkillSpec{
@@ -289,4 +303,13 @@ type staticSkillSource []SkillSpec
 
 func (s staticSkillSource) Skills(context.Context, SkillContext) ([]SkillSpec, error) {
 	return append([]SkillSpec(nil), s...), nil
+}
+
+type countingSkillSource struct {
+	called *bool
+}
+
+func (s countingSkillSource) Skills(context.Context, SkillContext) ([]SkillSpec, error) {
+	*s.called = true
+	return nil, nil
 }

--- a/packages/agent/runtimeprep/claude.go
+++ b/packages/agent/runtimeprep/claude.go
@@ -105,7 +105,7 @@ func installClaudeTuttiPlugin(pluginDir string, input PrepareInput) error {
 	if err := os.WriteFile(filepath.Join(manifestDir, "plugin.json"), append(content, '\n'), 0o600); err != nil {
 		return fmt.Errorf("write claude plugin manifest: %w", err)
 	}
-	if _, err := installProviderNativeSkills(filepath.Join(pluginDir, "skills"), input); err != nil {
+	if _, err := installProviderNativeSkillsSessionScoped(filepath.Join(pluginDir, "skills"), input); err != nil {
 		return fmt.Errorf("install claude tutti skill plugin: %w", err)
 	}
 	return nil

--- a/packages/agent/runtimeprep/claude.go
+++ b/packages/agent/runtimeprep/claude.go
@@ -56,18 +56,24 @@ func (p ClaudeCodePreparer) Prepare(_ context.Context, input ProviderPrepareInpu
 	if err := os.WriteFile(systemPromptPath, []byte(systemPrompt), 0o600); err != nil {
 		return ProviderPrepareResult{}, fmt.Errorf("write claude system prompt: %w", err)
 	}
-	pluginDir := filepath.Join(input.RuntimeRoot, "claude-plugin", "tutti-cli")
-	if err := installClaudeTuttiPlugin(pluginDir, input.PrepareInput); err != nil {
-		return ProviderPrepareResult{}, err
-	}
 	if input.Manifest != nil {
 		input.Manifest.RecordManagedFile(systemPromptPath, "provider-system-prompt", true)
-		input.Manifest.RecordManagedFile(pluginDir, "provider-plugin", true)
 	}
 	env := []string{
 		claudeSystemPromptFileEnv + "=" + systemPromptPath,
-		claudePluginDirEnv + "=" + pluginDir,
-		claudeSkillListingBudgetEnv + "=" + claudeSkillListingBudgetChars,
+	}
+	if !input.SkipSkills {
+		pluginDir := filepath.Join(input.RuntimeRoot, "claude-plugin", "tutti-cli")
+		if err := installClaudeTuttiPlugin(pluginDir, input.PrepareInput); err != nil {
+			return ProviderPrepareResult{}, err
+		}
+		if input.Manifest != nil {
+			input.Manifest.RecordManagedFile(pluginDir, "provider-plugin", true)
+		}
+		env = append(env,
+			claudePluginDirEnv+"="+pluginDir,
+			claudeSkillListingBudgetEnv+"="+claudeSkillListingBudgetChars,
+		)
 	}
 	env = append(env, p.claudeCodeExecutableEnv()...)
 	env = append(env, modelEndpointClaudeEnv(input.ModelEndpoint)...)

--- a/packages/agent/runtimeprep/codex.go
+++ b/packages/agent/runtimeprep/codex.go
@@ -145,7 +145,7 @@ func prepareCodexHome(codexHome string, input PrepareInput) error {
 	}
 	logRuntimePrepareTrace("runtime_prepare.codex.user_skills_resolved", input, nil)
 	logRuntimePrepareTrace("runtime_prepare.codex.native_skills_requested", input, nil)
-	skillPaths, err := installProviderNativeSkills(filepath.Join(codexHome, "skills"), input)
+	skillPaths, err := installProviderNativeSkillsSessionScoped(filepath.Join(codexHome, "skills"), input)
 	if err != nil {
 		return err
 	}

--- a/packages/agent/runtimeprep/codex.go
+++ b/packages/agent/runtimeprep/codex.go
@@ -139,19 +139,21 @@ func prepareCodexHome(codexHome string, input PrepareInput) error {
 		return err
 	}
 	logRuntimePrepareTrace("runtime_prepare.codex.session_config_resolved", input, nil)
-	logRuntimePrepareTrace("runtime_prepare.codex.user_skills_requested", input, nil)
-	if err := exposeUserCodexSkillFolders(filepath.Join(codexHome, "skills"), input); err != nil {
-		return err
+	if !input.SkipSkills {
+		logRuntimePrepareTrace("runtime_prepare.codex.user_skills_requested", input, nil)
+		if err := exposeUserCodexSkillFolders(filepath.Join(codexHome, "skills"), input); err != nil {
+			return err
+		}
+		logRuntimePrepareTrace("runtime_prepare.codex.user_skills_resolved", input, nil)
+		logRuntimePrepareTrace("runtime_prepare.codex.native_skills_requested", input, nil)
+		skillPaths, err := installProviderNativeSkillsSessionScoped(filepath.Join(codexHome, "skills"), input)
+		if err != nil {
+			return err
+		}
+		logRuntimePrepareTrace("runtime_prepare.codex.native_skills_resolved", input, map[string]any{
+			"skill_count": len(skillPaths),
+		})
 	}
-	logRuntimePrepareTrace("runtime_prepare.codex.user_skills_resolved", input, nil)
-	logRuntimePrepareTrace("runtime_prepare.codex.native_skills_requested", input, nil)
-	skillPaths, err := installProviderNativeSkillsSessionScoped(filepath.Join(codexHome, "skills"), input)
-	if err != nil {
-		return err
-	}
-	logRuntimePrepareTrace("runtime_prepare.codex.native_skills_resolved", input, map[string]any{
-		"skill_count": len(skillPaths),
-	})
 	logRuntimePrepareTrace("runtime_prepare.codex.approval_rules_requested", input, nil)
 	if err := installCodexApprovalRules(codexHome, input); err != nil {
 		return err

--- a/packages/agent/runtimeprep/preparer_test.go
+++ b/packages/agent/runtimeprep/preparer_test.go
@@ -1081,6 +1081,40 @@ func TestDefaultPreparerCodexExposesRelativeModelCatalogJSON(t *testing.T) {
 	}
 }
 
+func TestDefaultPreparerCodexReconcilesNativeSkillsAcrossRepeatedPrepare(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+
+	preparer := newTestPreparer(t.TempDir())
+	input := PrepareInput{
+		WorkspaceID:    "workspace-1",
+		AgentSessionID: "session-1",
+		AgentTargetID:  "local:codex",
+		Provider:       "codex",
+		Cwd:            t.TempDir(),
+	}
+	first, err := preparer.Prepare(t.Context(), input)
+	if err != nil {
+		t.Fatalf("first Prepare() error = %v", err)
+	}
+	second, err := preparer.Prepare(t.Context(), input)
+	if err != nil {
+		t.Fatalf("second Prepare() error = %v", err)
+	}
+
+	firstCodexHome := envValue(first.Env, "CODEX_HOME")
+	secondCodexHome := envValue(second.Env, "CODEX_HOME")
+	if firstCodexHome != secondCodexHome {
+		t.Fatalf("repeated Prepare() CODEX_HOME = %q and %q, want the same durable home", firstCodexHome, secondCodexHome)
+	}
+	if _, err := os.Stat(filepath.Join(secondCodexHome, "skills", "tutti-cli", "SKILL.md")); err != nil {
+		t.Fatalf("stable tutti-cli skill missing after repeated Prepare(): %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(secondCodexHome, "skills", "tutti-cli-tutti")); !os.IsNotExist(err) {
+		t.Fatalf("repeated Prepare() created a suffixed tutti-cli skill, err = %v", err)
+	}
+}
+
 func TestDefaultPreparerCodexUserSkillNameWinsBeforeTuttiInjection(t *testing.T) {
 	home := t.TempDir()
 	setTestHome(t, home)

--- a/packages/agent/runtimeprep/preparer_test.go
+++ b/packages/agent/runtimeprep/preparer_test.go
@@ -2161,6 +2161,37 @@ func TestTuttiAgentManagedConfigPreservesLegacyProviderWithExtraKey(t *testing.T
 	}
 }
 
+func TestDefaultPreparerClaudeReconcilesNativeSkillsAcrossRepeatedPrepare(t *testing.T) {
+	preparer := newTestPreparer(t.TempDir())
+	input := PrepareInput{
+		WorkspaceID:    "workspace-1",
+		AgentSessionID: "session-1",
+		AgentTargetID:  "local:claude-code",
+		Provider:       "claude-code",
+		Cwd:            t.TempDir(),
+	}
+	first, err := preparer.Prepare(t.Context(), input)
+	if err != nil {
+		t.Fatalf("first Prepare() error = %v", err)
+	}
+	second, err := preparer.Prepare(t.Context(), input)
+	if err != nil {
+		t.Fatalf("second Prepare() error = %v", err)
+	}
+
+	firstPluginDir := envValue(first.Env, claudePluginDirEnv)
+	secondPluginDir := envValue(second.Env, claudePluginDirEnv)
+	if firstPluginDir != secondPluginDir {
+		t.Fatalf("repeated Prepare() Claude plugin dir = %q and %q, want the same runtime root", firstPluginDir, secondPluginDir)
+	}
+	if _, err := os.Stat(filepath.Join(secondPluginDir, "skills", "tutti-cli", "SKILL.md")); err != nil {
+		t.Fatalf("stable tutti-cli skill missing after repeated Prepare(): %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(secondPluginDir, "skills", "tutti-cli-tutti")); !os.IsNotExist(err) {
+		t.Fatalf("repeated Prepare() created a suffixed tutti-cli skill, err = %v", err)
+	}
+}
+
 func TestDefaultPreparerCleanupRemovesClaudeSystemPromptRuntimeRoot(t *testing.T) {
 	stateDir := t.TempDir()
 	cwd := t.TempDir()

--- a/packages/agent/runtimeprep/preparer_test.go
+++ b/packages/agent/runtimeprep/preparer_test.go
@@ -1115,6 +1115,28 @@ func TestDefaultPreparerCodexReconcilesNativeSkillsAcrossRepeatedPrepare(t *test
 	}
 }
 
+func TestDefaultPreparerCodexSkipsSkillsForModelProbe(t *testing.T) {
+	preparer := newTestPreparer(t.TempDir())
+	prepared, err := preparer.Prepare(t.Context(), PrepareInput{
+		WorkspaceID:    "workspace-1",
+		AgentSessionID: "model-probe-1",
+		AgentTargetID:  "local:codex",
+		Provider:       "codex",
+		Cwd:            t.TempDir(),
+		SkipSkills:     true,
+	})
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+	codexHome := envValue(prepared.Env, "CODEX_HOME")
+	if codexHome == "" {
+		t.Fatalf("prepared env = %#v, want CODEX_HOME", prepared.Env)
+	}
+	if _, err := os.Stat(filepath.Join(codexHome, "skills")); !os.IsNotExist(err) {
+		t.Fatalf("model-only Prepare() created a Skill root, err = %v", err)
+	}
+}
+
 func TestDefaultPreparerCodexUserSkillNameWinsBeforeTuttiInjection(t *testing.T) {
 	home := t.TempDir()
 	setTestHome(t, home)

--- a/packages/agent/runtimeprep/provider_skill.go
+++ b/packages/agent/runtimeprep/provider_skill.go
@@ -255,6 +255,9 @@ func templateInputValues(input PrepareInput) func(string, string) []string {
 }
 
 func providerSkills(input PrepareInput) ([]providerSkillSpec, error) {
+	if input.SkipSkills {
+		return nil, nil
+	}
 	if input.resolved == nil {
 		return nil, errors.New("provider skills require resolved runtime capabilities")
 	}
@@ -293,6 +296,9 @@ func installProviderNativeSkillsStable(root string, input PrepareInput) ([]strin
 }
 
 func installProviderNativeSkillsSessionScoped(root string, input PrepareInput) ([]string, error) {
+	if input.SkipSkills {
+		return nil, nil
+	}
 	skills, err := providerSkills(input)
 	if err != nil {
 		return nil, err

--- a/packages/agent/runtimeprep/stable_skill_bundle.go
+++ b/packages/agent/runtimeprep/stable_skill_bundle.go
@@ -47,6 +47,9 @@ func materializeStableProviderSkills(
 	storeRoot string,
 	input PrepareInput,
 ) (string, error) {
+	if input.SkipSkills {
+		return "", nil
+	}
 	storeRoot = filepath.Clean(strings.TrimSpace(storeRoot))
 	if storeRoot == "." || !filepath.IsAbs(storeRoot) {
 		return "", fmt.Errorf("stable provider skill bundle root must be absolute")

--- a/packages/agent/runtimeprep/tutti_agent.go
+++ b/packages/agent/runtimeprep/tutti_agent.go
@@ -49,20 +49,25 @@ func (p TuttiAgentPreparer) Prepare(ctx context.Context, input ProviderPrepareIn
 			err = errors.Join(err, cleanup(ctx))
 		}
 	}()
-	extraSkillRoots, err := connectorSkillRoots(input.ConnectorRoutingHints)
-	if err != nil {
-		return ProviderPrepareResult{}, err
-	}
-	if strings.TrimSpace(p.StableSkillBundleRoot) == "" {
-		if _, err := installProviderNativeSkillsSessionScoped(filepath.Join(home, "skills"), input.PrepareInput); err != nil {
-			return ProviderPrepareResult{}, fmt.Errorf("install tutti-agent native skills: %w", err)
-		}
-	} else {
-		root, err := materializeStableProviderSkills(p.StableSkillBundleRoot, input.PrepareInput)
+	var extraSkillRoots []string
+	if !input.SkipSkills {
+		extraSkillRoots, err = connectorSkillRoots(input.ConnectorRoutingHints)
 		if err != nil {
-			return ProviderPrepareResult{}, fmt.Errorf("materialize tutti-agent stable skills: %w", err)
+			return ProviderPrepareResult{}, err
 		}
-		extraSkillRoots = append([]string{root}, extraSkillRoots...)
+		if strings.TrimSpace(p.StableSkillBundleRoot) == "" {
+			if _, err := installProviderNativeSkillsSessionScoped(filepath.Join(home, "skills"), input.PrepareInput); err != nil {
+				return ProviderPrepareResult{}, fmt.Errorf("install tutti-agent native skills: %w", err)
+			}
+		} else {
+			root, err := materializeStableProviderSkills(p.StableSkillBundleRoot, input.PrepareInput)
+			if err != nil {
+				return ProviderPrepareResult{}, fmt.Errorf("materialize tutti-agent stable skills: %w", err)
+			}
+			if root != "" {
+				extraSkillRoots = append([]string{root}, extraSkillRoots...)
+			}
+		}
 	}
 	logRuntimePrepareTrace("runtime_prepare.tutti_agent.home_prepared", input.PrepareInput, nil)
 	instructionsPath := filepath.Join(home, "AGENTS.md")
@@ -87,12 +92,14 @@ func (p TuttiAgentPreparer) Prepare(ctx context.Context, input ProviderPrepareIn
 		}
 		env = append(env, "TUTTI_AGENT_EXTRA_SKILL_ROOTS_JSON="+string(encodedRoots))
 	}
-	if root := strings.TrimSpace(p.StableSystemSkillBundleRoot); root != "" {
-		root = filepath.Clean(root)
-		if !filepath.IsAbs(root) {
-			return ProviderPrepareResult{}, fmt.Errorf("tutti-agent stable system skill bundle root must be absolute")
+	if !input.SkipSkills {
+		if root := strings.TrimSpace(p.StableSystemSkillBundleRoot); root != "" {
+			root = filepath.Clean(root)
+			if !filepath.IsAbs(root) {
+				return ProviderPrepareResult{}, fmt.Errorf("tutti-agent stable system skill bundle root must be absolute")
+			}
+			env = append(env, "TUTTI_AGENT_STABLE_SYSTEM_SKILLS_ROOT="+root)
 		}
-		env = append(env, "TUTTI_AGENT_STABLE_SYSTEM_SKILLS_ROOT="+root)
 	}
 	if input.ModelEndpoint.supportsCodex() {
 		env = append(env, codexModelPlanAPIKeyEnv+"="+input.ModelEndpoint.APIKey)

--- a/packages/agent/runtimeprep/tutti_agent.go
+++ b/packages/agent/runtimeprep/tutti_agent.go
@@ -54,7 +54,7 @@ func (p TuttiAgentPreparer) Prepare(ctx context.Context, input ProviderPrepareIn
 		return ProviderPrepareResult{}, err
 	}
 	if strings.TrimSpace(p.StableSkillBundleRoot) == "" {
-		if _, err := installProviderNativeSkills(filepath.Join(home, "skills"), input.PrepareInput); err != nil {
+		if _, err := installProviderNativeSkillsSessionScoped(filepath.Join(home, "skills"), input.PrepareInput); err != nil {
 			return ProviderPrepareResult{}, fmt.Errorf("install tutti-agent native skills: %w", err)
 		}
 	} else {

--- a/packages/agent/runtimeprep/tutti_agent_test.go
+++ b/packages/agent/runtimeprep/tutti_agent_test.go
@@ -117,6 +117,33 @@ func TestTuttiAgentPreparerReconcilesNativeSkillsAcrossRepeatedPrepare(t *testin
 	}
 }
 
+func TestTuttiAgentPreparerSkipsSkillsForModelProbe(t *testing.T) {
+	input := ProviderPrepareInput{
+		PrepareInput: testResolvedInput(t, PrepareInput{
+			AgentSessionID: "model-probe-1",
+			AgentTargetID:  "local:tutti-agent",
+			Provider:       "tutti-agent",
+			CLICommand:     "tutti",
+			SkipSkills:     true,
+		}),
+		RuntimeRoot: t.TempDir(),
+		Store:       LocalStore{StateDir: t.TempDir()},
+	}
+	result, err := (TuttiAgentPreparer{}).Prepare(t.Context(), input)
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+	home := filepath.Join(input.RuntimeRoot, "tutti-agent-home")
+	if _, err := os.Stat(filepath.Join(home, "skills")); !os.IsNotExist(err) {
+		t.Fatalf("model-only Prepare() created a Skill root, err = %v", err)
+	}
+	for _, env := range result.Env {
+		if strings.HasPrefix(env, "TUTTI_AGENT_EXTRA_SKILL_ROOTS_JSON=") || strings.HasPrefix(env, "TUTTI_AGENT_STABLE_SYSTEM_SKILLS_ROOT=") {
+			t.Fatalf("model-only Prepare() exposed Skill env %q", env)
+		}
+	}
+}
+
 func TestTuttiAgentPreparerRejectsRelativeAuthSource(t *testing.T) {
 	preparer := TuttiAgentPreparer{
 		ResolveAuthSource: func(context.Context, PrepareInput) (string, error) {

--- a/packages/agent/runtimeprep/tutti_agent_test.go
+++ b/packages/agent/runtimeprep/tutti_agent_test.go
@@ -87,6 +87,36 @@ func TestTuttiAgentPreparerUsesExplicitAuthSourceAndInstallsSkills(t *testing.T)
 	}
 }
 
+func TestTuttiAgentPreparerReconcilesNativeSkillsAcrossRepeatedPrepare(t *testing.T) {
+	userHome := t.TempDir()
+	setTestHome(t, userHome)
+	preparer := TuttiAgentPreparer{}
+	input := ProviderPrepareInput{
+		PrepareInput: testResolvedInput(t, PrepareInput{
+			AgentSessionID: "session-1",
+			AgentTargetID:  "local:tutti-agent",
+			Provider:       "tutti-agent",
+			CLICommand:     "tutti",
+		}),
+		RuntimeRoot: t.TempDir(),
+		Store:       LocalStore{StateDir: t.TempDir()},
+	}
+	if _, err := preparer.Prepare(t.Context(), input); err != nil {
+		t.Fatalf("first Prepare() error = %v", err)
+	}
+	if _, err := preparer.Prepare(t.Context(), input); err != nil {
+		t.Fatalf("second Prepare() error = %v", err)
+	}
+
+	skillRoot := filepath.Join(input.RuntimeRoot, "tutti-agent-home", "skills")
+	if _, err := os.Stat(filepath.Join(skillRoot, "tutti-cli", "SKILL.md")); err != nil {
+		t.Fatalf("stable tutti-cli skill missing after repeated Prepare(): %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(skillRoot, "tutti-cli-tutti")); !os.IsNotExist(err) {
+		t.Fatalf("repeated Prepare() created a suffixed tutti-cli skill, err = %v", err)
+	}
+}
+
 func TestTuttiAgentPreparerRejectsRelativeAuthSource(t *testing.T) {
 	preparer := TuttiAgentPreparer{
 		ResolveAuthSource: func(context.Context, PrepareInput) (string, error) {

--- a/packages/agent/runtimeprep/types.go
+++ b/packages/agent/runtimeprep/types.go
@@ -30,11 +30,15 @@ type SkillBundleRenderer interface {
 }
 
 type PrepareInput struct {
-	WorkspaceID            string
-	AgentSessionID         string
-	AgentTargetID          string
-	Provider               string
-	Cwd                    string
+	WorkspaceID    string
+	AgentSessionID string
+	AgentTargetID  string
+	Provider       string
+	Cwd            string
+	// SkipSkills keeps provider preparation limited to the runtime data needed
+	// by a model-only probe. It must not be used when launching a live Agent
+	// Session or when the caller needs the provider's Skill catalog.
+	SkipSkills             bool
 	CLICommand             string
 	CodexSaverMode         bool
 	Title                  string


### PR DESCRIPTION
## Summary

- reconcile native Skills for Codex, Claude Code, and Tutti Agent session runtimes
- add an upstream `SkipSkills` launch-preparation contract for model-only probes
- stop resolving or materializing Skill directories when `SkipSkills` is enabled
- stop reporting expected Composer-option supersede, abort, and engine-dispose cancellations as ordinary failures

## Root cause

The model catalog protocol already requests only `model/list`, but the TSH launch preparer still prepared the full provider runtime before starting the probe. That unnecessary preparation could allocate `tutti-cli` Skill directories and hit the exhausted-name failure even though the probe did not need Skills. Composer-options reads that return both models and Skills keep the normal Skill preparation path.

Repeated preparation also used collision-avoiding allocation inside durable session homes. The existing PR fix now reconciles Tutti-managed directories for Codex, Claude Code, and Tutti Agent without touching user-owned directories or shared workspace roots.

## Scope

- `SkipSkills` defaults to false, so normal live Session launches keep existing behavior.
- The TSH caller must set `SkipSkills=true` for model-only app-server probes after consuming the released Tutti API.
- Provider-queue cancellation, Codex HTTP error semantics, and TSH AbortSignal forwarding are TSH-owned changes and are not silently claimed as fixed by this Tutti PR.

## Validation

- `go test ./packages/agent/runtimeprep`
- `go test ./packages/agent/daemon/runtime/...`
- `pnpm test:ts -- --packages-json ["@tutti-os/agent-gui"]`
- `pnpm check:changed -- --push-ready` (18 lanes passed)
