### PR TITLE
fix(agent-gui): retry transient conversation rail reads

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1514,6 +1514,17 @@ non-blocking error through the host toast capability, falling back to the UI
 System toast when that optional capability is absent. An unresolved empty Rail
 scope retains the centered error state and its retry action.
 
+AgentGUI owns one bounded retry for first-page and targeted membership reads so
+every host receives the same recovery behavior across daemon restarts, transient
+upstream failures, and transport loss. A fast transient failure retries once
+after a short deterministic jitter while publication remains pending. A request
+that already reached its timeout publishes the retained or empty failure state,
+releases the interaction lock, and performs its one retry after a longer
+background delay. Cancellation and permanent authorization, parameter, or other
+non-retryable client failures never retry. Scope replacement and surface detach
+abort both the active read and any scheduled retry; hosts must propagate the
+controller-owned `AbortSignal` while retaining their own request timeout.
+
 Presentation-invisible Sessions remain canonical engine entities and stay
 available through exact Session selectors for trusted open, reconcile, and
 command flows. Plural consumer selectors exclude them before Rail and Message

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.retry.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.retry.spec.ts
@@ -1,0 +1,428 @@
+import {
+  normalizeAgentActivitySession,
+  type AgentActivitySession
+} from "@tutti-os/agent-activity-core";
+import { describe, expect, it, vi } from "vitest";
+import { createTestAgentSessionEngine } from "../../../shared/testing/createTestAgentSessionEngine";
+import type {
+  AgentGuiScheduledTask,
+  AgentGuiScheduler
+} from "../agentGuiScheduler";
+import { AgentGUIConversationRailQueryController } from "./AgentGUIConversationRailQueryController";
+import { AgentGUIConversationRailTargetedPageRefresher } from "./AgentGUIConversationRailTargetedPageRefresher";
+import {
+  CONVERSATION_RAIL_BACKGROUND_RETRY_DELAY_MIN_MS,
+  CONVERSATION_RAIL_BACKGROUND_RETRY_JITTER_MS,
+  CONVERSATION_RAIL_FOREGROUND_RETRY_DELAY_MIN_MS,
+  CONVERSATION_RAIL_FOREGROUND_RETRY_JITTER_MS
+} from "./agentGuiConversationRailRequestRetry";
+
+class ManualScheduler implements AgentGuiScheduler {
+  private readonly tasks: Array<{
+    canceled: boolean;
+    delayMs: number;
+    task(): void;
+  }> = [];
+
+  schedule(delayMs: number, task: () => void): AgentGuiScheduledTask {
+    const scheduled = { canceled: false, delayMs, task };
+    this.tasks.push(scheduled);
+    return {
+      cancel: () => {
+        scheduled.canceled = true;
+      }
+    };
+  }
+
+  get pendingDelayMs(): number | null {
+    return this.tasks.find((task) => !task.canceled)?.delayMs ?? null;
+  }
+
+  runNext(): void {
+    const index = this.tasks.findIndex((task) => !task.canceled);
+    if (index < 0) throw new Error("No scheduled retry");
+    const [scheduled] = this.tasks.splice(index, 1);
+    scheduled!.task();
+  }
+}
+
+describe("AgentGUIConversationRailQueryController retries", () => {
+  it("runs targeted refreshes when the runtime has no AbortSignal.any", async () => {
+    const descriptor = Object.getOwnPropertyDescriptor(AbortSignal, "any");
+    Object.defineProperty(AbortSignal, "any", {
+      configurable: true,
+      value: undefined
+    });
+    try {
+      const onResolved = vi.fn();
+      const refresher = new AgentGUIConversationRailTargetedPageRefresher({
+        onResolved,
+        pageSize: 5,
+        runtime: {
+          listSessionSectionPage: async (input) => ({
+            hasMore: false,
+            kind: "conversations",
+            sectionKey: input.sectionKey,
+            sessions: [],
+            totalCount: 0
+          })
+        },
+        scheduler: new ManualScheduler(),
+        workspaceId: "test-workspace"
+      });
+
+      refresher.refresh({
+        agentTargetId: "shared:one",
+        pageIds: ["conversations"]
+      });
+
+      await vi.waitFor(() => expect(onResolved).toHaveBeenCalledOnce());
+      refresher.cancel();
+    } finally {
+      if (descriptor) Object.defineProperty(AbortSignal, "any", descriptor);
+    }
+  });
+
+  it("retries a transient first-page failure before exposing an empty rail", async () => {
+    const engine = createTestAgentSessionEngine();
+    const scheduler = new ManualScheduler();
+    const session = createSession();
+    let attempts = 0;
+    const controller = new AgentGUIConversationRailQueryController({
+      engine,
+      getActiveConversationId: () => null,
+      runtime: {
+        listSessionSectionPage: async (input) => ({
+          hasMore: false,
+          kind: "conversations",
+          sectionKey: input.sectionKey,
+          sessions: [],
+          totalCount: 0
+        }),
+        listSessionSections: async (input) => {
+          attempts += 1;
+          if (attempts === 1) throw new TypeError("fetch failed");
+          return {
+            sections: [conversationSection(session)],
+            workspaceId: input.workspaceId
+          };
+        }
+      },
+      scheduler,
+      workspaceId: "test-workspace"
+    });
+    controller.configure({
+      conversationFilter: { kind: "all" },
+      userProjects: []
+    });
+    const detach = controller.attach();
+
+    await vi.waitFor(() => expect(scheduler.pendingDelayMs).not.toBeNull());
+    expect(controller.getSnapshot().runtimeRailFailed).toBe(false);
+    expect(controller.isInteractionLocked()).toBe(true);
+
+    scheduler.runNext();
+    await vi.waitFor(() =>
+      expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(false)
+    );
+    expect(attempts).toBe(2);
+    expect(controller.getSnapshot().runtimeRailFailed).toBe(false);
+    expect(
+      controller.getSnapshot().runtimeRailMemberships?.[0]?.sessionIds
+    ).toEqual([session.agentSessionId]);
+    expect(controller.isInteractionLocked()).toBe(false);
+
+    detach();
+    engine.dispose();
+  });
+
+  it("exposes a retryable empty rail while a timed-out first page retries in the background", async () => {
+    const engine = createTestAgentSessionEngine();
+    const scheduler = new ManualScheduler();
+    const session = createSession();
+    let attempts = 0;
+    const controller = new AgentGUIConversationRailQueryController({
+      engine,
+      getActiveConversationId: () => null,
+      runtime: {
+        listSessionSectionPage: async (input) => ({
+          hasMore: false,
+          kind: "conversations",
+          sectionKey: input.sectionKey,
+          sessions: [],
+          totalCount: 0
+        }),
+        listSessionSections: async (input) => {
+          attempts += 1;
+          if (attempts === 1) {
+            throw Object.assign(new Error("request timed out"), {
+              name: "TimeoutError"
+            });
+          }
+          return {
+            sections: [conversationSection(session)],
+            workspaceId: input.workspaceId
+          };
+        }
+      },
+      scheduler,
+      workspaceId: "test-workspace"
+    });
+    controller.configure({
+      conversationFilter: { kind: "all" },
+      userProjects: []
+    });
+    const detach = controller.attach();
+
+    await vi.waitFor(() =>
+      expect(controller.getSnapshot().runtimeRailFailed).toBe(true)
+    );
+    expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(false);
+    expect(controller.getSnapshot().runtimeRailMemberships).toEqual([]);
+    expect(controller.isInteractionLocked()).toBe(false);
+
+    scheduler.runNext();
+    await vi.waitFor(() =>
+      expect(controller.getSnapshot().runtimeRailFailed).toBe(false)
+    );
+    expect(attempts).toBe(2);
+    expect(
+      controller.getSnapshot().runtimeRailMemberships?.[0]?.sessionIds
+    ).toEqual([session.agentSessionId]);
+
+    detach();
+    engine.dispose();
+  });
+
+  it("retries a fast transient targeted refresh once before publishing failure", async () => {
+    const engine = createTestAgentSessionEngine();
+    const scheduler = new ManualScheduler();
+    const session = createSession();
+    let pinnedAttempts = 0;
+    let sectionAttempts = 0;
+    const controller = new AgentGUIConversationRailQueryController({
+      engine,
+      getActiveConversationId: () => session.agentSessionId,
+      runtime: {
+        listPinnedSessionsPage: vi.fn(async () => {
+          pinnedAttempts += 1;
+          if (pinnedAttempts === 1) {
+            throw Object.assign(new Error("upstream unavailable"), {
+              retryable: false,
+              status: 520
+            });
+          }
+          return {
+            hasMore: false,
+            sessions: [{ ...session, pinnedAtUnixMs: 10 }],
+            totalCount: 1
+          };
+        }),
+        listSessionSectionPage: vi.fn(async (input) => {
+          sectionAttempts += 1;
+          if (sectionAttempts === 1) {
+            await new Promise<never>((_resolve, reject) => {
+              input.signal?.addEventListener(
+                "abort",
+                () => reject(input.signal?.reason),
+                { once: true }
+              );
+            });
+          }
+          return {
+            hasMore: false,
+            kind: "conversations" as const,
+            sectionKey: input.sectionKey,
+            sessions: [],
+            totalCount: 0
+          };
+        }),
+        listSessionSections: async (input) => ({
+          sections: [conversationSection(session)],
+          workspaceId: input.workspaceId
+        })
+      },
+      scheduler,
+      workspaceId: "test-workspace"
+    });
+    controller.configure({
+      conversationFilter: { kind: "all" },
+      userProjects: []
+    });
+    const detach = controller.attach();
+    await vi.waitFor(() =>
+      expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(false)
+    );
+
+    engine.dispatch({
+      session: { ...session, pinnedAtUnixMs: 10, updatedAtUnixMs: 2 },
+      type: "session/upserted"
+    });
+
+    await vi.waitFor(() => expect(scheduler.pendingDelayMs).not.toBeNull());
+    expect(scheduler.pendingDelayMs).toBeGreaterThanOrEqual(
+      CONVERSATION_RAIL_FOREGROUND_RETRY_DELAY_MIN_MS
+    );
+    expect(scheduler.pendingDelayMs).toBeLessThanOrEqual(
+      CONVERSATION_RAIL_FOREGROUND_RETRY_DELAY_MIN_MS +
+        CONVERSATION_RAIL_FOREGROUND_RETRY_JITTER_MS
+    );
+    expect(controller.isInteractionLocked()).toBe(true);
+    expect(controller.getSnapshot().runtimeRailFailed).toBe(false);
+
+    scheduler.runNext();
+    await vi.waitFor(() => expect(pinnedAttempts).toBe(2));
+    expect(sectionAttempts).toBe(2);
+    expect(controller.getSnapshot().runtimeRailFailed).toBe(false);
+    expect(controller.isInteractionLocked()).toBe(false);
+    expect(
+      controller
+        .getSnapshot()
+        .runtimeRailMemberships?.find((section) => section.id === "pinned")
+        ?.sessionIds
+    ).toEqual([session.agentSessionId]);
+
+    detach();
+    engine.dispose();
+  });
+
+  it("unlocks retained rows while retrying a timed-out targeted refresh in the background", async () => {
+    const engine = createTestAgentSessionEngine();
+    const scheduler = new ManualScheduler();
+    const session = createSession();
+    let pinnedAttempts = 0;
+    const controller = new AgentGUIConversationRailQueryController({
+      engine,
+      getActiveConversationId: () => session.agentSessionId,
+      runtime: {
+        listPinnedSessionsPage: vi.fn(async () => {
+          pinnedAttempts += 1;
+          if (pinnedAttempts === 1) {
+            throw Object.assign(new Error("request timed out"), {
+              name: "TimeoutError"
+            });
+          }
+          return {
+            hasMore: false,
+            sessions: [{ ...session, pinnedAtUnixMs: 10 }],
+            totalCount: 1
+          };
+        }),
+        listSessionSectionPage: vi.fn(async (input) => ({
+          hasMore: false,
+          kind: "conversations" as const,
+          sectionKey: input.sectionKey,
+          sessions: [],
+          totalCount: 0
+        })),
+        listSessionSections: async (input) => ({
+          sections: [conversationSection(session)],
+          workspaceId: input.workspaceId
+        })
+      },
+      scheduler,
+      workspaceId: "test-workspace"
+    });
+    controller.configure({
+      conversationFilter: { kind: "all" },
+      userProjects: []
+    });
+    const detach = controller.attach();
+    await vi.waitFor(() =>
+      expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(false)
+    );
+
+    engine.dispatch({
+      session: { ...session, pinnedAtUnixMs: 10, updatedAtUnixMs: 2 },
+      type: "session/upserted"
+    });
+
+    await vi.waitFor(() =>
+      expect(controller.getSnapshot().runtimeRailFailed).toBe(true)
+    );
+    expect(controller.isInteractionLocked()).toBe(false);
+    expect(scheduler.pendingDelayMs).toBeGreaterThanOrEqual(
+      CONVERSATION_RAIL_BACKGROUND_RETRY_DELAY_MIN_MS
+    );
+    expect(scheduler.pendingDelayMs).toBeLessThanOrEqual(
+      CONVERSATION_RAIL_BACKGROUND_RETRY_DELAY_MIN_MS +
+        CONVERSATION_RAIL_BACKGROUND_RETRY_JITTER_MS
+    );
+    expect(
+      controller.getSnapshot().runtimeRailMemberships?.[0]?.sessionIds
+    ).toEqual([session.agentSessionId]);
+
+    scheduler.runNext();
+    await vi.waitFor(() =>
+      expect(controller.getSnapshot().runtimeRailFailed).toBe(false)
+    );
+    expect(pinnedAttempts).toBe(2);
+    expect(controller.isInteractionLocked()).toBe(false);
+
+    detach();
+    engine.dispose();
+  });
+
+  it("cancels a scheduled retry when its surface detaches", async () => {
+    const engine = createTestAgentSessionEngine();
+    const scheduler = new ManualScheduler();
+    let attempts = 0;
+    const controller = new AgentGUIConversationRailQueryController({
+      engine,
+      getActiveConversationId: () => null,
+      runtime: {
+        listSessionSectionPage: async (input) => ({
+          hasMore: false,
+          kind: "conversations",
+          sectionKey: input.sectionKey,
+          sessions: [],
+          totalCount: 0
+        }),
+        listSessionSections: async () => {
+          attempts += 1;
+          throw new TypeError("fetch failed");
+        }
+      },
+      scheduler,
+      workspaceId: "test-workspace"
+    });
+    controller.configure({
+      conversationFilter: { kind: "all" },
+      userProjects: []
+    });
+    const detach = controller.attach();
+
+    await vi.waitFor(() => expect(scheduler.pendingDelayMs).not.toBeNull());
+    detach();
+
+    expect(scheduler.pendingDelayMs).toBeNull();
+    expect(attempts).toBe(1);
+    engine.dispose();
+  });
+});
+
+function createSession(): AgentActivitySession {
+  return normalizeAgentActivitySession({
+    activeTurnId: null,
+    agentSessionId: "session-1",
+    agentTargetId: "shared:one",
+    cwd: "/workspace",
+    latestTurnInteractions: [],
+    pendingInteractions: [],
+    provider: "shared",
+    railSectionKey: "conversations",
+    title: "Session",
+    updatedAtUnixMs: 1,
+    workspaceId: "test-workspace"
+  });
+}
+
+function conversationSection(session: AgentActivitySession) {
+  return {
+    hasMore: false,
+    kind: "conversations" as const,
+    sectionKey: "conversations",
+    sessions: [session],
+    totalCount: 1
+  };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
@@ -624,6 +624,9 @@ describe("AgentGUIConversationRailQueryController", () => {
     await vi.waitFor(() =>
       expect(listSessionSections).toHaveBeenCalledTimes(1)
     );
+    await vi.waitFor(() =>
+      expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(false)
+    );
     detachFirst();
 
     const detachSecond = controller.attach();
@@ -716,7 +719,7 @@ describe("AgentGUIConversationRailQueryController", () => {
     engine.dispose();
   });
 
-  it("keeps the committed snapshot when targeted membership refresh fails", async () => {
+  it("keeps existing rows interactive when a targeted membership refresh is rejected", async () => {
     const engine = createTestAgentSessionEngine();
     const session = normalizeAgentActivitySession({
       activeTurnId: null,
@@ -732,10 +735,14 @@ describe("AgentGUIConversationRailQueryController", () => {
       workspaceId: "test-workspace"
     });
     const listPinnedSessionsPage = vi.fn(async () => {
-      throw new Error("pinned page failed");
+      throw Object.assign(new Error("pinned page rejected"), {
+        statusCode: 403
+      });
     });
     const listSessionSectionPage = vi.fn(async () => {
-      throw new Error("section page failed");
+      throw Object.assign(new Error("section page rejected"), {
+        statusCode: 403
+      });
     });
     const controller = new AgentGUIConversationRailQueryController({
       engine,
@@ -779,11 +786,13 @@ describe("AgentGUIConversationRailQueryController", () => {
     await vi.waitFor(() =>
       expect(controller.getSnapshot().runtimeRailFailed).toBe(true)
     );
-    expect(controller.isInteractionLocked()).toBe(true);
-    expect(presentation.getSnapshot()[0]?.pinnedAtUnixMs).toBeNull();
+    expect(controller.isInteractionLocked()).toBe(false);
+    expect(presentation.getSnapshot()[0]?.pinnedAtUnixMs).toBe(10);
     expect(
       controller.getSnapshot().runtimeRailMemberships?.[0]?.sessionIds
     ).toEqual(["session-1"]);
+    expect(listPinnedSessionsPage).toHaveBeenCalledTimes(1);
+    expect(listSessionSectionPage).toHaveBeenCalledTimes(1);
 
     presentation.dispose();
     detach();
@@ -885,7 +894,11 @@ describe("AgentGUIConversationRailQueryController", () => {
       NonNullable<ConversationRailQueryRuntime["listSessionSections"]>
     >(async (input) => {
       requestCount += 1;
-      if (requestCount === 2) throw new Error("transient failure");
+      if (requestCount === 2) {
+        throw Object.assign(new Error("request rejected"), {
+          statusCode: 403
+        });
+      }
       return {
         workspaceId: input.workspaceId,
         sections: [
@@ -1366,6 +1379,9 @@ describe("AgentGUIConversationRailQueryController", () => {
     const detach = controller.attach();
     await vi.waitFor(() =>
       expect(listSessionSections).toHaveBeenCalledTimes(1)
+    );
+    await vi.waitFor(() =>
+      expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(false)
     );
 
     controller.configure(scope("local:claude-code"));

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
@@ -45,6 +45,7 @@ import type {
 } from "./agentGuiConversationRailQueryTypes";
 import { resolveConversationRailQueryScope } from "./agentGuiConversationRailQueryTypes";
 import { AgentGUIConversationRailTargetedPageRefresher } from "./AgentGUIConversationRailTargetedPageRefresher";
+import { requestConversationRailWithRetry } from "./agentGuiConversationRailRequestRetry";
 import { AgentGUIConversationRailSearchController } from "./AgentGUIConversationRailSearchController";
 import {
   createAgentGUIConversationActivityController,
@@ -66,7 +67,8 @@ export class AgentGUIConversationRailQueryController {
   readonly getSnapshot = (): AgentGUIConversationRailQuerySnapshot =>
     this.snapshot;
   readonly isInteractionLocked = (): boolean =>
-    this.publicationBlocked() ||
+    this.sectionPublicationState === "pending" ||
+    this.searchController.publicationBlocked ||
     (this.queryState.pending &&
       this.queryState.resolvedScopeKey !== this.railSectionQueryKey &&
       !(this.searchController.searchQuery && this.snapshot.railSearch.enabled));
@@ -176,15 +178,14 @@ export class AgentGUIConversationRailQueryController {
           this.publishIfReady(undefined, true);
         },
         onFailed: () => {
-          this.queryFailed = true;
-          this.sectionPublicationState = "failed";
-          if (this.railSectionQueryKey) {
-            this.sessionSectionsQueryCache.invalidate(this.railSectionQueryKey);
-          }
-          this.publishFailure();
+          this.failTargetedPageRefresh();
+        },
+        onRetryScheduled: (mode) => {
+          if (mode === "background") this.failTargetedPageRefresh();
         },
         pageSize: this.sectionPageSize,
         runtime: this.runtime,
+        scheduler: this.scheduler,
         workspaceId: this.workspaceId
       });
     this.previousMembershipRecords =
@@ -481,11 +482,29 @@ export class AgentGUIConversationRailQueryController {
     this.firstPageAbortController?.abort();
     const abortController = new AbortController();
     this.firstPageAbortController = abortController;
-    const request = listSections({
+    const requestInput = {
       agentTargetId: agentTargetId || undefined,
       limitPerSection,
       signal: abortController.signal,
       workspaceId: this.workspaceId
+    };
+    const request = requestConversationRailWithRetry({
+      onRetryScheduled: ({ mode }) => {
+        if (
+          mode !== "background" ||
+          abortController.signal.aborted ||
+          requestSequence !== this.pagingRequestSequence ||
+          scopeKey !== this.railSectionQueryKey ||
+          !this.attached
+        ) {
+          return;
+        }
+        this.failFirstPageRefresh({ scopeKey, wasResolvedForScope });
+      },
+      request: () => listSections(requestInput),
+      retryKey: `${scopeKey}:first-pages`,
+      scheduler: this.scheduler,
+      signal: abortController.signal
     })
       .then((page) => {
         if (
@@ -505,7 +524,10 @@ export class AgentGUIConversationRailQueryController {
           cachedConversationRailQueryFromFirstPages(
             page,
             scopeKey,
-            queryStateForScope
+            this.queryState.resolvedScopeKey === scopeKey &&
+              this.queryState.sections !== null
+              ? this.queryState
+              : queryStateForScope
           )
         );
         const requestResolvedAt = this.diagnosticNow();
@@ -545,24 +567,7 @@ export class AgentGUIConversationRailQueryController {
           requestId: requestSequence,
           requestStartedAt
         });
-        this.queryState = wasResolvedForScope
-          ? {
-              ...this.queryState,
-              pending: false,
-              reconcilingSessionIds: []
-            }
-          : {
-              pending: false,
-              reconcilingSessionIds: [],
-              resolvedScopeKey: scopeKey,
-              sectionPageStates: new Map(),
-              sections: []
-            };
-        if (this.publicationBlocked()) {
-          this.sectionPublicationState = "failed";
-        } else {
-          this.publish(undefined, true);
-        }
+        this.failFirstPageRefresh({ scopeKey, wasResolvedForScope });
       })
       .finally(() => {
         if (this.firstPageAbortController === abortController) {
@@ -634,6 +639,49 @@ export class AgentGUIConversationRailQueryController {
     );
     if (snapshot === this.snapshot) return;
     this.commitSnapshot(snapshot);
+  }
+
+  private failTargetedPageRefresh(): void {
+    const alreadyPublished =
+      this.queryFailed && this.sectionPublicationState === "failed";
+    this.queryFailed = true;
+    this.sectionPublicationState = "failed";
+    if (this.railSectionQueryKey) {
+      this.sessionSectionsQueryCache.invalidate(this.railSectionQueryKey);
+    }
+    if (!alreadyPublished) this.publishFailure();
+  }
+
+  private failFirstPageRefresh(input: {
+    scopeKey: string;
+    wasResolvedForScope: boolean;
+  }): void {
+    const alreadyPublished =
+      this.queryFailed &&
+      !this.queryState.pending &&
+      this.queryState.resolvedScopeKey === input.scopeKey;
+    const publicationWasBlocked = this.publicationBlocked();
+    this.queryFailed = true;
+    this.queryState = input.wasResolvedForScope
+      ? {
+          ...this.queryState,
+          pending: false,
+          reconcilingSessionIds: []
+        }
+      : {
+          pending: false,
+          reconcilingSessionIds: [],
+          resolvedScopeKey: input.scopeKey,
+          sectionPageStates: new Map(),
+          sections: []
+        };
+    if (publicationWasBlocked) this.sectionPublicationState = "failed";
+    if (alreadyPublished) return;
+    if (publicationWasBlocked) {
+      this.publishFailure();
+    } else {
+      this.publish(undefined, true);
+    }
   }
 
   private publishFailure(): void {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailTargetedPageRefresher.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailTargetedPageRefresher.ts
@@ -1,5 +1,12 @@
 import type { AgentConversationRailRuntimePort } from "../../../agentConversationRailContracts";
+import type { AgentGuiScheduler } from "../agentGuiScheduler";
 import type { ConversationRailRefreshedPage } from "./agentGuiConversationRailQueryCache";
+import {
+  conversationRailRetryMode,
+  isConversationRailAbortError,
+  requestConversationRailWithRetry,
+  type ConversationRailRetryMode
+} from "./agentGuiConversationRailRequestRetry";
 
 type TargetedPageRuntime = Pick<
   AgentConversationRailRuntimePort,
@@ -15,8 +22,10 @@ export class AgentGUIConversationRailTargetedPageRefresher {
     private readonly input: {
       onFailed?(): void;
       onResolved(pages: readonly ConversationRailRefreshedPage[]): void;
+      onRetryScheduled?(mode: ConversationRailRetryMode): void;
       pageSize: number;
       runtime: TargetedPageRuntime;
+      scheduler: AgentGuiScheduler;
       workspaceId: string;
     }
   ) {}
@@ -30,50 +39,72 @@ export class AgentGUIConversationRailTargetedPageRefresher {
     this.abortController = abortController;
     const requestSequence = ++this.requestSequence;
     const pageIds = [...this.pendingPageIds];
-    const requests = pageIds.flatMap((id) => {
-      if (id === "pinned") {
-        const listPage = this.input.runtime.listPinnedSessionsPage;
+    const createRequests = (
+      signal: AbortSignal
+    ): Promise<ConversationRailRefreshedPage>[] =>
+      pageIds.flatMap((id) => {
+        if (id === "pinned") {
+          const listPage = this.input.runtime.listPinnedSessionsPage;
+          return listPage
+            ? [
+                listPage({
+                  agentTargetId: input.agentTargetId || undefined,
+                  limit: this.input.pageSize,
+                  signal,
+                  workspaceId: this.input.workspaceId
+                }).then(
+                  (page): ConversationRailRefreshedPage => ({
+                    kind: "pinned",
+                    page
+                  })
+                )
+              ]
+            : [];
+        }
+        const listPage = this.input.runtime.listSessionSectionPage;
         return listPage
           ? [
               listPage({
                 agentTargetId: input.agentTargetId || undefined,
                 limit: this.input.pageSize,
-                signal: abortController.signal,
+                sectionKey: id,
+                signal,
                 workspaceId: this.input.workspaceId
               }).then(
                 (page): ConversationRailRefreshedPage => ({
-                  kind: "pinned",
+                  id,
+                  kind: "section",
                   page
                 })
               )
             ]
           : [];
-      }
-      const listPage = this.input.runtime.listSessionSectionPage;
-      return listPage
-        ? [
-            listPage({
-              agentTargetId: input.agentTargetId || undefined,
-              limit: this.input.pageSize,
-              sectionKey: id,
-              signal: abortController.signal,
-              workspaceId: this.input.workspaceId
-            }).then(
-              (page): ConversationRailRefreshedPage => ({
-                id,
-                kind: "section",
-                page
-              })
-            )
-          ]
-        : [];
-    });
-    if (requests.length !== pageIds.length) {
+      });
+    const hasAllPageReaders = pageIds.every((id) =>
+      id === "pinned"
+        ? Boolean(this.input.runtime.listPinnedSessionsPage)
+        : Boolean(this.input.runtime.listSessionSectionPage)
+    );
+    if (!hasAllPageReaders) {
       for (const id of pageIds) this.pendingPageIds.delete(id);
       this.input.onFailed?.();
       return;
     }
-    void Promise.all(requests)
+    void requestConversationRailWithRetry({
+      onRetryScheduled: ({ mode }) => this.input.onRetryScheduled?.(mode),
+      request: () =>
+        requestTargetedPages({
+          createRequests,
+          signal: abortController.signal
+        }),
+      retryKey: JSON.stringify([
+        this.input.workspaceId,
+        input.agentTargetId,
+        pageIds
+      ]),
+      scheduler: this.input.scheduler,
+      signal: abortController.signal
+    })
       .then((pages) => {
         if (
           abortController.signal.aborted ||
@@ -102,4 +133,54 @@ export class AgentGUIConversationRailTargetedPageRefresher {
     this.abortController = null;
     this.pendingPageIds.clear();
   }
+}
+
+async function requestTargetedPages(input: {
+  createRequests(signal: AbortSignal): Promise<ConversationRailRefreshedPage>[];
+  signal: AbortSignal;
+}): Promise<ConversationRailRefreshedPage[]> {
+  const attemptAbortController = new AbortController();
+  const abortFromParent = (): void => {
+    attemptAbortController.abort(input.signal.reason);
+  };
+  input.signal.addEventListener("abort", abortFromParent, { once: true });
+  if (input.signal.aborted) abortFromParent();
+  const failures: unknown[] = [];
+  try {
+    const requests = input
+      .createRequests(attemptAbortController.signal)
+      .map((request) =>
+        request.catch((error: unknown) => {
+          failures.push(error);
+          attemptAbortController.abort(error);
+          throw error;
+        })
+      );
+    try {
+      return await Promise.all(requests);
+    } catch (error) {
+      attemptAbortController.abort(error);
+      await Promise.resolve();
+      throw preferredTargetedPageFailure(failures, error);
+    }
+  } finally {
+    input.signal.removeEventListener("abort", abortFromParent);
+  }
+}
+
+function preferredTargetedPageFailure(
+  failures: readonly unknown[],
+  fallback: unknown
+): unknown {
+  const eligible = failures.filter(
+    (error) => !isConversationRailAbortError(error)
+  );
+  return (
+    eligible.find((error) => conversationRailRetryMode(error) === null) ??
+    eligible.find(
+      (error) => conversationRailRetryMode(error) === "background"
+    ) ??
+    eligible[0] ??
+    fallback
+  );
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailRequestRetry.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailRequestRetry.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { conversationRailRetryMode } from "./agentGuiConversationRailRequestRetry";
+
+describe("conversationRailRetryMode", () => {
+  it("retries transient upstream failures even when an adapter defaulted retryable to false", () => {
+    expect(
+      conversationRailRetryMode(
+        Object.assign(new Error("upstream unavailable"), {
+          retryable: false,
+          status: 520
+        })
+      )
+    ).toBe("foreground");
+  });
+
+  it("does not retry authorization, parameter, or cancellation failures", () => {
+    expect(conversationRailRetryMode({ status: 400 })).toBeNull();
+    expect(conversationRailRetryMode({ statusCode: 403 })).toBeNull();
+    expect(
+      conversationRailRetryMode({
+        code: "common.invalid_input",
+        name: "TshAppError"
+      })
+    ).toBeNull();
+    expect(
+      conversationRailRetryMode({ code: "control_surface.unauthorized" })
+    ).toBeNull();
+    expect(conversationRailRetryMode({ name: "AbortError" })).toBeNull();
+    expect(conversationRailRetryMode(new Error("mapper failed"))).toBeNull();
+  });
+
+  it("retries only errors with explicit transport or retryable evidence", () => {
+    expect(conversationRailRetryMode(new TypeError("fetch failed"))).toBe(
+      "foreground"
+    );
+    expect(conversationRailRetryMode({ retryable: true })).toBe("foreground");
+  });
+
+  it("defers a second request after the first request timed out", () => {
+    expect(conversationRailRetryMode({ name: "TimeoutError" })).toBe(
+      "background"
+    );
+    expect(conversationRailRetryMode({ status: 504 })).toBe("background");
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailRequestRetry.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailRequestRetry.ts
@@ -1,0 +1,238 @@
+import type {
+  AgentGuiScheduledTask,
+  AgentGuiScheduler
+} from "../agentGuiScheduler";
+
+export const CONVERSATION_RAIL_FOREGROUND_RETRY_DELAY_MIN_MS = 150;
+export const CONVERSATION_RAIL_FOREGROUND_RETRY_JITTER_MS = 150;
+export const CONVERSATION_RAIL_BACKGROUND_RETRY_DELAY_MIN_MS = 1_500;
+export const CONVERSATION_RAIL_BACKGROUND_RETRY_JITTER_MS = 1_000;
+
+export type ConversationRailRetryMode = "background" | "foreground";
+
+export async function requestConversationRailWithRetry<T>(input: {
+  onRetryScheduled?(retry: {
+    delayMs: number;
+    error: unknown;
+    mode: ConversationRailRetryMode;
+  }): void;
+  request(): Promise<T>;
+  retryKey: string;
+  scheduler: AgentGuiScheduler;
+  signal: AbortSignal;
+}): Promise<T> {
+  try {
+    return await input.request();
+  } catch (error) {
+    if (input.signal.aborted) throw error;
+    const mode = conversationRailRetryMode(error);
+    if (!mode) throw error;
+    const delayMs = conversationRailRetryDelayMs(mode, input.retryKey);
+    input.onRetryScheduled?.({ delayMs, error, mode });
+    await waitForConversationRailRetry({
+      delayMs,
+      scheduler: input.scheduler,
+      signal: input.signal
+    });
+    return input.request();
+  }
+}
+
+export function conversationRailRetryMode(
+  error: unknown
+): ConversationRailRetryMode | null {
+  const chain = errorChain(error);
+  if (chain.some(isAbortErrorRecord)) return null;
+
+  const statusCode = firstFiniteNumber(chain, "statusCode", "status");
+  const errorCode = firstString(chain, "code").toLowerCase();
+  if (
+    statusCode === 408 ||
+    statusCode === 504 ||
+    statusCode === 522 ||
+    statusCode === 524 ||
+    chain.some(isTimeoutErrorRecord)
+  ) {
+    return "background";
+  }
+  if (
+    statusCode !== null &&
+    statusCode >= 400 &&
+    statusCode < 500 &&
+    statusCode !== 425 &&
+    statusCode !== 429
+  ) {
+    return null;
+  }
+  if (isPermanentErrorCode(errorCode)) return null;
+  if (
+    statusCode === 425 ||
+    statusCode === 429 ||
+    (statusCode !== null && statusCode >= 500)
+  ) {
+    return "foreground";
+  }
+  if (chain.some((record) => record.retryable === false)) return null;
+  if (chain.some((record) => record.retryable === true)) return "foreground";
+  if (chain.some(isTransportErrorRecord)) return "foreground";
+  return null;
+}
+
+export function isConversationRailAbortError(error: unknown): boolean {
+  return errorChain(error).some(isAbortErrorRecord);
+}
+
+function conversationRailRetryDelayMs(
+  mode: ConversationRailRetryMode,
+  retryKey: string
+): number {
+  const hash = stableHash(retryKey);
+  if (mode === "background") {
+    return (
+      CONVERSATION_RAIL_BACKGROUND_RETRY_DELAY_MIN_MS +
+      (hash % (CONVERSATION_RAIL_BACKGROUND_RETRY_JITTER_MS + 1))
+    );
+  }
+  return (
+    CONVERSATION_RAIL_FOREGROUND_RETRY_DELAY_MIN_MS +
+    (hash % (CONVERSATION_RAIL_FOREGROUND_RETRY_JITTER_MS + 1))
+  );
+}
+
+function waitForConversationRailRetry(input: {
+  delayMs: number;
+  scheduler: AgentGuiScheduler;
+  signal: AbortSignal;
+}): Promise<void> {
+  if (input.signal.aborted) return Promise.reject(abortReason(input.signal));
+  return new Promise<void>((resolve, reject) => {
+    let scheduledTask: AgentGuiScheduledTask | null = null;
+    const removeAbortListener = (): void => {
+      input.signal.removeEventListener("abort", onAbort);
+    };
+    const onAbort = (): void => {
+      scheduledTask?.cancel();
+      scheduledTask = null;
+      removeAbortListener();
+      reject(abortReason(input.signal));
+    };
+    input.signal.addEventListener("abort", onAbort, { once: true });
+    scheduledTask = input.scheduler.schedule(input.delayMs, () => {
+      scheduledTask = null;
+      removeAbortListener();
+      resolve();
+    });
+    if (input.signal.aborted) onAbort();
+  });
+}
+
+function errorChain(error: unknown): Record<string, unknown>[] {
+  const chain: Record<string, unknown>[] = [];
+  let current = asRecord(error);
+  for (let depth = 0; current && depth < 4; depth += 1) {
+    chain.push(current);
+    current = asRecord(current.cause);
+  }
+  return chain;
+}
+
+function isAbortErrorRecord(record: Record<string, unknown>): boolean {
+  const name = stringValue(record.name);
+  const code = stringValue(record.code).toUpperCase();
+  return (
+    name === "AbortError" ||
+    code === "ABORT_ERR" ||
+    code === "ERR_ABORTED" ||
+    code === "ERR_CANCELED"
+  );
+}
+
+function isTimeoutErrorRecord(record: Record<string, unknown>): boolean {
+  const name = stringValue(record.name);
+  const code = stringValue(record.code).toUpperCase();
+  return (
+    name === "TimeoutError" || code === "ETIMEDOUT" || code.includes("TIMEOUT")
+  );
+}
+
+function isTransportErrorRecord(record: Record<string, unknown>): boolean {
+  const name = stringValue(record.name);
+  const code = stringValue(record.code).toUpperCase();
+  return (
+    name === "TypeError" ||
+    [
+      "ABORT_ERR_SOCKET",
+      "ECONNREFUSED",
+      "ECONNRESET",
+      "EHOSTUNREACH",
+      "ENETDOWN",
+      "ENETUNREACH",
+      "EPIPE",
+      "ERR_NETWORK",
+      "FETCH_ERROR",
+      "UND_ERR_CONNECT_TIMEOUT",
+      "UND_ERR_SOCKET"
+    ].includes(code)
+  );
+}
+
+function firstFiniteNumber(
+  records: readonly Record<string, unknown>[],
+  ...keys: readonly string[]
+): number | null {
+  for (const record of records) {
+    for (const key of keys) {
+      const value = record[key];
+      if (typeof value === "number" && Number.isFinite(value)) return value;
+    }
+  }
+  return null;
+}
+
+function firstString(
+  records: readonly Record<string, unknown>[],
+  key: string
+): string {
+  for (const record of records) {
+    const value = record[key];
+    if (typeof value === "string") return value;
+  }
+  return "";
+}
+
+function isPermanentErrorCode(code: string): boolean {
+  return [
+    "unauthorized",
+    "unauthenticated",
+    "forbidden",
+    "permission_denied",
+    "invalid_argument",
+    "invalid_input",
+    "bad_request",
+    "not_found",
+    "unsupported"
+  ].some((token) => code.includes(token));
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException("Aborted", "AbortError");
+}
+
+function stableHash(value: string): number {
+  let hash = 2_166_136_261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16_777_619);
+  }
+  return hash >>> 0;
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.search.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.search.spec.tsx
@@ -845,7 +845,9 @@ describe("useAgentGUIConversationRailQuery search", () => {
     expect(workspaceSection).toBeTruthy();
     const workspaceHeader = workspaceSection?.firstElementChild;
     expect(workspaceHeader).toBeTruthy();
-    expect((workspaceHeader as HTMLElement).draggable).toBe(true);
+    await waitFor(() =>
+      expect((workspaceHeader as HTMLElement).draggable).toBe(true)
+    );
     expect(screen.queryByText("Conversations")).toBeNull();
     expect(screen.queryByText("Conversation unavailable")).toBeNull();
   });
@@ -981,6 +983,8 @@ describe("useAgentGUIConversationRailQuery search", () => {
     expect(
       conversationsSection?.getAttribute("data-project-dragging")
     ).toBeNull();
+
+    await waitFor(() => expect(alphaHeader.draggable).toBe(true));
 
     const alphaToggle = alphaHeader.querySelector("button") as HTMLElement;
     const moreButton = screen.getAllByRole("button", {


### PR DESCRIPTION
## Summary
- add one bounded retry for transient first-page and targeted Conversation Rail membership reads
- retain and unlock existing rows after a timeout while the single retry continues in the background
- cancel sibling, detached, and stale-scope reads without relying on `AbortSignal.any`, preserving Native compatibility
- document AgentGUI retry and host cancellation ownership

## Tests
- `pnpm check:changed -- --push-ready`
- `pnpm test:ts -- --packages-json '["@tutti-os/agent-gui"]'`
- `pnpm release:pack:check -- --packages-json '["@tutti-os/agent-gui"]'`

## Notes
- Affects Desktop, Mobile, and external AgentGUI hosts that provide Conversation Rail membership readers.
- No public input or output shape changes.
- Closed-source hosts were not executed locally; the implementation uses only the existing basic `AbortController` / `AbortSignal` contract.
