### PR TITLE
fix(agent): hide unsupported CodeBuddy goal control

### DIFF
--- a/docs/architecture/agent-extensions.md
+++ b/docs/architecture/agent-extensions.md
@@ -219,6 +219,14 @@ catalog and attach shared command effects such as submit-immediate, show-status,
 activate-goal-mode, and toggle-plan-mode. `tuttid` applies that declarative
 policy before returning composer options, so extension commands can reuse the
 shared AgentGUI slash-command behavior without a provider-name branch. Signed
+profiles remain the positive authority for controls, while the daemon may
+apply a fail-closed product compatibility policy that only removes an exact
+command/effect pair which Tutti cannot execute end to end. Such exceptions stay
+in the extension-profile resolver, require exact extension identity and focused
+coverage, and must never add or retarget commands in shared AgentGUI code. The
+current CodeBuddy exception removes `goal` with `activateGoalMode` until its
+structured Goal lifecycle is compatible with Tutti; directly typed
+provider-owned `/goal` input and the ACP runtime remain unchanged. Signed
 profiles may also set
 `skills.runtimeCommandProjection: "unlisted-as-skills"` alongside an
 authoritative slash-command catalog. In that mode, runtime-advertised entries

--- a/services/tuttid/agent_extension_composer_profile_resolver.go
+++ b/services/tuttid/agent_extension_composer_profile_resolver.go
@@ -69,5 +69,29 @@ func (r agentExtensionComposerProfileResolver) ResolveExtensionComposerProfile(
 			})
 		}
 	}
-	return result, nil
+	return applyAgentExtensionComposerCompatibilityPolicy(installationID, result), nil
+}
+
+func applyAgentExtensionComposerCompatibilityPolicy(
+	installationID string,
+	profile agentservice.ExtensionComposerProfile,
+) agentservice.ExtensionComposerProfile {
+	agentKey, _, ok := strings.Cut(strings.TrimSpace(installationID), "@")
+	if !ok || agentKey != "codebuddy" || len(profile.SlashCommands) == 0 {
+		return profile
+	}
+
+	// CodeBuddy advertises /goal, but it does not currently implement Tutti's
+	// structured Goal lifecycle. Keep this provider-specific presentation guard
+	// in the daemon product adapter instead of branching in shared AgentGUI code.
+	commands := make([]agentservice.ExtensionComposerSlashCommand, 0, len(profile.SlashCommands))
+	for _, command := range profile.SlashCommands {
+		if strings.EqualFold(strings.TrimSpace(command.Name), "goal") &&
+			strings.TrimSpace(command.Effect) == "activateGoalMode" {
+			continue
+		}
+		commands = append(commands, command)
+	}
+	profile.SlashCommands = commands
+	return profile
 }

--- a/services/tuttid/agent_extension_composer_profile_resolver_test.go
+++ b/services/tuttid/agent_extension_composer_profile_resolver_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"slices"
+	"testing"
+
+	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
+)
+
+func TestApplyAgentExtensionComposerCompatibilityPolicyHidesCodeBuddyGoalControl(t *testing.T) {
+	profile := agentservice.ExtensionComposerProfile{
+		SlashCommandCatalogAuthoritative: true,
+		SlashCommands: []agentservice.ExtensionComposerSlashCommand{
+			{Name: "compact", Effect: "submitImmediate"},
+			{Name: " goal ", Effect: "activateGoalMode"},
+			{Name: "plan", Effect: "togglePlanMode"},
+		},
+	}
+
+	got := applyAgentExtensionComposerCompatibilityPolicy("codebuddy@2.0.3", profile)
+	want := []agentservice.ExtensionComposerSlashCommand{
+		{Name: "compact", Effect: "submitImmediate"},
+		{Name: "plan", Effect: "togglePlanMode"},
+	}
+	if !slices.Equal(got.SlashCommands, want) {
+		t.Fatalf("slash commands = %#v, want %#v", got.SlashCommands, want)
+	}
+	if !got.SlashCommandCatalogAuthoritative {
+		t.Fatal("authoritative command catalog must be preserved")
+	}
+	if len(profile.SlashCommands) != 3 {
+		t.Fatalf("input profile was mutated: %#v", profile.SlashCommands)
+	}
+}
+
+func TestApplyAgentExtensionComposerCompatibilityPolicyKeepsOtherGoalCommands(t *testing.T) {
+	tests := []struct {
+		name           string
+		installationID string
+		effect         string
+	}{
+		{name: "other extension", installationID: "example@1.0.0", effect: "activateGoalMode"},
+		{name: "provider owned CodeBuddy command", installationID: "codebuddy@2.0.3", effect: "submitImmediate"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			command := agentservice.ExtensionComposerSlashCommand{Name: "goal", Effect: test.effect}
+			profile := agentservice.ExtensionComposerProfile{
+				SlashCommands: []agentservice.ExtensionComposerSlashCommand{command},
+			}
+
+			got := applyAgentExtensionComposerCompatibilityPolicy(test.installationID, profile)
+			if !slices.Equal(got.SlashCommands, []agentservice.ExtensionComposerSlashCommand{command}) {
+				t.Fatalf("slash commands = %#v, want goal command preserved", got.SlashCommands)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- remove the exact CodeBuddy `goal` + `activateGoalMode` mapping while resolving its effective Agent Extension composer profile
- keep the compatibility policy in the `tuttid` product adapter so shared AgentGUI and Agent Host remain provider-neutral
- cover the CodeBuddy match, other extensions, and a provider-owned CodeBuddy `/goal` effect with focused tests
- document the fail-closed extension-profile compatibility boundary

CodeBuddy currently advertises a provider-owned `/goal` command, while its signed composer profile maps that command to Tutti structured Goal control. The current CodeBuddy integration does not provide the end-to-end structured Goal lifecycle needed by that control, so exposing it in the panel can enter a flow that repeatedly fails. This change hides only that structured panel entry until the lifecycle is compatible.

This does **not** change Session, Turn, Goal, or runtime-operation lifecycle semantics. tsh and other Host consumers do not need this behavior; it is Tutti product policy for the CodeBuddy Agent Extension catalog.

## Risk assessment

Overall risk is **low**:

- the rule requires the exact `codebuddy` installation key, normalized `goal` command name, and exact `activateGoalMode` effect
- other Agent Extensions and CodeBuddy commands such as `compact`, `status`, and `plan` are unchanged
- a future CodeBuddy `goal` entry with an ordinary provider-owned effect is preserved
- ACP transport, runtime launch, permissions, models, typed Goal APIs, and shared AgentGUI behavior are unchanged
- manually typing `/goal` is not intercepted; this change only narrows the projected panel catalog
- the current signed CodeBuddy profile keeps the catalog authoritative, so the omitted entry also filters the runtime-advertised command from the panel
- rollback is limited to removing the compatibility policy after CodeBuddy supports the structured lifecycle
- the change is platform-neutral string/list projection logic and has no Windows-specific impact

## Verification

- `go test . -run 'TestApplyAgentExtensionComposerCompatibilityPolicy' -count=1` from `services/tuttid`
- `pnpm setup:worktree`
- `pnpm check:changed -- --base upstream/main` — 5 lanes passed
- `go build ./...` from `services/tuttid`
- pre-commit formatting and staged boundary checks passed
- pre-push `pnpm check:changed -- --push-ready` — 6 lanes passed

## Fallback Three Questions

- **Source:** the immutable signed CodeBuddy composer profile maps its provider-owned `/goal` command to Tutti `activateGoalMode`, but the integration does not yet provide a compatible structured Goal lifecycle.
- **Why can it not be fixed at that source?** Existing signed CodeBuddy releases are immutable and already installed. A future extension release alone cannot protect users of those supported versions, so Tutti must fail closed while resolving their effective presentation policy.
- **Removal condition:** delete this compatibility policy after every supported CodeBuddy extension/runtime combination either implements the Tutti structured Goal lifecycle or no longer declares the mapping, and older affected releases are no longer supported.

## Checklist

- [x] This PR does not change agent lifecycle semantics; it changes daemon-owned presentation/product policy only.
- [x] I kept the change focused on one concern.
- [x] I updated the Agent Extensions architecture documentation for the behavior and ownership boundary.
- [x] No README or CONTRIBUTING source changed, so language-variant updates are not required.
- [x] I ran the lowest meaningful local checks selected for the changed surface.
- [x] The commit is signed off with DCO.

