### PR TITLE
fix: connector UI improvements - sticky tabs and bottom padding

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
@@ -515,7 +515,7 @@ export function WorkspaceSettingsPanel({
                   />
                 ) : settingsState.agentTab === "connectors" &&
                   connectorsVisible ? (
-                  <ConnectorMarketPanel 
+                  <ConnectorMarketPanel
                     i18n={connectorMarketI18n}
                     locale={desktopPreferencesState.locale}
                     onError={handleConnectorMarketError}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
@@ -424,43 +424,46 @@ export function WorkspaceSettingsPanel({
                 workbenchShortcuts={desktopPreferencesState.workbenchShortcuts}
               />
             ) : settingsState.activeSection === "agent" ? (
-              <div className="flex min-h-0 flex-col gap-5 pt-5">
-                <SectionTabs
-                  ariaLabel={t("workspace.settings.nav.agent")}
-                  className="h-8 shrink-0"
-                  tabs={[
-                    {
-                      value: "general" as const,
-                      label: t("workspace.settings.agent.tabs.general")
-                    },
-                    {
-                      value: "agents" as const,
-                      label: t("workspace.settings.agent.tabs.agents")
-                    },
-                    ...(connectorsVisible
-                      ? [
-                          {
-                            value: "connectors" as const,
-                            label: translateConnectorMarket("title")
-                          }
-                        ]
-                      : []),
-                    {
-                      value: "customAgents" as const,
-                      label: t("workspace.settings.agent.tabs.customAgents")
-                    },
-                    ...(automationRulesEnabled
-                      ? [
-                          {
-                            value: "automation" as const,
-                            label: t("workspace.settings.agent.tabs.automation")
-                          }
-                        ]
-                      : [])
-                  ]}
-                  value={settingsState.agentTab}
-                  onValueChange={(tab) => settingsService.selectAgentTab(tab)}
-                />
+              <div className="flex min-h-0 flex-col gap-5">
+              <div className="pb-[20px]">
+                <div className="sticky top-0 z-10 -mx-[22px] px-[22px] py-3 bg-[var(--background-fronted)]">
+                  <SectionTabs
+                    ariaLabel={t("workspace.settings.nav.agent")}
+                    className="h-8 shrink-0"
+                    tabs={[
+                      {
+                        value: "general" as const,
+                        label: t("workspace.settings.agent.tabs.general")
+                      },
+                      {
+                        value: "agents" as const,
+                        label: t("workspace.settings.agent.tabs.agents")
+                      },
+                      ...(connectorsVisible
+                        ? [
+                            {
+                              value: "connectors" as const,
+                              label: translateConnectorMarket("title")
+                            }
+                          ]
+                        : []),
+                      {
+                        value: "customAgents" as const,
+                        label: t("workspace.settings.agent.tabs.customAgents")
+                      },
+                      ...(automationRulesEnabled
+                        ? [
+                            {
+                              value: "automation" as const,
+                              label: t("workspace.settings.agent.tabs.automation")
+                            }
+                          ]
+                        : [])
+                    ]}
+                    value={settingsState.agentTab}
+                    onValueChange={(tab) => settingsService.selectAgentTab(tab)}
+                  />
+                </div>
                 {settingsState.agentTab === "agents" ? (
                   <WorkspaceAgentsSettingsTab
                     autoCheckEnabled={
@@ -512,7 +515,7 @@ export function WorkspaceSettingsPanel({
                   />
                 ) : settingsState.agentTab === "connectors" &&
                   connectorsVisible ? (
-                  <ConnectorMarketPanel
+                  <ConnectorMarketPanel 
                     i18n={connectorMarketI18n}
                     locale={desktopPreferencesState.locale}
                     onError={handleConnectorMarketError}
@@ -564,6 +567,7 @@ export function WorkspaceSettingsPanel({
                     onOpenExternalAgentImport={onOpenExternalAgentImport}
                   />
                 )}
+              </div>
               </div>
             ) : settingsState.activeSection === "appearance" ? (
               <WorkspaceAppearanceSettingsSection

--- a/packages/connector/market/src/ui/ConnectorMarketPanel.tsx
+++ b/packages/connector/market/src/ui/ConnectorMarketPanel.tsx
@@ -37,7 +37,7 @@ export function ConnectorMarketPanel({
     >
       <section
         className={cn(
-          "flex min-h-0 flex-1 flex-col gap-5 pb-5",
+          "flex min-h-0 flex-1 flex-col gap-5",
           className
         )}
         data-testid="connector-market-panel"
@@ -47,7 +47,7 @@ export function ConnectorMarketPanel({
             {i18n.t("description")}
           </p>
         </header>
-        <div className="sticky top-0 z-10 bg-[var(--background-panel)]"><ConnectorMarketToolbar /></div>
+        <div><ConnectorMarketToolbar /></div>
         <ConnectorCatalog />
       </section>
     </ConnectorMarketRootProvider>

--- a/packages/connector/market/src/ui/dialogs/ConnectorAuthorizationDialog.tsx
+++ b/packages/connector/market/src/ui/dialogs/ConnectorAuthorizationDialog.tsx
@@ -81,7 +81,7 @@ export function ConnectorAuthorizationDialog({
     <DialogContent className="max-h-[min(720px,calc(100vh-32px))] overflow-y-auto sm:max-w-[520px]">
       <DialogHeader className="items-center px-5 pt-4 text-center">
         <div className="mb-1 flex items-center gap-3">
-          <span className="flex size-12 items-center justify-center rounded-xl bg-[var(--accent-bg)] text-[var(--accent)]">
+          <span className="flex size-12 items-center justify-center rounded-xl bg-[var(--transparency-block)] text-[var(--accent)]">
             <TuttiMarkNew size={32} />
           </span>
           <ChangeLined className="size-4 text-[var(--text-tertiary)]" />


### PR DESCRIPTION
## 改进内容

- 修复设置-Agent标签栏固定定位问题
- 添加连接器列表底部间距（20px padding）
- 改进用户体验，确保滚动时标签栏始终可见

## 修改文件

- apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
- packages/connector/market/src/ui/ConnectorMarketPanel.tsx
- packages/connector/market/src/ui/dialogs/ConnectorAuthorizationDialog.tsx

## 测试

- 手动测试标签栏固定效果
- 验证底部间距正确显示