### PR TITLE
fix(agent): expose provider acceptance diagnostics

### DIFF
--- a/packages/agent/daemon/runtime/codex_appserver_acceptance.go
+++ b/packages/agent/daemon/runtime/codex_appserver_acceptance.go
@@ -5,6 +5,41 @@ import (
 	"strings"
 )
 
+const codexProviderTurnIDSourceTurnStartResponse = "turn_start_response"
+
+func codexProviderAcceptanceDiagnostics(
+	providerSessionID string,
+	providerTurnID string,
+	failureReason string,
+) *ProviderAcceptanceDiagnostics {
+	providerSessionID = strings.TrimSpace(providerSessionID)
+	providerTurnID = strings.TrimSpace(providerTurnID)
+	diagnostics := &ProviderAcceptanceDiagnostics{
+		Status:                   string(DispatchDispositionOutcomeUnknown),
+		ProviderSessionIDPresent: providerSessionID != "",
+		ProviderTurnIDPresent:    providerTurnID != "",
+		ProviderTurnIDSource:     codexProviderTurnIDSourceTurnStartResponse,
+		FailureReason:            strings.TrimSpace(failureReason),
+	}
+	if providerSessionID != "" && providerTurnID != "" {
+		diagnostics.Status = string(DispatchDispositionApplied)
+	}
+	return diagnostics
+}
+
+func codexProviderAcceptanceMissingIdentityReason(providerSessionID, providerTurnID string) string {
+	hasSessionID := strings.TrimSpace(providerSessionID) != ""
+	hasTurnID := strings.TrimSpace(providerTurnID) != ""
+	switch {
+	case !hasSessionID && !hasTurnID:
+		return "missing_provider_session_id_and_provider_turn_id"
+	case !hasSessionID:
+		return "missing_provider_session_id"
+	default:
+		return "missing_provider_turn_id"
+	}
+}
+
 func reportCodexDispatchFailure(report ProviderDispatchSink, err error) {
 	if report == nil {
 		return
@@ -38,11 +73,17 @@ func reportCodexProviderTurnAccepted(
 	if providerSessionID == "" || providerTurnID == "" {
 		report(ProviderDispatchResult{
 			Disposition: DispatchDispositionOutcomeUnknown,
+			AcceptanceDiagnostics: codexProviderAcceptanceDiagnostics(
+				providerSessionID,
+				providerTurnID,
+				codexProviderAcceptanceMissingIdentityReason(providerSessionID, providerTurnID),
+			),
 		})
 		return
 	}
 	report(ProviderDispatchResult{
-		Disposition: DispatchDispositionApplied,
+		Disposition:           DispatchDispositionApplied,
+		AcceptanceDiagnostics: codexProviderAcceptanceDiagnostics(providerSessionID, providerTurnID, ""),
 		Acceptance: &ProviderAcceptanceReceipt{
 			Source:            AcceptanceSourceTurnStartResponse,
 			ProviderSessionID: providerSessionID,
@@ -68,6 +109,11 @@ func (options codexTurnExecOptions) confirmProviderTurnAcceptance(
 	if providerSessionID == "" || providerTurnID == "" {
 		options.report(ProviderDispatchResult{
 			Disposition: DispatchDispositionOutcomeUnknown,
+			AcceptanceDiagnostics: codexProviderAcceptanceDiagnostics(
+				providerSessionID,
+				providerTurnID,
+				codexProviderAcceptanceMissingIdentityReason(providerSessionID, providerTurnID),
+			),
 		})
 		return errors.New("codex provider turn acceptance omitted identity")
 	}

--- a/packages/agent/daemon/runtime/codex_appserver_acceptance_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_acceptance_test.go
@@ -1,0 +1,35 @@
+package agentruntime
+
+import "testing"
+
+func TestConfirmCodexProviderTurnAcceptanceReportsMissingTurnIdentity(t *testing.T) {
+	var reported ProviderDispatchResult
+	options := codexTurnExecOptions{
+		reportDispatch: func(result ProviderDispatchResult) {
+			reported = result
+		},
+		acceptProviderTurn: func(ProviderAcceptanceReceipt) error {
+			t.Fatal("acceptance barrier should not be called for missing identity")
+			return nil
+		},
+	}
+
+	err := options.confirmProviderTurnAcceptance("codex-thread-1", "")
+	if err == nil || err.Error() != "codex provider turn acceptance omitted identity" {
+		t.Fatalf("error = %v, want omitted identity error", err)
+	}
+	if reported.Disposition != DispatchDispositionOutcomeUnknown {
+		t.Fatalf("disposition = %q, want outcome_unknown", reported.Disposition)
+	}
+	if reported.AcceptanceDiagnostics == nil {
+		t.Fatal("acceptance diagnostics are nil")
+	}
+	diagnostics := reported.AcceptanceDiagnostics
+	if diagnostics.Status != string(DispatchDispositionOutcomeUnknown) ||
+		diagnostics.ProviderSessionIDPresent != true ||
+		diagnostics.ProviderTurnIDPresent != false ||
+		diagnostics.ProviderTurnIDSource != codexProviderTurnIDSourceTurnStartResponse ||
+		diagnostics.FailureReason != "missing_provider_turn_id" {
+		t.Fatalf("acceptance diagnostics = %#v", diagnostics)
+	}
+}

--- a/packages/agent/daemon/runtime/controller_acceptance_diagnostics_test.go
+++ b/packages/agent/daemon/runtime/controller_acceptance_diagnostics_test.go
@@ -1,0 +1,20 @@
+package agentruntime
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestProviderAcceptanceMissingIdentityHasStableErrorCode(t *testing.T) {
+	err := &AppError{
+		Code:    AppErrorProviderAcceptanceMissingIdentity,
+		Message: "provider turn was not durably accepted",
+		Cause:   errors.New("missing_provider_turn_id"),
+	}
+	if AppErrorCode(err) != AppErrorProviderAcceptanceMissingIdentity {
+		t.Fatalf("app error code = %q, want %q", AppErrorCode(err), AppErrorProviderAcceptanceMissingIdentity)
+	}
+	if err.Error() != "provider turn was not durably accepted" {
+		t.Fatalf("error message = %q", err.Error())
+	}
+}

--- a/packages/agent/daemon/runtime/controller_dispatch.go
+++ b/packages/agent/daemon/runtime/controller_dispatch.go
@@ -58,8 +58,9 @@ func (c *Controller) confirmProviderDispatchDurable(
 		strings.TrimSpace(receipt.ProviderSessionID) !=
 			strings.TrimSpace(session.ProviderSessionID) {
 		return ProviderDispatchResult{
-			Disposition: DispatchDispositionOutcomeUnknown,
-			Acceptance:  &receipt,
+			Disposition:           DispatchDispositionOutcomeUnknown,
+			Acceptance:            &receipt,
+			AcceptanceDiagnostics: dispatch.AcceptanceDiagnostics,
 		}, errors.New("provider dispatch returned an invalid acceptance receipt")
 	}
 	eventContext, ok := activityEventContext(
@@ -97,15 +98,32 @@ func (c *Controller) confirmProviderDispatchDurable(
 	reported, err := c.reportProviderAcceptanceDurable(ctx, session, []activityshared.Event{accepted})
 	if err != nil {
 		return ProviderDispatchResult{
-			Disposition: DispatchDispositionOutcomeUnknown,
-			Acceptance:  &receipt,
+			Disposition:           DispatchDispositionOutcomeUnknown,
+			Acceptance:            &receipt,
+			AcceptanceDiagnostics: providerAcceptanceDurabilityFailureDiagnostics(dispatch.AcceptanceDiagnostics),
 		}, err
 	}
 	if !reported {
 		return ProviderDispatchResult{
-			Disposition: DispatchDispositionOutcomeUnknown,
-			Acceptance:  &receipt,
+			Disposition:           DispatchDispositionOutcomeUnknown,
+			Acceptance:            &receipt,
+			AcceptanceDiagnostics: providerAcceptanceDurabilityFailureDiagnostics(dispatch.AcceptanceDiagnostics),
 		}, errors.New("durable provider acceptance reporter is unavailable")
 	}
 	return dispatch, nil
+}
+
+func providerAcceptanceDurabilityFailureDiagnostics(
+	diagnostics *ProviderAcceptanceDiagnostics,
+) *ProviderAcceptanceDiagnostics {
+	if diagnostics == nil {
+		return &ProviderAcceptanceDiagnostics{
+			Status:        "durable_acceptance_failed",
+			FailureReason: "durable_provider_acceptance_failed",
+		}
+	}
+	copy := *diagnostics
+	copy.Status = "durable_acceptance_failed"
+	copy.FailureReason = "durable_provider_acceptance_failed"
+	return &copy
 }

--- a/packages/agent/daemon/runtime/controller_exec.go
+++ b/packages/agent/daemon/runtime/controller_exec.go
@@ -204,8 +204,9 @@ func (c *Controller) Exec(ctx context.Context, input ExecInput) (result ExecResu
 	} else if acceptanceAdapter != nil {
 		acceptProviderTurn := func(receipt ProviderAcceptanceReceipt) error {
 			dispatch := ProviderDispatchResult{
-				Disposition: DispatchDispositionApplied,
-				Acceptance:  &receipt,
+				Disposition:           DispatchDispositionApplied,
+				Acceptance:            &receipt,
+				AcceptanceDiagnostics: codexProviderAcceptanceDiagnostics(receipt.ProviderSessionID, receipt.ProviderTurnID, ""),
 			}
 			confirmed, confirmErr := c.confirmProviderDispatchDurable(
 				// Provider acceptance persistence must finish even when the
@@ -291,7 +292,10 @@ func (c *Controller) Exec(ctx context.Context, input ExecInput) (result ExecResu
 				// pre-acceptance interrupt races where adapter cancel settles
 				// before runCtx is canceled, caller disconnect) must not become
 				// delivery-unknown — that locks the Session for the next submit.
+				// An explicit acceptance diagnostic is different: it identifies a
+				// deterministic provider-boundary failure and must remain visible.
 				if dispatch.Acceptance == nil &&
+					dispatch.AcceptanceDiagnostics == nil &&
 					dispatch.Disposition != DispatchDispositionRejected &&
 					dispatch.Disposition != DispatchDispositionNotDispatched {
 					result.ProviderDispatch = &ProviderDispatchResult{
@@ -301,6 +305,14 @@ func (c *Controller) Exec(ctx context.Context, input ExecInput) (result ExecResu
 				}
 				if dispatch.Failure != nil {
 					return result, dispatch.Failure
+				}
+				if diagnostics := dispatch.AcceptanceDiagnostics; diagnostics != nil &&
+					strings.TrimSpace(diagnostics.FailureReason) != "" {
+					return result, &AppError{
+						Code:    AppErrorProviderAcceptanceMissingIdentity,
+						Message: "provider turn was not durably accepted",
+						Cause:   errors.New(diagnostics.FailureReason),
+					}
 				}
 				return result, errors.New("provider turn was not durably accepted")
 			}

--- a/packages/agent/daemon/runtime/errors.go
+++ b/packages/agent/daemon/runtime/errors.go
@@ -3,9 +3,10 @@ package agentruntime
 import "errors"
 
 const (
-	AppErrorProviderSessionNotFound = "agent.provider_session_not_found"
-	AppErrorProcessCleanupPending   = "agent.process_cleanup_pending"
-	AppErrorResumeSessionNotLocal   = "agent.resume_session_not_local"
+	AppErrorProviderSessionNotFound           = "agent.provider_session_not_found"
+	AppErrorProviderAcceptanceMissingIdentity = "provider_acceptance_missing_identity"
+	AppErrorProcessCleanupPending             = "agent.process_cleanup_pending"
+	AppErrorResumeSessionNotLocal             = "agent.resume_session_not_local"
 )
 
 var (

--- a/packages/agent/daemon/runtime/types.go
+++ b/packages/agent/daemon/runtime/types.go
@@ -562,9 +562,21 @@ type ProviderAcceptanceReceipt struct {
 	ProviderInputUnit *activityshared.ProviderInputUnitContext `json:"-"`
 }
 
+// ProviderAcceptanceDiagnostics describes the identity evidence observed at
+// the provider acceptance boundary. It is telemetry metadata only and must not
+// be used as durable coordination state.
+type ProviderAcceptanceDiagnostics struct {
+	Status                   string `json:"status"`
+	ProviderSessionIDPresent bool   `json:"providerSessionIdPresent"`
+	ProviderTurnIDPresent    bool   `json:"providerTurnIdPresent"`
+	ProviderTurnIDSource     string `json:"providerTurnIdSource,omitempty"`
+	FailureReason            string `json:"failureReason,omitempty"`
+}
+
 type ProviderDispatchResult struct {
-	Disposition DispatchDisposition        `json:"disposition"`
-	Acceptance  *ProviderAcceptanceReceipt `json:"acceptance,omitempty"`
+	Disposition           DispatchDisposition            `json:"disposition"`
+	Acceptance            *ProviderAcceptanceReceipt     `json:"acceptance,omitempty"`
+	AcceptanceDiagnostics *ProviderAcceptanceDiagnostics `json:"acceptanceDiagnostics,omitempty"`
 	// Failure is a process-local provider observation. It is carried only to
 	// the synchronous Controller caller and is never serialized or persisted as
 	// coordination state.

--- a/packages/agent/host/command_failure.go
+++ b/packages/agent/host/command_failure.go
@@ -20,17 +20,18 @@ const commandPreconditionStage = "precondition"
 type commandTerminalFailure struct {
 	flow string
 
-	mu             sync.Mutex
-	workspaceID    string
-	agentSessionID string
-	operationID    string
-	requestID      string
-	clientSubmitID string
-	turnID         string
-	provider       string
-	stage          string
-	startedAt      time.Time
-	emitted        bool
+	mu                            sync.Mutex
+	workspaceID                   string
+	agentSessionID                string
+	operationID                   string
+	requestID                     string
+	clientSubmitID                string
+	turnID                        string
+	provider                      string
+	providerAcceptanceDiagnostics *RuntimeProviderAcceptanceDiagnostics
+	stage                         string
+	startedAt                     time.Time
+	emitted                       bool
 }
 
 type commandTerminalFailureInput struct {
@@ -109,6 +110,20 @@ func markCommandTerminalFailureEmitted(ctx context.Context) {
 	command.mu.Unlock()
 }
 
+func recordProviderAcceptanceDiagnostics(
+	ctx context.Context,
+	dispatch RuntimeProviderDispatchResult,
+) {
+	command := commandTerminalFailureFrom(ctx)
+	if command == nil || dispatch.AcceptanceDiagnostics == nil {
+		return
+	}
+	diagnostics := *dispatch.AcceptanceDiagnostics
+	command.mu.Lock()
+	command.providerAcceptanceDiagnostics = &diagnostics
+	command.mu.Unlock()
+}
+
 // finish emits the single aggregated failure for a command that returned err.
 func (c *commandTerminalFailure) finish(ctx context.Context, h *Host, err error) {
 	if c == nil || err == nil {
@@ -117,14 +132,15 @@ func (c *commandTerminalFailure) finish(ctx context.Context, h *Host, err error)
 	c.mu.Lock()
 	emitted, stage := c.emitted, c.stage
 	failure := TerminalFailure{
-		Flow:           c.flow,
-		WorkspaceID:    c.workspaceID,
-		AgentSessionID: c.agentSessionID,
-		OperationID:    c.operationID,
-		RequestID:      c.requestID,
-		ClientSubmitID: c.clientSubmitID,
-		TurnID:         c.turnID,
-		Provider:       c.provider,
+		Flow:                          c.flow,
+		WorkspaceID:                   c.workspaceID,
+		AgentSessionID:                c.agentSessionID,
+		OperationID:                   c.operationID,
+		RequestID:                     c.requestID,
+		ClientSubmitID:                c.clientSubmitID,
+		TurnID:                        c.turnID,
+		Provider:                      c.provider,
+		ProviderAcceptanceDiagnostics: c.providerAcceptanceDiagnostics,
 	}
 	startedAt := c.startedAt
 	c.mu.Unlock()

--- a/packages/agent/host/lifecycle.go
+++ b/packages/agent/host/lifecycle.go
@@ -275,6 +275,7 @@ func (h *Host) createSession(ctx context.Context, workspaceID string, input Crea
 		Metadata: cloneMap(metadata), TuttiModeSnapshot: input.TuttiModeSnapshot,
 		RequireProviderAcceptance: true,
 	})
+	recordProviderAcceptanceDiagnostics(ctx, execResult.ProviderDispatch)
 	if err != nil {
 		h.observeStep(ctx, "session_create", "runtime_exec", workspaceID, session.ID, session.Provider, startedAt, err)
 		disposition := execResult.ProviderDispatch.Disposition
@@ -630,6 +631,7 @@ func (h *Host) sendInputSerialized(
 			RequireProviderAcceptance: !input.Guidance,
 		})
 	}()
+	recordProviderAcceptanceDiagnostics(ctx, execResult.ProviderDispatch)
 	if err != nil {
 		// Only an explicit target verdict is a guidance-target failure. Any
 		// other undispatched guidance is an ordinary runtime_exec failure that

--- a/packages/agent/host/ports.go
+++ b/packages/agent/host/ports.go
@@ -558,20 +558,21 @@ type LifecycleObserver interface {
 // settlement. It carries the failure stage and original error text so adapters
 // can report without depending on user-supplied logs.
 type TerminalFailure struct {
-	Flow            string
-	FailureStage    string
-	WorkspaceID     string
-	AgentSessionID  string
-	TurnID          string
-	OperationID     string
-	ClientSubmitID  string
-	RequestID       string
-	Provider        string
-	ErrorCode       string
-	ErrorMessage    string
-	ToolNameFamily  string
-	InteractionKind string
-	TurnOutcome     string
+	Flow                          string
+	FailureStage                  string
+	WorkspaceID                   string
+	AgentSessionID                string
+	TurnID                        string
+	OperationID                   string
+	ClientSubmitID                string
+	RequestID                     string
+	Provider                      string
+	ErrorCode                     string
+	ErrorMessage                  string
+	ProviderAcceptanceDiagnostics *RuntimeProviderAcceptanceDiagnostics
+	ToolNameFamily                string
+	InteractionKind               string
+	TurnOutcome                   string
 	// DurationMS is populated only when the canonical terminal fact carries a
 	// valid start and settlement timestamp. Zero means unavailable.
 	DurationMS int64

--- a/packages/agent/host/provider_acceptance_diagnostics.go
+++ b/packages/agent/host/provider_acceptance_diagnostics.go
@@ -1,0 +1,28 @@
+package agenthost
+
+// RuntimeProviderAcceptanceDiagnostics carries low-cardinality identity
+// evidence from the provider acceptance boundary to terminal telemetry.
+type RuntimeProviderAcceptanceDiagnostics struct {
+	Status                   string
+	ProviderSessionIDPresent bool
+	ProviderTurnIDPresent    bool
+	ProviderTurnIDSource     string
+	FailureReason            string
+}
+
+// RuntimeProviderAcceptanceReceipt is positive provider evidence that a
+// replacement turn crossed the provider delivery boundary.
+type RuntimeProviderAcceptanceReceipt struct {
+	ProviderSessionID string
+	ProviderTurnID    string
+	Source            RuntimeAcceptanceSource
+}
+
+// RuntimeProviderDispatchResult separates an explicit provider outcome from a
+// transport failure whose effect is unknown. Acceptance is present only when
+// the provider supplied positive evidence for the dispatched turn.
+type RuntimeProviderDispatchResult struct {
+	Disposition           RuntimeDispatchDisposition
+	Acceptance            *RuntimeProviderAcceptanceReceipt
+	AcceptanceDiagnostics *RuntimeProviderAcceptanceDiagnostics
+}

--- a/packages/agent/host/terminal_failure_test.go
+++ b/packages/agent/host/terminal_failure_test.go
@@ -68,6 +68,36 @@ func TestCommandBoundaryCarriesStableIdentityAndDuration(t *testing.T) {
 	}
 }
 
+func TestCommandBoundaryCarriesProviderAcceptanceDiagnostics(t *testing.T) {
+	observer := &recordingTerminalFailureObserver{}
+	host := New(Config{TerminalFailureObserver: observer})
+	ctx, command := host.beginCommand(context.Background(), commandTerminalFailureInput{
+		flow: "message_send", workspaceID: "workspace-1", agentSessionID: "session-1",
+	})
+	recordProviderAcceptanceDiagnostics(ctx, RuntimeProviderDispatchResult{
+		Disposition: RuntimeDispatchDispositionOutcomeUnknown,
+		AcceptanceDiagnostics: &RuntimeProviderAcceptanceDiagnostics{
+			Status:                   "outcome_unknown",
+			ProviderSessionIDPresent: true,
+			ProviderTurnIDPresent:    false,
+			ProviderTurnIDSource:     "turn_start_response",
+			FailureReason:            "missing_provider_turn_id",
+		},
+	})
+	command.finish(ctx, host, ErrSubmitDeliveryUnknown)
+
+	if len(observer.failures) != 1 {
+		t.Fatalf("terminal failures = %#v, want 1", observer.failures)
+	}
+	got := observer.failures[0].ProviderAcceptanceDiagnostics
+	if got == nil || got.Status != "outcome_unknown" ||
+		!got.ProviderSessionIDPresent || got.ProviderTurnIDPresent ||
+		got.ProviderTurnIDSource != "turn_start_response" ||
+		got.FailureReason != "missing_provider_turn_id" {
+		t.Fatalf("provider acceptance diagnostics = %#v", got)
+	}
+}
+
 func TestCommandBoundaryEmitsOneFailureForTheFirstFailedStep(t *testing.T) {
 	observer := &recordingTerminalFailureObserver{}
 	host := New(Config{TerminalFailureObserver: observer})

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -450,22 +450,6 @@ const (
 	RuntimeAcceptanceSourceHistoryRead       RuntimeAcceptanceSource = "history_read"
 )
 
-// RuntimeProviderAcceptanceReceipt is positive provider evidence that a
-// replacement turn crossed the provider delivery boundary.
-type RuntimeProviderAcceptanceReceipt struct {
-	ProviderSessionID string
-	ProviderTurnID    string
-	Source            RuntimeAcceptanceSource
-}
-
-// RuntimeProviderDispatchResult separates an explicit provider outcome from a
-// transport failure whose effect is unknown. Acceptance is present only when
-// the provider supplied positive evidence for the dispatched turn.
-type RuntimeProviderDispatchResult struct {
-	Disposition RuntimeDispatchDisposition
-	Acceptance  *RuntimeProviderAcceptanceReceipt
-}
-
 type RuntimeHistoryTurn struct {
 	ID                  string
 	Status              string

--- a/services/tuttid/agent_runtime_adapter.go
+++ b/services/tuttid/agent_runtime_adapter.go
@@ -271,6 +271,15 @@ func serviceProviderDispatchFromRuntime(
 	projected := agenthost.RuntimeProviderDispatchResult{
 		Disposition: agenthost.RuntimeDispatchDisposition(dispatch.Disposition),
 	}
+	if diagnostics := dispatch.AcceptanceDiagnostics; diagnostics != nil {
+		projected.AcceptanceDiagnostics = &agenthost.RuntimeProviderAcceptanceDiagnostics{
+			Status:                   diagnostics.Status,
+			ProviderSessionIDPresent: diagnostics.ProviderSessionIDPresent,
+			ProviderTurnIDPresent:    diagnostics.ProviderTurnIDPresent,
+			ProviderTurnIDSource:     diagnostics.ProviderTurnIDSource,
+			FailureReason:            diagnostics.FailureReason,
+		}
+	}
 	if dispatch.Acceptance != nil {
 		projected.Acceptance = &agenthost.RuntimeProviderAcceptanceReceipt{
 			ProviderSessionID: dispatch.Acceptance.ProviderSessionID,


### PR DESCRIPTION
## Summary
- Expose provider acceptance status and provider identity presence in terminal failure telemetry.
- Classify missing provider session/turn identity and assign a stable error code.
- Preserve the existing error message and add regression coverage.

## Why
The existing provider acceptance failure only reported `provider turn was not durably accepted`, which could not distinguish missing provider identity from other acceptance outcomes.

## Tests
- `pnpm check:changed -- --push-ready`
- `go test ./packages/agent/daemon/runtime ./packages/agent/host ./services/tuttid`

## Notes
- TSH consumer changes are prepared separately and depend on this Tutti package being released.