### PR TITLE
fix(agent-gui): add structured performance failure telemetry

### DIFF
--- a/packages/agent/gui/README.md
+++ b/packages/agent/gui/README.md
@@ -215,6 +215,17 @@ The daemon DTO mapper belongs to
 `@tutti-os/agent-activity-tuttid-adapter`, so Desktop and Mobile do not keep
 separate parser implementations for Composer capabilities or option catalogs.
 
+## Performance Failure Events
+
+`AgentGUIPerformanceEvent` failure settlements carry a bounded `errorCode` and
+`failureStage` when the operation fails. `errorCode` comes from a stable
+machine-readable error field and falls back to `unknown`; raw error messages
+are never included. Composer option failures use `options_load`, Session
+activation uses `session_activation`, Prompt admission uses `prompt_admission`,
+and Turn failures use `turn_settlement`. Each settlement keeps its existing
+`operationId`, so hosts can deduplicate repeated observations without using
+provider names, timestamps, or error text.
+
 ## Quick Composer
 
 `@tutti-os/agent-gui/quick-composer` renders the canonical DOM Composer for a

--- a/packages/agent/gui/agentGUIPerformanceEvents.ts
+++ b/packages/agent/gui/agentGUIPerformanceEvents.ts
@@ -16,6 +16,13 @@ export type AgentGUIFirstTokenKind = "other" | "plan" | "reasoning" | "text";
 
 export type AgentGUIComposerOptionsLoadSource = "runtime" | "session-engine";
 
+export type AgentGUIPerformanceFailureStage =
+  | "options_load"
+  | "session_activation"
+  | "prompt_admission"
+  | "turn_settlement"
+  | "unknown";
+
 interface AgentGUIPerformanceEventBase {
   agentSessionId: string;
   durationBucket: AgentGUIPerformanceDurationBucket;
@@ -32,6 +39,8 @@ export type AgentGUIPerformanceEvent =
       commandDurationMs?: number;
       commandOutcome: PendingActivationCommandOutcome;
       errorCategory?: string;
+      errorCode?: string;
+      failureStage?: AgentGUIPerformanceFailureStage;
       hasInitialPrompt: boolean;
       lastObservedStage: PendingActivationLastObservedStage;
       mode: "existing" | "new";
@@ -42,6 +51,8 @@ export type AgentGUIPerformanceEvent =
     })
   | (AgentGUIPerformanceEventBase & {
       errorCategory?: string;
+      errorCode?: string;
+      failureStage?: AgentGUIPerformanceFailureStage;
       outcome: "accepted" | "failed";
       queued: boolean;
       source: "activation" | "submit";
@@ -57,6 +68,8 @@ export type AgentGUIPerformanceEvent =
     })
   | (AgentGUIPerformanceEventBase & {
       errorCategory?: string;
+      errorCode?: string;
+      failureStage?: AgentGUIPerformanceFailureStage;
       outcome: "canceled" | "completed" | "failed" | "interrupted";
       source: "activation" | "submit";
       turnId: string;
@@ -79,6 +92,8 @@ export type AgentGUIPerformanceEvent =
       durationBucket: AgentGUIPerformanceDurationBucket;
       durationMs: number;
       errorCategory?: string;
+      errorCode?: string;
+      failureStage?: AgentGUIPerformanceFailureStage;
       force: boolean;
       hasDirectory: boolean;
       modelCount?: number;

--- a/packages/agent/gui/agentGUIPerformanceMonitor.spec.ts
+++ b/packages/agent/gui/agentGUIPerformanceMonitor.spec.ts
@@ -8,7 +8,8 @@ import { describe, expect, it, vi } from "vitest";
 import {
   agentGUIPerformanceDuration,
   createAgentGUIPerformanceMonitor,
-  trackAgentGUIComposerOptionsLoad
+  trackAgentGUIComposerOptionsLoad,
+  type AgentGUIComposerOptionsPerformanceEvent
 } from "./agentGUIPerformanceMonitor";
 
 describe("createAgentGUIPerformanceMonitor", () => {
@@ -116,6 +117,8 @@ describe("createAgentGUIPerformanceMonitor", () => {
         durationBucket: "3s_to_10s",
         durationMs: 4_000,
         errorCategory: "composer_options_timeout",
+        errorCode: "composer_options_timeout",
+        failureStage: "options_load",
         outcome: "failed",
         source: "session-engine",
         type: "composer_options_load_settled"
@@ -125,6 +128,47 @@ describe("createAgentGUIPerformanceMonitor", () => {
       "private provider response"
     );
     monitor.dispose();
+  });
+
+  it("uses bounded unknown for a missing Composer error code and rethrows it", async () => {
+    const sinkFailure = new Error("event sink failed");
+    const failure = new Error("private provider response");
+    const onEvent = vi.fn<
+      (event: AgentGUIComposerOptionsPerformanceEvent) => void
+    >(() => {
+      throw sinkFailure;
+    });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    try {
+      const pending = trackAgentGUIComposerOptionsLoad({
+        agentTargetId: "codex-target",
+        load: () => Promise.reject(failure),
+        onEvent,
+        provider: "codex",
+        source: "runtime",
+        workspaceId: "workspace-1"
+      });
+
+      await expect(pending).rejects.toBe(failure);
+      expect(onEvent).toHaveBeenCalledTimes(2);
+      expect(onEvent.mock.calls[1]?.[0]).toEqual(
+        expect.objectContaining({
+          errorCategory: "unknown",
+          errorCode: "unknown",
+          failureStage: "options_load",
+          outcome: "failed",
+          type: "composer_options_load_settled"
+        })
+      );
+      expect(JSON.stringify(onEvent.mock.calls)).not.toContain(
+        "private provider response"
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   it("does not let a Composer options event sink change the load result", async () => {

--- a/packages/agent/gui/agentGUIPerformanceMonitor.ts
+++ b/packages/agent/gui/agentGUIPerformanceMonitor.ts
@@ -19,6 +19,7 @@ export type {
   AgentGUIComposerOptionsLoadSource,
   AgentGUIComposerOptionsPerformanceEvent,
   AgentGUIFirstTokenKind,
+  AgentGUIPerformanceFailureStage,
   AgentGUIPerformanceDurationBucket,
   AgentGUIPerformanceEvent
 } from "./agentGUIPerformanceEvents.ts";
@@ -274,7 +275,10 @@ export function createAgentGUIPerformanceMonitor(input: {
           ...(commandDurationMs === null ? {} : { commandDurationMs }),
           commandOutcome: activation.commandOutcome,
           ...(activation.status === "failed"
-            ? { errorCategory: activation.errorCode ?? "runtime" }
+            ? {
+                ...performanceErrorFieldsFromCode(activation.errorCode),
+                failureStage: "session_activation"
+              }
             : {}),
           hasInitialPrompt,
           lastObservedStage: activation.lastObservedStage,
@@ -296,7 +300,10 @@ export function createAgentGUIPerformanceMonitor(input: {
           agentSessionId: activation.agentSessionId,
           ...duration,
           ...(activation.status === "failed"
-            ? { errorCategory: activation.errorCode ?? "runtime" }
+            ? {
+                ...performanceErrorFieldsFromCode(activation.errorCode),
+                failureStage: "prompt_admission"
+              }
             : {}),
           observedAtUnixMs,
           operationId,
@@ -350,7 +357,10 @@ export function createAgentGUIPerformanceMonitor(input: {
           agentSessionId: submit.agentSessionId,
           ...duration,
           ...(submit.status === "failed"
-            ? { errorCategory: submit.errorCode ?? "runtime" }
+            ? {
+                ...performanceErrorFieldsFromCode(submit.errorCode),
+                failureStage: "prompt_admission"
+              }
             : {}),
           observedAtUnixMs,
           operationId: submit.clientSubmitId,
@@ -393,7 +403,10 @@ export function createAgentGUIPerformanceMonitor(input: {
         agentSessionId: turn.agentSessionId,
         ...duration,
         ...(turn.outcome === "failed"
-          ? { errorCategory: turn.error?.code ?? "runtime" }
+          ? {
+              ...performanceErrorFieldsFromCode(turn.error?.code),
+              failureStage: "turn_settlement"
+            }
           : {}),
         observedAtUnixMs,
         operationId: context.operationId,
@@ -514,7 +527,8 @@ export async function trackAgentGUIComposerOptionsLoad(
     emitPerformanceEvent(input.onEvent, {
       agentTargetId,
       ...agentGUIPerformanceDuration(observedAtUnixMs - startedAtUnixMs),
-      errorCategory: performanceErrorCategory(error),
+      ...performanceErrorFieldsFromError(error),
+      failureStage: "options_load",
       force,
       hasDirectory,
       observedAtUnixMs,
@@ -661,13 +675,23 @@ function performanceTurnKey(agentSessionId: string, turnId: string): string {
   return `${agentSessionId}\u0000${turnId}`;
 }
 
-function performanceErrorCategory(error: unknown): string {
-  const record = asRecord(error);
-  const candidate =
-    stringField(record, "code") ??
-    (error instanceof Error ? error.name : undefined) ??
-    "unknown";
-  const normalized = candidate
+function performanceErrorFieldsFromError(error: unknown): {
+  errorCategory: string;
+  errorCode: string;
+} {
+  return performanceErrorFieldsFromCode(stringField(asRecord(error), "code"));
+}
+
+function performanceErrorFieldsFromCode(value: unknown): {
+  errorCategory: string;
+  errorCode: string;
+} {
+  const errorCode = normalizePerformanceErrorCode(value);
+  return { errorCategory: errorCode, errorCode };
+}
+
+function normalizePerformanceErrorCode(value: unknown): string {
+  const normalized = (typeof value === "string" ? value : "")
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9_.:-]+/g, "_")

--- a/packages/agent/gui/index.ts
+++ b/packages/agent/gui/index.ts
@@ -219,6 +219,7 @@ export type {
   AgentGUIFirstTokenKind,
   AgentGUIPerformanceDurationBucket,
   AgentGUIPerformanceEvent,
+  AgentGUIPerformanceFailureStage,
   AgentGUIPerformanceMonitor
 } from "./agentGUIPerformanceMonitor";
 export type {


### PR DESCRIPTION
## Summary
- Add typed `errorCode` and `failureStage` to AgentGUI performance failure settlements.
- Normalize machine error codes with an `unknown` fallback and stage Composer, Session activation, Prompt admission, and Turn settlement failures.
- Keep telemetry sinks isolated from runtime failures and document the public contract.

## Tests
- `pnpm check:changed -- --push-ready` (12 lanes passed)
- `pnpm --filter @tutti-os/agent-gui test -- agentGUIPerformanceMonitor.spec.ts --run` (320 files, 2858 tests passed)
- `pnpm --filter @tutti-os/agent-gui build`

## Notes
- Raw error messages are not added to AgentGUI performance events.
- `pnpm check:full` remains blocked by pre-existing bare `http.Client` lint findings in `services/tuttid/service/mobileremote/relay_control_plane.go` and `packages/agent/runtimeprep/mutagen_auth.go`; neither file is changed by this PR.