### PR TITLE
fix(agent): speed up composer model discovery

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -1282,7 +1282,10 @@ test("desktop agent activity adapter normalizes provider composer options", asyn
     {
       agentTargetId: null,
       durationMs: "number",
+      modelCount: 2,
+      modelNames: "gpt-5.5,gpt-5.4",
       provider: "codex",
+      section: "full",
       status: "ready"
     }
   );

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -197,6 +197,7 @@ export function createDesktopAgentActivityAdapter({
       const startedAt = Date.now();
       const cwd = input.cwd?.trim();
       const agentTargetId = input.agentTargetId?.trim();
+      const section = input.section ?? "full";
       try {
         const result = await withAbortableRequestTimeout(
           (signal) =>
@@ -205,6 +206,10 @@ export function createDesktopAgentActivityAdapter({
               {
                 ...(agentTargetId ? { agentTargetId } : {}),
                 ...(cwd ? { cwd } : {}),
+                ...(section !== "full" ? { section } : {}),
+                ...(input.waitForFreshModelCatalog
+                  ? { waitForFreshModelCatalog: true }
+                  : {}),
                 workspaceId: input.workspaceId,
                 settings: tuttiAgentSessionComposerSettingsFromActivity(
                   input.settings
@@ -218,20 +223,25 @@ export function createDesktopAgentActivityAdapter({
             timeoutMs: composerOptionsRequestTimeoutMs
           }
         );
+        const options = agentActivityComposerOptionsFromTuttidResult(
+          input.provider,
+          result
+        );
+        const modelNames = desktopComposerModelNames(options.models);
         reportDesktopAgentComposerOptionsDiagnostic(
           runtimeApi,
           input.workspaceId,
           {
             agentTargetId: agentTargetId ?? null,
             durationMs: Date.now() - startedAt,
+            modelCount: options.models.length,
+            ...(modelNames ? { modelNames } : {}),
             provider: input.provider,
+            section,
             status: "ready"
           }
         );
-        return agentActivityComposerOptionsFromTuttidResult(
-          input.provider,
-          result
-        );
+        return options;
       } catch (error) {
         reportDesktopAgentComposerOptionsDiagnostic(
           runtimeApi,
@@ -240,6 +250,7 @@ export function createDesktopAgentActivityAdapter({
             agentTargetId: agentTargetId ?? null,
             durationMs: Date.now() - startedAt,
             provider: input.provider,
+            section,
             status: "error",
             ...normalizeDesktopAgentDiagnosticError(error)
           }
@@ -727,6 +738,31 @@ function reportDesktopAgentComposerOptionsDiagnostic(
   } catch {
     // Diagnostic logging must not affect composer option loading.
   }
+}
+
+function desktopComposerModelNames(
+  models: readonly { value: string }[]
+): string | undefined {
+  const names: string[] = [];
+  const seen = new Set<string>();
+  let totalLength = 0;
+  for (const model of models) {
+    let withoutControls = "";
+    for (const character of model.value) {
+      const code = character.charCodeAt(0);
+      if ((code >= 0 && code <= 0x1f) || (code >= 0x7f && code <= 0x9f)) {
+        continue;
+      }
+      withoutControls += character;
+    }
+    const name = withoutControls.replace(/\s+/g, " ").trim().slice(0, 120);
+    if (!name || seen.has(name)) continue;
+    if (names.length >= 32 || totalLength + name.length > 1_024) break;
+    names.push(name);
+    seen.add(name);
+    totalLength += name.length;
+  }
+  return names.length > 0 ? names.join(",") : undefined;
 }
 
 function normalizeDesktopAgentDiagnosticError(

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -888,7 +888,9 @@ export class WorkspaceAgentActivityService
     agentTargetId: string;
     cwd?: string | null;
     force?: boolean;
+    waitForFreshModelCatalog?: boolean;
     provider?: string;
+    section?: "full" | "core" | "capabilities";
     signal?: AbortSignal;
     settings?: Parameters<typeof normalizeComposerSettings>[0] | null;
     workspaceId: string;
@@ -899,7 +901,11 @@ export class WorkspaceAgentActivityService
     return entry.engine.loadComposerOptions({
       cwd: input.cwd,
       force: input.force,
+      waitForFreshModelCatalog: input.waitForFreshModelCatalog,
       provider,
+      ...(input.section && input.section !== "full"
+        ? { section: input.section }
+        : {}),
       settings: normalizeComposerSettings(input.settings),
       signal: input.signal,
       targetKey: input.agentTargetId

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentComposerOptionsInvalidationCoordinator.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentComposerOptionsInvalidationCoordinator.test.ts
@@ -48,8 +48,8 @@ test("connector Lab visibility changes invalidate cached Composer Options", () =
   publishVisibility(true);
 
   assert.deepEqual(dispatched, [
-    { type: "composerOptions/invalidated" },
-    { type: "composerOptions/invalidated" }
+    { sections: ["capabilities"], type: "composerOptions/invalidated" },
+    { sections: ["capabilities"], type: "composerOptions/invalidated" }
   ]);
   assert.deepEqual(catalogInvalidations, [{ revision: 1 }, { revision: 2 }]);
 });

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentComposerOptionsInvalidationCoordinator.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentComposerOptionsInvalidationCoordinator.ts
@@ -97,6 +97,7 @@ export class WorkspaceAgentComposerOptionsInvalidationCoordinator {
     for (const host of this.hosts()) {
       host.engine.dispatch({
         providers: event.providers,
+        sections: ["core"],
         type: "composerOptions/invalidated"
       });
     }
@@ -114,6 +115,7 @@ export class WorkspaceAgentComposerOptionsInvalidationCoordinator {
     if (!normalizedAgentTargetId) return;
     for (const host of this.hosts()) {
       host.engine.dispatch({
+        sections: ["core"],
         targetKeys: [normalizedAgentTargetId],
         type: "composerOptions/invalidated"
       });
@@ -147,7 +149,10 @@ export class WorkspaceAgentComposerOptionsInvalidationCoordinator {
     );
     this.connectorCatalogEventRevision = revision;
     for (const host of this.hosts()) {
-      host.engine.dispatch({ type: "composerOptions/invalidated" });
+      host.engine.dispatch({
+        sections: ["capabilities"],
+        type: "composerOptions/invalidated"
+      });
     }
     for (const listener of this.connectorCatalogListeners) {
       listener({

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.ts
@@ -286,6 +286,12 @@ export function createWorkspaceAgentSessionEngineHost(
               agentTargetId: command.targetKey,
               ...(command.cwd !== undefined ? { cwd: command.cwd } : {}),
               provider: command.provider,
+              ...(command.waitForFreshModelCatalog
+                ? { waitForFreshModelCatalog: true }
+                : {}),
+              ...(command.section !== undefined
+                ? { section: command.section }
+                : {}),
               ...(command.settings !== undefined
                 ? { settings: command.settings }
                 : {}),

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/workspaceAgentActivityService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/workspaceAgentActivityService.interface.ts
@@ -177,7 +177,9 @@ export interface IWorkspaceAgentActivityService {
     agentTargetId: string;
     cwd?: string | null;
     force?: boolean;
+    waitForFreshModelCatalog?: boolean;
     provider?: string;
+    section?: "full" | "core" | "capabilities";
     signal?: AbortSignal;
     settings?: AgentHostAgentSessionComposerSettings | null;
     workspaceId: string;

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -889,16 +889,27 @@ Core capability booleans must not be reconstructed from private
 `runtimeContext` fields or represented as plugin/tool entries in the composer
 capability catalog.
 The activity snapshot also exposes the composer-options request lifecycle per
-opaque target key. Consumers use `loading` only for the initial request when no
-cached options exist; background refreshes keep rendering the last successful
-catalog, and failures transition to `error` instead of leaving indefinite
-loading UI. Desktop and Mobile request options through the semantic
+opaque target key and per independent section. `core` contains model,
+reasoning, speed, permission, and effective-settings data; `capabilities`
+contains skills, commands, and capability-catalog data. Desktop requests
+`core` for the model/reasoning/speed consumer and requests `capabilities` only
+when a capability surface is opened or used; neither capability discovery nor
+its eight-second provider timeout blocks the model controls. `full` remains the
+compatibility request for callers that need the combined response. Consumers use
+`loading` only for the initial
+request when no cached options exist; background refreshes keep rendering the
+last successful catalog, and failures transition to `error` instead of leaving
+indefinite loading UI. Desktop and Mobile request options through the semantic
 `AgentSessionEngine.loadComposerOptions` method. It owns request identity,
-signature-aware cache reuse, identical in-flight joining, supersession, exact
-settlement, caller abort, and engine disposal. The host extension adapter owns
-only the transport call and DTO mapping; hosts must not reconstruct this
-protocol with raw `composerOptions/loadRequested` dispatch plus snapshot
-subscriptions.
+section-scoped signature-aware cache reuse, identical in-flight joining,
+supersession, exact settlement, caller abort, and engine disposal. The host
+extension adapter owns only the transport call and DTO mapping; hosts must not
+reconstruct this protocol with raw `composerOptions/loadRequested` dispatch
+plus snapshot subscriptions.
+The daemon also persists the last successful credential-bound model catalog.
+After restart it may serve that catalog as stale and refresh in the background;
+the explicit model-picker-open request sets `waitForFreshModelCatalog` and waits
+for the provider refresh before returning.
 Provider context-window and quota updates enter the daemon at the runtime
 adapter boundary, are split into typed durable session metadata, and reach
 Agent GUI through the protocol-v2 `usage` field. GUI projections must not read

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2477,8 +2477,10 @@ before calling either the runtime `getComposerOptions` or exposed Engine
 with exact duration. An unmatched start therefore remains observable when a
 Provider options request never settles. The facts distinguish runtime from
 session-Engine entry, force refresh, directory presence, bounded error
-category, and model count without carrying paths, settings, model names, or
-error messages.
+category, section/stage, and model count. Settled Composer events may include
+a bounded, deduplicated, control-character-cleaned allowlist of model
+identifiers; paths, settings, prompts, credentials, and error messages remain
+excluded.
 Hosts map those facts to their own analytics catalogs; they must not copy the
 Turn-binding, early-event buffering, duration-bucket, or token-classification
 logic.

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -231,6 +231,15 @@ preference. A model or dependent setting explicitly supplied by the caller
 remains strict. If the runtime rejects an explicit model selection, startup
 fails rather than continuing with an undisclosed provider default.
 
+Composer model catalogs are daemon-owned snapshots. A provider auth/config
+change invalidates the snapshot and closes its provider app-server session, but
+the daemon may return the last known list as stale while refreshing it in the
+background. AgentGUI may render that stale projection with its loading state;
+model validation must wait for an authoritative snapshot. The daemon shares
+concurrent catalog loads, reuses a warm app-server session, and publishes the
+existing catalog invalidation hint after a successful refresh so open composers
+can converge without owning provider or cache policy.
+
 Settings that affect provider preparation are immutable after launch. The
 daemon validates them against current product policy and resolved provider
 capability before runtime preparation; an active Session cannot reinterpret

--- a/docs/conventions/api-contracts.md
+++ b/docs/conventions/api-contracts.md
@@ -175,6 +175,12 @@ Rules:
 while response `effectiveSettings` is the only contract for resolved homepage
 composer defaults.
 
+The same endpoint accepts an optional `section`: `core` returns the model,
+reasoning, speed, permission, and effective-settings projection;
+`capabilities` returns skills, commands, and capability-catalog data; omitted
+or `full` preserves the combined response for compatibility. Sectioned
+responses are additive projections, not alternate sources of resolved settings.
+
 ## Desktop Agent Conversation Detail Mode
 
 `agentConversationDetailMode` is a global desktop preference, not a provider-specific

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -995,14 +995,23 @@ file or directory`. A failed `codex app-server` probe is diagnostic evidence,
   Start model-catalog loading before capability discovery so the two independent
   app-server exchanges overlap. Run every short-lived Codex app-server in its
   own process group, begin process reaping immediately, and make timeout cancel
-  the entire group. Keep the Desktop deadline unchanged so a genuinely stuck
-  daemon request still fails closed.
+  the entire group. The daemon then shares concurrent catalog loads, keeps one
+  initialized Codex app-server session warm per provider for up to two minutes,
+  and refreshes the five-minute catalog in the background after expiry or an
+  auth/config invalidation. Identical atomic rewrites of Codex auth/config do
+  not invalidate the catalog because the watcher compares file content. Keep
+  the Desktop deadline unchanged so a genuinely stuck daemon request still
+  fails closed.
 - Validation:
   Block both catalog fixtures and assert both start before either is released.
   Use a fake app-server whose child retains stdout and assert model and
-  capability timeouts return promptly with no surviving child. Finally, time a
-  cold Composer Options request and confirm it completes within the Desktop
-  deadline.
+  capability timeouts return promptly with no surviving child. Assert concurrent
+  cold catalog callers share one fetch, stale options remain visible while the
+  background refresh runs, and repeated requests reuse one app-server process.
+  Finally, time a cold Composer Options request and confirm it completes within
+  the Desktop deadline. Useful logs are
+  `agent.model_catalog.fetch_start`, `stage_settled`, `fetch_settled`,
+  `request_settled`, and `process_idle_close`.
 - References:
   [composer_options.go](../../../services/tuttid/service/agent/composer_options.go)
   [codex_appserver_process.go](../../../services/tuttid/service/agent/codex_appserver_process.go)

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -985,23 +985,27 @@ file or directory`. A failed `codex app-server` probe is diagnostic evidence,
   after the request, the canceled handler did not finish cleaning up its
   discovery subprocess.
 - Root cause:
-  Codex Composer Options needs both `model/list` and the app-server capability
-  catalog. Running those independent, individually bounded probes in series
-  can exceed the Desktop's aggregate request deadline. A second failure mode
-  occurs when timeout kills only the JavaScript launcher: its native child
-  inherits stdout, the response scanner never receives EOF, and deferred
-  `Wait` cannot run because it sits behind that scanner.
+  Codex Composer Options has two independent waits: `model/list` feeds the
+  model, reasoning, and speed controls, while app-server capability discovery
+  feeds skills and capability entries. A legacy combined response can still
+  wait for both, and repeated capability failures can otherwise start another
+  eight-second probe for every refresh.
 - Fix:
-  Start model-catalog loading before capability discovery so the two independent
-  app-server exchanges overlap. Run every short-lived Codex app-server in its
-  own process group, begin process reaping immediately, and make timeout cancel
-  the entire group. The daemon then shares concurrent catalog loads, keeps one
-  initialized Codex app-server session warm per provider for up to two minutes,
-  and refreshes the five-minute catalog in the background after expiry or an
-  auth/config invalidation. Identical atomic rewrites of Codex auth/config do
-  not invalidate the catalog because the watcher compares file content. Keep
-  the Desktop deadline unchanged so a genuinely stuck daemon request still
-  fails closed.
+  Desktop requests `section=core` for model controls. It requests
+  `section=capabilities` only when the user opens or uses a capability surface,
+  so the capability response and its eight-second provider timeout never block
+  the model controls. The legacy `section=full` response still starts both
+  catalogs concurrently. Capability loads use single-flight sharing plus a
+  short negative cache so identical callers do not stampede a broken app-server.
+  Run every short-lived Codex
+  app-server in its own process group, begin process reaping immediately, and
+  make timeout cancel the entire group. The daemon keeps one initialized Codex
+  app-server session warm per provider for up to two minutes, and refreshes the
+  five-minute model catalog in the background after expiry or an auth/config
+  invalidation. Identical atomic rewrites of Codex auth/config do not
+  invalidate the catalog because the watcher compares file content. Keep the
+  Desktop deadline unchanged so a genuinely stuck daemon request still fails
+  closed.
 - Validation:
   Block both catalog fixtures and assert both start before either is released.
   Use a fake app-server whose child retains stdout and assert model and
@@ -1011,7 +1015,12 @@ file or directory`. A failed `codex app-server` probe is diagnostic evidence,
   Finally, time a cold Composer Options request and confirm it completes within
   the Desktop deadline. Useful logs are
   `agent.model_catalog.fetch_start`, `stage_settled`, `fetch_settled`,
-  `request_settled`, and `process_idle_close`.
+  `request_settled`, `agent.composer_options.load`, and `process_idle_close`.
+  Composer telemetry reports section/stage, outcome, duration, and bounded
+  model identifiers without paths or settings. When an auth/config watcher
+  causes invalidation, `agent.model_catalog.invalidated` also includes the
+  exact changed file and change kind; use that field to distinguish Codex
+  auth/config churn from a provider-side fetch failure.
 - References:
   [composer_options.go](../../../services/tuttid/service/agent/composer_options.go)
   [codex_appserver_process.go](../../../services/tuttid/service/agent/codex_appserver_process.go)

--- a/packages/agent/activity-core/README.md
+++ b/packages/agent/activity-core/README.md
@@ -184,12 +184,15 @@ current snapshot reference and does not notify subscribers.
 
 ## Composer Options Cache
 
-`engine.loadComposerOptions({ targetKey, provider, ... })` caches results in a
-single key space, `composerOptionsByTargetKey`. After non-empty boundary
-normalization, `targetKey` is an **opaque** cache key: the engine never parses
-or derives meaning from it. Callers pass the already-resolved directory target
-id; two distinct targets that share a `provider` therefore keep isolated caches
-(no provider-dimension fallback).
+`engine.loadComposerOptions({ targetKey, provider, section, ... })` caches
+results in a single target key space with independent `core` and
+`capabilities` entries. `core` owns model, reasoning, speed, permission, and
+effective settings; `capabilities` owns skills, commands, and capability
+catalog data. After non-empty boundary normalization, `targetKey` is an
+**opaque** cache key: the engine never parses or derives meaning from it.
+Callers pass the already-resolved directory target id; two distinct targets
+that share a `provider` therefore keep isolated caches (no provider-dimension
+fallback).
 
 The semantic Engine method owns request identity, signature-aware cache reuse,
 joining an identical in-flight request, supersession by a newer request, exact

--- a/packages/agent/activity-core/src/composerOptions.types.ts
+++ b/packages/agent/activity-core/src/composerOptions.types.ts
@@ -163,6 +163,9 @@ export interface AgentActivityLoadComposerOptionsInput {
   agentTargetId?: string | null;
   workspaceId: string;
   provider: string;
+  section?: "full" | "core" | "capabilities";
+  /** Wait only when the user explicitly opens the model picker. */
+  waitForFreshModelCatalog?: boolean;
   cwd?: string | null;
   settings?: AgentActivityComposerSettings | null;
   signal?: AbortSignal;

--- a/packages/agent/activity-core/src/engine/composerOptions.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/composerOptions.reducer.test.ts
@@ -142,6 +142,19 @@ test("force reloads even when a ready cache exists", () => {
   assert.equal(result.state.entriesByTargetKey["target-1"]?.status, "loading");
 });
 
+test("force joins an identical in-flight request", () => {
+  const state = composerOptionsReducer(
+    createInitialComposerOptionsState(),
+    loadRequest()
+  ).state;
+  const result = composerOptionsReducer(state, {
+    ...loadRequest(true),
+    commandId: "cmd-2"
+  });
+  assert.equal(result.commands.length, 0);
+  assert.equal(result.state, state);
+});
+
 test("validated settings success refreshes provider-declared target options", () => {
   let state = composerOptionsReducer(
     createInitialComposerOptionsState(),
@@ -236,9 +249,11 @@ test("a superseded load result is ignored", () => {
     createInitialComposerOptionsState(),
     loadRequest()
   ).state;
-  // a newer forced request supersedes cmd-1
+  // A newer forced request with a different semantic signature supersedes
+  // cmd-1. An identical forced request is intentionally joined instead.
   state = composerOptionsReducer(state, {
     ...loadRequest(true),
+    cwd: "/workspace/new",
     commandId: "cmd-2"
   }).state;
   const result = composerOptionsReducer(state, {

--- a/packages/agent/activity-core/src/engine/composerOptions.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/composerOptions.reducer.test.ts
@@ -189,9 +189,10 @@ test("validated settings success refreshes provider-declared target options", ()
   assert.deepEqual(refreshed.commands, [
     {
       commandId: "composer-options:after-settings:settings-1",
-      correlationId: "target-1",
+      correlationId: "target-1::core",
       cwd: "/workspace",
       provider: "codex",
+      section: "core",
       settings: {
         model: "model-2",
         permissionModeId: "acceptEdits",

--- a/packages/agent/activity-core/src/engine/composerOptions.reducer.ts
+++ b/packages/agent/activity-core/src/engine/composerOptions.reducer.ts
@@ -5,15 +5,16 @@ import type {
 } from "../types.ts";
 import type { ScopedSessionResultValidation } from "./commandResult.validation.ts";
 import type {
+  ComposerOptionsEntry,
+  ComposerOptionsLoadRequestedIntent,
+  ComposerOptionsSection,
+  ComposerOptionsState
+} from "./composerOptions.types.ts";
+import type {
   EngineCommand,
   EngineIntent,
   EngineReducerResult
 } from "./types.ts";
-import type {
-  ComposerOptionsEntry,
-  ComposerOptionsLoadRequestedIntent,
-  ComposerOptionsState
-} from "./composerOptions.types.ts";
 import {
   areComposerOptionsEqual,
   cloneAgentActivityComposerOptions,
@@ -23,7 +24,12 @@ import {
 const NO_COMMANDS: readonly EngineCommand[] = [];
 
 export function createInitialComposerOptionsState(): ComposerOptionsState {
-  return { optionsByTargetKey: {}, entriesByTargetKey: {} };
+  return {
+    entriesByTargetKey: {},
+    optionsByTargetKey: {},
+    sectionEntriesByTargetKey: {},
+    sectionOptionsByTargetKey: {}
+  };
 }
 
 export function composerOptionsReducer(
@@ -37,7 +43,12 @@ export function composerOptionsReducer(
     case "composerOptions/loadRequested":
       return requestLoad(state, intent);
     case "composerOptions/invalidated":
-      return invalidate(state, intent.providers, intent.targetKeys);
+      return invalidate(
+        state,
+        intent.providers,
+        intent.targetKeys,
+        intent.sections
+      );
     case "engine/commandResult":
       if (intent.commandType === "composerOptions/load") {
         return settleLoad(state, intent);
@@ -74,6 +85,7 @@ function refreshAfterSettings(
     cwd: session.cwd,
     force: true,
     provider: session.provider,
+    section: "core",
     settings: composerSettingsFromSession(session),
     targetKey,
     type: "composerOptions/loadRequested",
@@ -109,12 +121,13 @@ function requestLoad(
   if (!targetKey || !provider || !workspaceId || !commandId) {
     return unchanged(state);
   }
+  const section = intent.section;
   const signature = composerOptionsRequestSignature({
     provider,
     cwd: intent.cwd,
     settings: intent.settings
   });
-  const current = state.entriesByTargetKey[targetKey];
+  const current = entryFor(state, targetKey, section);
   if (current) {
     const cacheHit =
       !intent.force &&
@@ -122,9 +135,7 @@ function requestLoad(
       current.settledSignature === signature;
     const inFlightDuplicate =
       current.status === "loading" && current.loadingSignature === signature;
-    if (cacheHit || inFlightDuplicate) {
-      return unchanged(state);
-    }
+    if (cacheHit || inFlightDuplicate) return unchanged(state);
   }
   const entry: ComposerOptionsEntry = {
     status: "loading",
@@ -139,15 +150,19 @@ function requestLoad(
       {
         type: "composerOptions/load",
         commandId,
-        correlationId: targetKey,
+        correlationId: correlationKey(targetKey, section),
         targetKey,
         provider,
         workspaceId,
         ...(intent.cwd !== undefined ? { cwd: intent.cwd } : {}),
+        ...(intent.waitForFreshModelCatalog
+          ? { waitForFreshModelCatalog: true }
+          : {}),
+        ...(intent.section !== undefined ? { section: intent.section } : {}),
         ...(intent.settings !== undefined ? { settings: intent.settings } : {})
       }
     ],
-    state: replaceEntry(state, targetKey, entry)
+    state: replaceEntry(state, targetKey, section, entry)
   };
 }
 
@@ -155,90 +170,229 @@ function settleLoad(
   state: ComposerOptionsState,
   intent: Extract<EngineIntent, { type: "engine/commandResult" }>
 ): EngineReducerResult<ComposerOptionsState> {
-  const targetKey = intent.correlationId?.trim() ?? "";
-  const current = state.entriesByTargetKey[targetKey];
-  // A superseded load carries a stale commandId; ignore it so a late result
-  // never clobbers a newer request. Invalidation deliberately keeps the active
-  // command attached so its caller still receives a terminal result.
+  const { section, targetKey } = parseCorrelationKey(
+    intent.correlationId?.trim() ?? ""
+  );
+  const current = entryFor(state, targetKey, section);
   if (!current || current.inFlightCommandId !== intent.commandId) {
     return unchanged(state);
   }
+  const settledEntry = (
+    status: ComposerOptionsEntry["status"]
+  ): ComposerOptionsEntry => ({
+    ...current,
+    status,
+    ...(status === "ready"
+      ? { settledSignature: current.loadingSignature }
+      : {}),
+    loadingSignature: null,
+    inFlightCommandId: null
+  });
   if (intent.outcome !== "succeeded") {
     return changed(
-      replaceEntry(state, targetKey, {
-        ...current,
-        status: "error",
-        loadingSignature: null,
-        inFlightCommandId: null
-      })
+      replaceEntry(state, targetKey, section, settledEntry("error"))
     );
   }
   const options = composerOptionsFromValue(intent.value);
   if (!options) {
     return changed(
-      replaceEntry(state, targetKey, {
-        ...current,
-        status: "error",
-        loadingSignature: null,
-        inFlightCommandId: null
-      })
+      replaceEntry(state, targetKey, section, settledEntry("error"))
     );
   }
-  const settledEntry: ComposerOptionsEntry = {
-    ...current,
-    status: "ready",
-    settledSignature: current.loadingSignature,
-    loadingSignature: null,
-    inFlightCommandId: null
+  const nextEntry = settledEntry("ready");
+  if (!section) {
+    const existing = state.optionsByTargetKey[targetKey];
+    return changed({
+      ...state,
+      entriesByTargetKey: {
+        ...state.entriesByTargetKey,
+        [targetKey]: nextEntry
+      },
+      optionsByTargetKey:
+        existing && areComposerOptionsEqual(existing, options)
+          ? state.optionsByTargetKey
+          : {
+              ...state.optionsByTargetKey,
+              [targetKey]: cloneAgentActivityComposerOptions(options)
+            }
+    });
+  }
+  const previous = state.optionsByTargetKey[targetKey];
+  const merged = mergeSectionOptions(previous, options, section);
+  const sectionOptions = {
+    ...(state.sectionOptionsByTargetKey[targetKey] ?? {}),
+    [section]: cloneAgentActivityComposerOptions(options)
   };
-  const existing = state.optionsByTargetKey[targetKey];
-  const optionsUnchanged = Boolean(
-    existing && areComposerOptionsEqual(existing, options)
-  );
+  const sectionEntries = {
+    ...(state.sectionEntriesByTargetKey[targetKey] ?? {}),
+    [section]: nextEntry
+  };
   return changed({
-    entriesByTargetKey: {
-      ...state.entriesByTargetKey,
-      [targetKey]: settledEntry
+    ...state,
+    entriesByTargetKey:
+      section === "core"
+        ? { ...state.entriesByTargetKey, [targetKey]: nextEntry }
+        : state.entriesByTargetKey,
+    optionsByTargetKey: {
+      ...state.optionsByTargetKey,
+      [targetKey]: merged
     },
-    optionsByTargetKey: optionsUnchanged
-      ? state.optionsByTargetKey
-      : {
-          ...state.optionsByTargetKey,
-          [targetKey]: cloneAgentActivityComposerOptions(options)
-        }
+    sectionEntriesByTargetKey: {
+      ...state.sectionEntriesByTargetKey,
+      [targetKey]: sectionEntries
+    },
+    sectionOptionsByTargetKey: {
+      ...state.sectionOptionsByTargetKey,
+      [targetKey]: sectionOptions
+    }
+  });
+}
+
+function mergeSectionOptions(
+  existing: AgentActivityComposerOptions | undefined,
+  incoming: AgentActivityComposerOptions,
+  section: ComposerOptionsSection
+): AgentActivityComposerOptions {
+  if (!existing) return cloneAgentActivityComposerOptions(incoming);
+  if (section === "core") {
+    return cloneAgentActivityComposerOptions({
+      ...existing,
+      ...incoming,
+      skills: existing.skills,
+      capabilityCatalog: existing.capabilityCatalog,
+      commands: existing.commands,
+      loadedAtUnixMs: incoming.loadedAtUnixMs
+    });
+  }
+  return cloneAgentActivityComposerOptions({
+    ...existing,
+    capabilities: incoming.capabilities ?? existing.capabilities,
+    commands: incoming.commands,
+    skills: incoming.skills,
+    capabilityCatalog: incoming.capabilityCatalog,
+    slashCommandPolicy: incoming.slashCommandPolicy,
+    loadedAtUnixMs: incoming.loadedAtUnixMs
   });
 }
 
 function invalidate(
   state: ComposerOptionsState,
   providers: readonly string[] | undefined,
-  targetKeys: readonly string[] | undefined
+  targetKeys: readonly string[] | undefined,
+  sections: readonly ComposerOptionsSection[] | undefined
 ): EngineReducerResult<ComposerOptionsState> {
   const providerSet = providers?.length ? new Set(providers) : null;
   const targetKeySet = targetKeys?.length
     ? new Set(targetKeys.map((value) => value.trim()).filter(Boolean))
     : null;
-  let entriesByTargetKey: Record<string, ComposerOptionsEntry> | null = null;
+  const sectionSet = sections?.length ? new Set(sections) : null;
+  let next = state;
   for (const [targetKey, entry] of Object.entries(state.entriesByTargetKey)) {
-    const matches =
-      (providerSet === null && targetKeySet === null) ||
-      providerSet?.has(entry.provider) === true ||
-      targetKeySet?.has(targetKey) === true;
-    if (!matches) continue;
-    entriesByTargetKey ??= { ...state.entriesByTargetKey };
-    entriesByTargetKey[targetKey] = {
-      ...entry,
-      // Drop cache validity so a subsequent request refetches. Keep an active
-      // command attached: its caller still needs a terminal result, while the
-      // cleared loading signature prevents a post-invalidation dedupe.
-      settledSignature: null,
-      loadingSignature: null,
-      loadVersion: entry.loadVersion + 1
+    if (!matchesInvalidation(targetKey, entry, providerSet, targetKeySet))
+      continue;
+    next = replaceEntry(next, targetKey, undefined, invalidatedEntry(entry));
+  }
+  for (const [targetKey, entries] of Object.entries(
+    state.sectionEntriesByTargetKey
+  )) {
+    for (const [section, entry] of Object.entries(entries)) {
+      const typedSection = section as ComposerOptionsSection;
+      if (sectionSet !== null && !sectionSet.has(typedSection)) continue;
+      if (!matchesInvalidation(targetKey, entry, providerSet, targetKeySet))
+        continue;
+      next = replaceEntry(
+        next,
+        targetKey,
+        typedSection,
+        invalidatedEntry(entry)
+      );
+    }
+  }
+  return next === state ? unchanged(state) : changed(next);
+}
+
+function invalidatedEntry(entry: ComposerOptionsEntry): ComposerOptionsEntry {
+  return {
+    ...entry,
+    settledSignature: null,
+    loadingSignature: null,
+    loadVersion: entry.loadVersion + 1
+  };
+}
+
+function matchesInvalidation(
+  targetKey: string,
+  entry: ComposerOptionsEntry,
+  providers: Set<string> | null,
+  targetKeys: Set<string> | null
+): boolean {
+  return (
+    (providers === null && targetKeys === null) ||
+    providers?.has(entry.provider) === true ||
+    targetKeys?.has(targetKey) === true
+  );
+}
+
+function entryFor(
+  state: ComposerOptionsState,
+  targetKey: string,
+  section: ComposerOptionsSection | undefined
+): ComposerOptionsEntry | undefined {
+  return section
+    ? state.sectionEntriesByTargetKey[targetKey]?.[section]
+    : state.entriesByTargetKey[targetKey];
+}
+
+function replaceEntry(
+  state: ComposerOptionsState,
+  targetKey: string,
+  section: ComposerOptionsSection | undefined,
+  entry: ComposerOptionsEntry
+): ComposerOptionsState {
+  if (!section) {
+    return {
+      ...state,
+      entriesByTargetKey: { ...state.entriesByTargetKey, [targetKey]: entry }
     };
   }
-  return entriesByTargetKey
-    ? changed({ ...state, entriesByTargetKey })
-    : unchanged(state);
+  const sectionEntriesByTargetKey = {
+    ...state.sectionEntriesByTargetKey,
+    [targetKey]: {
+      ...(state.sectionEntriesByTargetKey[targetKey] ?? {}),
+      [section]: entry
+    }
+  };
+  return {
+    ...state,
+    ...(section === "core"
+      ? {
+          entriesByTargetKey: {
+            ...state.entriesByTargetKey,
+            [targetKey]: entry
+          }
+        }
+      : {}),
+    sectionEntriesByTargetKey
+  };
+}
+
+function correlationKey(
+  targetKey: string,
+  section: ComposerOptionsSection | undefined
+): string {
+  return section ? `${targetKey}::${section}` : targetKey;
+}
+
+function parseCorrelationKey(value: string): {
+  section: ComposerOptionsSection | undefined;
+  targetKey: string;
+} {
+  const separator = value.lastIndexOf("::");
+  const suffix = separator >= 0 ? value.slice(separator + 2) : "";
+  if (suffix === "core" || suffix === "capabilities") {
+    return { section: suffix, targetKey: value.slice(0, separator) };
+  }
+  return { section: undefined, targetKey: value };
 }
 
 function composerOptionsFromValue(
@@ -249,17 +403,6 @@ function composerOptionsFromValue(
   return typeof candidate["provider"] === "string"
     ? (value as AgentActivityComposerOptions)
     : null;
-}
-
-function replaceEntry(
-  state: ComposerOptionsState,
-  targetKey: string,
-  entry: ComposerOptionsEntry
-): ComposerOptionsState {
-  return {
-    ...state,
-    entriesByTargetKey: { ...state.entriesByTargetKey, [targetKey]: entry }
-  };
 }
 
 function changed(

--- a/packages/agent/activity-core/src/engine/composerOptions.reducer.ts
+++ b/packages/agent/activity-core/src/engine/composerOptions.reducer.ts
@@ -115,9 +115,11 @@ function requestLoad(
     settings: intent.settings
   });
   const current = state.entriesByTargetKey[targetKey];
-  if (!intent.force && current) {
+  if (current) {
     const cacheHit =
-      current.status === "ready" && current.settledSignature === signature;
+      !intent.force &&
+      current.status === "ready" &&
+      current.settledSignature === signature;
     const inFlightDuplicate =
       current.status === "loading" && current.loadingSignature === signature;
     if (cacheHit || inFlightDuplicate) {

--- a/packages/agent/activity-core/src/engine/composerOptions.selectors.ts
+++ b/packages/agent/activity-core/src/engine/composerOptions.selectors.ts
@@ -3,6 +3,7 @@ import type {
   AgentActivityComposerOptionsLoadStatus
 } from "../types.ts";
 import type { AgentSessionEngineStateBase } from "./types.ts";
+import type { ComposerOptionsSection } from "./composerOptions.types.ts";
 
 export function selectComposerOptions(
   state: AgentSessionEngineStateBase,
@@ -20,4 +21,15 @@ export function selectComposerOptionsLoadStatus(
   const key = targetKey?.trim() ?? "";
   if (!key) return undefined;
   return state.composerOptions.entriesByTargetKey[key]?.status;
+}
+
+export function selectComposerOptionsSectionLoadStatus(
+  state: AgentSessionEngineStateBase,
+  targetKey: string | null | undefined,
+  section: ComposerOptionsSection
+): AgentActivityComposerOptionsLoadStatus | undefined {
+  const key = targetKey?.trim() ?? "";
+  if (!key) return undefined;
+  return state.composerOptions.sectionEntriesByTargetKey[key]?.[section]
+    ?.status;
 }

--- a/packages/agent/activity-core/src/engine/composerOptions.semantic.test.ts
+++ b/packages/agent/activity-core/src/engine/composerOptions.semantic.test.ts
@@ -5,7 +5,10 @@ import { createAgentSessionEngine } from "./createAgentSessionEngine.ts";
 import { createTestEngineCommandPort } from "./testEngineCommandPort.ts";
 import type { EngineExternalCommand, EngineScheduler } from "./types.ts";
 
-function composerOptions(model: string): AgentActivityComposerOptions {
+function composerOptions(
+  model: string,
+  overrides: Partial<AgentActivityComposerOptions> = {}
+): AgentActivityComposerOptions {
   return {
     behavior: {
       collapseModelOptionsToLatest: false,
@@ -20,7 +23,8 @@ function composerOptions(model: string): AgentActivityComposerOptions {
     provider: "codex",
     reasoningEfforts: [],
     skills: [],
-    speeds: []
+    speeds: [],
+    ...overrides
   };
 }
 
@@ -66,6 +70,48 @@ function loadInput(overrides: { cwd?: string; force?: boolean } = {}) {
     ...overrides
   };
 }
+
+test("core settles before capabilities and section requests do not share in-flight state", async () => {
+  const harness = createHarness();
+  const core = harness.engine.loadComposerOptions({
+    ...loadInput(),
+    section: "core"
+  });
+  const capabilities = harness.engine.loadComposerOptions({
+    ...loadInput(),
+    section: "capabilities"
+  });
+
+  assert.equal(harness.commands.length, 2);
+  assert.equal(harness.commands[0]?.type, "composerOptions/load");
+  assert.equal(harness.commands[1]?.type, "composerOptions/load");
+  assert.equal(harness.commands[0]?.section, "core");
+  assert.equal(harness.commands[1]?.section, "capabilities");
+
+  harness.succeed(
+    harness.commands[0]!.commandId,
+    composerOptions("core-model")
+  );
+  const coreOptions = await core;
+  assert.equal(coreOptions.models[0]?.value, "core-model");
+  assert.equal(harness.commands.length, 2);
+
+  harness.succeed(
+    harness.commands[1]!.commandId,
+    composerOptions("capability-response", {
+      skills: [
+        {
+          name: "search",
+          sourceKind: "project",
+          trigger: "/search"
+        }
+      ]
+    })
+  );
+  const merged = await capabilities;
+  assert.equal(merged.models[0]?.value, "core-model");
+  assert.equal(merged.skills[0]?.name, "search");
+});
 
 test("semantic composer load joins an identical request and reuses its ready cache", async () => {
   const harness = createHarness();

--- a/packages/agent/activity-core/src/engine/composerOptions.semantic.test.ts
+++ b/packages/agent/activity-core/src/engine/composerOptions.semantic.test.ts
@@ -123,6 +123,23 @@ test("aborting one joined caller does not abort the shared composer load", async
   assert.equal((await first).models[0]?.value, "shared-model");
 });
 
+test("a forced identical request joins an already-running composer load", async () => {
+  const harness = createHarness();
+  const first = harness.engine.loadComposerOptions(loadInput());
+  const second = harness.engine.loadComposerOptions({
+    ...loadInput(),
+    force: true
+  });
+
+  assert.equal(harness.commands.length, 1);
+  harness.succeed(
+    harness.commands[0]!.commandId,
+    composerOptions("forced-shared-model")
+  );
+  assert.equal((await first).models[0]?.value, "forced-shared-model");
+  assert.equal((await second).models[0]?.value, "forced-shared-model");
+});
+
 test("invalidation keeps the current composer caller attached and makes the next load refetch", async () => {
   const harness = createHarness();
   const first = harness.engine.loadComposerOptions(loadInput());

--- a/packages/agent/activity-core/src/engine/composerOptions.types.ts
+++ b/packages/agent/activity-core/src/engine/composerOptions.types.ts
@@ -4,6 +4,8 @@ import type {
   AgentActivityComposerSettings
 } from "../types.ts";
 
+export type ComposerOptionsSection = "core" | "capabilities";
+
 /**
  * Per-target load bookkeeping. Replaces the former imperative cache
  * coordinator: `loadingSignature` deduplicates in-flight loads, `settledSignature`
@@ -22,6 +24,20 @@ export interface ComposerOptionsEntry {
 export interface ComposerOptionsState {
   optionsByTargetKey: Readonly<Record<string, AgentActivityComposerOptions>>;
   entriesByTargetKey: Readonly<Record<string, ComposerOptionsEntry>>;
+  sectionOptionsByTargetKey: Readonly<
+    Record<
+      string,
+      Readonly<
+        Partial<Record<ComposerOptionsSection, AgentActivityComposerOptions>>
+      >
+    >
+  >;
+  sectionEntriesByTargetKey: Readonly<
+    Record<
+      string,
+      Readonly<Partial<Record<ComposerOptionsSection, ComposerOptionsEntry>>>
+    >
+  >;
 }
 
 export interface ComposerOptionsLoadRequestedIntent {
@@ -33,11 +49,14 @@ export interface ComposerOptionsLoadRequestedIntent {
   cwd?: string | null;
   settings?: AgentActivityComposerSettings | null;
   force?: boolean;
+  waitForFreshModelCatalog?: boolean;
+  section?: ComposerOptionsSection;
 }
 
 export interface ComposerOptionsInvalidatedIntent {
   type: "composerOptions/invalidated";
   providers?: readonly string[];
+  sections?: readonly ComposerOptionsSection[];
   targetKeys?: readonly string[];
 }
 
@@ -54,6 +73,8 @@ export interface ComposerOptionsLoadCommand {
   workspaceId: string;
   cwd?: string | null;
   settings?: AgentActivityComposerSettings | null;
+  section?: ComposerOptionsSection;
+  waitForFreshModelCatalog?: boolean;
 }
 
 export type ComposerOptionsCommand = ComposerOptionsLoadCommand;

--- a/packages/agent/activity-core/src/engine/createAgentSessionEngine.ts
+++ b/packages/agent/activity-core/src/engine/createAgentSessionEngine.ts
@@ -310,7 +310,6 @@ export function createAgentSessionEngine({
     const initialEntry =
       publicSnapshot.composerOptions.entriesByTargetKey[targetKey];
     const joinedCommandId =
-      !input.force &&
       initialEntry?.status === "loading" &&
       initialEntry.loadingSignature === signature
         ? initialEntry.inFlightCommandId
@@ -393,7 +392,7 @@ export function createAgentSessionEngine({
       awaitedCommandId =
         entry?.inFlightCommandId === commandId
           ? commandId
-          : !input.force && entry?.loadingSignature === signature
+          : entry?.loadingSignature === signature
             ? (entry.inFlightCommandId ?? null)
             : null;
       previousEntry = entry;

--- a/packages/agent/activity-core/src/engine/createAgentSessionEngine.ts
+++ b/packages/agent/activity-core/src/engine/createAgentSessionEngine.ts
@@ -307,8 +307,12 @@ export function createAgentSessionEngine({
       provider,
       settings: input.settings
     });
-    const initialEntry =
-      publicSnapshot.composerOptions.entriesByTargetKey[targetKey];
+    const section = input.section;
+    const initialEntry = section
+      ? publicSnapshot.composerOptions.sectionEntriesByTargetKey[targetKey]?.[
+          section
+        ]
+      : publicSnapshot.composerOptions.entriesByTargetKey[targetKey];
     const joinedCommandId =
       initialEntry?.status === "loading" &&
       initialEntry.loadingSignature === signature
@@ -343,7 +347,9 @@ export function createAgentSessionEngine({
       const observe = (): void => {
         if (settled || !awaitedCommandId) return;
         const composerOptions = publicSnapshot.composerOptions;
-        const entry = composerOptions.entriesByTargetKey[targetKey];
+        const entry = section
+          ? composerOptions.sectionEntriesByTargetKey[targetKey]?.[section]
+          : composerOptions.entriesByTargetKey[targetKey];
         if (entry?.inFlightCommandId === awaitedCommandId) {
           previousEntry = entry;
           return;
@@ -377,6 +383,10 @@ export function createAgentSessionEngine({
         cwd: input.cwd,
         force: input.force,
         provider,
+        ...(input.waitForFreshModelCatalog
+          ? { waitForFreshModelCatalog: true }
+          : {}),
+        ...(section !== undefined ? { section } : {}),
         settings: input.settings,
         targetKey,
         type: "composerOptions/loadRequested",
@@ -384,7 +394,9 @@ export function createAgentSessionEngine({
       });
 
       const composerOptions = publicSnapshot.composerOptions;
-      const entry = composerOptions.entriesByTargetKey[targetKey];
+      const entry = section
+        ? composerOptions.sectionEntriesByTargetKey[targetKey]?.[section]
+        : composerOptions.entriesByTargetKey[targetKey];
       if (entry?.status === "ready" && entry.settledSignature === signature) {
         resolveOnce(composerOptions.optionsByTargetKey[targetKey]);
         return;

--- a/packages/agent/activity-core/src/engine/types.ts
+++ b/packages/agent/activity-core/src/engine/types.ts
@@ -458,7 +458,9 @@ export type AgentSessionEngineIntentObserver = (intent: EngineIntent) => void;
 export interface AgentSessionLoadComposerOptionsInput {
   cwd?: string | null;
   force?: boolean;
+  waitForFreshModelCatalog?: boolean;
   provider: string;
+  section?: import("./composerOptions.types.ts").ComposerOptionsSection;
   settings?: AgentActivityComposerSettings | null;
   signal?: AbortSignal;
   targetKey: string;

--- a/packages/agent/activity-core/src/index.ts
+++ b/packages/agent/activity-core/src/index.ts
@@ -198,11 +198,13 @@ export {
 export type { SessionMessagesState } from "./engine/sessionMessages.types.ts";
 export {
   selectComposerOptions,
-  selectComposerOptionsLoadStatus
+  selectComposerOptionsLoadStatus,
+  selectComposerOptionsSectionLoadStatus
 } from "./engine/composerOptions.selectors.ts";
 export type {
   ComposerOptionsIntent,
   ComposerOptionsCommand,
+  ComposerOptionsSection,
   ComposerOptionsState
 } from "./engine/composerOptions.types.ts";
 export type {

--- a/packages/agent/daemon/providerregistry/codex.go
+++ b/packages/agent/daemon/providerregistry/codex.go
@@ -85,6 +85,10 @@ func codexDescriptor() ProviderDescriptor {
 						Paths:          []string{"auth.json", "config.toml"},
 					},
 				},
+				// Codex and external credential switchers commonly rewrite these
+				// files atomically. Compare content so an identical rewrite does
+				// not evict the warm model catalog or its app-server process.
+				ContentFingerprint: AuthWatchContentFingerprintFullFile,
 			},
 		},
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -151,6 +151,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     onPromptImagesUnsupported,
     onSubmitInteractivePrompt,
     onCapabilitySettingsRequest,
+    onRetryComposerOptions,
     onSlashStatusOpen,
     onLinkAction,
     onRequestWorkspaceReferences = null,
@@ -160,6 +161,33 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     onRequestGitBranches = null,
     referenceProvenanceFilters = null
   } = props;
+  const capabilitiesRequestedKeyRef = useRef<string | null>(null);
+  const requestCapabilitiesForDraft = useCallback(
+    (nextDraft: AgentComposerDraft): void => {
+      if (!onRetryComposerOptions) {
+        return;
+      }
+      const nextPrompt = agentComposerDraftPrompt(nextDraft).trimStart();
+      if (!nextPrompt.startsWith("/")) {
+        return;
+      }
+      const requestKey = `${provider}:${agentSessionId ?? "draft"}`;
+      if (capabilitiesRequestedKeyRef.current === requestKey) {
+        return;
+      }
+      capabilitiesRequestedKeyRef.current = requestKey;
+      onRetryComposerOptions({ section: "capabilities" });
+    },
+    [agentSessionId, onRetryComposerOptions, provider]
+  );
+  const handleDraftContentChange: AgentComposerProps["onDraftContentChange"] =
+    useCallback(
+      (nextDraft, sourceScopeKey) => {
+        requestCapabilitiesForDraft(nextDraft);
+        onDraftContentChange(nextDraft, sourceScopeKey);
+      },
+      [onDraftContentChange, requestCapabilitiesForDraft]
+    );
   const {
     canQueueWhileBusy,
     editorDisabled: disabled,
@@ -298,7 +326,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     entries: inputHistory,
     hasOlderPage: inputHistoryHasOlderPage,
     isLoadingOlderPage: inputHistoryIsLoadingOlderPage,
-    onDraftContentChange,
+    onDraftContentChange: handleDraftContentChange,
     onRequestOlderPage: onRequestOlderInputHistoryPage,
     runtime: agentActivityRuntime,
     workspaceId
@@ -463,7 +491,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     // missing flag as enabled.
     tuttiModeSupported: capabilityMenuState?.tuttiMode?.enabled === true,
     capabilityControlsReadOnly,
-    onDraftContentChange,
+    onDraftContentChange: handleDraftContentChange,
     onSettingsChange,
     onSubmit: submitWithComposerModifiers,
     onSubmitEmpty,
@@ -515,7 +543,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     draftPromptRef,
     setPaletteDraftPrompt,
     setIsPaletteOpen,
-    onDraftContentChange,
+    onDraftContentChange: handleDraftContentChange,
     showFileMentionPalette,
     mentionHighlightedKey,
     mentionSearchState,
@@ -559,7 +587,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     setPaletteDraftPrompt,
     setIsPaletteOpen,
     clearActiveFileMentionTrigger,
-    onDraftContentChange,
+    onDraftContentChange: handleDraftContentChange,
     onPromptImagesUnsupported,
     onContentEntered: reportContentEntered,
     onRequestWorkspaceReferences,

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerModelReasoningDropdown.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerModelReasoningDropdown.tsx
@@ -88,7 +88,10 @@ export function AgentModelReasoningDropdown({
    * exact target; explicit null disables model history.
    */
   modelHistoryTargetId?: string | null;
-  onRetryComposerOptions?: () => void;
+  onRetryComposerOptions?: (options?: {
+    section?: "core" | "capabilities";
+    waitForFreshModelCatalog?: boolean;
+  }) => void;
   onSettingsChange: (patch: {
     model?: string;
     reasoningEffort?: string;
@@ -113,6 +116,10 @@ export function AgentModelReasoningDropdown({
   } = modelHistory;
   const handleMenuOpenChange = (open: boolean): void => {
     if (open) {
+      // Opening the picker is the explicit consumer action that is allowed to
+      // wait for an authoritative catalog. Background composer loads keep the
+      // last successful list and refresh it asynchronously.
+      onRetryComposerOptions?.({ waitForFreshModelCatalog: true });
       // Pick up writes from other windows and clear the previous filter.
       modelHistory.refreshFromStorage();
       setModelSearchQuery("");
@@ -190,7 +197,7 @@ export function AgentModelReasoningDropdown({
       disabled={triggerDisabled}
       onClick={
         composerOptionsError && !retryDisabled
-          ? onRetryComposerOptions
+          ? () => onRetryComposerOptions?.()
           : undefined
       }
       data-agent-model-reasoning-trigger="true"

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
@@ -169,6 +169,28 @@ describe("AgentModelReasoningDropdown", () => {
     expect(screen.queryByText("Model selection")).not.toBeInTheDocument();
   });
 
+  it("requests a fresh model catalog when the model picker opens", async () => {
+    const onRetryComposerOptions = vi.fn();
+    render(
+      <AgentModelReasoningDropdown
+        composerSettings={composerModelSettings()}
+        labels={modelSettingsLabels}
+        onRetryComposerOptions={onRetryComposerOptions}
+        onSettingsChange={vi.fn()}
+      />
+    );
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Model / Reasoning" }),
+      { button: 0, ctrlKey: false, pointerType: "mouse" }
+    );
+
+    expect(await screen.findByText("Model selection")).toBeInTheDocument();
+    expect(onRetryComposerOptions).toHaveBeenCalledWith({
+      waitForFreshModelCatalog: true
+    });
+  });
+
   it("disables the compact retry while composer options are loading", () => {
     const onRetryComposerOptions = vi.fn();
     render(

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
@@ -419,8 +419,11 @@ export interface AgentComposerProps {
     computerUse?: boolean;
     permissionModeId?: string | null;
   }) => void;
-  /** Retries the target-scoped composer options request after a terminal failure. */
-  onRetryComposerOptions?: () => void;
+  /** Retries or explicitly refreshes the target-scoped composer options. */
+  onRetryComposerOptions?: (options?: {
+    section?: "core" | "capabilities";
+    waitForFreshModelCatalog?: boolean;
+  }) => void;
   onTuttiModeChange?: (active: boolean) => void;
   onTuttiModeEffectChange?: (value: number) => void;
   onTuttiModeSpeedChange?: (value: number) => void;

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
@@ -741,6 +741,7 @@ export function AgentComposerView(input: Props): React.JSX.Element {
             onProviderSelect={onProviderSelect}
             onLinkAction={onLinkAction}
             availableSkills={availableSkills}
+            onRetryComposerOptions={input.props.onRetryComposerOptions}
             onCapabilitySettingsRequest={
               input.props.onCapabilitySettingsRequest
             }
@@ -748,7 +749,6 @@ export function AgentComposerView(input: Props): React.JSX.Element {
             onWorkspaceReferencePicker={handleWorkspaceReferencePicker}
             onMentionPaletteButton={handleMentionPaletteButton}
             onSettingsChange={onSettingsChange}
-            onRetryComposerOptions={input.props.onRetryComposerOptions}
             onSubmit={onSubmit}
             onClearGoalMode={clearGoalModeBadge}
             draftPrompt={draftPrompt}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerConnectorsMenu.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerConnectorsMenu.tsx
@@ -31,6 +31,7 @@ interface Props {
   connectors: readonly AgentGUIProviderSkillOption[];
   disabled: boolean;
   labels: ComposerConnectorsMenuLabels;
+  onOpenChange?: (open: boolean) => void;
   onOpenConnector: (connectorKey: string) => void;
   onOpenConnectors: () => void;
 }
@@ -49,6 +50,7 @@ export function ComposerConnectorsMenu({
   connectors,
   disabled,
   labels,
+  onOpenChange,
   onOpenConnector,
   onOpenConnectors
 }: Props): React.JSX.Element {
@@ -70,7 +72,13 @@ export function ComposerConnectorsMenu({
   };
 
   return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
+    <DropdownMenu
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        onOpenChange?.(nextOpen);
+      }}
+    >
       <DropdownMenuTrigger asChild>
         <button
           type="button"
@@ -111,7 +119,20 @@ export function ComposerConnectorsMenu({
             </>
           ) : (
             <>
-              <span aria-hidden className="inline-block size-4 bg-current transition-colors" style={{ WebkitMaskImage: `url("${connectorLinedIconUrl}")`, WebkitMaskPosition: "center", WebkitMaskRepeat: "no-repeat", WebkitMaskSize: "contain", maskImage: `url("${connectorLinedIconUrl}")`, maskPosition: "center", maskRepeat: "no-repeat", maskSize: "contain" }} />
+              <span
+                aria-hidden
+                className="inline-block size-4 bg-current transition-colors"
+                style={{
+                  WebkitMaskImage: `url("${connectorLinedIconUrl}")`,
+                  WebkitMaskPosition: "center",
+                  WebkitMaskRepeat: "no-repeat",
+                  WebkitMaskSize: "contain",
+                  maskImage: `url("${connectorLinedIconUrl}")`,
+                  maskPosition: "center",
+                  maskRepeat: "no-repeat",
+                  maskSize: "contain"
+                }}
+              />
               <span>{labels.connectors}</span>
             </>
           )}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerFooter.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerFooter.tsx
@@ -77,12 +77,12 @@ interface Props {
   onProviderSelect: AgentComposerProps["onProviderSelect"];
   onLinkAction: AgentComposerProps["onLinkAction"];
   availableSkills: AgentComposerProps["availableSkills"];
+  onRetryComposerOptions?: AgentComposerProps["onRetryComposerOptions"];
   onCapabilitySettingsRequest: AgentComposerProps["onCapabilitySettingsRequest"];
   onRequestWorkspaceReferences: AgentComposerProps["onRequestWorkspaceReferences"];
   onWorkspaceReferencePicker: () => void;
   onMentionPaletteButton: () => void;
   onSettingsChange: AgentComposerProps["onSettingsChange"];
-  onRetryComposerOptions: AgentComposerProps["onRetryComposerOptions"];
   onSubmit: AgentComposerProps["onSubmit"];
   onClearGoalMode: () => void;
   draftPrompt: string;
@@ -132,12 +132,12 @@ export function ComposerFooter({
   onProviderSelect,
   onLinkAction,
   availableSkills,
+  onRetryComposerOptions,
   onCapabilitySettingsRequest,
   onRequestWorkspaceReferences,
   onWorkspaceReferencePicker: handleWorkspaceReferencePicker,
   onMentionPaletteButton: handleMentionPaletteButton,
   onSettingsChange,
-  onRetryComposerOptions,
   onSubmit,
   onClearGoalMode: clearGoalModeBadge,
   draftPrompt: _draftPrompt,
@@ -224,6 +224,7 @@ export function ComposerFooter({
             isTuttiModeActive={isTuttiModeActive}
             isTuttiModeUpdating={isTuttiModeUpdating}
             labels={labels}
+            onRetryComposerOptions={onRetryComposerOptions}
             onCapabilitySettingsRequest={onCapabilitySettingsRequest}
             onTuttiModeChange={onTuttiModeChange}
             tuttiModeSupported={tuttiModeSupported}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerPrimaryCapabilityControl.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerPrimaryCapabilityControl.spec.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentComposerProps } from "./AgentComposer.types";
 import { ComposerPrimaryCapabilityControl } from "./ComposerPrimaryCapabilityControl";
@@ -40,6 +40,7 @@ describe("ComposerPrimaryCapabilityControl", () => {
   });
 
   it("shows only connectors when connectors are enabled", () => {
+    const onRetryComposerOptions = vi.fn();
     render(
       <ComposerPrimaryCapabilityControl
         availableSkills={[]}
@@ -48,6 +49,7 @@ describe("ComposerPrimaryCapabilityControl", () => {
         isTuttiModeActive={false}
         isTuttiModeUpdating={false}
         labels={labels}
+        onRetryComposerOptions={onRetryComposerOptions}
         onCapabilitySettingsRequest={vi.fn()}
         onTuttiModeChange={vi.fn()}
         tuttiModeSupported={true}
@@ -60,5 +62,12 @@ describe("ComposerPrimaryCapabilityControl", () => {
     expect(
       screen.queryByTestId("agent-gui-composer-tutti-mode-toggle")
     ).not.toBeInTheDocument();
+    fireEvent.pointerDown(
+      screen.getByTestId("agent-gui-composer-connectors-trigger"),
+      { button: 0, ctrlKey: false, pointerType: "mouse" }
+    );
+    expect(onRetryComposerOptions).toHaveBeenCalledWith({
+      section: "capabilities"
+    });
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerPrimaryCapabilityControl.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerPrimaryCapabilityControl.tsx
@@ -10,6 +10,7 @@ interface Props {
   isTuttiModeActive: boolean;
   isTuttiModeUpdating: boolean;
   labels: AgentComposerProps["labels"];
+  onRetryComposerOptions?: AgentComposerProps["onRetryComposerOptions"];
   onCapabilitySettingsRequest: AgentComposerProps["onCapabilitySettingsRequest"];
   onTuttiModeChange?: (active: boolean) => void;
   tuttiModeSupported: boolean;
@@ -27,6 +28,7 @@ export function ComposerPrimaryCapabilityControl({
   isTuttiModeActive,
   isTuttiModeUpdating,
   labels,
+  onRetryComposerOptions,
   onCapabilitySettingsRequest,
   onTuttiModeChange,
   tuttiModeSupported
@@ -55,6 +57,11 @@ export function ComposerPrimaryCapabilityControl({
         connectorAuthorize: labels.addContentConnectorAuthorize,
         connectorEmpty: labels.addContentConnectorEmpty,
         connectorMore: labels.addContentConnectorMore
+      }}
+      onOpenChange={(open) => {
+        if (open) {
+          onRetryComposerOptions?.({ section: "capabilities" });
+        }
       }}
       onOpenConnector={(connectorKey) =>
         onCapabilitySettingsRequest?.({

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerCapabilities.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerCapabilities.ts
@@ -3,6 +3,7 @@ import {
   resolveAgentActivityUsage,
   selectComposerOptions,
   selectComposerOptionsLoadStatus,
+  selectComposerOptionsSectionLoadStatus,
   type AgentActivityUsage,
   type CanonicalAgentSession,
   type AgentSessionEngine
@@ -55,10 +56,19 @@ export function useAgentGUIComposerCapabilities(
     input.sessionEngine,
     (state) => selectComposerOptionsLoadStatus(state, composerTargetKey)
   );
+  const capabilitiesLoadStatus = useEngineSelector(
+    input.sessionEngine,
+    (state) =>
+      selectComposerOptionsSectionLoadStatus(
+        state,
+        composerTargetKey,
+        "capabilities"
+      )
+  );
   const composerOptionsLoading = Boolean(
     composerTargetKey &&
-    !providerComposerOptions &&
-    composerOptionsLoadStatus === "loading"
+    (capabilitiesLoadStatus === "loading" ||
+      (!providerComposerOptions && composerOptionsLoadStatus === "loading"))
   );
   const defaultReasoningEffort: AgentSessionReasoningEffort | null = "high";
   const sessionCapabilities = input.activeEngineSession?.capabilities ?? null;

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerOptionsSync.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerOptionsSync.spec.tsx
@@ -61,6 +61,9 @@ describe("useAgentGUIComposerOptionsSync", () => {
 
     await waitFor(() => {
       expect(getComposerOptions).toHaveBeenCalledTimes(1);
+      expect(getComposerOptions).toHaveBeenCalledWith(
+        expect.objectContaining({ section: "core" })
+      );
       expect(
         authorityReconcilerRef.current.reconcileHomeDefaults
       ).toHaveBeenCalledWith(

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerOptionsSync.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerOptionsSync.ts
@@ -38,7 +38,13 @@ export function useAgentGUIComposerOptionsSync(input: {
   isComposerHome: boolean;
   isComposerHomeRef: RefObject<boolean>;
   isCreatingConversation: boolean;
-  loadDraftComposerOptionsRef: RefObject<() => void>;
+  loadDraftComposerOptionsRef: RefObject<
+    (options?: {
+      force?: boolean;
+      section?: "core" | "capabilities";
+      waitForFreshModelCatalog?: boolean;
+    }) => void
+  >;
   loadSessionState(agentSessionId: string): void;
   onComposerDefaultsAuthorityReloadedRef: RefObject<AgentGUIComposerDefaultsAuthorityReconciler>;
   providerComposerOptions:
@@ -62,6 +68,8 @@ export function useAgentGUIComposerOptionsSync(input: {
         allowWhileCreating?: boolean;
         excludePersistentDefaults?: boolean;
         force?: boolean;
+        section?: "core" | "capabilities";
+        waitForFreshModelCatalog?: boolean;
         reconcileAcknowledgedDefaults?: boolean;
         settings?: AgentSessionComposerSettings;
       }
@@ -98,16 +106,24 @@ export function useAgentGUIComposerOptionsSync(input: {
         input.selectedProjectPathRef.current?.trim() ||
         input.workspacePath.trim() ||
         "";
-      return Promise.resolve(
-        input.agentActivityRuntime.getComposerOptions({
-          workspaceId: input.workspaceId,
-          cwd,
-          force: options?.force || authorityRead.force ? true : undefined,
-          provider: targetData.provider,
-          agentTargetId: targetData.agentTargetId,
-          settings: requestSettings
-        })
-      ).then((returnedOptions) => {
+      const request = {
+        workspaceId: input.workspaceId,
+        cwd,
+        force: options?.force || authorityRead.force ? true : undefined,
+        waitForFreshModelCatalog: options?.waitForFreshModelCatalog,
+        provider: targetData.provider,
+        agentTargetId: targetData.agentTargetId,
+        settings: requestSettings
+      } as const;
+      const section = options?.section ?? "core";
+      const composerOptions = input.agentActivityRuntime.getComposerOptions({
+        ...request,
+        section
+      });
+      return Promise.resolve(composerOptions).then((returnedOptions) => {
+        if (section === "capabilities") {
+          return;
+        }
         const loadedOptions =
           composerOptionsForTarget({
             snapshot: input.agentActivityRuntime.getSnapshot(input.workspaceId),
@@ -134,7 +150,11 @@ export function useAgentGUIComposerOptionsSync(input: {
     ]
   );
   const loadDraftComposerOptions = useCallback(
-    (options?: { force?: boolean }) => {
+    (options?: {
+      force?: boolean;
+      section?: "core" | "capabilities";
+      waitForFreshModelCatalog?: boolean;
+    }) => {
       void loadComposerOptionsForTarget(
         composerTargetDataForConversation({
           activeConversationId: input.activeConversationIdRef.current,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.ts
@@ -2,7 +2,7 @@ import {
   selectEngineSession,
   type AgentActivityComposerOptions,
   type AgentActivityTurn,
-  type AgentSessionEngine,
+  type AgentSessionEngine
 } from "@tutti-os/agent-activity-core";
 import type { Dispatch, RefObject, SetStateAction } from "react";
 import { useCallback, useRef } from "react";
@@ -10,13 +10,13 @@ import type { AgentGUIRuntime } from "../../../agentActivityRuntime";
 import { translate } from "../../../i18n/index";
 import type {
   AgentSessionComposerSettings,
-  AgentSessionReasoningEffort,
+  AgentSessionReasoningEffort
 } from "../../../shared/agentSessionTypes";
 import type { AgentGUINodeData } from "../../../types";
 import {
   normalizePlanIssueBudgetPreset,
   planIssueBudgetPresetsEqual,
-  type PlanIssueBudgetPreset,
+  type PlanIssueBudgetPreset
 } from "../../../shared/agentConversation/planImplementationPresentation";
 import { useStableControllerEventCallback } from "./agentGuiController.stableHelpers";
 import {
@@ -26,14 +26,14 @@ import {
   normalizePermissionModeId,
   readNodeDefaultDraftSettings,
   resolveEffectiveComposerSettings,
-  sameComposerSettings,
+  sameComposerSettings
 } from "./agentGuiController.composerHelpers";
 import {
   enforceComposerModelBindingForHomeDefaults,
   effectiveComposerSettingsFromOptions,
   nodeDataMatchesComposerTarget,
   sanitizeComposerSettingsForTarget,
-  type AgentGUIComposerTargetData,
+  type AgentGUIComposerTargetData
 } from "./agentGuiController.composerPresentation";
 import {
   acknowledgeAgentGUIComposerDefaultsMutation,
@@ -47,7 +47,7 @@ import {
   type AgentGUIComposerDefaultsAuthorityReconciler,
   type AgentGUIComposerDefaultsAuthorityReadReceipt,
   type AgentGUIComposerDefaultsMutation,
-  type AgentGUIRetiredComposerDefault,
+  type AgentGUIRetiredComposerDefault
 } from "./agentGuiComposerDefaultsReconciliation";
 import { normalizeOptionalText } from "./agentGuiController.promptHelpers";
 import {
@@ -55,7 +55,7 @@ import {
   composerOptionsForTarget,
   rememberComposerDefaultsFields,
   type AgentGUIRememberComposerDefaultsInput,
-  type AgentGUIRememberComposerDefaultsResult,
+  type AgentGUIRememberComposerDefaultsResult
 } from "./agentGuiController.providerHelpers";
 import type { useAgentGUIActivation } from "./useAgentGUIActivation";
 
@@ -72,14 +72,18 @@ interface UseAgentGUIComposerSettingsActionsInput {
     Record<string, AgentSessionComposerSettings>
   >;
   isMountedRef: RefObject<boolean>;
-  loadDraftComposerOptions(options?: { force?: boolean }): void;
+  loadDraftComposerOptions(options?: {
+    force?: boolean;
+    section?: "core" | "capabilities";
+    waitForFreshModelCatalog?: boolean;
+  }): void;
   onDataChangeRef: RefObject<
     (updater: (current: AgentGUINodeData) => AgentGUINodeData) => void
   >;
   onComposerDefaultsAuthorityReloadedRef: RefObject<AgentGUIComposerDefaultsAuthorityReconciler>;
   onRememberComposerDefaultsRef: RefObject<
     | ((
-        input: AgentGUIRememberComposerDefaultsInput,
+        input: AgentGUIRememberComposerDefaultsInput
       ) => void | Promise<AgentGUIRememberComposerDefaultsResult>)
     | undefined
   >;
@@ -103,7 +107,7 @@ interface UseAgentGUIComposerSettingsActionsInput {
 }
 
 export function useAgentGUIComposerSettingsActions(
-  input: UseAgentGUIComposerSettingsActionsInput,
+  input: UseAgentGUIComposerSettingsActionsInput
 ) {
   const {
     activation,
@@ -126,19 +130,19 @@ export function useAgentGUIComposerSettingsActions(
     setDraftSettingsBySessionId,
     setDetailError,
     updateComposerSettingsRef,
-    workspaceId,
+    workspaceId
   } = input;
   const composerSupport = {
     permissionModeChangeDeferred:
-      input.composerSupportPermissionModeChangeDeferred,
+      input.composerSupportPermissionModeChangeDeferred
   };
   const composerDefaultsLedgerRef = useRef(
-    createAgentGUIComposerDefaultsLedger(),
+    createAgentGUIComposerDefaultsLedger()
   );
   const retireAcknowledgedDefaultsForRead = useCallback(
     (
       receipt: AgentGUIComposerDefaultsAuthorityReadReceipt | null,
-      options: AgentActivityComposerOptions,
+      options: AgentActivityComposerOptions
     ) => {
       if (!isMountedRef.current || !receipt) return;
       const currentDraft =
@@ -150,31 +154,31 @@ export function useAgentGUIComposerSettingsActions(
         composerDefaultsLedgerRef.current,
         receipt,
         currentDraft,
-        authoritativeSettings,
+        authoritativeSettings
       );
       if (retired.length === 0) return;
       draftSettingsBySessionIdRef.current = reconcileRetiredDraftMap(
         draftSettingsBySessionIdRef.current,
         receipt.draftKey,
-        retired,
+        retired
       );
       setDraftSettingsBySessionId((current) =>
-        reconcileRetiredDraftMap(current, receipt.draftKey, retired),
+        reconcileRetiredDraftMap(current, receipt.draftKey, retired)
       );
     },
-    [draftSettingsBySessionIdRef, isMountedRef, setDraftSettingsBySessionId],
+    [draftSettingsBySessionIdRef, isMountedRef, setDraftSettingsBySessionId]
   );
   const prepareComposerDefaultsAuthorityRead = useCallback(
     (
       target: AgentGUIComposerTargetData,
-      settings: AgentSessionComposerSettings,
+      settings: AgentSessionComposerSettings
     ) =>
       prepareAcknowledgedComposerDefaultsAuthorityRead(
         composerDefaultsLedgerRef.current,
         nodeDefaultDraftKey(target.provider, target.agentTargetId),
-        settings,
+        settings
       ),
-    [],
+    []
   );
   onComposerDefaultsAuthorityReloadedRef.current = {
     prepareRead: prepareComposerDefaultsAuthorityRead,
@@ -184,14 +188,14 @@ export function useAgentGUIComposerSettingsActions(
         activeConversationIdRef.current !== null ||
         !nodeDataMatchesComposerTarget(
           selectedComposerTargetDataRef.current.data,
-          target,
+          target
         )
       ) {
         return;
       }
       const draftKey = nodeDefaultDraftKey(
         target.provider,
-        target.agentTargetId,
+        target.agentTargetId
       );
       const currentDraft = draftSettingsBySessionIdRef.current[draftKey];
       if (!currentDraft) {
@@ -206,34 +210,34 @@ export function useAgentGUIComposerSettingsActions(
             sanitizeComposerSettingsForTarget({
               settings: currentDraft,
               target,
-              options,
+              options
             }),
-            options,
-          ),
+            options
+          )
         );
       if (sameComposerSettings(currentDraft, reconciledDraft)) {
         return;
       }
       draftSettingsBySessionIdRef.current = {
         ...draftSettingsBySessionIdRef.current,
-        [draftKey]: reconciledDraft,
+        [draftKey]: reconciledDraft
       };
       setDraftSettingsBySessionId((current) => ({
         ...current,
-        [draftKey]: reconciledDraft,
+        [draftKey]: reconciledDraft
       }));
       onDataChangeRef.current((current) =>
         nodeDataFromComposerSettings(
           {
             ...current,
             provider: target.provider,
-            agentTargetId: target.agentTargetId,
+            agentTargetId: target.agentTargetId
           },
-          reconciledDraft,
-        ),
+          reconciledDraft
+        )
       );
     },
-    reloaded: retireAcknowledgedDefaultsForRead,
+    reloaded: retireAcknowledgedDefaultsForRead
   };
   const updateComposerSettings = useCallback(
     (nextSettings: Partial<AgentSessionComposerSettings>) => {
@@ -246,7 +250,7 @@ export function useAgentGUIComposerSettingsActions(
       // Values pass through unclamped: the toggle visibility is capability
       // gated and the daemon clamps persisted settings per provider.
       const supportedNextSettings: Partial<AgentSessionComposerSettings> = {
-        ...nextSettings,
+        ...nextSettings
       };
       // Persistent selections only originate from rendered menu values. A
       // transient empty select value during options refresh is not a user
@@ -267,19 +271,19 @@ export function useAgentGUIComposerSettingsActions(
         const targetData = selectedComposerTargetDataRef.current;
         const defaultDraftKey = nodeDefaultDraftKey(
           targetData.provider,
-          targetData.agentTargetId,
+          targetData.agentTargetId
         );
         const storedIntent = readNodeDefaultDraftSettings({
           data: targetData.data,
           defaultReasoningEffort,
-          drafts: draftSettingsBySessionIdRef.current,
+          drafts: draftSettingsBySessionIdRef.current
         });
         const previousSettings = resolveEffectiveComposerSettings({
-          settings: storedIntent,
+          settings: storedIntent
         });
         const mergedIntent: AgentSessionComposerSettings = {
           ...storedIntent,
-          ...supportedNextSettings,
+          ...supportedNextSettings
         };
         for (const field of rememberComposerDefaultsFields) {
           if (supportedNextSettings[field] !== undefined) {
@@ -287,39 +291,39 @@ export function useAgentGUIComposerSettingsActions(
               [field]:
                 field === "codexSaverMode"
                   ? supportedNextSettings.codexSaverMode === true
-                  : normalizeOptionalText(supportedNextSettings[field]),
+                  : normalizeOptionalText(supportedNextSettings[field])
             });
           }
         }
         const snapshotComposerOptions = composerOptionsForTarget({
           snapshot: agentActivityRuntime.getSnapshot(workspaceId),
-          target: targetData,
+          target: targetData
         });
         draftSettingsBySessionIdRef.current = {
           ...draftSettingsBySessionIdRef.current,
-          [defaultDraftKey]: mergedIntent,
+          [defaultDraftKey]: mergedIntent
         };
         setDraftSettingsBySessionId((current) => ({
           ...current,
-          [defaultDraftKey]: mergedIntent,
+          [defaultDraftKey]: mergedIntent
         }));
         const rememberedDefaultsPatch = composerDefaultsPatchFromSettings(
           supportedNextSettings,
-          mergedIntent,
+          mergedIntent
         );
         if (rememberedDefaultsPatch) {
           const mutation = registerAgentGUIComposerDefaultsMutation(
             composerDefaultsLedgerRef.current,
             defaultDraftKey,
-            rememberedDefaultsPatch,
+            rememberedDefaultsPatch
           );
           const acknowledgement = invokeRememberComposerDefaults(
             onRememberComposerDefaultsRef.current,
             {
               agentTargetId: targetData.agentTargetId,
               provider: targetData.provider,
-              defaults: rememberedDefaultsPatch,
-            },
+              defaults: rememberedDefaultsPatch
+            }
           );
           if (targetData.agentTargetId && acknowledgement) {
             void reconcileAcknowledgedHomeDefaults({
@@ -330,7 +334,7 @@ export function useAgentGUIComposerSettingsActions(
               ledger: composerDefaultsLedgerRef.current,
               mutation,
               reloadComposerOptionsForTarget,
-              target: targetData,
+              target: targetData
             }).catch(() => undefined);
           }
         }
@@ -339,20 +343,20 @@ export function useAgentGUIComposerSettingsActions(
           provider: targetData.provider,
           previousSettings,
           nextSettings: resolveEffectiveComposerSettings({
-            settings: mergedIntent,
-          }),
+            settings: mergedIntent
+          })
         });
         loadDraftComposerOptions(
           snapshotComposerOptions?.behavior
             ?.refreshModelOptionsAfterSettings === true
             ? { force: true }
-            : undefined,
+            : undefined
         );
         return;
       }
       const canonicalSession = selectEngineSession(
         sessionEngine.getSnapshot(),
-        agentSessionId,
+        agentSessionId
       );
       // The optimistic pre-activation window (see startConversation): the id
       // is already the active conversation but the backend session has not
@@ -364,14 +368,14 @@ export function useAgentGUIComposerSettingsActions(
         canonicalSession === null &&
         activation.stateFor(agentSessionId) === "activating";
       const sessionSettings = cloneComposerSettings(
-        canonicalSession ? activeCanonicalComposerSettings : null,
+        canonicalSession ? activeCanonicalComposerSettings : null
       );
       const nextPermission =
         supportedNextSettings.permissionModeId !== undefined
           ? normalizeOptionalText(supportedNextSettings.permissionModeId)
           : undefined;
       const currentPermission = normalizeOptionalText(
-        sessionSettings?.permissionModeId,
+        sessionSettings?.permissionModeId
       );
       const nextModel =
         supportedNextSettings.model !== undefined
@@ -398,7 +402,7 @@ export function useAgentGUIComposerSettingsActions(
 
       const rememberedDefaultsPatch = composerDefaultsPatchFromSettings(
         supportedNextSettings,
-        supportedNextSettings as AgentSessionComposerSettings,
+        supportedNextSettings as AgentSessionComposerSettings
       );
       if (rememberedDefaultsPatch) {
         const defaultAgentTargetId =
@@ -411,8 +415,8 @@ export function useAgentGUIComposerSettingsActions(
           {
             agentTargetId: defaultAgentTargetId,
             provider: defaultProvider,
-            defaults: rememberedDefaultsPatch,
-          },
+            defaults: rememberedDefaultsPatch
+          }
         );
         if (saving) {
           // Defaults persistence is independent from the active-session
@@ -464,7 +468,7 @@ export function useAgentGUIComposerSettingsActions(
         if (composerSupport.permissionModeChangeDeferred && isTurnInFlight) {
           onShowMessageRef.current?.(
             translate("messages.agentPermissionModeAppliesNextTurn"),
-            "info",
+            "info"
           );
         }
       }
@@ -476,12 +480,12 @@ export function useAgentGUIComposerSettingsActions(
           sessionEngine.dispatch({
             type: "activation/settingsPatched",
             agentSessionId,
-            settings: { ...sessionSettingsPatch },
+            settings: { ...sessionSettingsPatch }
           });
         } else {
           sessionEngine.updateSessionSettings({
             agentSessionId,
-            settings: { ...sessionSettingsPatch },
+            settings: { ...sessionSettingsPatch }
           });
         }
         return;
@@ -496,8 +500,8 @@ export function useAgentGUIComposerSettingsActions(
       reloadComposerOptionsForTarget,
       sessionEngine,
       workspaceId,
-      setDetailError,
-    ],
+      setDetailError
+    ]
   );
   updateComposerSettingsRef.current = updateComposerSettings;
 
@@ -508,32 +512,41 @@ export function useAgentGUIComposerSettingsActions(
       onDataChangeRef.current((current) =>
         planIssueBudgetPresetsEqual(current.planIssueBudgetPreset, normalized)
           ? current
-          : { ...current, planIssueBudgetPreset: normalized },
+          : { ...current, planIssueBudgetPreset: normalized }
       );
-    },
+    }
   );
 
   // Recovery entry for the composer-options terminal error state. Leave the
   // request non-forced so Activity Core joins an already-running load when a
   // user double-clicks the retry control instead of superseding it.
-  const retryComposerOptions = useStableControllerEventCallback(() => {
-    loadDraftComposerOptions();
-  });
+  const retryComposerOptions = useStableControllerEventCallback(
+    (options?: {
+      section?: "core" | "capabilities";
+      waitForFreshModelCatalog?: boolean;
+    }) => {
+      if (options === undefined) {
+        loadDraftComposerOptions();
+        return;
+      }
+      loadDraftComposerOptions(options);
+    }
+  );
 
   return {
     retryComposerOptions,
     updateComposerSettings,
-    updatePlanIssueBudgetPreset,
+    updatePlanIssueBudgetPreset
   };
 }
 
 function invokeRememberComposerDefaults(
   callback:
     | ((
-        input: AgentGUIRememberComposerDefaultsInput,
+        input: AgentGUIRememberComposerDefaultsInput
       ) => void | Promise<AgentGUIRememberComposerDefaultsResult>)
     | undefined,
-  input: AgentGUIRememberComposerDefaultsInput,
+  input: AgentGUIRememberComposerDefaultsInput
 ): Promise<AgentGUIRememberComposerDefaultsResult> | undefined {
   if (!callback) return undefined;
   try {
@@ -571,21 +584,21 @@ async function reconcileAcknowledgedHomeDefaults(input: {
     !acknowledgeAgentGUIComposerDefaultsMutation(
       input.ledger,
       input.mutation,
-      result,
+      result
     )
   ) {
     return;
   }
   await input.reloadComposerOptionsForTarget({
     settings: currentDraft,
-    target: input.target,
+    target: input.target
   });
 }
 
 function reconcileRetiredDraftMap(
   current: Record<string, AgentSessionComposerSettings>,
   draftKey: string,
-  retired: readonly AgentGUIRetiredComposerDefault[],
+  retired: readonly AgentGUIRetiredComposerDefault[]
 ): Record<string, AgentSessionComposerSettings> {
   const draft = current[draftKey];
   if (!draft) return current;

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIControllerRefs.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIControllerRefs.ts
@@ -71,7 +71,13 @@ export function useAgentGUIControllerRefs(
   const onShowMessageRef = useRef(input.onShowMessage);
   const handledPrefillPromptSequenceRef = useRef<number | null>(null);
   const handledComposerAppendSequenceRef = useRef<number | null>(null);
-  const loadDraftComposerOptionsRef = useRef<() => void>(() => {});
+  const loadDraftComposerOptionsRef = useRef<
+    (options?: {
+      force?: boolean;
+      section?: "core" | "capabilities";
+      waitForFreshModelCatalog?: boolean;
+    }) => void
+  >(() => {});
   const onComposerDefaultsAuthorityReloadedRef =
     useRef<AgentGUIComposerDefaultsAuthorityReconciler>({
       prepareRead: (_target, settings) => ({

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
@@ -678,7 +678,9 @@ export interface AgentGUINodeViewProps extends AgentGUIComposerExternalPromptPro
       permissionMode?: string;
     }) => void;
     /** Re-issues the composer-options load after a terminal error state. */
-    retryComposerOptions: () => void;
+    retryComposerOptions: NonNullable<
+      AgentComposerProps["onRetryComposerOptions"]
+    >;
     setTuttiModeActive: (active: boolean) => void;
     setTuttiModeEffect: (value: number) => void;
     setTuttiModeSpeed: (value: number) => void;

--- a/packages/agent/gui/agentActivityRuntime.tsx
+++ b/packages/agent/gui/agentActivityRuntime.tsx
@@ -129,7 +129,9 @@ export interface AgentActivityRuntimeGetComposerOptionsInput {
   agentTargetId: string;
   cwd?: string | null;
   force?: boolean;
+  waitForFreshModelCatalog?: boolean;
   provider?: string;
+  section?: "full" | "core" | "capabilities";
   settings?: AgentHostAgentSessionComposerSettings | null;
   workspaceId: string;
 }

--- a/packages/agent/gui/agentGUIPerformanceComposerOptions.ts
+++ b/packages/agent/gui/agentGUIPerformanceComposerOptions.ts
@@ -1,0 +1,343 @@
+import type { AgentActivityComposerOptions } from "@tutti-os/agent-activity-core";
+import type {
+  AgentGUIComposerOptionsLoadSource,
+  AgentGUIComposerOptionsPerformanceEvent,
+  AgentGUIPerformanceDurationBucket,
+  AgentGUIPerformanceEvent
+} from "./agentGUIPerformanceEvents.ts";
+
+const MAX_PERFORMANCE_DIMENSION_LENGTH = 80;
+const MAX_MODEL_NAMES = 32;
+const MAX_MODEL_NAME_LENGTH = 120;
+const MAX_MODEL_NAMES_LENGTH = 1_024;
+
+export interface AgentGUIComposerOptionsLoadInput {
+  agentTargetId: string;
+  cwd?: string | null;
+  force?: boolean;
+  load: () => Promise<AgentActivityComposerOptions>;
+  section?: string | null;
+  stage?: string | null;
+  provider?: string | null;
+  source: AgentGUIComposerOptionsLoadSource;
+}
+
+export interface AgentGUIComposerOptionsPerformanceTrackerInput extends AgentGUIComposerOptionsLoadInput {
+  createOperationId?: () => string;
+  nowUnixMs?: () => number;
+  onEvent: (event: AgentGUIComposerOptionsPerformanceEvent) => void;
+  workspaceId: string;
+}
+
+export async function trackAgentGUIComposerOptionsLoad(
+  input: AgentGUIComposerOptionsPerformanceTrackerInput
+): Promise<AgentActivityComposerOptions> {
+  const nowUnixMs = input.nowUnixMs ?? Date.now;
+  const startedAtUnixMs = safeNowUnixMs(nowUnixMs);
+  const operationId = composerOptionsOperationId(input, startedAtUnixMs);
+  const agentTargetId = input.agentTargetId.trim();
+  const force = input.force === true;
+  const hasDirectory = Boolean(input.cwd?.trim());
+  const provider = input.provider?.trim() || "unknown";
+  const stage = composerOptionsStage(input.section, input.stage);
+  emitPerformanceEvent(input.onEvent, {
+    agentTargetId,
+    force,
+    hasDirectory,
+    observedAtUnixMs: startedAtUnixMs,
+    operationId,
+    provider,
+    source: input.source,
+    startedAtUnixMs,
+    type: "composer_options_load_started",
+    workspaceId: input.workspaceId
+  });
+  if (stage) {
+    emitPerformanceEvent(input.onEvent, {
+      agentTargetId,
+      force,
+      hasDirectory,
+      observedAtUnixMs: startedAtUnixMs,
+      operationId,
+      provider,
+      section: stage.section,
+      source: input.source,
+      stage: stage.stage,
+      startedAtUnixMs,
+      type: "composer_options_stage_started",
+      workspaceId: input.workspaceId
+    });
+  }
+
+  let options: AgentActivityComposerOptions;
+  try {
+    options = await input.load();
+  } catch (error) {
+    const observedAtUnixMs = safeNowUnixMs(nowUnixMs);
+    const errorFields = performanceErrorFieldsFromError(error);
+    if (!isExpectedComposerOptionsCancellation(error)) {
+      if (stage) {
+        emitPerformanceEvent(input.onEvent, {
+          agentTargetId,
+          ...agentGUIPerformanceDuration(observedAtUnixMs - startedAtUnixMs),
+          ...errorFields,
+          failureStage: "options_load",
+          force,
+          hasDirectory,
+          observedAtUnixMs,
+          operationId,
+          outcome: "failed",
+          provider,
+          section: stage.section,
+          source: input.source,
+          stage: stage.stage,
+          startedAtUnixMs,
+          type: "composer_options_stage_settled",
+          workspaceId: input.workspaceId
+        });
+      }
+      emitPerformanceEvent(input.onEvent, {
+        agentTargetId,
+        ...agentGUIPerformanceDuration(observedAtUnixMs - startedAtUnixMs),
+        ...errorFields,
+        failureStage: "options_load",
+        force,
+        hasDirectory,
+        observedAtUnixMs,
+        operationId,
+        outcome: "failed",
+        provider,
+        source: input.source,
+        startedAtUnixMs,
+        type: "composer_options_load_settled",
+        workspaceId: input.workspaceId
+      });
+    } else if (stage) {
+      emitPerformanceEvent(input.onEvent, {
+        agentTargetId,
+        ...agentGUIPerformanceDuration(observedAtUnixMs - startedAtUnixMs),
+        force,
+        hasDirectory,
+        observedAtUnixMs,
+        operationId,
+        outcome: "failed",
+        provider,
+        section: stage.section,
+        source: input.source,
+        stage: stage.stage,
+        startedAtUnixMs,
+        type: "composer_options_stage_settled",
+        workspaceId: input.workspaceId
+      });
+    }
+    throw error;
+  }
+
+  const observedAtUnixMs = safeNowUnixMs(nowUnixMs);
+  const modelNames = performanceModelNames(options.models);
+  if (stage) {
+    emitPerformanceEvent(input.onEvent, {
+      agentTargetId,
+      ...agentGUIPerformanceDuration(observedAtUnixMs - startedAtUnixMs),
+      force,
+      hasDirectory,
+      ...(modelNames ? { modelNames } : {}),
+      observedAtUnixMs,
+      operationId,
+      outcome: "completed",
+      provider: options.provider?.trim() || provider,
+      section: stage.section,
+      source: input.source,
+      stage: stage.stage,
+      startedAtUnixMs,
+      type: "composer_options_stage_settled",
+      workspaceId: input.workspaceId
+    });
+  }
+  emitPerformanceEvent(input.onEvent, {
+    agentTargetId,
+    ...agentGUIPerformanceDuration(observedAtUnixMs - startedAtUnixMs),
+    force,
+    hasDirectory,
+    modelCount: Array.isArray(options.models) ? options.models.length : 0,
+    ...(modelNames ? { modelNames } : {}),
+    observedAtUnixMs,
+    operationId,
+    outcome: "completed",
+    provider: options.provider?.trim() || provider,
+    source: input.source,
+    startedAtUnixMs,
+    type: "composer_options_load_settled",
+    workspaceId: input.workspaceId
+  });
+  return options;
+}
+
+export function agentGUIPerformanceDuration(durationMs: number): {
+  durationBucket: AgentGUIPerformanceDurationBucket;
+  durationMs: number;
+} {
+  const normalizedDurationMs = Number.isFinite(durationMs)
+    ? Math.max(0, durationMs)
+    : 0;
+  const durationBucket =
+    normalizedDurationMs < 1_000
+      ? "lt_1s"
+      : normalizedDurationMs < 3_000
+        ? "1s_to_3s"
+        : normalizedDurationMs < 10_000
+          ? "3s_to_10s"
+          : normalizedDurationMs < 30_000
+            ? "10s_to_30s"
+            : normalizedDurationMs < 60_000
+              ? "30s_to_60s"
+              : "gte_60s";
+  return { durationBucket, durationMs: normalizedDurationMs };
+}
+
+export function emitPerformanceEvent<TEvent extends AgentGUIPerformanceEvent>(
+  onEvent: (event: TEvent) => void,
+  event: TEvent
+): void {
+  try {
+    onEvent(event);
+  } catch (error) {
+    // Performance reporting must never affect the Agent runtime.
+    console.error("[agent-gui] performance event sink failed", error);
+  }
+}
+
+function composerOptionsStage(
+  section: string | null | undefined,
+  stage: string | null | undefined
+): { section: string; stage: string } | null {
+  const normalizedSection = normalizePerformanceDimension(section);
+  const normalizedStage = normalizePerformanceDimension(stage);
+  return normalizedSection && normalizedStage
+    ? { section: normalizedSection, stage: normalizedStage }
+    : null;
+}
+
+function normalizePerformanceDimension(
+  value: string | null | undefined
+): string | undefined {
+  const normalized = (value ?? "")
+    .trim()
+    .replace(/[^a-zA-Z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, MAX_PERFORMANCE_DIMENSION_LENGTH);
+  return normalized || undefined;
+}
+
+function performanceModelNames(
+  models: AgentActivityComposerOptions["models"]
+): string[] | undefined {
+  const names: string[] = [];
+  const seen = new Set<string>();
+  let totalLength = 0;
+  for (const model of models) {
+    const name = normalizePerformanceModelName(model.value);
+    if (!name || seen.has(name)) continue;
+    if (
+      names.length >= MAX_MODEL_NAMES ||
+      totalLength + name.length > MAX_MODEL_NAMES_LENGTH
+    ) {
+      break;
+    }
+    names.push(name);
+    seen.add(name);
+    totalLength += name.length;
+  }
+  return names.length > 0 ? names : undefined;
+}
+
+function normalizePerformanceModelName(value: string): string | undefined {
+  let withoutControls = "";
+  for (const character of value) {
+    const code = character.charCodeAt(0);
+    if ((code >= 0 && code <= 0x1f) || (code >= 0x7f && code <= 0x9f)) {
+      continue;
+    }
+    withoutControls += character;
+  }
+  const normalized = withoutControls
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, MAX_MODEL_NAME_LENGTH);
+  return normalized || undefined;
+}
+
+function performanceErrorFieldsFromError(error: unknown): {
+  errorCategory: string;
+  errorCode: string;
+} {
+  const record = asRecord(error);
+  const rawCode = stringField(record, "code") ?? "unknown";
+  const errorCode = rawCode
+    .toLowerCase()
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 120);
+  return {
+    errorCategory: errorCode || "unknown",
+    errorCode: errorCode || "unknown"
+  };
+}
+
+function isExpectedComposerOptionsCancellation(error: unknown): boolean {
+  const record = asRecord(error);
+  const candidates = [
+    stringField(record, "code"),
+    error instanceof Error ? error.name : undefined,
+    error instanceof Error ? error.message : undefined
+  ]
+    .map((value) => value?.trim().toLowerCase())
+    .filter((value): value is string => Boolean(value));
+  return candidates.some((value) =>
+    [
+      "composer_options_load_aborted",
+      "composer_options_load_superseded",
+      "agent_session_engine_disposed"
+    ].includes(value)
+  );
+}
+
+function composerOptionsOperationId(
+  input: Pick<
+    AgentGUIComposerOptionsPerformanceTrackerInput,
+    "createOperationId"
+  >,
+  startedAtUnixMs: number
+): string {
+  const fallback = `composer-options:${startedAtUnixMs}:${Math.random()
+    .toString(36)
+    .slice(2)}`;
+  try {
+    return input.createOperationId?.().trim() || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function safeNowUnixMs(nowUnixMs: () => number): number {
+  try {
+    const value = nowUnixMs();
+    return Number.isFinite(value) ? value : Date.now();
+  } catch {
+    return Date.now();
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function stringField(
+  value: Record<string, unknown> | null,
+  key: string
+): string | undefined {
+  const field = value?.[key];
+  return typeof field === "string" && field.trim() ? field.trim() : undefined;
+}

--- a/packages/agent/gui/agentGUIPerformanceEvents.ts
+++ b/packages/agent/gui/agentGUIPerformanceEvents.ts
@@ -97,6 +97,7 @@ export type AgentGUIPerformanceEvent =
       force: boolean;
       hasDirectory: boolean;
       modelCount?: number;
+      modelNames?: string[];
       observedAtUnixMs: number;
       operationId: string;
       outcome: "completed" | "failed";
@@ -105,9 +106,50 @@ export type AgentGUIPerformanceEvent =
       startedAtUnixMs: number;
       type: "composer_options_load_settled";
       workspaceId: string;
+    }
+  | {
+      agentTargetId: string;
+      force: boolean;
+      hasDirectory: boolean;
+      observedAtUnixMs: number;
+      operationId: string;
+      provider: string;
+      section: string;
+      source: AgentGUIComposerOptionsLoadSource;
+      stage: string;
+      startedAtUnixMs: number;
+      type: "composer_options_stage_started";
+      workspaceId: string;
+    }
+  | {
+      agentTargetId: string;
+      durationBucket: AgentGUIPerformanceDurationBucket;
+      durationMs: number;
+      errorCategory?: string;
+      errorCode?: string;
+      failureStage?: AgentGUIPerformanceFailureStage;
+      force: boolean;
+      hasDirectory: boolean;
+      modelNames?: string[];
+      observedAtUnixMs: number;
+      operationId: string;
+      outcome: "completed" | "failed";
+      provider: string;
+      section: string;
+      source: AgentGUIComposerOptionsLoadSource;
+      stage: string;
+      startedAtUnixMs: number;
+      type: "composer_options_stage_settled";
+      workspaceId: string;
     };
 
 export type AgentGUIComposerOptionsPerformanceEvent = Extract<
   AgentGUIPerformanceEvent,
-  { type: "composer_options_load_settled" | "composer_options_load_started" }
+  {
+    type:
+      | "composer_options_load_settled"
+      | "composer_options_load_started"
+      | "composer_options_stage_settled"
+      | "composer_options_stage_started";
+  }
 >;

--- a/packages/agent/gui/agentGUIPerformanceMonitor.spec.ts
+++ b/packages/agent/gui/agentGUIPerformanceMonitor.spec.ts
@@ -130,6 +130,57 @@ describe("createAgentGUIPerformanceMonitor", () => {
     monitor.dispose();
   });
 
+  it("reports section stages and bounded model names", async () => {
+    const onEvent = vi.fn();
+    const options = {
+      models: [
+        { label: "GPT-5", value: "gpt-5" },
+        { label: "GPT-5 duplicate", value: "gpt-5" },
+        { label: "Other", value: "model\nwith-control" }
+      ],
+      provider: "codex"
+    } as AgentActivityComposerOptions;
+
+    await expect(
+      trackAgentGUIComposerOptionsLoad({
+        agentTargetId: "codex-target",
+        cwd: "/private/workspace",
+        load: () => Promise.resolve(options),
+        onEvent,
+        provider: "codex",
+        section: "core",
+        source: "runtime",
+        stage: "model_catalog",
+        workspaceId: "workspace-1"
+      })
+    ).resolves.toBe(options);
+
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        section: "core",
+        stage: "model_catalog",
+        type: "composer_options_stage_started"
+      })
+    );
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelNames: ["gpt-5", "modelwith-control"],
+        section: "core",
+        stage: "model_catalog",
+        type: "composer_options_stage_settled"
+      })
+    );
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelNames: ["gpt-5", "modelwith-control"],
+        type: "composer_options_load_settled"
+      })
+    );
+    expect(JSON.stringify(onEvent.mock.calls)).not.toContain(
+      "/private/workspace"
+    );
+  });
+
   it("uses bounded unknown for a missing Composer error code and rethrows it", async () => {
     const sinkFailure = new Error("event sink failed");
     const failure = new Error("private provider response");

--- a/packages/agent/gui/agentGUIPerformanceMonitor.ts
+++ b/packages/agent/gui/agentGUIPerformanceMonitor.ts
@@ -7,13 +7,23 @@ import {
   type AgentSessionEngine,
   type AgentSessionEngineState
 } from "@tutti-os/agent-activity-core";
+import {
+  agentGUIPerformanceDuration,
+  emitPerformanceEvent,
+  trackAgentGUIComposerOptionsLoad,
+  type AgentGUIComposerOptionsLoadInput
+} from "./agentGUIPerformanceComposerOptions.ts";
 import type {
-  AgentGUIComposerOptionsLoadSource,
-  AgentGUIComposerOptionsPerformanceEvent,
   AgentGUIFirstTokenKind,
-  AgentGUIPerformanceDurationBucket,
   AgentGUIPerformanceEvent
 } from "./agentGUIPerformanceEvents.ts";
+
+export {
+  agentGUIPerformanceDuration,
+  trackAgentGUIComposerOptionsLoad,
+  type AgentGUIComposerOptionsLoadInput,
+  type AgentGUIComposerOptionsPerformanceTrackerInput
+} from "./agentGUIPerformanceComposerOptions.ts";
 
 export type {
   AgentGUIComposerOptionsLoadSource,
@@ -25,22 +35,6 @@ export type {
 } from "./agentGUIPerformanceEvents.ts";
 
 const MAX_RETAINED_PERFORMANCE_RECORDS = 512;
-
-export interface AgentGUIComposerOptionsLoadInput {
-  agentTargetId: string;
-  cwd?: string | null;
-  force?: boolean;
-  load: () => Promise<AgentActivityComposerOptions>;
-  provider?: string | null;
-  source: AgentGUIComposerOptionsLoadSource;
-}
-
-export interface AgentGUIComposerOptionsPerformanceTrackerInput extends AgentGUIComposerOptionsLoadInput {
-  createOperationId?: () => string;
-  nowUnixMs?: () => number;
-  onEvent: (event: AgentGUIComposerOptionsPerformanceEvent) => void;
-  workspaceId: string;
-}
 
 export interface AgentGUIPerformanceMonitor {
   dispose(): void;
@@ -496,96 +490,6 @@ export function createAgentGUIPerformanceMonitor(input: {
   };
 }
 
-export async function trackAgentGUIComposerOptionsLoad(
-  input: AgentGUIComposerOptionsPerformanceTrackerInput
-): Promise<AgentActivityComposerOptions> {
-  const nowUnixMs = input.nowUnixMs ?? Date.now;
-  const startedAtUnixMs = safeNowUnixMs(nowUnixMs);
-  const operationId = composerOptionsOperationId(input, startedAtUnixMs);
-  const agentTargetId = input.agentTargetId.trim();
-  const force = input.force === true;
-  const hasDirectory = Boolean(input.cwd?.trim());
-  const provider = input.provider?.trim() || "unknown";
-  emitPerformanceEvent(input.onEvent, {
-    agentTargetId,
-    force,
-    hasDirectory,
-    observedAtUnixMs: startedAtUnixMs,
-    operationId,
-    provider,
-    source: input.source,
-    startedAtUnixMs,
-    type: "composer_options_load_started",
-    workspaceId: input.workspaceId
-  });
-
-  let options: AgentActivityComposerOptions;
-  try {
-    options = await input.load();
-  } catch (error) {
-    const observedAtUnixMs = safeNowUnixMs(nowUnixMs);
-    if (!isExpectedComposerOptionsCancellation(error)) {
-      emitPerformanceEvent(input.onEvent, {
-        agentTargetId,
-        ...agentGUIPerformanceDuration(observedAtUnixMs - startedAtUnixMs),
-        ...performanceErrorFieldsFromError(error),
-        failureStage: "options_load",
-        force,
-        hasDirectory,
-        observedAtUnixMs,
-        operationId,
-        outcome: "failed",
-        provider,
-        source: input.source,
-        startedAtUnixMs,
-        type: "composer_options_load_settled",
-        workspaceId: input.workspaceId
-      });
-    }
-    throw error;
-  }
-
-  const observedAtUnixMs = safeNowUnixMs(nowUnixMs);
-  emitPerformanceEvent(input.onEvent, {
-    agentTargetId,
-    ...agentGUIPerformanceDuration(observedAtUnixMs - startedAtUnixMs),
-    force,
-    hasDirectory,
-    modelCount: Array.isArray(options.models) ? options.models.length : 0,
-    observedAtUnixMs,
-    operationId,
-    outcome: "completed",
-    provider: options.provider?.trim() || provider,
-    source: input.source,
-    startedAtUnixMs,
-    type: "composer_options_load_settled",
-    workspaceId: input.workspaceId
-  });
-  return options;
-}
-
-export function agentGUIPerformanceDuration(durationMs: number): {
-  durationBucket: AgentGUIPerformanceDurationBucket;
-  durationMs: number;
-} {
-  const normalizedDurationMs = Number.isFinite(durationMs)
-    ? Math.max(0, durationMs)
-    : 0;
-  const durationBucket =
-    normalizedDurationMs < 1_000
-      ? "lt_1s"
-      : normalizedDurationMs < 3_000
-        ? "1s_to_3s"
-        : normalizedDurationMs < 10_000
-          ? "3s_to_10s"
-          : normalizedDurationMs < 30_000
-            ? "10s_to_30s"
-            : normalizedDurationMs < 60_000
-              ? "30s_to_60s"
-              : "gte_60s";
-  return { durationBucket, durationMs: normalizedDurationMs };
-}
-
 function firstTokenObservation(
   event: unknown,
   workspaceId: string,
@@ -677,13 +581,6 @@ function performanceTurnKey(agentSessionId: string, turnId: string): string {
   return `${agentSessionId}\u0000${turnId}`;
 }
 
-function performanceErrorFieldsFromError(error: unknown): {
-  errorCategory: string;
-  errorCode: string;
-} {
-  return performanceErrorFieldsFromCode(stringField(asRecord(error), "code"));
-}
-
 function performanceErrorFieldsFromCode(value: unknown): {
   errorCategory: string;
   errorCode: string;
@@ -700,62 +597,6 @@ function normalizePerformanceErrorCode(value: unknown): string {
     .replace(/^_+|_+$/g, "")
     .slice(0, 120);
   return normalized || "unknown";
-}
-
-function isExpectedComposerOptionsCancellation(error: unknown): boolean {
-  const record = asRecord(error);
-  const candidates = [
-    stringField(record, "code"),
-    error instanceof Error ? error.name : undefined,
-    error instanceof Error ? error.message : undefined
-  ]
-    .map((value) => value?.trim().toLowerCase())
-    .filter((value): value is string => Boolean(value));
-  return candidates.some((value) =>
-    [
-      "composer_options_load_aborted",
-      "composer_options_load_superseded",
-      "agent_session_engine_disposed"
-    ].includes(value)
-  );
-}
-
-function composerOptionsOperationId(
-  input: Pick<
-    AgentGUIComposerOptionsPerformanceTrackerInput,
-    "createOperationId"
-  >,
-  startedAtUnixMs: number
-): string {
-  const fallback = `composer-options:${startedAtUnixMs}:${Math.random()
-    .toString(36)
-    .slice(2)}`;
-  try {
-    return input.createOperationId?.().trim() || fallback;
-  } catch {
-    return fallback;
-  }
-}
-
-function safeNowUnixMs(nowUnixMs: () => number): number {
-  try {
-    const value = nowUnixMs();
-    return Number.isFinite(value) ? value : Date.now();
-  } catch {
-    return Date.now();
-  }
-}
-
-function emitPerformanceEvent<TEvent extends AgentGUIPerformanceEvent>(
-  onEvent: (event: TEvent) => void,
-  event: TEvent
-): void {
-  try {
-    onEvent(event);
-  } catch (error) {
-    // Performance reporting must never affect the Agent runtime.
-    console.error("[agent-gui] performance event sink failed", error);
-  }
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {

--- a/packages/agent/host/ports.go
+++ b/packages/agent/host/ports.go
@@ -17,8 +17,9 @@ type CanonicalSessionStore interface {
 }
 
 type RuntimeSessionInitialization struct {
-	Session       ProviderRuntimeSession
-	RailPlacement *RailPlacement
+	Session                    ProviderRuntimeSession
+	RailPlacement              *RailPlacement
+	RailPlacementAuthoritative bool
 }
 
 type CanonicalTurnStore interface {

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -665,6 +665,11 @@ type CreateSessionInput struct {
 	ConversationDetailMode string
 	Visible                *bool
 	RailPlacement          *RailPlacement
+	// RailPlacementAuthoritative declares that RailPlacement was selected by
+	// an external canonical authority and may name a project absent from this
+	// Host's local project registry. It applies only to first initialization
+	// and never permits replacing an existing canonical placement.
+	RailPlacementAuthoritative bool
 }
 
 type SendInput struct {

--- a/packages/agent/store-sqlite/repository.go
+++ b/packages/agent/store-sqlite/repository.go
@@ -717,15 +717,19 @@ type SessionStateReport struct {
 	ImportProjectPath string
 	// RailPlacement is an explicit caller-selected placement for a newly
 	// created session. The first accepted value is immutable.
-	RailPlacement    *RailSection
-	Title            string
-	Status           string
-	CurrentPhase     string
-	LastError        string
-	OccurredAtUnixMS int64
-	StartedAtUnixMS  int64
-	EndedAtUnixMS    int64
-	CreatedAtUnixMS  int64
+	RailPlacement *RailSection
+	// RailPlacementAuthoritative accepts an explicit project placement even
+	// when it is absent from this store's local project registry. It does not
+	// permit changing an existing session's immutable placement.
+	RailPlacementAuthoritative bool
+	Title                      string
+	Status                     string
+	CurrentPhase               string
+	LastError                  string
+	OccurredAtUnixMS           int64
+	StartedAtUnixMS            int64
+	EndedAtUnixMS              int64
+	CreatedAtUnixMS            int64
 }
 
 type StateReportResult struct {

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -1909,6 +1909,14 @@ export type AgentProviderComposerConfig = {
 
 export type GetAgentProviderComposerOptionsRequest = {
   /**
+   * Selects the independently loadable composer section. Core contains model, reasoning, speed, permission, and runtime settings; capabilities contains skills and capability catalog data. Full is retained for callers that need the combined legacy response.
+   */
+  section?: "full" | "core" | "capabilities";
+  /**
+   * Waits for an authoritative model catalog when the cached result is stale. Use only for an explicit model-picker request; ordinary composer loads should render the last successful catalog first.
+   */
+  waitForFreshModelCatalog?: boolean;
+  /**
    * Agent target whose provider and runtime context the composer options resolve against. Optional; when omitted the provider path parameter is used directly.
    */
   agentTargetId?: string;
@@ -1922,6 +1930,10 @@ export type GetAgentProviderComposerOptionsRequest = {
 };
 
 export type GetWorkspaceAppFactoryAgentTargetComposerOptionsRequest = {
+  /**
+   * Independently loadable composer section.
+   */
+  section?: "full" | "core" | "capabilities";
   locale?: DesktopLocale;
   settings?: AgentSessionComposerSettings;
 };

--- a/services/tuttid/agent_replay_composition.go
+++ b/services/tuttid/agent_replay_composition.go
@@ -238,13 +238,15 @@ func applyAgentReplayRuntimeComposition(
 func startProviderAuthWatcher(
 	replay bool,
 	onChange func([]string),
+	onChangeDetailed func([]agentservice.ProviderAuthChange),
 ) *agentservice.ProviderAuthWatcher {
 	if replay {
 		return nil
 	}
 	watcher := &agentservice.ProviderAuthWatcher{
-		Entries:  agentservice.DefaultProviderAuthWatchEntries(),
-		OnChange: onChange,
+		Entries:          agentservice.DefaultProviderAuthWatchEntries(),
+		OnChange:         onChange,
+		OnChangeDetailed: onChangeDetailed,
 	}
 	watcher.Start()
 	return watcher

--- a/services/tuttid/api/daemon_agent_composer_options_test.go
+++ b/services/tuttid/api/daemon_agent_composer_options_test.go
@@ -61,6 +61,12 @@ func TestDaemonAPIGeneratedRoutesGetAgentProviderComposerOptions(t *testing.T) {
 				if input.Settings.Model != "gpt-5" || input.Settings.ReasoningEffort != "high" {
 					t.Fatalf("settings = %#v", input.Settings)
 				}
+				if input.Section != agentservice.ComposerOptionsSectionCore {
+					t.Fatalf("section = %q, want core", input.Section)
+				}
+				if !input.WaitForFreshModelCatalog {
+					t.Fatal("waitForFreshModelCatalog = false, want true")
+				}
 				return agentservice.ComposerOptions{
 					Capabilities: []string{"imageInput", "planMode", "browserUse"},
 					Commands: []agentservice.ComposerCommandOption{{
@@ -145,8 +151,10 @@ func TestDaemonAPIGeneratedRoutesGetAgentProviderComposerOptions(t *testing.T) {
 	}))
 
 	recorder := performGeneratedRouteRequest(t, mux, http.MethodPost, "/v1/agent-providers/codex/composer-options", map[string]any{
-		"cwd":    "/workspace/project",
-		"locale": "zh-CN",
+		"cwd":                      "/workspace/project",
+		"locale":                   "zh-CN",
+		"section":                  "core",
+		"waitForFreshModelCatalog": true,
 		"settings": map[string]any{
 			"model":            "gpt-5",
 			"permissionModeId": "auto",

--- a/services/tuttid/api/daemon_agent_sessions.go
+++ b/services/tuttid/api/daemon_agent_sessions.go
@@ -85,9 +85,13 @@ func (api DaemonAPI) GetAgentProviderComposerOptions(ctx context.Context, reques
 		Provider: string(request.Provider),
 	}
 	if request.Body != nil {
+		if request.Body.Section != nil {
+			input.Section = agentservice.ComposerOptionsSection(*request.Body.Section)
+		}
 		input.AgentTargetID = optionalStringValue(request.Body.AgentTargetId)
 		input.Cwd = optionalStringValue(request.Body.Cwd)
 		input.WorkspaceID = optionalStringValue(request.Body.WorkspaceId)
+		input.WaitForFreshModelCatalog = request.Body.WaitForFreshModelCatalog != nil && *request.Body.WaitForFreshModelCatalog
 	}
 	if request.Body != nil && request.Body.Settings != nil {
 		input.Settings = composerSettingsFromGenerated(*request.Body.Settings)

--- a/services/tuttid/api/daemon_app_factory.go
+++ b/services/tuttid/api/daemon_app_factory.go
@@ -116,6 +116,10 @@ func (api DaemonAPI) GetWorkspaceAppFactoryAgentTargetComposerOptions(ctx contex
 		}, nil
 	}
 	settings := agentservice.ComposerSettings{}
+	section := agentservice.ComposerOptionsSectionFull
+	if request.Body != nil && request.Body.Section != nil {
+		section = agentservice.ComposerOptionsSection(*request.Body.Section)
+	}
 	if request.Body != nil && request.Body.Settings != nil {
 		settings = composerSettingsFromGenerated(*request.Body.Settings)
 	}
@@ -126,6 +130,7 @@ func (api DaemonAPI) GetWorkspaceAppFactoryAgentTargetComposerOptions(ctx contex
 	options, err := api.AppFactoryService.GetAgentTargetComposerOptions(ctx, workspaceID, workspaceservice.AppFactoryAgentTargetComposerOptionsInput{
 		AgentTargetID: agentTargetID,
 		Locale:        locale,
+		Section:       section,
 		Settings:      settings,
 	})
 	if err != nil {

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -2320,6 +2320,48 @@ func (e ExternalAgentImportArchiveKind) Valid() bool {
 	}
 }
 
+// Defines values for GetAgentProviderComposerOptionsRequestSection.
+const (
+	GetAgentProviderComposerOptionsRequestSectionCapabilities GetAgentProviderComposerOptionsRequestSection = "capabilities"
+	GetAgentProviderComposerOptionsRequestSectionCore         GetAgentProviderComposerOptionsRequestSection = "core"
+	GetAgentProviderComposerOptionsRequestSectionFull         GetAgentProviderComposerOptionsRequestSection = "full"
+)
+
+// Valid indicates whether the value is a known member of the GetAgentProviderComposerOptionsRequestSection enum.
+func (e GetAgentProviderComposerOptionsRequestSection) Valid() bool {
+	switch e {
+	case GetAgentProviderComposerOptionsRequestSectionCapabilities:
+		return true
+	case GetAgentProviderComposerOptionsRequestSectionCore:
+		return true
+	case GetAgentProviderComposerOptionsRequestSectionFull:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetWorkspaceAppFactoryAgentTargetComposerOptionsRequestSection.
+const (
+	GetWorkspaceAppFactoryAgentTargetComposerOptionsRequestSectionCapabilities GetWorkspaceAppFactoryAgentTargetComposerOptionsRequestSection = "capabilities"
+	GetWorkspaceAppFactoryAgentTargetComposerOptionsRequestSectionCore         GetWorkspaceAppFactoryAgentTargetComposerOptionsRequestSection = "core"
+	GetWorkspaceAppFactoryAgentTargetComposerOptionsRequestSectionFull         GetWorkspaceAppFactoryAgentTargetComposerOptionsRequestSection = "full"
+)
+
+// Valid indicates whether the value is a known member of the GetWorkspaceAppFactoryAgentTargetComposerOptionsRequestSection enum.
+func (e GetWorkspaceAppFactoryAgentTargetComposerOptionsRequestSection) Valid() bool {
+	switch e {
+	case GetWorkspaceAppFactoryAgentTargetComposerOptionsRequestSectionCapabilities:
+		return true
+	case GetWorkspaceAppFactoryAgentTargetComposerOptionsRequestSectionCore:
+		return true
+	case GetWorkspaceAppFactoryAgentTargetComposerOptionsRequestSectionFull:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for HealthStatusResponseStatus.
 const (
 	Ok HealthStatusResponseStatus = "ok"
@@ -7082,20 +7124,35 @@ type ForkWorkspaceAgentSessionRequest struct {
 // GetAgentProviderComposerOptionsRequest defines model for GetAgentProviderComposerOptionsRequest.
 type GetAgentProviderComposerOptionsRequest struct {
 	// AgentTargetId Agent target whose provider and runtime context the composer options resolve against. Optional; when omitted the provider path parameter is used directly.
-	AgentTargetId *string                       `json:"agentTargetId,omitempty"`
-	Cwd           *string                       `json:"cwd,omitempty"`
-	Locale        *DesktopLocale                `json:"locale,omitempty"`
-	Settings      *AgentSessionComposerSettings `json:"settings,omitempty"`
+	AgentTargetId *string        `json:"agentTargetId,omitempty"`
+	Cwd           *string        `json:"cwd,omitempty"`
+	Locale        *DesktopLocale `json:"locale,omitempty"`
+
+	// Section Selects the independently loadable composer section. Core contains model, reasoning, speed, permission, and runtime settings; capabilities contains skills and capability catalog data. Full is retained for callers that need the combined legacy response.
+	Section  *GetAgentProviderComposerOptionsRequestSection `json:"section,omitempty"`
+	Settings *AgentSessionComposerSettings                  `json:"settings,omitempty"`
+
+	// WaitForFreshModelCatalog Waits for an authoritative model catalog when the cached result is stale. Use only for an explicit model-picker request; ordinary composer loads should render the last successful catalog first.
+	WaitForFreshModelCatalog *bool `json:"waitForFreshModelCatalog,omitempty"`
 
 	// WorkspaceId Workspace used for Claude Code live model discovery.
 	WorkspaceId *string `json:"workspaceId,omitempty"`
 }
 
+// GetAgentProviderComposerOptionsRequestSection Selects the independently loadable composer section. Core contains model, reasoning, speed, permission, and runtime settings; capabilities contains skills and capability catalog data. Full is retained for callers that need the combined legacy response.
+type GetAgentProviderComposerOptionsRequestSection string
+
 // GetWorkspaceAppFactoryAgentTargetComposerOptionsRequest defines model for GetWorkspaceAppFactoryAgentTargetComposerOptionsRequest.
 type GetWorkspaceAppFactoryAgentTargetComposerOptionsRequest struct {
-	Locale   *DesktopLocale                `json:"locale,omitempty"`
-	Settings *AgentSessionComposerSettings `json:"settings,omitempty"`
+	Locale *DesktopLocale `json:"locale,omitempty"`
+
+	// Section Independently loadable composer section.
+	Section  *GetWorkspaceAppFactoryAgentTargetComposerOptionsRequestSection `json:"section,omitempty"`
+	Settings *AgentSessionComposerSettings                                   `json:"settings,omitempty"`
 }
+
+// GetWorkspaceAppFactoryAgentTargetComposerOptionsRequestSection Independently loadable composer section.
+type GetWorkspaceAppFactoryAgentTargetComposerOptionsRequestSection string
 
 // HealthStatusResponse defines model for HealthStatusResponse.
 type HealthStatusResponse struct {

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -11496,6 +11496,24 @@ components:
       type: object
       additionalProperties: false
       properties:
+        section:
+          type: string
+          enum:
+            - full
+            - core
+            - capabilities
+          default: full
+          description: >-
+            Selects the independently loadable composer section. Core contains
+            model, reasoning, speed, permission, and runtime settings;
+            capabilities contains skills and capability catalog data. Full is
+            retained for callers that need the combined legacy response.
+        waitForFreshModelCatalog:
+          type: boolean
+          description: >-
+            Waits for an authoritative model catalog when the cached result is
+            stale. Use only for an explicit model-picker request; ordinary
+            composer loads should render the last successful catalog first.
         agentTargetId:
           type: string
           description:
@@ -11515,6 +11533,14 @@ components:
       type: object
       additionalProperties: false
       properties:
+        section:
+          type: string
+          enum:
+            - full
+            - core
+            - capabilities
+          default: full
+          description: Independently loadable composer section.
         locale:
           $ref: "#/components/schemas/DesktopLocale"
         settings:

--- a/services/tuttid/service/agent/codex_appserver_model_session.go
+++ b/services/tuttid/service/agent/codex_appserver_model_session.go
@@ -1,0 +1,231 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+)
+
+// codexAppServerSession keeps one provider app-server alive across model/list
+// requests. The session is deliberately owned by the model catalog, not by a
+// request, so concurrent composer callers share both the process and the
+// initialized protocol connection.
+type codexAppServerSession struct {
+	mu          sync.Mutex
+	base        CodexCLIModelLister
+	process     *codexAppServerProcess
+	cancel      context.CancelFunc
+	scanner     *bufio.Scanner
+	nextID      int
+	initialized bool
+	idleTimer   *time.Timer
+}
+
+func newCodexAppServerSession(base CodexCLIModelLister) *codexAppServerSession {
+	base.Session = nil
+	return &codexAppServerSession{base: base, nextID: 1}
+}
+
+func (s *codexAppServerSession) ListModels(ctx context.Context, lister CodexCLIModelLister) (AgentModelListResult, error) {
+	if s == nil {
+		return lister.listModelsOnce(ctx)
+	}
+	timeout := lister.Timeout
+	if timeout <= 0 {
+		timeout = codexAppServerModelListTimeout
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.process == nil || s.process.exited() {
+		if err := s.startLocked(requestCtx, lister); err != nil {
+			return AgentModelListResult{}, err
+		}
+	}
+	models, err := s.runWithContextLocked(requestCtx, func() ([]AgentModelOption, error) {
+		return s.requestModelsLocked(lister.clientName())
+	})
+	if err == nil {
+		s.armIdleTimerLocked()
+		return AgentModelListResult{Models: models}, nil
+	}
+	if requestCtx.Err() != nil {
+		return AgentModelListResult{}, fmt.Errorf("codex app-server model/list timed out: %w", requestCtx.Err())
+	}
+	process := s.process
+	_ = s.closeLocked()
+	if process != nil {
+		if stderr := strings.TrimSpace(process.stderr.String()); stderr != "" {
+			err = fmt.Errorf("%w: %s", err, stderr)
+		}
+	}
+	return AgentModelListResult{}, err
+}
+
+func (s *codexAppServerSession) startLocked(ctx context.Context, lister CodexCLIModelLister) error {
+	command, args, env, err := lister.resolveLaunch(ctx)
+	if err != nil {
+		return err
+	}
+	processContext, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	slog.Info("agent model catalog process launch",
+		"event", "agent.model_catalog.process_start",
+		"provider", lister.Provider,
+		"command", command,
+		"args", args,
+		"provider_command_resolver", lister.ProviderCommands != nil,
+		"persistent", true,
+	)
+	process, err := startCodexAppServerProcess(processContext, command, args, env)
+	if err != nil {
+		cancel()
+		return err
+	}
+	s.process = process
+	s.cancel = cancel
+	s.scanner = bufio.NewScanner(process.stdout)
+	s.scanner.Buffer(make([]byte, 0, 64*1024), codexModelListMaxLineBytes)
+	s.nextID = 1
+	s.initialized = false
+	return nil
+}
+
+func (s *codexAppServerSession) requestModelsLocked(clientName string) ([]AgentModelOption, error) {
+	if s.process == nil || s.scanner == nil {
+		return nil, fmt.Errorf("codex app-server session is not running")
+	}
+	encoder := json.NewEncoder(s.process.stdin)
+	if !s.initialized {
+		initializeID := s.nextRequestIDLocked()
+		if err := writeCodexInitializeRequest(encoder, initializeID, clientName); err != nil {
+			return nil, err
+		}
+		initializeStartedAt := time.Now()
+		if err := readCodexInitializeResponseForID(s.scanner, initializeID); err != nil {
+			return nil, err
+		}
+		slog.Info("agent model catalog request stage settled",
+			"event", "agent.model_catalog.stage_settled",
+			"provider", s.base.Provider,
+			"stage", "initialize",
+			"durationMs", time.Since(initializeStartedAt).Milliseconds(),
+			"persistent", true,
+		)
+		if err := writeCodexInitializedNotification(encoder); err != nil {
+			return nil, err
+		}
+		s.initialized = true
+	}
+	modelListID := s.nextRequestIDLocked()
+	if err := writeCodexModelListRequest(encoder, modelListID); err != nil {
+		return nil, err
+	}
+	modelListStartedAt := time.Now()
+	models, err := readCodexModelListResponseForID(s.scanner, modelListID)
+	slog.Info("agent model catalog request stage settled",
+		"event", "agent.model_catalog.stage_settled",
+		"provider", s.base.Provider,
+		"stage", "model_list",
+		"durationMs", time.Since(modelListStartedAt).Milliseconds(),
+		"persistent", true,
+		"error", err,
+	)
+	return models, err
+}
+
+func (s *codexAppServerSession) nextRequestIDLocked() string {
+	id := fmt.Sprintf("%d", s.nextID)
+	s.nextID++
+	return id
+}
+
+func (s *codexAppServerSession) runWithContextLocked(
+	ctx context.Context,
+	request func() ([]AgentModelOption, error),
+) ([]AgentModelOption, error) {
+	resultCh := make(chan struct {
+		models []AgentModelOption
+		err    error
+	}, 1)
+	go func() {
+		models, err := request()
+		resultCh <- struct {
+			models []AgentModelOption
+			err    error
+		}{models: models, err: err}
+	}()
+	select {
+	case result := <-resultCh:
+		return result.models, result.err
+	case <-ctx.Done():
+		_ = s.closeLocked()
+		return nil, ctx.Err()
+	}
+}
+
+func (s *codexAppServerSession) closeLocked() error {
+	if s.idleTimer != nil {
+		s.idleTimer.Stop()
+		s.idleTimer = nil
+	}
+	if s.process == nil {
+		return nil
+	}
+	process := s.process
+	cancel := s.cancel
+	s.process = nil
+	s.cancel = nil
+	s.scanner = nil
+	s.initialized = false
+	if cancel == nil {
+		cancel = func() {}
+	}
+	return process.stop(cancel)
+}
+
+func (s *codexAppServerSession) armIdleTimerLocked() {
+	if s.idleTimer != nil {
+		s.idleTimer.Stop()
+	}
+	process := s.process
+	s.idleTimer = time.AfterFunc(codexAppServerIdleTTL, func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if s.process != process {
+			return
+		}
+		slog.Info("agent model catalog idle process closed",
+			"event", "agent.model_catalog.process_idle_close",
+			"provider", s.base.Provider,
+		)
+		_ = s.closeLocked()
+	})
+}
+
+func (s *codexAppServerSession) Close() error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closeLocked()
+}
+
+func (p *codexAppServerProcess) exited() bool {
+	if p == nil {
+		return true
+	}
+	select {
+	case <-p.waitDone:
+		return true
+	default:
+		return false
+	}
+}

--- a/services/tuttid/service/agent/codex_appserver_process.go
+++ b/services/tuttid/service/agent/codex_appserver_process.go
@@ -5,13 +5,16 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"sync"
 )
 
 type codexAppServerProcess struct {
 	stdin    io.WriteCloser
 	stdout   *io.PipeReader
 	stderr   *truncatingBuffer
-	waitDone <-chan error
+	waitDone chan struct{}
+	stopOnce sync.Once
+	stopErr  error
 }
 
 func startCodexAppServerProcess(
@@ -40,18 +43,19 @@ func startCodexAppServerProcess(
 		return nil, fmt.Errorf("start codex app-server: %w", err)
 	}
 
-	waitDone := make(chan error, 1)
-	go func() {
-		waitErr := cmd.Wait()
-		_ = stdoutWriter.Close()
-		waitDone <- waitErr
-	}()
-	return &codexAppServerProcess{
+	waitDone := make(chan struct{})
+	process := &codexAppServerProcess{
 		stdin:    stdin,
 		stdout:   stdout,
 		stderr:   stderr,
 		waitDone: waitDone,
-	}, nil
+	}
+	go func() {
+		_ = cmd.Wait()
+		_ = stdoutWriter.Close()
+		close(waitDone)
+	}()
+	return process, nil
 }
 
 func (p *codexAppServerProcess) stop(cancel context.CancelFunc) error {
@@ -59,11 +63,17 @@ func (p *codexAppServerProcess) stop(cancel context.CancelFunc) error {
 		cancel()
 		return nil
 	}
-	_ = p.stdin.Close()
-	cancel()
-	// A response parser can finish before the app-server exits. Closing the
-	// reader keeps os/exec's stdout copier from making process reaping depend on
-	// unread provider notifications.
-	_ = p.stdout.Close()
-	return <-p.waitDone
+	p.stopOnce.Do(func() {
+		_ = p.stdin.Close()
+		cancel()
+		// A response parser can finish before the app-server exits. Closing the
+		// reader keeps os/exec's stdout copier from making process reaping depend
+		// on unread provider notifications.
+		_ = p.stdout.Close()
+		<-p.waitDone
+		// stop is an intentional shutdown path. A context cancellation normally
+		// makes os/exec report SIGKILL/ExitError; that is not a cleanup failure.
+		p.stopErr = nil
+	})
+	return p.stopErr
 }

--- a/services/tuttid/service/agent/codex_appserver_process_windows_test.go
+++ b/services/tuttid/service/agent/codex_appserver_process_windows_test.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestCodexAppServerProcessStopsOnWindows(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	process, err := startCodexAppServerProcess(ctx, "cmd.exe", []string{
+		"/D",
+		"/S",
+		"/C",
+		"ping 127.0.0.1 -n 20 >NUL",
+	}, nil)
+	if err != nil {
+		t.Fatalf("startCodexAppServerProcess returned error: %v", err)
+	}
+
+	startedAt := time.Now()
+	cancel()
+	if err := process.stop(cancel); err != nil {
+		t.Fatalf("stop returned error: %v", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed > 3*time.Second {
+		t.Fatalf("process cleanup took %s, want bounded Windows kill", elapsed)
+	}
+}

--- a/services/tuttid/service/agent/codex_capability_catalog.go
+++ b/services/tuttid/service/agent/codex_capability_catalog.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -101,6 +102,12 @@ func composerCapabilityCatalogLister(profile composerProfile) (CodexCLICapabilit
 }
 
 func (l CodexCLICapabilityLister) List(ctx context.Context, cwd string) ([]ComposerCapabilityOption, error) {
+	startedAt := time.Now()
+	slog.Info("agent capability catalog fetch started",
+		"event", "agent.capability_catalog.fetch_start",
+		"provider", "codex",
+		"request_set", l.RequestSet,
+	)
 	timeout := l.Timeout
 	if timeout <= 0 {
 		timeout = codexAppServerCapabilityListTimeout
@@ -123,9 +130,31 @@ func (l CodexCLICapabilityLister) List(ctx context.Context, cwd string) ([]Compo
 	defer cancel()
 	process, err := startCodexAppServerProcess(processCtx, command, args, processEnv)
 	if err != nil {
+		slog.Info("agent capability catalog fetch settled",
+			"event", "agent.capability_catalog.fetch_settled",
+			"provider", "codex",
+			"request_set", l.RequestSet,
+			"durationMs", time.Since(startedAt).Milliseconds(),
+			"error", err,
+		)
 		return nil, err
 	}
+	slog.Info("agent capability catalog process launch",
+		"event", "agent.capability_catalog.process_start",
+		"provider", "codex",
+		"command", command,
+		"args", args,
+	)
+	requestStartedAt := time.Now()
 	if err := writeAppServerCapabilityListRequests(process.stdin, cwd, l.RequestSet); err != nil {
+		slog.Info("agent capability catalog request stage settled",
+			"event", "agent.capability_catalog.stage_settled",
+			"provider", "codex",
+			"request_set", l.RequestSet,
+			"stage", "request_dispatch",
+			"durationMs", time.Since(requestStartedAt).Milliseconds(),
+			"error", err,
+		)
 		processErr := processCtx.Err()
 		_ = process.stop(cancel)
 		if processErr != nil {
@@ -133,18 +162,51 @@ func (l CodexCLICapabilityLister) List(ctx context.Context, cwd string) ([]Compo
 		}
 		return nil, err
 	}
+	slog.Info("agent capability catalog request stage settled",
+		"event", "agent.capability_catalog.stage_settled",
+		"provider", "codex",
+		"request_set", l.RequestSet,
+		"stage", "request_dispatch",
+		"durationMs", time.Since(requestStartedAt).Milliseconds(),
+	)
+	responseStartedAt := time.Now()
 	options, err := readAppServerCapabilityListResponses(process.stdout, l.RequestSet)
+	slog.Info("agent capability catalog response stage settled",
+		"event", "agent.capability_catalog.stage_settled",
+		"provider", "codex",
+		"request_set", l.RequestSet,
+		"stage", "capability_response",
+		"durationMs", time.Since(responseStartedAt).Milliseconds(),
+		"optionCount", len(options),
+		"error", err,
+	)
 	processErr := processCtx.Err()
 	_ = process.stop(cancel)
+	settled := func(settledErr error) {
+		slog.Info("agent capability catalog fetch settled",
+			"event", "agent.capability_catalog.fetch_settled",
+			"provider", "codex",
+			"request_set", l.RequestSet,
+			"durationMs", time.Since(startedAt).Milliseconds(),
+			"optionCount", len(options),
+			"error", settledErr,
+		)
+	}
 	if err == nil {
+		settled(nil)
 		return options, nil
 	}
 	if processErr != nil {
-		return nil, fmt.Errorf("codex app-server capability discovery timed out: %w", processErr)
+		timeoutErr := fmt.Errorf("codex app-server capability discovery timed out: %w", processErr)
+		settled(timeoutErr)
+		return nil, timeoutErr
 	}
 	if stderr := strings.TrimSpace(process.stderr.String()); stderr != "" {
-		return nil, fmt.Errorf("%w: %s", err, stderr)
+		stderrErr := fmt.Errorf("%w: %s", err, stderr)
+		settled(stderrErr)
+		return nil, stderrErr
 	}
+	settled(err)
 	return nil, err
 }
 

--- a/services/tuttid/service/agent/codex_model_catalog.go
+++ b/services/tuttid/service/agent/codex_model_catalog.go
@@ -20,6 +20,7 @@ import (
 const (
 	codexAppServerModelListTimeout  = 8 * time.Second
 	codexAppServerShutdownWaitDelay = 100 * time.Millisecond
+	codexAppServerIdleTTL           = 2 * time.Minute
 	codexModelListMaxLineBytes      = 16 * 1024 * 1024
 	codexModelListMaxStderrBytes    = 1024 * 1024
 )
@@ -36,6 +37,7 @@ type CodexCLIModelLister struct {
 	HomeDir          func() (string, error)
 	IsExecutableFile func(string) bool
 	LookPath         func(string) (string, error)
+	Session          *codexAppServerSession
 }
 
 type ProviderCommandResolver interface {
@@ -65,48 +67,22 @@ func (b *truncatingBuffer) String() string {
 }
 
 func (l CodexCLIModelLister) ListModels(ctx context.Context) (AgentModelListResult, error) {
+	if l.Session != nil {
+		return l.Session.ListModels(ctx, l)
+	}
+	return l.listModelsOnce(ctx)
+}
+
+func (l CodexCLIModelLister) listModelsOnce(ctx context.Context) (AgentModelListResult, error) {
 	timeout := l.Timeout
 	if timeout <= 0 {
 		timeout = codexAppServerModelListTimeout
 	}
 	processCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-
-	command := strings.TrimSpace(l.Command)
-	if command == "" {
-		command = "codex"
-	}
-	args := append([]string{}, l.Args...)
-	resolver := runtimecmd.Resolver{
-		Environ:          l.Environ,
-		HomeDir:          l.HomeDir,
-		IsExecutableFile: l.IsExecutableFile,
-		LookPath:         l.LookPath,
-	}
-	var envOverrides []string
-	if l.ProviderCommands != nil && strings.TrimSpace(l.Provider) != "" {
-		resolution, err := l.ProviderCommands.ResolveProviderCommand(processCtx, l.Provider)
-		if err != nil {
-			return AgentModelListResult{}, fmt.Errorf("resolve %s model-list command: %w", l.Provider, err)
-		}
-		if len(resolution.Command) == 0 || strings.TrimSpace(resolution.Command[0]) == "" {
-			return AgentModelListResult{}, fmt.Errorf("resolve %s model-list command: command is empty", l.Provider)
-		}
-		command = resolution.Command[0]
-		args = append([]string{}, resolution.Command[1:]...)
-		envOverrides = resolution.Env
-	}
-	env := resolver.Env(envOverrides)
-	if l.PrepareEnv != nil {
-		var err error
-		env, err = l.PrepareEnv(processCtx, env)
-		if err != nil {
-			return AgentModelListResult{}, err
-		}
-	}
-	command = resolver.Resolve(command, env)
-	if len(args) == 0 {
-		args = []string{"app-server"}
+	command, args, env, err := l.resolveLaunch(processCtx)
+	if err != nil {
+		return AgentModelListResult{}, err
 	}
 	slog.Info("agent model catalog process launch",
 		"event", "agent.model_catalog.process_start",
@@ -119,7 +95,16 @@ func (l CodexCLIModelLister) ListModels(ctx context.Context) (AgentModelListResu
 	if err != nil {
 		return AgentModelListResult{}, err
 	}
+	requestStartedAt := time.Now()
 	models, err := requestCodexModelList(process.stdin, process.stdout, l.clientName())
+	slog.Info("agent model catalog request stage settled",
+		"event", "agent.model_catalog.stage_settled",
+		"provider", l.Provider,
+		"stage", "initialize_and_model_list",
+		"durationMs", time.Since(requestStartedAt).Milliseconds(),
+		"persistent", false,
+		"error", err,
+	)
 	processErr := processCtx.Err()
 	_ = process.stop(cancel)
 	if err == nil {
@@ -134,6 +119,46 @@ func (l CodexCLIModelLister) ListModels(ctx context.Context) (AgentModelListResu
 	return AgentModelListResult{}, err
 }
 
+func (l CodexCLIModelLister) resolveLaunch(ctx context.Context) (string, []string, []string, error) {
+	command := strings.TrimSpace(l.Command)
+	if command == "" {
+		command = "codex"
+	}
+	args := append([]string{}, l.Args...)
+	resolver := runtimecmd.Resolver{
+		Environ:          l.Environ,
+		HomeDir:          l.HomeDir,
+		IsExecutableFile: l.IsExecutableFile,
+		LookPath:         l.LookPath,
+	}
+	var envOverrides []string
+	if l.ProviderCommands != nil && strings.TrimSpace(l.Provider) != "" {
+		resolution, err := l.ProviderCommands.ResolveProviderCommand(ctx, l.Provider)
+		if err != nil {
+			return "", nil, nil, fmt.Errorf("resolve %s model-list command: %w", l.Provider, err)
+		}
+		if len(resolution.Command) == 0 || strings.TrimSpace(resolution.Command[0]) == "" {
+			return "", nil, nil, fmt.Errorf("resolve %s model-list command: command is empty", l.Provider)
+		}
+		command = resolution.Command[0]
+		args = append([]string{}, resolution.Command[1:]...)
+		envOverrides = resolution.Env
+	}
+	env := resolver.Env(envOverrides)
+	if l.PrepareEnv != nil {
+		var err error
+		env, err = l.PrepareEnv(ctx, env)
+		if err != nil {
+			return "", nil, nil, err
+		}
+	}
+	command = resolver.Resolve(command, env)
+	if len(args) == 0 {
+		args = []string{"app-server"}
+	}
+	return command, args, env, nil
+}
+
 func (l CodexCLIModelLister) clientName() string {
 	if name := strings.TrimSpace(l.ClientName); name != "" {
 		return name
@@ -142,11 +167,37 @@ func (l CodexCLIModelLister) clientName() string {
 }
 
 func requestCodexModelList(stdin io.Writer, stdout io.Reader, clientName string) ([]AgentModelOption, error) {
-	encoder := json.NewEncoder(stdin)
 	scanner := bufio.NewScanner(stdout)
 	scanner.Buffer(make([]byte, 0, 64*1024), codexModelListMaxLineBytes)
+	return requestCodexModelListWithScanner(stdin, scanner, clientName, "1", "2")
+}
+
+func requestCodexModelListWithScanner(
+	stdin io.Writer,
+	scanner *bufio.Scanner,
+	clientName string,
+	initializeID string,
+	modelListID string,
+) ([]AgentModelOption, error) {
+	encoder := json.NewEncoder(stdin)
+	if err := writeCodexInitializeRequest(encoder, initializeID, clientName); err != nil {
+		return nil, err
+	}
+	if err := readCodexInitializeResponseForID(scanner, initializeID); err != nil {
+		return nil, err
+	}
+	if err := writeCodexInitializedNotification(encoder); err != nil {
+		return nil, err
+	}
+	if err := writeCodexModelListRequest(encoder, modelListID); err != nil {
+		return nil, err
+	}
+	return readCodexModelListResponseForID(scanner, modelListID)
+}
+
+func writeCodexInitializeRequest(encoder *json.Encoder, initializeID string, clientName string) error {
 	if err := encoder.Encode(map[string]any{
-		"id":     "1",
+		"id":     initializeID,
 		"method": "initialize",
 		"params": map[string]any{
 			"clientInfo": map[string]string{
@@ -155,30 +206,35 @@ func requestCodexModelList(stdin io.Writer, stdout io.Reader, clientName string)
 			},
 		},
 	}); err != nil {
-		return nil, fmt.Errorf("write codex app-server initialize: %w", err)
+		return fmt.Errorf("write codex app-server initialize: %w", err)
 	}
-	if err := readCodexInitializeResponse(scanner); err != nil {
-		return nil, err
-	}
+	return nil
+}
+
+func writeCodexInitializedNotification(encoder *json.Encoder) error {
 	if err := encoder.Encode(map[string]any{
 		"method": "initialized",
 		"params": map[string]any{},
 	}); err != nil {
-		return nil, fmt.Errorf("write codex app-server initialized: %w", err)
+		return fmt.Errorf("write codex app-server initialized: %w", err)
 	}
+	return nil
+}
+
+func writeCodexModelListRequest(encoder *json.Encoder, modelListID string) error {
 	if err := encoder.Encode(map[string]any{
-		"id":     "2",
+		"id":     modelListID,
 		"method": "model/list",
 		"params": map[string]any{
 			"limit": 200,
 		},
 	}); err != nil {
-		return nil, fmt.Errorf("write codex app-server model/list: %w", err)
+		return fmt.Errorf("write codex app-server model/list: %w", err)
 	}
-	return readCodexModelListResponse(scanner)
+	return nil
 }
 
-func readCodexInitializeResponse(scanner *bufio.Scanner) error {
+func readCodexInitializeResponseForID(scanner *bufio.Scanner, initializeID string) error {
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
@@ -188,7 +244,7 @@ func readCodexInitializeResponse(scanner *bufio.Scanner) error {
 		if err := json.Unmarshal([]byte(line), &payload); err != nil {
 			continue
 		}
-		if !codexRPCIDMatches(payload["id"], "1") {
+		if !codexRPCIDMatches(payload["id"], initializeID) {
 			continue
 		}
 		if rawError, ok := payload["error"]; ok && string(rawError) != "null" {
@@ -205,13 +261,13 @@ func readCodexInitializeResponse(scanner *bufio.Scanner) error {
 	return errors.New("codex app-server exited before initialize response")
 }
 
-func readCodexModelListResponse(scanner *bufio.Scanner) ([]AgentModelOption, error) {
+func readCodexModelListResponseForID(scanner *bufio.Scanner, modelListID string) ([]AgentModelOption, error) {
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
 			continue
 		}
-		models, handled, err := parseCodexModelListLine([]byte(line))
+		models, handled, err := parseCodexModelListLineForID([]byte(line), modelListID)
 		if !handled {
 			continue
 		}
@@ -223,8 +279,8 @@ func readCodexModelListResponse(scanner *bufio.Scanner) ([]AgentModelOption, err
 	return nil, errors.New("codex app-server exited before model/list response")
 }
 
-func parseCodexModelListLine(line []byte) ([]AgentModelOption, bool, error) {
-	return modelcatalog.ParseCodexModelListLine(line, "2")
+func parseCodexModelListLineForID(line []byte, modelListID string) ([]AgentModelOption, bool, error) {
+	return modelcatalog.ParseCodexModelListLine(line, modelListID)
 }
 
 func codexRPCIDMatches(raw json.RawMessage, want string) bool {

--- a/services/tuttid/service/agent/codex_model_catalog.go
+++ b/services/tuttid/service/agent/codex_model_catalog.go
@@ -96,11 +96,27 @@ func (l CodexCLIModelLister) listModelsOnce(ctx context.Context) (AgentModelList
 		return AgentModelListResult{}, err
 	}
 	requestStartedAt := time.Now()
-	models, err := requestCodexModelList(process.stdin, process.stdout, l.clientName())
+	models, err := requestCodexModelListWithStages(
+		process.stdin,
+		process.stdout,
+		l.clientName(),
+		func(stage string, stageStartedAt time.Time, stageErr error) {
+			slog.Info("agent model catalog request stage settled",
+				"event", "agent.model_catalog.stage_settled",
+				"provider", l.Provider,
+				"operation", "model_list",
+				"stage", stage,
+				"durationMs", time.Since(stageStartedAt).Milliseconds(),
+				"persistent", false,
+				"error", stageErr,
+			)
+		},
+	)
 	slog.Info("agent model catalog request stage settled",
 		"event", "agent.model_catalog.stage_settled",
 		"provider", l.Provider,
-		"stage", "initialize_and_model_list",
+		"operation", "model_list",
+		"stage", "request_total",
 		"durationMs", time.Since(requestStartedAt).Milliseconds(),
 		"persistent", false,
 		"error", err,
@@ -170,6 +186,41 @@ func requestCodexModelList(stdin io.Writer, stdout io.Reader, clientName string)
 	scanner := bufio.NewScanner(stdout)
 	scanner.Buffer(make([]byte, 0, 64*1024), codexModelListMaxLineBytes)
 	return requestCodexModelListWithScanner(stdin, scanner, clientName, "1", "2")
+}
+
+func requestCodexModelListWithStages(
+	stdin io.Writer,
+	stdout io.Reader,
+	clientName string,
+	stageSettled func(stage string, startedAt time.Time, err error),
+) ([]AgentModelOption, error) {
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), codexModelListMaxLineBytes)
+	encoder := json.NewEncoder(stdin)
+
+	initializeStartedAt := time.Now()
+	if err := writeCodexInitializeRequest(encoder, "1", clientName); err != nil {
+		stageSettled("initialize", initializeStartedAt, err)
+		return nil, err
+	}
+	if err := readCodexInitializeResponseForID(scanner, "1"); err != nil {
+		stageSettled("initialize", initializeStartedAt, err)
+		return nil, err
+	}
+	stageSettled("initialize", initializeStartedAt, nil)
+
+	modelListStartedAt := time.Now()
+	if err := writeCodexInitializedNotification(encoder); err != nil {
+		stageSettled("model_list", modelListStartedAt, err)
+		return nil, err
+	}
+	if err := writeCodexModelListRequest(encoder, "2"); err != nil {
+		stageSettled("model_list", modelListStartedAt, err)
+		return nil, err
+	}
+	models, err := readCodexModelListResponseForID(scanner, "2")
+	stageSettled("model_list", modelListStartedAt, err)
+	return models, err
 }
 
 func requestCodexModelListWithScanner(

--- a/services/tuttid/service/agent/codex_model_catalog_test.go
+++ b/services/tuttid/service/agent/codex_model_catalog_test.go
@@ -90,6 +90,31 @@ func TestRequestCodexModelListReadsInitializeResponseBeforeFollowingRequests(t *
 	}
 }
 
+func TestRequestCodexModelListWithStagesReportsProviderStages(t *testing.T) {
+	transport := &strictCodexHandshakeTransport{}
+	var stages []string
+	models, err := requestCodexModelListWithStages(
+		transport,
+		transport,
+		"tuttid-test",
+		func(stage string, _ time.Time, stageErr error) {
+			if stageErr != nil {
+				t.Fatalf("stage %q returned error: %v", stage, stageErr)
+			}
+			stages = append(stages, stage)
+		},
+	)
+	if err != nil {
+		t.Fatalf("requestCodexModelListWithStages returned error: %v", err)
+	}
+	if len(models) != 1 || models[0].ID != "gpt-5" {
+		t.Fatalf("models = %#v, want gpt-5", models)
+	}
+	if !reflect.DeepEqual(stages, []string{"initialize", "model_list"}) {
+		t.Fatalf("stages = %#v, want initialize then model_list", stages)
+	}
+}
+
 type strictCodexHandshakeTransport struct {
 	methods                []string
 	initializeRequested    bool
@@ -365,6 +390,144 @@ func TestCachedAgentModelCatalogRefreshesStaleModelsInBackground(t *testing.T) {
 	}
 	if fresh.Stale || len(fresh.Models) == 0 || fresh.Models[0].ID != "new-model" {
 		t.Fatalf("fresh result = %#v, want new model", fresh)
+	}
+}
+
+func TestCachedAgentModelCatalogLoadsPersistentCatalogBeforeBackgroundRefresh(t *testing.T) {
+	persistentPath := filepath.Join(t.TempDir(), "model-catalog.json")
+	first := &CachedAgentModelCatalog{
+		Codex: &fakeAgentModelLister{
+			models: []AgentModelOption{{ID: "old-model", DisplayName: "Old"}},
+		},
+		PersistentPath: persistentPath,
+		AuthFingerprint: func(string) string {
+			return "account-a"
+		},
+	}
+	if _, err := first.ListModels(context.Background(), AgentModelCatalogInput{Provider: "codex"}); err != nil {
+		t.Fatalf("initial ListModels returned error: %v", err)
+	}
+
+	refreshLister := &blockingAgentModelLister{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+		models:  []AgentModelOption{{ID: "new-model", DisplayName: "New"}},
+	}
+	refreshed := make(chan string, 1)
+	second := &CachedAgentModelCatalog{
+		Codex:          refreshLister,
+		PersistentPath: persistentPath,
+		AuthFingerprint: func(string) string {
+			return "account-a"
+		},
+		OnRefresh: func(provider string) {
+			refreshed <- provider
+		},
+	}
+	result, err := second.ListModels(context.Background(), AgentModelCatalogInput{Provider: "codex"})
+	if err != nil {
+		t.Fatalf("persistent ListModels returned error: %v", err)
+	}
+	if !result.Stale || len(result.Models) == 0 || result.Models[0].ID != "old-model" {
+		t.Fatalf("persistent result = %#v, want stale old model", result)
+	}
+	select {
+	case <-refreshLister.started:
+	case <-time.After(time.Second):
+		t.Fatal("persistent catalog did not start background refresh")
+	}
+	close(refreshLister.release)
+	select {
+	case provider := <-refreshed:
+		if provider != "codex" {
+			t.Fatalf("refresh provider = %q, want codex", provider)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("persistent catalog refresh did not settle")
+	}
+}
+
+func TestCachedAgentModelCatalogWaitForFreshBlocksUntilRefreshSettles(t *testing.T) {
+	lister := &sequencedAgentModelLister{
+		models: []AgentModelListResult{
+			{Models: []AgentModelOption{{ID: "old-model"}}},
+			{Models: []AgentModelOption{{ID: "new-model"}}},
+		},
+		secondStarted: make(chan struct{}),
+		secondRelease: make(chan struct{}),
+	}
+	catalog := &CachedAgentModelCatalog{Codex: lister}
+	if _, err := catalog.ListModels(context.Background(), AgentModelCatalogInput{Provider: "codex"}); err != nil {
+		t.Fatalf("initial ListModels returned error: %v", err)
+	}
+	catalog.Invalidate("codex")
+	resultCh := make(chan struct {
+		result AgentModelCatalogResult
+		err    error
+	}, 1)
+	go func() {
+		result, err := catalog.ListModels(context.Background(), AgentModelCatalogInput{
+			Provider:     "codex",
+			WaitForFresh: true,
+		})
+		resultCh <- struct {
+			result AgentModelCatalogResult
+			err    error
+		}{result: result, err: err}
+	}()
+	select {
+	case <-lister.secondStarted:
+	case <-time.After(time.Second):
+		t.Fatal("fresh catalog refresh did not start")
+	}
+	select {
+	case result := <-resultCh:
+		t.Fatalf("fresh request returned before refresh settled: %#v", result)
+	default:
+	}
+	close(lister.secondRelease)
+	select {
+	case result := <-resultCh:
+		if result.err != nil {
+			t.Fatalf("fresh ListModels returned error: %v", result.err)
+		}
+		if result.result.Stale || result.result.Models[0].ID != "new-model" {
+			t.Fatalf("fresh result = %#v, want new model", result.result)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("fresh request did not settle")
+	}
+}
+
+func TestCachedAgentModelCatalogRejectsPersistentCatalogFromAnotherAuthGeneration(t *testing.T) {
+	persistentPath := filepath.Join(t.TempDir(), "model-catalog.json")
+	first := &CachedAgentModelCatalog{
+		Codex:          &fakeAgentModelLister{models: []AgentModelOption{{ID: "old-model"}}},
+		PersistentPath: persistentPath,
+		AuthFingerprint: func(string) string {
+			return "account-a"
+		},
+	}
+	if _, err := first.ListModels(context.Background(), AgentModelCatalogInput{Provider: "codex"}); err != nil {
+		t.Fatalf("initial ListModels returned error: %v", err)
+	}
+	secondLister := &fakeAgentModelLister{models: []AgentModelOption{{ID: "new-model"}}}
+	second := &CachedAgentModelCatalog{
+		Codex:          secondLister,
+		PersistentPath: persistentPath,
+		AuthFingerprint: func(string) string {
+			return "account-b"
+		},
+	}
+	result, err := second.ListModels(context.Background(), AgentModelCatalogInput{Provider: "codex"})
+	if err != nil {
+		t.Fatalf("auth-generation ListModels returned error: %v", err)
+	}
+	if result.Stale || len(result.Models) == 0 || result.Models[0].ID != "new-model" {
+		t.Fatalf("auth-generation result = %#v, want fresh new model", result)
+	}
+	if secondLister.calls != 1 {
+		t.Fatalf("new-account lister calls = %d, want one", secondLister.calls)
 	}
 }
 

--- a/services/tuttid/service/agent/codex_model_catalog_test.go
+++ b/services/tuttid/service/agent/codex_model_catalog_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 )
@@ -197,6 +198,62 @@ done
 	}
 }
 
+func TestCodexCLIModelListerReusesPersistentAppServerSession(t *testing.T) {
+	tempDir := t.TempDir()
+	scriptPath := filepath.Join(tempDir, "codex")
+	countPath := filepath.Join(tempDir, "starts")
+	script := "#!/bin/sh\n" +
+		"count=0\n" +
+		"if [ -f \"$CODEX_TEST_STARTS\" ]; then count=$(cat \"$CODEX_TEST_STARTS\"); fi\n" +
+		"count=$((count + 1))\n" +
+		"printf '%s' \"$count\" > \"$CODEX_TEST_STARTS\"\n" +
+		"while IFS= read -r line; do\n" +
+		"  case \"$line\" in\n" +
+		"    *'\"method\":\"initialize\"'*)\n" +
+		"      id=$(printf '%s' \"$line\" | sed -n 's/.*\"id\":\"\\([^\"]*\\)\".*/\\1/p')\n" +
+		"      printf '{\"id\":\"%s\",\"result\":{}}\\n' \"$id\"\n" +
+		"      ;;\n" +
+		"    *'\"method\":\"model/list\"'*)\n" +
+		"      id=$(printf '%s' \"$line\" | sed -n 's/.*\"id\":\"\\([^\"]*\\)\".*/\\1/p')\n" +
+		"      printf '{\"id\":\"%s\",\"result\":{\"data\":[{\"id\":\"gpt-5\",\"displayName\":\"GPT-5\"}]}}\\n' \"$id\"\n" +
+		"      ;;\n" +
+		"  esac\n" +
+		"done\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write persistent fake codex: %v", err)
+	}
+	base := CodexCLIModelLister{
+		Command: scriptPath,
+		Environ: func() []string {
+			return []string{"PATH=/usr/bin:/bin", "CODEX_TEST_STARTS=" + countPath}
+		},
+		Timeout: 2 * time.Second,
+	}
+	lister := base
+	lister.Session = newCodexAppServerSession(base)
+	first, err := lister.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("first ListModels returned error: %v", err)
+	}
+	second, err := lister.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("second ListModels returned error: %v", err)
+	}
+	if len(first.Models) != 1 || len(second.Models) != 1 || first.Models[0].ID != "gpt-5" || second.Models[0].ID != "gpt-5" {
+		t.Fatalf("models = %#v / %#v, want gpt-5", first.Models, second.Models)
+	}
+	starts, err := os.ReadFile(countPath)
+	if err != nil {
+		t.Fatalf("read process start count: %v", err)
+	}
+	if string(starts) != "1" {
+		t.Fatalf("app-server starts = %q, want one persistent process", starts)
+	}
+	if err := lister.Session.Close(); err != nil {
+		t.Fatalf("close persistent app-server: %v", err)
+	}
+}
+
 func TestCachedAgentModelCatalogCachesCodexModels(t *testing.T) {
 	now := time.UnixMilli(1000)
 	lister := &fakeAgentModelLister{
@@ -225,6 +282,92 @@ func TestCachedAgentModelCatalogCachesCodexModels(t *testing.T) {
 	}
 }
 
+func TestCachedAgentModelCatalogSharesConcurrentColdFetch(t *testing.T) {
+	lister := &blockingAgentModelLister{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+		models:  []AgentModelOption{{ID: "gpt-5", DisplayName: "GPT-5"}},
+	}
+	catalog := &CachedAgentModelCatalog{Codex: lister}
+	results := make(chan error, 2)
+	for range 2 {
+		go func() {
+			_, err := catalog.ListModels(context.Background(), AgentModelCatalogInput{Provider: "codex"})
+			results <- err
+		}()
+	}
+	select {
+	case <-lister.started:
+	case <-time.After(time.Second):
+		t.Fatal("model lister did not start")
+	}
+	close(lister.release)
+	for range 2 {
+		select {
+		case err := <-results:
+			if err != nil {
+				t.Fatalf("ListModels returned error: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("shared model catalog fetch did not settle")
+		}
+	}
+	if lister.calls() != 1 {
+		t.Fatalf("lister calls = %d, want one shared fetch", lister.calls())
+	}
+}
+
+func TestCachedAgentModelCatalogRefreshesStaleModelsInBackground(t *testing.T) {
+	lister := &sequencedAgentModelLister{
+		models: []AgentModelListResult{
+			{Models: []AgentModelOption{{ID: "old-model", DisplayName: "Old"}}},
+			{Models: []AgentModelOption{{ID: "new-model", DisplayName: "New"}}},
+		},
+		secondStarted: make(chan struct{}),
+		secondRelease: make(chan struct{}),
+	}
+	refreshed := make(chan string, 1)
+	catalog := &CachedAgentModelCatalog{
+		Codex: lister,
+		OnRefresh: func(provider string) {
+			refreshed <- provider
+		},
+	}
+	first, err := catalog.ListModels(context.Background(), AgentModelCatalogInput{Provider: "codex"})
+	if err != nil {
+		t.Fatalf("initial ListModels returned error: %v", err)
+	}
+	catalog.Invalidate("codex")
+	stale, err := catalog.ListModels(context.Background(), AgentModelCatalogInput{Provider: "codex"})
+	if err != nil {
+		t.Fatalf("stale ListModels returned error: %v", err)
+	}
+	if !stale.Stale || stale.Models[0].ID != first.Models[0].ID {
+		t.Fatalf("stale result = %#v, want old model marked stale", stale)
+	}
+	select {
+	case <-lister.secondStarted:
+	case <-time.After(time.Second):
+		t.Fatal("background refresh did not start")
+	}
+	close(lister.secondRelease)
+	select {
+	case provider := <-refreshed:
+		if provider != "codex" {
+			t.Fatalf("refresh provider = %q, want codex", provider)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("background refresh did not publish completion")
+	}
+	fresh, err := catalog.ListModels(context.Background(), AgentModelCatalogInput{Provider: "codex"})
+	if err != nil {
+		t.Fatalf("fresh ListModels returned error: %v", err)
+	}
+	if fresh.Stale || len(fresh.Models) == 0 || fresh.Models[0].ID != "new-model" {
+		t.Fatalf("fresh result = %#v, want new model", fresh)
+	}
+}
+
 type fakeAgentModelLister struct {
 	calls    int
 	models   []AgentModelOption
@@ -235,4 +378,59 @@ type fakeAgentModelLister struct {
 func (f *fakeAgentModelLister) ListModels(context.Context) (AgentModelListResult, error) {
 	f.calls += 1
 	return AgentModelListResult{Models: f.models, IsFallback: f.fallback}, f.err
+}
+
+type blockingAgentModelLister struct {
+	started chan struct{}
+	release chan struct{}
+	models  []AgentModelOption
+	mu      sync.Mutex
+	count   int
+	once    sync.Once
+}
+
+func (l *blockingAgentModelLister) ListModels(ctx context.Context) (AgentModelListResult, error) {
+	l.mu.Lock()
+	l.count++
+	l.mu.Unlock()
+	l.once.Do(func() { close(l.started) })
+	select {
+	case <-l.release:
+		return AgentModelListResult{Models: l.models}, nil
+	case <-ctx.Done():
+		return AgentModelListResult{}, ctx.Err()
+	}
+}
+
+func (l *blockingAgentModelLister) calls() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.count
+}
+
+type sequencedAgentModelLister struct {
+	models        []AgentModelListResult
+	secondStarted chan struct{}
+	secondRelease chan struct{}
+	mu            sync.Mutex
+	count         int
+}
+
+func (l *sequencedAgentModelLister) ListModels(ctx context.Context) (AgentModelListResult, error) {
+	l.mu.Lock()
+	index := l.count
+	l.count++
+	l.mu.Unlock()
+	if index == 1 {
+		close(l.secondStarted)
+		select {
+		case <-l.secondRelease:
+		case <-ctx.Done():
+			return AgentModelListResult{}, ctx.Err()
+		}
+	}
+	if index >= len(l.models) {
+		index = len(l.models) - 1
+	}
+	return l.models[index], nil
 }

--- a/services/tuttid/service/agent/composer_capability_cache.go
+++ b/services/tuttid/service/agent/composer_capability_cache.go
@@ -9,7 +9,10 @@ import (
 	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 )
 
-const defaultCapabilityCatalogCacheTTL = 30 * time.Second
+const (
+	defaultCapabilityCatalogCacheTTL      = 30 * time.Second
+	defaultCapabilityCatalogErrorCacheTTL = 5 * time.Second
+)
 
 type composerCapabilityCatalogCache struct {
 	mu      sync.Mutex
@@ -18,6 +21,7 @@ type composerCapabilityCatalogCache struct {
 
 type composerCapabilityCatalogCacheEntry struct {
 	cachedAt time.Time
+	errors   []string
 	options  []ComposerCapabilityOption
 }
 
@@ -27,21 +31,30 @@ func newComposerCapabilityCatalogCache() *composerCapabilityCatalogCache {
 	}
 }
 
-func (c *composerCapabilityCatalogCache) get(key string, now time.Time, ttl time.Duration) ([]ComposerCapabilityOption, bool) {
-	if c == nil || ttl <= 0 {
-		return nil, false
+func (c *composerCapabilityCatalogCache) get(
+	key string,
+	now time.Time,
+	successTTL time.Duration,
+	errorTTL time.Duration,
+) ([]ComposerCapabilityOption, []string, bool) {
+	if c == nil {
+		return nil, nil, false
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	entry, ok := c.entries[key]
 	if !ok {
-		return nil, false
+		return nil, nil, false
 	}
-	if now.Sub(entry.cachedAt) > ttl {
+	ttl := successTTL
+	if len(entry.errors) > 0 {
+		ttl = errorTTL
+	}
+	if ttl <= 0 || now.Sub(entry.cachedAt) > ttl {
 		delete(c.entries, key)
-		return nil, false
+		return nil, nil, false
 	}
-	return cloneComposerCapabilityOptions(entry.options), true
+	return cloneComposerCapabilityOptions(entry.options), append([]string(nil), entry.errors...), true
 }
 
 func (c *composerCapabilityCatalogCache) set(key string, now time.Time, options []ComposerCapabilityOption) {
@@ -56,6 +69,18 @@ func (c *composerCapabilityCatalogCache) set(key string, now time.Time, options 
 	}
 }
 
+func (c *composerCapabilityCatalogCache) setFailure(key string, now time.Time, errors []string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = composerCapabilityCatalogCacheEntry{
+		cachedAt: now,
+		errors:   append([]string(nil), errors...),
+	}
+}
+
 func (s *Service) listComposerCapabilityOptions(
 	ctx context.Context,
 	provider string,
@@ -64,14 +89,41 @@ func (s *Service) listComposerCapabilityOptions(
 ) ([]ComposerCapabilityOption, []string) {
 	cacheKey := composerCapabilityCatalogCacheKey(provider, cwd, fallbackSkills)
 	now := time.Now().UTC()
-	if cached, ok := s.capabilityCatalogCache.get(cacheKey, now, s.capabilityCatalogCacheTTL()); ok {
-		return cached, nil
+	if cached, errors, ok := s.capabilityCatalogCache.get(
+		cacheKey,
+		now,
+		s.capabilityCatalogCacheTTL(),
+		defaultCapabilityCatalogErrorCacheTTL,
+	); ok {
+		return cached, errors
 	}
-	options, errors := s.composerCapabilityLister().ListComposerCapabilityOptions(ctx, provider, cwd, fallbackSkills)
-	if len(errors) == 0 {
-		s.capabilityCatalogCache.set(cacheKey, now, options)
+	loaded, _, _ := s.capabilityCatalogGroup.Do(cacheKey, func() (any, error) {
+		if cached, errors, ok := s.capabilityCatalogCache.get(
+			cacheKey,
+			time.Now().UTC(),
+			s.capabilityCatalogCacheTTL(),
+			defaultCapabilityCatalogErrorCacheTTL,
+		); ok {
+			return capabilityCatalogLoadResult{options: cached, errors: errors}, nil
+		}
+		options, errors := s.composerCapabilityLister().ListComposerCapabilityOptions(ctx, provider, cwd, fallbackSkills)
+		if len(errors) == 0 {
+			s.capabilityCatalogCache.set(cacheKey, time.Now().UTC(), options)
+		} else {
+			s.capabilityCatalogCache.setFailure(cacheKey, time.Now().UTC(), errors)
+		}
+		return capabilityCatalogLoadResult{options: options, errors: errors}, nil
+	})
+	result, ok := loaded.(capabilityCatalogLoadResult)
+	if !ok {
+		return nil, []string{"capability catalog load returned an invalid result"}
 	}
-	return cloneComposerCapabilityOptions(options), append([]string(nil), errors...)
+	return cloneComposerCapabilityOptions(result.options), append([]string(nil), result.errors...)
+}
+
+type capabilityCatalogLoadResult struct {
+	errors  []string
+	options []ComposerCapabilityOption
 }
 
 func (s *Service) capabilityCatalogCacheTTL() time.Duration {

--- a/services/tuttid/service/agent/composer_model_catalog.go
+++ b/services/tuttid/service/agent/composer_model_catalog.go
@@ -27,20 +27,25 @@ func startComposerModelCatalogLoad(
 	provider string,
 	cwd string,
 	selectedModel string,
+	waitForFresh bool,
 ) <-chan composerModelCatalogLoadResult {
 	result := make(chan composerModelCatalogLoadResult, 1)
 	go func() {
-		projection, ok := composerModelOptionsFromCatalog(ctx, catalog, provider, cwd, selectedModel)
+		projection, ok := composerModelOptionsFromCatalog(ctx, catalog, provider, cwd, selectedModel, waitForFresh)
 		result <- composerModelCatalogLoadResult{projection: projection, ok: ok}
 	}()
 	return result
 }
 
-func composerModelOptionsFromCatalog(ctx context.Context, catalog AgentModelCatalog, provider string, cwd string, selectedModel string) (composerModelCatalogProjection, bool) {
+func composerModelOptionsFromCatalog(ctx context.Context, catalog AgentModelCatalog, provider string, cwd string, selectedModel string, waitForFresh ...bool) (composerModelCatalogProjection, bool) {
 	if catalog == nil {
 		return composerModelCatalogProjection{}, false
 	}
-	result, err := catalog.ListModels(ctx, AgentModelCatalogInput{Provider: provider, Cwd: cwd})
+	result, err := catalog.ListModels(ctx, AgentModelCatalogInput{
+		Provider:     provider,
+		Cwd:          cwd,
+		WaitForFresh: len(waitForFresh) > 0 && waitForFresh[0],
+	})
 	if err != nil {
 		// The model list drives the composer's model selector; when it fails the
 		// selector renders empty. Surface the cause instead of swallowing it so a

--- a/services/tuttid/service/agent/composer_model_catalog.go
+++ b/services/tuttid/service/agent/composer_model_catalog.go
@@ -13,6 +13,7 @@ type composerModelCatalogProjection struct {
 	ModelOptions      []ComposerConfigOptionValue
 	ReasoningProfiles map[string]modelcatalog.ReasoningProfile
 	Source            string
+	Stale             bool
 }
 
 type composerModelCatalogLoadResult struct {
@@ -69,6 +70,7 @@ func composerModelOptionsFromCatalog(ctx context.Context, catalog AgentModelCata
 		ModelOptions:      options,
 		ReasoningProfiles: catalogProjection.ReasoningOptionsByModel,
 		Source:            strings.TrimSpace(result.Source),
+		Stale:             result.Stale,
 	}, true
 }
 

--- a/services/tuttid/service/agent/composer_options.go
+++ b/services/tuttid/service/agent/composer_options.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 	modelplanbiz "github.com/tutti-os/tutti/services/tuttid/biz/modelplan"
 	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
+	"golang.org/x/sync/errgroup"
 )
 
 type PermissionModeSemantic string
@@ -71,7 +72,12 @@ type ComposerOptionsInput struct {
 	Provider                 string
 	WorkspaceID              string
 	Settings                 ComposerSettings
+	Section                  ComposerOptionsSection
 	IncludeCapabilityCatalog *bool
+	// WaitForFreshModelCatalog is reserved for an explicit model-picker open.
+	// Ordinary composer loads may render the last successful list while the
+	// daemon refreshes it asynchronously.
+	WaitForFreshModelCatalog bool
 	CodexSaverMode           *bool
 	// ResolvedModelPlan is a daemon-only exact plan override supplied by a
 	// WorkspaceAgent resolver. It may contain a credential and must never be
@@ -84,6 +90,26 @@ type ComposerOptionsInput struct {
 	IgnoreModelPlanBinding   bool
 	providerTargetRef        map[string]any
 	extensionComposerProfile ExtensionComposerProfile
+}
+
+// ComposerOptionsSection lets callers consume the independent parts of the
+// composer catalog without making the model picker wait for app-server
+// capability discovery. Full remains the compatibility behavior.
+type ComposerOptionsSection string
+
+const (
+	ComposerOptionsSectionFull         ComposerOptionsSection = "full"
+	ComposerOptionsSectionCore         ComposerOptionsSection = "core"
+	ComposerOptionsSectionCapabilities ComposerOptionsSection = "capabilities"
+)
+
+func normalizeComposerOptionsSection(section ComposerOptionsSection) ComposerOptionsSection {
+	switch section {
+	case ComposerOptionsSectionCore, ComposerOptionsSectionCapabilities:
+		return section
+	default:
+		return ComposerOptionsSectionFull
+	}
 }
 
 type ComposerSkillOption struct {
@@ -147,6 +173,7 @@ type ComposerOptions struct {
 }
 
 func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsInput) (ComposerOptions, error) {
+	section := normalizeComposerOptionsSection(input.Section)
 	requestedPermissionModeID := strings.TrimSpace(input.Settings.PermissionModeID)
 	provider := agentprovider.Normalize(input.Provider)
 	agentTargetID := strings.TrimSpace(input.AgentTargetID)
@@ -260,7 +287,7 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 		settings.Model = planEndpoint.Model
 	}
 	var catalogLoad <-chan composerModelCatalogLoadResult
-	if planEndpoint == nil && (composerOptionsProviderUsesModelCatalog(provider) ||
+	if section != ComposerOptionsSectionCapabilities && planEndpoint == nil && (composerOptionsProviderUsesModelCatalog(provider) ||
 		(s.ReplayMode && s.ModelCatalog != nil)) {
 		catalogLoad = startComposerModelCatalogLoad(
 			ctx,
@@ -268,27 +295,50 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 			provider,
 			input.Cwd,
 			settings.Model,
+			input.WaitForFreshModelCatalog,
 		)
 	}
-	skills := filterWorkspaceAgentComposerSkills(
-		s.discoverComposerSkillOptionsForLaunch(ctx, provider, input.Cwd, nil, input.providerTargetRef),
-		launchInput.AgentSkills,
-		launchInput.AgentCapabilitiesExplicit,
-	)
+	skills := []ComposerSkillOption{}
+	if section != ComposerOptionsSectionCore {
+		skills = filterWorkspaceAgentComposerSkills(
+			s.discoverComposerSkillOptionsForLaunch(ctx, provider, input.Cwd, nil, input.providerTargetRef),
+			launchInput.AgentSkills,
+			launchInput.AgentCapabilitiesExplicit,
+		)
+	}
 	capabilityCatalog := []ComposerCapabilityOption{}
 	capabilityErrors := []string(nil)
-	if composerOptionsIncludeCapabilityCatalog(input) {
-		capabilityCatalog, capabilityErrors = s.listComposerCapabilityOptions(ctx, provider, input.Cwd, skills)
-		connectorsVisible, err := s.connectorCatalogVisible(ctx)
-		if err != nil {
-			capabilityErrors = append(capabilityErrors, "load connector visibility: "+err.Error())
+	if section != ComposerOptionsSectionCore && composerOptionsIncludeCapabilityCatalog(input) {
+		var (
+			connectorsVisible   = true
+			connectorVisibleErr error
+			localConnectors     []ComposerCapabilityOption
+			localConnectorsErr  error
+		)
+		capabilityGroup, capabilityContext := errgroup.WithContext(ctx)
+		capabilityGroup.Go(func() error {
+			capabilityCatalog, capabilityErrors = s.listComposerCapabilityOptions(capabilityContext, provider, input.Cwd, skills)
+			return nil
+		})
+		capabilityGroup.Go(func() error {
+			connectorsVisible, connectorVisibleErr = s.connectorCatalogVisible(capabilityContext)
+			return nil
+		})
+		if s.ConnectorMarketSnapshots != nil {
+			capabilityGroup.Go(func() error {
+				localConnectors, localConnectorsErr = localConnectorCapabilityOptions(capabilityContext, s.ConnectorMarketSnapshots)
+				return nil
+			})
+		}
+		_ = capabilityGroup.Wait()
+		if connectorVisibleErr != nil {
+			capabilityErrors = append(capabilityErrors, "load connector visibility: "+connectorVisibleErr.Error())
 		}
 		if !connectorsVisible {
 			capabilityCatalog = replaceComposerConnectorCapabilities(capabilityCatalog, nil)
 		} else if s.ConnectorMarketSnapshots != nil {
-			localConnectors, err := localConnectorCapabilityOptions(ctx, s.ConnectorMarketSnapshots)
-			if err != nil {
-				capabilityErrors = append(capabilityErrors, "load local connectors: "+err.Error())
+			if localConnectorsErr != nil {
+				capabilityErrors = append(capabilityErrors, "load local connectors: "+localConnectorsErr.Error())
 			}
 			capabilityCatalog = replaceComposerConnectorCapabilities(capabilityCatalog, localConnectors)
 		}
@@ -451,7 +501,7 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 		Behavior:                composerProfileFor(provider).Behavior,
 		SlashCommandPolicy:      slashCommandPolicy,
 	}
-	if planEndpoint == nil && !s.ReplayMode && (composerProfileFor(provider).LiveModelDiscovery ||
+	if section != ComposerOptionsSectionCapabilities && planEndpoint == nil && !s.ReplayMode && (composerProfileFor(provider).LiveModelDiscovery ||
 		providerTargetRefKind(input.providerTargetRef) == "agent_extension") {
 		var err error
 		options, err = s.mergeLiveComposerModelsForComposerOptions(ctx, input, effectiveSettings, options)
@@ -734,160 +784,4 @@ func permissionModeConfigHasModeID(config PermissionConfig, modeID string) bool 
 		}
 	}
 	return false
-}
-
-func composerOptionsProviderUsesModelCatalog(provider string) bool {
-	return composerProfileFor(provider).UsesModelCatalog
-}
-
-func composerModelConfig(provider string, selected string, options []ComposerConfigOptionValue) ComposerConfigOption {
-	if composerProfileFor(provider).Behavior.ModelOptionsAuthoritative {
-		return ComposerConfigOption{}
-	}
-	values := make([]ComposerConfigOptionValue, 0, len(options))
-	for _, option := range options {
-		value := strings.TrimSpace(option.Value)
-		if value == "" {
-			continue
-		}
-		label := strings.TrimSpace(option.Label)
-		if label == "" {
-			label = value
-		}
-		values = append(values, ComposerConfigOptionValue{
-			ID:                 value,
-			Label:              label,
-			Value:              value,
-			Description:        strings.TrimSpace(option.Description),
-			SupportsImageInput: option.SupportsImageInput,
-			Requested:          option.Requested,
-		})
-	}
-	selected = strings.TrimSpace(selected)
-	return ComposerConfigOption{
-		Configurable: composerProfileFor(provider).ModelSelection,
-		CurrentValue: selected,
-		DefaultValue: selected,
-		Options:      values,
-	}
-}
-
-func composerSelectedModelOptions(model string) []ComposerConfigOptionValue {
-	model = strings.TrimSpace(model)
-	if model == "" {
-		return []ComposerConfigOptionValue{}
-	}
-	// Bootstrap echo: the sole entry mirrors the requested/effective settings,
-	// so it carries the requested provenance marker.
-	return []ComposerConfigOptionValue{{ID: model, Label: model, Value: model, Requested: true}}
-}
-
-func reasoningConfigOptionID(provider string) string {
-	return strings.TrimSpace(composerProfileFor(provider).ReasoningConfigOptionID)
-}
-
-// speedProviderSupportsSpeed reports whether the provider exposes the speed
-// dimension. Speed combines orthogonally with model and reasoning effort.
-//
-//   - Codex: the codex app-server honours `service_tier` (fast → priority).
-//   - Claude Code: the SDK sidecar maps the `standard` / `fast` tiers onto
-//     `Settings.fastMode`.
-func speedProviderSupportsSpeed(provider string) bool {
-	return composerProfileFor(provider).Speed
-}
-
-// speedConfigOptionID is the live config-option id the adapter sets. Codex maps
-// the tier onto the app-server `service_tier` config; Claude Code sets a `fast`
-// ACP config option when the agent advertises it.
-func speedConfigOptionID(provider string) string {
-	return strings.TrimSpace(composerProfileFor(provider).SpeedConfigOptionID)
-}
-
-func speedTierValuesForProvider(provider string) []string {
-	return append([]string(nil), composerProfileFor(provider).SpeedValues...)
-}
-
-func normalizeSpeedForProvider(provider string, value string) string {
-	if !speedProviderSupportsSpeed(provider) {
-		return ""
-	}
-	normalized := strings.TrimSpace(value)
-	for _, candidate := range speedTierValuesForProvider(provider) {
-		if candidate == normalized {
-			return normalized
-		}
-	}
-	return strings.TrimSpace(composerProfileFor(provider).DefaultSpeed)
-}
-
-func composerSpeedOptionValues(provider string, locale string) []ComposerConfigOptionValue {
-	values := speedTierValuesForProvider(provider)
-	options := make([]ComposerConfigOptionValue, 0, len(values))
-	for _, value := range values {
-		label, description := speedDisplay(value, locale)
-		options = append(options, ComposerConfigOptionValue{
-			ID:          value,
-			Label:       label,
-			Value:       value,
-			Description: description,
-		})
-	}
-	return options
-}
-
-func composerSpeedConfigFromOptions(provider string, selected string, options []ComposerConfigOptionValue) ComposerConfigOption {
-	selected = strings.TrimSpace(selected)
-	return ComposerConfigOption{
-		Configurable: speedProviderSupportsSpeed(provider) && len(options) > 0,
-		CurrentValue: selected,
-		DefaultValue: selected,
-		Options:      cloneComposerConfigOptionValues(options),
-	}
-}
-
-func composerAdvertisedSpeedOptionValues(locale string, advertised []AgentModelSpeedOption) []ComposerConfigOptionValue {
-	options := make([]ComposerConfigOptionValue, 0, len(advertised))
-	for _, advertisedOption := range advertised {
-		value := strings.TrimSpace(advertisedOption.Value)
-		if value == "" {
-			continue
-		}
-		label, description := speedDisplay(value, locale)
-		if advertisedLabel := strings.TrimSpace(advertisedOption.Label); advertisedLabel != "" {
-			label = advertisedLabel
-		}
-		if advertisedDescription := strings.TrimSpace(advertisedOption.Description); advertisedDescription != "" {
-			description = advertisedDescription
-		}
-		options = append(options, ComposerConfigOptionValue{
-			ID: value, Label: label, Value: value, Description: description,
-		})
-	}
-	return options
-}
-
-func resolveAdvertisedSpeed(selected string, advertisedDefault string, advertised []AgentModelSpeedOption) string {
-	selected = strings.TrimSpace(selected)
-	advertisedDefault = strings.TrimSpace(advertisedDefault)
-	firstValue := ""
-	defaultSupported := false
-	for _, option := range advertised {
-		value := strings.TrimSpace(option.Value)
-		if value == "" {
-			continue
-		}
-		if firstValue == "" {
-			firstValue = value
-		}
-		if value == selected {
-			return selected
-		}
-		if value == advertisedDefault {
-			defaultSupported = true
-		}
-	}
-	if defaultSupported {
-		return advertisedDefault
-	}
-	return firstValue
 }

--- a/services/tuttid/service/agent/composer_options.go
+++ b/services/tuttid/service/agent/composer_options.go
@@ -394,6 +394,13 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 	if catalogProjectionOK {
 		modelOptions = s.enrichModelCapabilityOptions(ctx, provider, catalogProjection.ModelOptions)
 		runtimeContext["modelCatalogSource"] = catalogProjection.Source
+		if catalogProjection.Stale {
+			// Keep the last known catalog visible while the daemon refreshes it in
+			// the background. The activity adapter exposes this existing loading
+			// signal so the picker can distinguish stale options from a settled
+			// authoritative catalog.
+			runtimeContext["appServerStartup"] = map[string]any{"models": "loading"}
+		}
 		if composerProfileFor(provider).ReasoningEffort && len(catalogProjection.ReasoningProfiles) > 0 {
 			reasoningOptionsByModel = composerModelReasoningOptionsByModel(
 				provider,
@@ -554,7 +561,7 @@ func composerDefaultModel(
 ) string {
 	if composerOptionsProviderUsesModelCatalog(provider) && catalog != nil {
 		result, err := catalog.ListModels(ctx, AgentModelCatalogInput{Provider: provider, Cwd: cwd})
-		if err == nil {
+		if err == nil && !result.Stale {
 			for _, model := range result.Models {
 				modelID := strings.TrimSpace(model.ID)
 				if model.IsDefault && modelID != "" {

--- a/services/tuttid/service/agent/composer_options_catalog_concurrency_test.go
+++ b/services/tuttid/service/agent/composer_options_catalog_concurrency_test.go
@@ -2,6 +2,8 @@ package agent
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -88,6 +90,110 @@ func TestServiceGetComposerOptionsLoadsModelAndCapabilityCatalogsConcurrently(t 
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("GetComposerOptions did not finish after catalog releases")
+	}
+}
+
+func TestServiceGetComposerOptionsCoreDoesNotStartCapabilityCatalog(t *testing.T) {
+	capabilityLister := &blockingComposerCapabilityLister{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	service := newIsolatedAgentService(newFakeRuntime())
+	service.CapabilityLister = capabilityLister
+
+	result, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+		Provider: "codex",
+		Section:  ComposerOptionsSectionCore,
+	})
+	if err != nil {
+		t.Fatalf("core composer options returned error: %v", err)
+	}
+	if result.Provider != "codex" {
+		t.Fatalf("provider = %q, want codex", result.Provider)
+	}
+	select {
+	case <-capabilityLister.started:
+		t.Fatal("core composer options started capability discovery")
+	default:
+	}
+}
+
+func TestServiceGetComposerOptionsCapabilitiesDoesNotStartModelCatalog(t *testing.T) {
+	modelCatalog := &blockingComposerModelCatalog{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	service := newIsolatedAgentService(newFakeRuntime())
+	service.ModelCatalog = modelCatalog
+	includeCapabilities := true
+
+	_, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+		IncludeCapabilityCatalog: &includeCapabilities,
+		Provider:                 "codex",
+		Section:                  ComposerOptionsSectionCapabilities,
+	})
+	if err != nil {
+		t.Fatalf("capabilities composer options returned error: %v", err)
+	}
+	select {
+	case <-modelCatalog.started:
+		t.Fatal("capabilities composer options started model discovery")
+	default:
+	}
+}
+
+type countingComposerCapabilityLister struct {
+	allow   chan struct{}
+	called  atomic.Int32
+	started chan struct{}
+	once    sync.Once
+}
+
+func (l *countingComposerCapabilityLister) ListComposerCapabilityOptions(
+	context.Context,
+	string,
+	string,
+	[]ComposerSkillOption,
+) ([]ComposerCapabilityOption, []string) {
+	l.called.Add(1)
+	l.once.Do(func() { close(l.started) })
+	<-l.allow
+	return []ComposerCapabilityOption{{ID: "test", Kind: "skill", Name: "test", Label: "test"}}, nil
+}
+
+func TestServiceGetComposerOptionsDeduplicatesCapabilityDiscovery(t *testing.T) {
+	lister := &countingComposerCapabilityLister{
+		allow:   make(chan struct{}),
+		started: make(chan struct{}),
+	}
+	service := newIsolatedAgentService(newFakeRuntime())
+	service.CapabilityLister = lister
+	includeCapabilities := true
+	inputs := ComposerOptionsInput{
+		IncludeCapabilityCatalog: &includeCapabilities,
+		Provider:                 "codex",
+		Section:                  ComposerOptionsSectionCapabilities,
+	}
+	results := make(chan error, 2)
+	for range 2 {
+		go func() {
+			_, err := service.GetComposerOptions(context.Background(), inputs)
+			results <- err
+		}()
+	}
+	select {
+	case <-lister.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("capability discovery did not start")
+	}
+	close(lister.allow)
+	for range 2 {
+		if err := <-results; err != nil {
+			t.Fatalf("composer options returned error: %v", err)
+		}
+	}
+	if got := lister.called.Load(); got != 1 {
+		t.Fatalf("capability discovery calls = %d, want 1", got)
 	}
 }
 

--- a/services/tuttid/service/agent/composer_options_catalog_projection.go
+++ b/services/tuttid/service/agent/composer_options_catalog_projection.go
@@ -1,0 +1,159 @@
+package agent
+
+import "strings"
+
+func composerOptionsProviderUsesModelCatalog(provider string) bool {
+	return composerProfileFor(provider).UsesModelCatalog
+}
+
+func composerModelConfig(provider string, selected string, options []ComposerConfigOptionValue) ComposerConfigOption {
+	if composerProfileFor(provider).Behavior.ModelOptionsAuthoritative {
+		return ComposerConfigOption{}
+	}
+	values := make([]ComposerConfigOptionValue, 0, len(options))
+	for _, option := range options {
+		value := strings.TrimSpace(option.Value)
+		if value == "" {
+			continue
+		}
+		label := strings.TrimSpace(option.Label)
+		if label == "" {
+			label = value
+		}
+		values = append(values, ComposerConfigOptionValue{
+			ID:                 value,
+			Label:              label,
+			Value:              value,
+			Description:        strings.TrimSpace(option.Description),
+			SupportsImageInput: option.SupportsImageInput,
+			Requested:          option.Requested,
+		})
+	}
+	selected = strings.TrimSpace(selected)
+	return ComposerConfigOption{
+		Configurable: composerProfileFor(provider).ModelSelection,
+		CurrentValue: selected,
+		DefaultValue: selected,
+		Options:      values,
+	}
+}
+
+func composerSelectedModelOptions(model string) []ComposerConfigOptionValue {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return []ComposerConfigOptionValue{}
+	}
+	// Bootstrap echo: the sole entry mirrors the requested/effective settings,
+	// so it carries the requested provenance marker.
+	return []ComposerConfigOptionValue{{ID: model, Label: model, Value: model, Requested: true}}
+}
+
+func reasoningConfigOptionID(provider string) string {
+	return strings.TrimSpace(composerProfileFor(provider).ReasoningConfigOptionID)
+}
+
+// speedProviderSupportsSpeed reports whether the provider exposes the speed
+// dimension. Speed combines orthogonally with model and reasoning effort.
+//
+//   - Codex: the codex app-server honours `service_tier` (fast → priority).
+//   - Claude Code: the SDK sidecar maps the `standard` / `fast` tiers onto
+//     `Settings.fastMode`.
+func speedProviderSupportsSpeed(provider string) bool {
+	return composerProfileFor(provider).Speed
+}
+
+// speedConfigOptionID is the live config-option id the adapter sets. Codex maps
+// the tier onto the app-server `service_tier` config; Claude Code sets a `fast`
+// ACP config option when the agent advertises it.
+func speedConfigOptionID(provider string) string {
+	return strings.TrimSpace(composerProfileFor(provider).SpeedConfigOptionID)
+}
+
+func speedTierValuesForProvider(provider string) []string {
+	return append([]string(nil), composerProfileFor(provider).SpeedValues...)
+}
+
+func normalizeSpeedForProvider(provider string, value string) string {
+	if !speedProviderSupportsSpeed(provider) {
+		return ""
+	}
+	normalized := strings.TrimSpace(value)
+	for _, candidate := range speedTierValuesForProvider(provider) {
+		if candidate == normalized {
+			return normalized
+		}
+	}
+	return strings.TrimSpace(composerProfileFor(provider).DefaultSpeed)
+}
+
+func composerSpeedOptionValues(provider string, locale string) []ComposerConfigOptionValue {
+	values := speedTierValuesForProvider(provider)
+	options := make([]ComposerConfigOptionValue, 0, len(values))
+	for _, value := range values {
+		label, description := speedDisplay(value, locale)
+		options = append(options, ComposerConfigOptionValue{
+			ID:          value,
+			Label:       label,
+			Value:       value,
+			Description: description,
+		})
+	}
+	return options
+}
+
+func composerSpeedConfigFromOptions(provider string, selected string, options []ComposerConfigOptionValue) ComposerConfigOption {
+	selected = strings.TrimSpace(selected)
+	return ComposerConfigOption{
+		Configurable: speedProviderSupportsSpeed(provider) && len(options) > 0,
+		CurrentValue: selected,
+		DefaultValue: selected,
+		Options:      cloneComposerConfigOptionValues(options),
+	}
+}
+
+func composerAdvertisedSpeedOptionValues(locale string, advertised []AgentModelSpeedOption) []ComposerConfigOptionValue {
+	options := make([]ComposerConfigOptionValue, 0, len(advertised))
+	for _, advertisedOption := range advertised {
+		value := strings.TrimSpace(advertisedOption.Value)
+		if value == "" {
+			continue
+		}
+		label, description := speedDisplay(value, locale)
+		if advertisedLabel := strings.TrimSpace(advertisedOption.Label); advertisedLabel != "" {
+			label = advertisedLabel
+		}
+		if advertisedDescription := strings.TrimSpace(advertisedOption.Description); advertisedDescription != "" {
+			description = advertisedDescription
+		}
+		options = append(options, ComposerConfigOptionValue{
+			ID: value, Label: label, Value: value, Description: description,
+		})
+	}
+	return options
+}
+
+func resolveAdvertisedSpeed(selected string, advertisedDefault string, advertised []AgentModelSpeedOption) string {
+	selected = strings.TrimSpace(selected)
+	advertisedDefault = strings.TrimSpace(advertisedDefault)
+	firstValue := ""
+	defaultSupported := false
+	for _, option := range advertised {
+		value := strings.TrimSpace(option.Value)
+		if value == "" {
+			continue
+		}
+		if firstValue == "" {
+			firstValue = value
+		}
+		if value == selected {
+			return selected
+		}
+		if value == advertisedDefault {
+			defaultSupported = true
+		}
+	}
+	if defaultSupported {
+		return advertisedDefault
+	}
+	return firstValue
+}

--- a/services/tuttid/service/agent/host_conformance_test.go
+++ b/services/tuttid/service/agent/host_conformance_test.go
@@ -791,7 +791,8 @@ func (d *legacyHostConformanceDriver) Create(
 		ProviderTargetRef: input.ProviderTargetRef, ReasoningEffort: input.ReasoningEffort,
 		RuntimeContext: input.RuntimeContext, Speed: input.Speed,
 		ConversationDetailMode: input.ConversationDetailMode, Visible: input.Visible,
-		RailPlacement: input.RailPlacement,
+		RailPlacement:              input.RailPlacement,
+		RailPlacementAuthoritative: input.RailPlacementAuthoritative,
 	})
 	if err != nil {
 		return hostconformance.SessionObservation{}, "", err

--- a/services/tuttid/service/agent/host_conformance_test.go
+++ b/services/tuttid/service/agent/host_conformance_test.go
@@ -1602,6 +1602,15 @@ func (i legacyHostConformanceSessionInitializer) InitializeRuntimeSession(
 	session ProviderRuntimeSession,
 	railPlacement *agenthost.RailPlacement,
 ) (PersistedSession, error) {
+	return i.InitializeRuntimeSessionWithRailAuthority(ctx, session, railPlacement, false)
+}
+
+func (i legacyHostConformanceSessionInitializer) InitializeRuntimeSessionWithRailAuthority(
+	ctx context.Context,
+	session ProviderRuntimeSession,
+	railPlacement *agenthost.RailPlacement,
+	railPlacementAuthoritative bool,
+) (PersistedSession, error) {
 	if i.fail {
 		return PersistedSession{}, errors.New("injected canonical session initialization failure")
 	}
@@ -1629,12 +1638,22 @@ func (i legacyHostConformanceSessionInitializer) InitializeRuntimeSession(
 		} else if err != nil {
 			return PersistedSession{}, err
 		}
+		var canonicalRail *agentactivitybiz.RailSection
+		if railPlacement != nil {
+			canonicalRail = &agentactivitybiz.RailSection{
+				Kind:        string(railPlacement.Kind),
+				ProjectPath: railPlacement.ProjectPath,
+				Key:         railPlacement.SectionKey,
+			}
+		}
 		if _, err := i.canonicalStore.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{
-			WorkspaceID:       persisted.WorkspaceID,
-			AgentSessionID:    persisted.ID,
-			Provider:          persisted.Provider,
-			ProviderSessionID: persisted.ProviderSessionID,
-			OccurredAtUnixMS:  persisted.UpdatedAtUnixMS,
+			WorkspaceID:                persisted.WorkspaceID,
+			AgentSessionID:             persisted.ID,
+			Provider:                   persisted.Provider,
+			ProviderSessionID:          persisted.ProviderSessionID,
+			RailPlacement:              canonicalRail,
+			RailPlacementAuthoritative: railPlacementAuthoritative,
+			OccurredAtUnixMS:           persisted.UpdatedAtUnixMS,
 		}); err != nil {
 			return PersistedSession{}, err
 		}

--- a/services/tuttid/service/agent/host_test_adapters_test.go
+++ b/services/tuttid/service/agent/host_test_adapters_test.go
@@ -71,7 +71,9 @@ func (a serviceHostStore) RollbackRuntimeSessionInitialization(ctx context.Conte
 }
 
 func (a serviceHostStore) InitializeRuntimeSession(ctx context.Context, input agenthost.RuntimeSessionInitialization) (storesqlite.Session, error) {
-	persisted, err := a.service.initializeRuntimeSession(ctx, input.Session, input.RailPlacement)
+	persisted, err := a.service.initializeRuntimeSessionWithRailAuthority(
+		ctx, input.Session, input.RailPlacement, input.RailPlacementAuthoritative,
+	)
 	return activitySessionFromPersisted(persisted), err
 }
 

--- a/services/tuttid/service/agent/model_catalog.go
+++ b/services/tuttid/service/agent/model_catalog.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -45,6 +46,10 @@ type AgentModelCatalogResult struct {
 type AgentModelCatalogInput struct {
 	Provider string
 	Cwd      string
+	// WaitForFresh makes a stale cached result synchronous. Normal composer
+	// loads leave this false so the stale result can render immediately while a
+	// refresh runs in the background; the explicit model picker request sets it.
+	WaitForFresh bool
 }
 
 type AgentModelCatalog interface {
@@ -186,15 +191,23 @@ type CachedAgentModelCatalog struct {
 	ModelCapabilities ModelCapabilitiesResolver
 	ProviderCommands  ProviderCommandResolver
 	Now               func() time.Time
+	// PersistentPath is configured by the daemon composition root. Keeping the
+	// path injectable leaves unit tests in-memory and avoids coupling them to a
+	// developer's real provider cache.
+	PersistentPath string
+	// AuthFingerprint is injectable for tests; production uses the watched
+	// provider auth/config files.
+	AuthFingerprint func(provider string) string
 	// OnRefresh is called after a stale catalog has been refreshed successfully.
 	// It is an invalidation hint; the next consumer read remains authoritative.
 	OnRefresh func(provider string)
 
-	mu            sync.Mutex
-	cache         map[string]*agentModelCatalogCacheEntry
-	generation    map[string]uint64
-	codexSessions map[string]*codexAppServerSession
-	loads         singleflight.Group
+	mu             sync.Mutex
+	cache          map[string]*agentModelCatalogCacheEntry
+	generation     map[string]uint64
+	codexSessions  map[string]*codexAppServerSession
+	loads          singleflight.Group
+	persistentOnce sync.Once
 }
 
 type agentModelCatalogCacheEntry struct {
@@ -204,6 +217,20 @@ type agentModelCatalogCacheEntry struct {
 	refreshRetryAtMS int64
 	stale            bool
 	generation       uint64
+	authFingerprint  string
+}
+
+type persistedAgentModelCatalog struct {
+	Version int                                        `json:"version"`
+	Entries map[string]persistedAgentModelCatalogEntry `json:"entries"`
+}
+
+type persistedAgentModelCatalogEntry struct {
+	Provider        string             `json:"provider"`
+	Source          string             `json:"source"`
+	FetchedAt       time.Time          `json:"fetchedAt"`
+	Models          []AgentModelOption `json:"models"`
+	AuthFingerprint string             `json:"authFingerprint,omitempty"`
 }
 
 type agentModelCatalogFetchOutcome struct {
@@ -217,10 +244,97 @@ func NewAgentModelCatalog() *CachedAgentModelCatalog {
 	return &CachedAgentModelCatalog{}
 }
 
+func (c *CachedAgentModelCatalog) ensurePersistentCacheLoaded() {
+	if c == nil || strings.TrimSpace(c.PersistentPath) == "" {
+		return
+	}
+	c.persistentOnce.Do(func() {
+		path := strings.TrimSpace(c.PersistentPath)
+		data, err := os.ReadFile(path)
+		if os.IsNotExist(err) {
+			return
+		}
+		if err != nil {
+			slog.Warn("agent model catalog persistent cache read failed",
+				"event", "agent.model_catalog.persistent_load_failed",
+				"path", path,
+				"error", err,
+			)
+			return
+		}
+		var persisted persistedAgentModelCatalog
+		if err := json.Unmarshal(data, &persisted); err != nil || persisted.Version != 1 {
+			if err == nil {
+				err = fmt.Errorf("unsupported cache version %d", persisted.Version)
+			}
+			slog.Warn("agent model catalog persistent cache ignored",
+				"event", "agent.model_catalog.persistent_load_ignored",
+				"path", path,
+				"error", err,
+			)
+			return
+		}
+		now := c.now()
+		loaded := 0
+		c.mu.Lock()
+		if c.cache == nil {
+			c.cache = make(map[string]*agentModelCatalogCacheEntry)
+		}
+		if c.generation == nil {
+			c.generation = make(map[string]uint64)
+		}
+		for provider, entry := range persisted.Entries {
+			provider = agentprovider.Normalize(provider)
+			if provider == "" || len(entry.Models) == 0 {
+				continue
+			}
+			if strings.TrimSpace(entry.Provider) == "" {
+				entry.Provider = provider
+			}
+			c.cache[provider] = &agentModelCatalogCacheEntry{
+				result: AgentModelCatalogResult{
+					Provider:  entry.Provider,
+					Source:    entry.Source,
+					FetchedAt: entry.FetchedAt,
+					Models:    cloneAgentModelOptions(entry.Models),
+					Stale:     true,
+				},
+				expiresAtMS:     now.UnixMilli(),
+				stale:           true,
+				authFingerprint: entry.AuthFingerprint,
+			}
+			loaded++
+		}
+		c.mu.Unlock()
+		if loaded > 0 {
+			slog.Info("agent model catalog persistent cache loaded",
+				"event", "agent.model_catalog.persistent_loaded",
+				"path", path,
+				"providerCount", loaded,
+			)
+		}
+	})
+}
+
+func (c *CachedAgentModelCatalog) authFingerprint(provider string) string {
+	if c.AuthFingerprint != nil {
+		return strings.TrimSpace(c.AuthFingerprint(provider))
+	}
+	return providerAuthFingerprint(provider)
+}
+
+func (c *CachedAgentModelCatalog) cacheAuthMatches(provider, cachedFingerprint string) bool {
+	if strings.TrimSpace(cachedFingerprint) == "" {
+		return true
+	}
+	return cachedFingerprint == c.authFingerprint(provider)
+}
+
 func (c *CachedAgentModelCatalog) ListModels(ctx context.Context, input AgentModelCatalogInput) (AgentModelCatalogResult, error) {
 	provider := agentprovider.Normalize(input.Provider)
 	input.Provider = provider
 	input.Cwd = strings.TrimSpace(input.Cwd)
+	c.ensurePersistentCacheLoaded()
 	spec, ok := agentModelCatalogSpecs[provider]
 	if !ok {
 		return AgentModelCatalogResult{}, ErrInvalidArgument
@@ -228,7 +342,19 @@ func (c *CachedAgentModelCatalog) ListModels(ctx context.Context, input AgentMod
 	now := c.now()
 	if specCachesModelCatalog(spec) {
 		if cached := c.readCache(provider, now); cached != nil {
+			if !c.cacheAuthMatches(provider, cached.authFingerprint) {
+				slog.Info("agent model catalog cache rejected for auth generation",
+					"event", "agent.model_catalog.cache_rejected",
+					"provider", provider,
+					"reason", "auth_fingerprint_mismatch",
+				)
+				c.Invalidate(provider)
+				return c.loadModels(ctx, input, spec, false, c.currentGeneration(provider))
+			}
 			if cached.err == nil && cached.stale {
+				if input.WaitForFresh {
+					return c.loadModels(ctx, input, spec, false, cached.generation)
+				}
 				if now.UnixMilli() >= cached.refreshRetryAtMS {
 					c.startBackgroundRefresh(input, spec, cached.generation)
 				}
@@ -338,11 +464,45 @@ func (c *CachedAgentModelCatalog) fetchModels(
 		"provider", provider,
 		"durationMs", time.Since(startedAt).Milliseconds(),
 		"modelCount", len(models),
+		"modelNames", diagnosticModelNames(models),
 		"stale_refresh", staleRefresh,
 		"accepted", accepted,
 		"error", err,
 	)
 	return agentModelCatalogFetchOutcome{result: result, err: err, staleRefresh: staleRefresh, accepted: accepted}
+}
+
+func diagnosticModelNames(models []AgentModelOption) []string {
+	const (
+		maxNames       = 32
+		maxNameLength  = 120
+		maxTotalLength = 1024
+	)
+	names := make([]string, 0, min(len(models), maxNames))
+	seen := make(map[string]struct{}, maxNames)
+	totalLength := 0
+	for _, model := range models {
+		name := strings.TrimSpace(model.ID)
+		if name == "" {
+			continue
+		}
+		name = strings.Map(func(r rune) rune {
+			if r < 0x20 || (r >= 0x7f && r <= 0x9f) {
+				return -1
+			}
+			return r
+		}, name)
+		if len(name) > maxNameLength {
+			name = name[:maxNameLength]
+		}
+		if _, ok := seen[name]; ok || name == "" || len(names) >= maxNames || totalLength+len(name) > maxTotalLength {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+		totalLength += len(name)
+	}
+	return names
 }
 
 func specCachesModelCatalog(spec agentModelCatalogSpec) bool {
@@ -484,6 +644,7 @@ func (c *CachedAgentModelCatalog) readCache(provider string, now time.Time) *age
 		refreshRetryAtMS: entry.refreshRetryAtMS,
 		stale:            entry.stale,
 		generation:       entry.generation,
+		authFingerprint:  entry.authFingerprint,
 	}
 }
 
@@ -507,10 +668,11 @@ func (c *CachedAgentModelCatalog) writeCache(
 	if ttl <= 0 {
 		return true
 	}
+	authFingerprint := c.authFingerprint(provider)
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	currentGeneration := c.generation[provider]
 	if currentGeneration != expectedGeneration {
+		c.mu.Unlock()
 		return false
 	}
 	if c.cache == nil {
@@ -523,15 +685,110 @@ func (c *CachedAgentModelCatalog) writeCache(
 		if entry := c.cache[provider]; entry != nil && entry.generation == expectedGeneration {
 			entry.refreshRetryAtMS = now.Add(ttl).UnixMilli()
 		}
+		c.mu.Unlock()
 		return false
 	}
 	c.cache[provider] = &agentModelCatalogCacheEntry{
-		result:      cloneAgentModelCatalogResult(result),
-		err:         err,
-		expiresAtMS: now.Add(ttl).UnixMilli(),
-		generation:  expectedGeneration,
+		result:          cloneAgentModelCatalogResult(result),
+		err:             err,
+		expiresAtMS:     now.Add(ttl).UnixMilli(),
+		generation:      expectedGeneration,
+		authFingerprint: authFingerprint,
+	}
+	c.mu.Unlock()
+	if err == nil && !isFallback && len(result.Models) > 0 {
+		c.persistCache()
 	}
 	return true
+}
+
+func (c *CachedAgentModelCatalog) persistCache() {
+	path := strings.TrimSpace(c.PersistentPath)
+	if path == "" {
+		return
+	}
+	persisted := persistedAgentModelCatalog{Version: 1, Entries: make(map[string]persistedAgentModelCatalogEntry)}
+	c.mu.Lock()
+	for provider, entry := range c.cache {
+		if entry == nil || entry.err != nil || len(entry.result.Models) == 0 {
+			continue
+		}
+		persisted.Entries[provider] = persistedAgentModelCatalogEntry{
+			Provider:        entry.result.Provider,
+			Source:          entry.result.Source,
+			FetchedAt:       entry.result.FetchedAt,
+			Models:          cloneAgentModelOptions(entry.result.Models),
+			AuthFingerprint: entry.authFingerprint,
+		}
+	}
+	c.mu.Unlock()
+	if len(persisted.Entries) == 0 {
+		return
+	}
+	data, err := json.MarshalIndent(persisted, "", "  ")
+	if err != nil {
+		slog.Warn("agent model catalog persistent cache encode failed",
+			"event", "agent.model_catalog.persistent_write_failed",
+			"path", path,
+			"error", err,
+		)
+		return
+	}
+	directory := filepath.Dir(path)
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		slog.Warn("agent model catalog persistent cache directory failed",
+			"event", "agent.model_catalog.persistent_write_failed",
+			"path", path,
+			"error", err,
+		)
+		return
+	}
+	temporary, err := os.CreateTemp(directory, ".model-catalog-*.tmp")
+	if err != nil {
+		slog.Warn("agent model catalog persistent cache temp file failed",
+			"event", "agent.model_catalog.persistent_write_failed",
+			"path", path,
+			"error", err,
+		)
+		return
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	writeOK := false
+	if chmodErr := temporary.Chmod(0o600); chmodErr != nil {
+		err = chmodErr
+	} else if _, writeErr := temporary.Write(data); writeErr != nil {
+		err = writeErr
+	} else if syncErr := temporary.Sync(); syncErr != nil {
+		err = syncErr
+	}
+	if closeErr := temporary.Close(); err == nil {
+		err = closeErr
+	}
+	if err == nil {
+		err = os.Rename(temporaryPath, path)
+		if err != nil {
+			// Windows does not replace an existing destination with Rename. The
+			// file is only a recoverable cache, so remove that old copy and retry.
+			if removeErr := os.Remove(path); removeErr == nil || os.IsNotExist(removeErr) {
+				err = os.Rename(temporaryPath, path)
+			}
+		}
+		writeOK = err == nil
+	}
+	if !writeOK {
+		slog.Warn("agent model catalog persistent cache write failed",
+			"event", "agent.model_catalog.persistent_write_failed",
+			"path", path,
+			"error", err,
+		)
+		return
+	}
+	slog.Info("agent model catalog persistent cache written",
+		"event", "agent.model_catalog.persistent_written",
+		"path", path,
+		"providerCount", len(persisted.Entries),
+	)
 }
 
 func (c *CachedAgentModelCatalog) currentGeneration(provider string) uint64 {

--- a/services/tuttid/service/agent/model_catalog.go
+++ b/services/tuttid/service/agent/model_catalog.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,11 +16,13 @@ import (
 	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 	tuttiagentservice "github.com/tutti-os/tutti/services/tuttid/service/tuttiagent"
 	tuttitypes "github.com/tutti-os/tutti/services/tuttid/types"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
-	codexModelCacheTTL      = 30 * time.Second
-	codexModelErrorCacheTTL = 5 * time.Second
+	codexModelCacheTTL       = 5 * time.Minute
+	codexModelErrorCacheTTL  = 5 * time.Second
+	modelCatalogFetchTimeout = 12 * time.Second
 )
 
 type AgentModelOption = modelcatalog.ModelOption
@@ -33,6 +36,10 @@ type AgentModelCatalogResult struct {
 	Source    string
 	FetchedAt time.Time
 	Models    []AgentModelOption
+	// Stale means the result is usable for presentation but is being refreshed
+	// after an auth/config change or TTL expiry. Callers that need an
+	// authoritative validation result must not accept stale models.
+	Stale bool
 }
 
 type AgentModelCatalogInput struct {
@@ -115,12 +122,14 @@ func agentModelCatalogSpecFromDescriptor(descriptor providerregistry.ProviderDes
 				if c.Codex != nil {
 					return c.Codex
 				}
-				return CodexCLIModelLister{
+				lister := CodexCLIModelLister{
 					Command:          command[0],
 					Args:             append([]string(nil), command[1:]...),
 					Provider:         descriptor.Identity.ID,
 					ProviderCommands: c.ProviderCommands,
 				}
+				lister.Session = c.codexSession(descriptor.Identity.ID, lister)
+				return lister
 			},
 			configuredDefaultModel:    readCodexConfiguredDefaultModel,
 			missingDefaultDescription: descriptor.Identity.DisplayName + " configured custom model",
@@ -155,7 +164,9 @@ func agentModelCatalogSpecFromDescriptor(descriptor providerregistry.ProviderDes
 				if c.TuttiAgent != nil {
 					return c.TuttiAgent
 				}
-				return defaultTuttiAgentModelLister(descriptor.Identity.ID, c.ProviderCommands)
+				lister := defaultTuttiAgentModelLister(descriptor.Identity.ID, c.ProviderCommands)
+				lister.Session = c.codexSession(descriptor.Identity.ID, lister)
+				return lister
 			},
 			configuredDefaultModel: func() string { return "" },
 		}, true, nil
@@ -175,15 +186,31 @@ type CachedAgentModelCatalog struct {
 	ModelCapabilities ModelCapabilitiesResolver
 	ProviderCommands  ProviderCommandResolver
 	Now               func() time.Time
+	// OnRefresh is called after a stale catalog has been refreshed successfully.
+	// It is an invalidation hint; the next consumer read remains authoritative.
+	OnRefresh func(provider string)
 
-	mu    sync.Mutex
-	cache map[string]*agentModelCatalogCacheEntry
+	mu            sync.Mutex
+	cache         map[string]*agentModelCatalogCacheEntry
+	generation    map[string]uint64
+	codexSessions map[string]*codexAppServerSession
+	loads         singleflight.Group
 }
 
 type agentModelCatalogCacheEntry struct {
-	result      AgentModelCatalogResult
-	err         error
-	expiresAtMS int64
+	result           AgentModelCatalogResult
+	err              error
+	expiresAtMS      int64
+	refreshRetryAtMS int64
+	stale            bool
+	generation       uint64
+}
+
+type agentModelCatalogFetchOutcome struct {
+	result       AgentModelCatalogResult
+	err          error
+	staleRefresh bool
+	accepted     bool
 }
 
 func NewAgentModelCatalog() *CachedAgentModelCatalog {
@@ -201,9 +228,97 @@ func (c *CachedAgentModelCatalog) ListModels(ctx context.Context, input AgentMod
 	now := c.now()
 	if specCachesModelCatalog(spec) {
 		if cached := c.readCache(provider, now); cached != nil {
+			if cached.err == nil && cached.stale {
+				if now.UnixMilli() >= cached.refreshRetryAtMS {
+					c.startBackgroundRefresh(input, spec, cached.generation)
+				}
+				stale := cloneAgentModelCatalogResult(cached.result)
+				stale.Stale = true
+				return stale, nil
+			}
 			return cached.result, cached.err
 		}
 	}
+	return c.loadModels(ctx, input, spec, false, c.currentGeneration(provider))
+}
+
+func (c *CachedAgentModelCatalog) loadModels(
+	ctx context.Context,
+	input AgentModelCatalogInput,
+	spec agentModelCatalogSpec,
+	staleRefresh bool,
+	expectedGeneration uint64,
+) (AgentModelCatalogResult, error) {
+	provider := agentprovider.Normalize(input.Provider)
+	key := provider
+	if !specCachesModelCatalog(spec) {
+		key += "\x00" + strings.TrimSpace(input.Cwd)
+	}
+	startedAt := time.Now()
+	resultCh := c.loads.DoChan(key, func() (any, error) {
+		fetchContext, cancel := context.WithTimeout(context.WithoutCancel(ctx), modelCatalogFetchTimeout)
+		defer cancel()
+		return c.fetchModels(fetchContext, input, spec, staleRefresh, expectedGeneration), nil
+	})
+	select {
+	case <-ctx.Done():
+		return AgentModelCatalogResult{}, ctx.Err()
+	case shared := <-resultCh:
+		outcome, ok := shared.Val.(agentModelCatalogFetchOutcome)
+		if !ok {
+			return AgentModelCatalogResult{}, fmt.Errorf("model catalog fetch returned invalid result")
+		}
+		if !outcome.accepted && !staleRefresh && specCachesModelCatalog(spec) {
+			// An auth/config invalidation raced the cold fetch. Do not return a
+			// catalog produced from the old credential generation.
+			return c.loadModels(ctx, input, spec, false, c.currentGeneration(provider))
+		}
+		slog.Info("agent model catalog request settled",
+			"event", "agent.model_catalog.request_settled",
+			"provider", provider,
+			"shared", shared.Shared,
+			"stale_refresh", staleRefresh,
+			"durationMs", time.Since(startedAt).Milliseconds(),
+			"error", outcome.err,
+		)
+		return cloneAgentModelCatalogResult(outcome.result), outcome.err
+	}
+}
+
+func (c *CachedAgentModelCatalog) startBackgroundRefresh(
+	input AgentModelCatalogInput,
+	spec agentModelCatalogSpec,
+	expectedGeneration uint64,
+) {
+	provider := agentprovider.Normalize(input.Provider)
+	key := provider
+	if !specCachesModelCatalog(spec) {
+		key += "\x00" + strings.TrimSpace(input.Cwd)
+	}
+	resultCh := c.loads.DoChan(key, func() (any, error) {
+		fetchContext, cancel := context.WithTimeout(context.WithoutCancel(context.Background()), modelCatalogFetchTimeout)
+		defer cancel()
+		return c.fetchModels(fetchContext, input, spec, true, expectedGeneration), nil
+	})
+	go func() {
+		<-resultCh
+	}()
+}
+
+func (c *CachedAgentModelCatalog) fetchModels(
+	ctx context.Context,
+	input AgentModelCatalogInput,
+	spec agentModelCatalogSpec,
+	staleRefresh bool,
+	expectedGeneration uint64,
+) agentModelCatalogFetchOutcome {
+	provider := agentprovider.Normalize(input.Provider)
+	startedAt := time.Now()
+	slog.Info("agent model catalog fetch started",
+		"event", "agent.model_catalog.fetch_start",
+		"provider", provider,
+		"stale_refresh", staleRefresh,
+	)
 	listResult, err := spec.lister(c, input).ListModels(ctx)
 	configuredDefaultModel := spec.configuredDefaultModel()
 	models := applyConfiguredDefaultModel(listResult.Models, configuredDefaultModel, spec.missingDefaultDescription)
@@ -211,11 +326,23 @@ func (c *CachedAgentModelCatalog) ListModels(ctx context.Context, input AgentMod
 	result := AgentModelCatalogResult{
 		Provider:  provider,
 		Source:    spec.source,
-		FetchedAt: now,
+		FetchedAt: startedAt,
 		Models:    models,
 	}
-	c.writeCache(provider, spec, now, result, listResult.IsFallback, err)
-	return cloneAgentModelCatalogResult(result), err
+	accepted := c.writeCache(provider, spec, startedAt, result, listResult.IsFallback, err, expectedGeneration, staleRefresh)
+	if accepted && staleRefresh && err == nil && c.OnRefresh != nil {
+		c.OnRefresh(provider)
+	}
+	slog.Info("agent model catalog fetch settled",
+		"event", "agent.model_catalog.fetch_settled",
+		"provider", provider,
+		"durationMs", time.Since(startedAt).Milliseconds(),
+		"modelCount", len(models),
+		"stale_refresh", staleRefresh,
+		"accepted", accepted,
+		"error", err,
+	)
+	return agentModelCatalogFetchOutcome{result: result, err: err, staleRefresh: staleRefresh, accepted: accepted}
 }
 
 func specCachesModelCatalog(spec agentModelCatalogSpec) bool {
@@ -301,21 +428,37 @@ func withoutEnvKeys(env []string, keys ...string) []string {
 	return filtered
 }
 
-// Invalidate drops any cached model list for the given providers. Providers
-// without model-list caching are unaffected. Used when provider auth or config
-// files change on disk (for example via an external credential switcher).
+// Invalidate marks cached model lists stale for the given providers and closes
+// their persistent app-server sessions. The last known list remains available
+// for presentation while the next read refreshes it in the background.
 func (c *CachedAgentModelCatalog) Invalidate(providers ...string) {
 	if c == nil {
 		return
 	}
+	var sessions []*codexAppServerSession
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	for _, provider := range providers {
 		normalized := agentprovider.Normalize(provider)
 		if normalized == "" {
 			continue
 		}
-		delete(c.cache, normalized)
+		if c.generation == nil {
+			c.generation = make(map[string]uint64)
+		}
+		c.generation[normalized]++
+		if entry := c.cache[normalized]; entry != nil {
+			entry.stale = true
+			entry.refreshRetryAtMS = 0
+			entry.generation = c.generation[normalized]
+		}
+		if session := c.codexSessions[normalized]; session != nil {
+			sessions = append(sessions, session)
+			delete(c.codexSessions, normalized)
+		}
+	}
+	c.mu.Unlock()
+	for _, session := range sessions {
+		_ = session.Close()
 	}
 }
 
@@ -323,13 +466,24 @@ func (c *CachedAgentModelCatalog) readCache(provider string, now time.Time) *age
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	entry := c.cache[provider]
-	if entry == nil || now.UnixMilli() > entry.expiresAtMS {
+	if entry == nil {
+		return nil
+	}
+	if entry.err != nil && now.UnixMilli() > entry.expiresAtMS {
 		delete(c.cache, provider)
 		return nil
 	}
+	if !entry.stale && entry.err == nil && now.UnixMilli() > entry.expiresAtMS {
+		entry.stale = true
+		entry.refreshRetryAtMS = 0
+	}
 	return &agentModelCatalogCacheEntry{
-		result: cloneAgentModelCatalogResult(entry.result),
-		err:    entry.err,
+		result:           cloneAgentModelCatalogResult(entry.result),
+		err:              entry.err,
+		expiresAtMS:      entry.expiresAtMS,
+		refreshRetryAtMS: entry.refreshRetryAtMS,
+		stale:            entry.stale,
+		generation:       entry.generation,
 	}
 }
 
@@ -340,7 +494,9 @@ func (c *CachedAgentModelCatalog) writeCache(
 	result AgentModelCatalogResult,
 	isFallback bool,
 	err error,
-) {
+	expectedGeneration uint64,
+	staleRefresh bool,
+) bool {
 	ttl := spec.ttl
 	switch {
 	case err != nil:
@@ -349,18 +505,75 @@ func (c *CachedAgentModelCatalog) writeCache(
 		ttl = spec.fallbackTTL
 	}
 	if ttl <= 0 {
-		return
+		return true
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	currentGeneration := c.generation[provider]
+	if currentGeneration != expectedGeneration {
+		return false
+	}
 	if c.cache == nil {
 		c.cache = make(map[string]*agentModelCatalogCacheEntry)
+	}
+	if c.generation == nil {
+		c.generation = make(map[string]uint64)
+	}
+	if err != nil && staleRefresh {
+		if entry := c.cache[provider]; entry != nil && entry.generation == expectedGeneration {
+			entry.refreshRetryAtMS = now.Add(ttl).UnixMilli()
+		}
+		return false
 	}
 	c.cache[provider] = &agentModelCatalogCacheEntry{
 		result:      cloneAgentModelCatalogResult(result),
 		err:         err,
 		expiresAtMS: now.Add(ttl).UnixMilli(),
+		generation:  expectedGeneration,
 	}
+	return true
+}
+
+func (c *CachedAgentModelCatalog) currentGeneration(provider string) uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.generation[provider]
+}
+
+func (c *CachedAgentModelCatalog) codexSession(provider string, lister CodexCLIModelLister) *codexAppServerSession {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.codexSessions == nil {
+		c.codexSessions = make(map[string]*codexAppServerSession)
+	}
+	if session := c.codexSessions[provider]; session != nil {
+		return session
+	}
+	lister.Session = nil
+	session := newCodexAppServerSession(lister)
+	c.codexSessions[provider] = session
+	return session
+}
+
+// Close releases persistent provider app-server processes owned by the catalog.
+func (c *CachedAgentModelCatalog) Close() error {
+	if c == nil {
+		return nil
+	}
+	c.mu.Lock()
+	sessions := make([]*codexAppServerSession, 0, len(c.codexSessions))
+	for provider, session := range c.codexSessions {
+		sessions = append(sessions, session)
+		delete(c.codexSessions, provider)
+	}
+	c.mu.Unlock()
+	var closeErr error
+	for _, session := range sessions {
+		if err := session.Close(); err != nil && closeErr == nil {
+			closeErr = err
+		}
+	}
+	return closeErr
 }
 
 func (c *CachedAgentModelCatalog) now() time.Time {
@@ -376,6 +589,7 @@ func cloneAgentModelCatalogResult(result AgentModelCatalogResult) AgentModelCata
 		Source:    result.Source,
 		FetchedAt: result.FetchedAt,
 		Models:    cloneAgentModelOptions(result.Models),
+		Stale:     result.Stale,
 	}
 }
 

--- a/services/tuttid/service/agent/model_catalog_test.go
+++ b/services/tuttid/service/agent/model_catalog_test.go
@@ -203,34 +203,56 @@ func TestAgentModelCatalogDoesNotReturnClaudeStaticModels(t *testing.T) {
 	}
 }
 
-func TestAgentModelCatalogInvalidateDropsCodexCacheBeforeTTL(t *testing.T) {
-	now := time.UnixMilli(1000)
-	lister := &fakeAgentModelLister{
-		models: []AgentModelOption{{ID: "gpt-5.2-codex", DisplayName: "gpt-5.2-codex", IsDefault: true}},
+func TestAgentModelCatalogInvalidateServesStaleModelsWhileRefreshing(t *testing.T) {
+	lister := &sequencedAgentModelLister{
+		models: []AgentModelListResult{
+			{Models: []AgentModelOption{{ID: "gpt-5.2-codex", DisplayName: "Old", IsDefault: true}}},
+			{Models: []AgentModelOption{{ID: "gpt-5.3-codex", DisplayName: "New", IsDefault: true}}},
+		},
+		secondStarted: make(chan struct{}),
+		secondRelease: make(chan struct{}),
 	}
+	refreshed := make(chan string, 1)
 	catalog := &CachedAgentModelCatalog{
 		Codex: lister,
-		Now: func() time.Time {
-			return now
+		OnRefresh: func(provider string) {
+			refreshed <- provider
 		},
 	}
 
-	if _, err := catalog.ListModels(context.Background(), AgentModelCatalogInput{Provider: "codex"}); err != nil {
+	first, err := catalog.ListModels(context.Background(), AgentModelCatalogInput{Provider: "codex"})
+	if err != nil {
 		t.Fatalf("first ListModels returned error: %v", err)
-	}
-	if _, err := catalog.ListModels(context.Background(), AgentModelCatalogInput{Provider: "codex"}); err != nil {
-		t.Fatalf("second ListModels returned error: %v", err)
-	}
-	if lister.calls != 1 {
-		t.Fatalf("lister calls before invalidate = %d, want 1", lister.calls)
 	}
 
 	catalog.Invalidate("codex")
-	if _, err := catalog.ListModels(context.Background(), AgentModelCatalogInput{Provider: "codex"}); err != nil {
+	stale, err := catalog.ListModels(context.Background(), AgentModelCatalogInput{Provider: "codex"})
+	if err != nil {
 		t.Fatalf("ListModels after invalidate returned error: %v", err)
 	}
-	if lister.calls != 2 {
-		t.Fatalf("lister calls after invalidate = %d, want 2", lister.calls)
+	if !stale.Stale || stale.Models[0].ID != first.Models[0].ID {
+		t.Fatalf("stale result = %#v, want old catalog marked stale", stale)
+	}
+	select {
+	case <-lister.secondStarted:
+	case <-time.After(time.Second):
+		t.Fatal("background refresh did not start")
+	}
+	close(lister.secondRelease)
+	select {
+	case provider := <-refreshed:
+		if provider != "codex" {
+			t.Fatalf("refresh provider = %q, want codex", provider)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("background refresh did not settle")
+	}
+	fresh, err := catalog.ListModels(context.Background(), AgentModelCatalogInput{Provider: "codex"})
+	if err != nil {
+		t.Fatalf("fresh ListModels returned error: %v", err)
+	}
+	if fresh.Stale || fresh.Models[0].ID != "gpt-5.3-codex" {
+		t.Fatalf("fresh result = %#v, want new catalog", fresh)
 	}
 }
 

--- a/services/tuttid/service/agent/model_validation.go
+++ b/services/tuttid/service/agent/model_validation.go
@@ -90,6 +90,9 @@ func (s *Service) availableComposerModelsForValidationProfile(
 		if err != nil {
 			return nil, false, nil
 		}
+		if result.Stale {
+			return nil, false, nil
+		}
 		values := make([]string, 0, len(result.Models))
 		seen := make(map[string]struct{}, len(result.Models))
 		for _, model := range result.Models {
@@ -135,6 +138,9 @@ func (s *Service) availableComposerModelsForValidationProfile(
 		}
 		result, err := s.ModelCatalog.ListModels(ctx, AgentModelCatalogInput{Provider: provider, Cwd: cwd})
 		if err != nil {
+			return nil, false, nil
+		}
+		if result.Stale {
 			return nil, false, nil
 		}
 		values := make([]string, 0, len(result.Models))

--- a/services/tuttid/service/agent/provider_auth_watcher.go
+++ b/services/tuttid/service/agent/provider_auth_watcher.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -36,6 +37,15 @@ type ProviderAuthWatchEntry struct {
 	// state file and is rewritten continuously while any session runs, but its
 	// auth-relevant fields only change on a real credential switch.
 	ContentFingerprint func(path string, data []byte) string
+}
+
+// ProviderAuthChange identifies the exact watched file that caused a provider
+// catalog invalidation. Paths are diagnostics only; file contents are never
+// included.
+type ProviderAuthChange struct {
+	Provider string
+	Path     string
+	Kind     string
 }
 
 // DefaultProviderAuthWatchEntries returns the auth/config marker files for the
@@ -186,6 +196,60 @@ func hashProviderAuthFileContent(_ string, data []byte) string {
 	return hex.EncodeToString(sum[:])
 }
 
+// providerAuthFingerprint returns a stable, opaque fingerprint for the files
+// that define the active provider credentials/configuration. It is shared by
+// the persisted model catalog so a catalog from a different account is never
+// presented after restart.
+func providerAuthFingerprint(provider string) string {
+	provider = agentprovider.Normalize(provider)
+	if provider == "" {
+		return ""
+	}
+	entries := DefaultProviderAuthWatchEntries()
+	hasher := sha256.New()
+	found := false
+	seen := make(map[string]struct{})
+	for _, entry := range entries {
+		if agentprovider.Normalize(entry.Provider) != provider {
+			continue
+		}
+		for _, path := range entry.Paths {
+			path = filepath.Clean(path)
+			if _, ok := seen[path]; ok {
+				continue
+			}
+			seen[path] = struct{}{}
+			found = true
+			fingerprint := statProviderAuthFile(path)
+			if entry.ContentFingerprint != nil && fingerprint.exists {
+				fingerprint.contentKey = readProviderAuthContentKey(
+					path,
+					fingerprint.size,
+					entry.ContentFingerprint,
+				)
+			}
+			hasher.Write([]byte(path))
+			hasher.Write([]byte{0})
+			hasher.Write([]byte(strconv.FormatBool(fingerprint.exists)))
+			hasher.Write([]byte{0})
+			if fingerprint.contentKey != "" {
+				// The watcher treats an identical-content rewrite as unchanged;
+				// keep persisted cache identity consistent with that rule.
+				hasher.Write([]byte(fingerprint.contentKey))
+			} else {
+				hasher.Write([]byte(strconv.FormatInt(fingerprint.modTime.UnixNano(), 10)))
+				hasher.Write([]byte{0})
+				hasher.Write([]byte(strconv.FormatInt(fingerprint.size, 10)))
+			}
+			hasher.Write([]byte{0})
+		}
+	}
+	if !found {
+		return ""
+	}
+	return hex.EncodeToString(hasher.Sum(nil))
+}
+
 // jsonSubsetFingerprint hashes the raw values of the given top-level keys of a
 // JSON object. Returns false when the payload is not a JSON object.
 func jsonSubsetFingerprint(data []byte, keys []string) (string, bool) {
@@ -219,6 +283,10 @@ type ProviderAuthWatcher struct {
 	// Called from the watcher goroutine; implementations must not block for
 	// long.
 	OnChange func(providers []string)
+	// OnChangeDetailed receives the same coalesced change with the triggering
+	// paths attached. It is optional so existing consumers can keep using
+	// OnChange while diagnostics opt into the richer signal.
+	OnChangeDetailed func(changes []ProviderAuthChange)
 	// OnClose releases resources attached to the watcher, such as persistent
 	// provider processes owned by the same composition root.
 	OnClose func()
@@ -247,7 +315,7 @@ func (f providerAuthFileFingerprint) statEqual(other providerAuthFileFingerprint
 // Start begins polling in a background goroutine. The first poll only records
 // the baseline fingerprints; changes are reported from the second poll on.
 func (w *ProviderAuthWatcher) Start() {
-	if w == nil || w.OnChange == nil || len(w.Entries) == 0 {
+	if w == nil || (w.OnChange == nil && w.OnChangeDetailed == nil) || len(w.Entries) == 0 {
 		return
 	}
 	w.stop = make(chan struct{})
@@ -294,6 +362,7 @@ func (w *ProviderAuthWatcher) run() {
 	ticker := time.NewTicker(w.interval())
 	defer ticker.Stop()
 	pendingProviders := make(map[string]struct{})
+	pendingChanges := make(map[string]ProviderAuthChange)
 	var coalesceTimer *time.Timer
 	var coalesceTimerC <-chan time.Time
 	stopCoalesceTimer := func() {
@@ -310,19 +379,36 @@ func (w *ProviderAuthWatcher) run() {
 		coalesceTimerC = nil
 	}
 	flushPendingProviders := func() {
-		if len(pendingProviders) == 0 {
+		if len(pendingProviders) == 0 && len(pendingChanges) == 0 {
 			return
 		}
 		providers := providerAuthPendingProviders(w.Entries, pendingProviders)
+		changes := make([]ProviderAuthChange, 0, len(pendingChanges))
+		for _, change := range pendingChanges {
+			changes = append(changes, change)
+		}
+		sort.Slice(changes, func(i, j int) bool {
+			if changes[i].Provider != changes[j].Provider {
+				return changes[i].Provider < changes[j].Provider
+			}
+			return changes[i].Path < changes[j].Path
+		})
 		pendingProviders = make(map[string]struct{})
-		if len(providers) > 0 {
+		pendingChanges = make(map[string]ProviderAuthChange)
+		if len(providers) > 0 && w.OnChange != nil {
 			w.OnChange(providers)
 		}
+		if len(changes) > 0 && w.OnChangeDetailed != nil {
+			w.OnChangeDetailed(changes)
+		}
 	}
-	scheduleProviderChanges := func(changed []string) {
-		for _, provider := range changed {
-			if normalized := agentprovider.Normalize(provider); normalized != "" {
-				pendingProviders[normalized] = struct{}{}
+	scheduleProviderChanges := func(changed []ProviderAuthChange) {
+		for _, change := range changed {
+			provider := agentprovider.Normalize(change.Provider)
+			if provider != "" {
+				pendingProviders[provider] = struct{}{}
+				change.Provider = provider
+				pendingChanges[provider+"\x00"+change.Path] = change
 			}
 		}
 		if len(pendingProviders) == 0 {
@@ -345,7 +431,7 @@ func (w *ProviderAuthWatcher) run() {
 			return
 		case <-ticker.C:
 			next := w.collectFingerprints(fingerprints)
-			changed := changedProviders(w.Entries, fingerprints, next)
+			changed := changedProviderAuthFiles(w.Entries, fingerprints, next)
 			fingerprints = next
 			if len(changed) > 0 {
 				scheduleProviderChanges(changed)
@@ -453,26 +539,61 @@ func changedProviders(
 	previous map[string]providerAuthFileFingerprint,
 	next map[string]providerAuthFileFingerprint,
 ) []string {
-	changed := make([]string, 0, len(entries))
-	seen := make(map[string]struct{}, len(entries))
+	changes := changedProviderAuthFiles(entries, previous, next)
+	providers := make([]string, 0, len(changes))
+	seen := make(map[string]struct{}, len(changes))
+	for _, change := range changes {
+		if _, ok := seen[change.Provider]; ok {
+			continue
+		}
+		seen[change.Provider] = struct{}{}
+		providers = append(providers, change.Provider)
+	}
+	return providers
+}
+
+func changedProviderAuthFiles(
+	entries []ProviderAuthWatchEntry,
+	previous map[string]providerAuthFileFingerprint,
+	next map[string]providerAuthFileFingerprint,
+) []ProviderAuthChange {
+	changed := make([]ProviderAuthChange, 0, len(entries))
+	seenPaths := make(map[string]struct{})
 	for _, entry := range entries {
 		provider := agentprovider.Normalize(entry.Provider)
 		if provider == "" {
 			continue
 		}
-		if _, ok := seen[provider]; ok {
-			continue
-		}
 		for _, path := range entry.Paths {
+			path = filepath.Clean(path)
+			if _, ok := seenPaths[path]; ok {
+				continue
+			}
+			seenPaths[path] = struct{}{}
 			if !providerAuthFileChanged(previous[path], next[path]) {
 				continue
 			}
-			seen[provider] = struct{}{}
-			changed = append(changed, provider)
-			break
+			changed = append(changed, ProviderAuthChange{
+				Provider: provider,
+				Path:     path,
+				Kind:     providerAuthFileChangeKind(previous[path], next[path]),
+			})
 		}
 	}
 	return changed
+}
+
+func providerAuthFileChangeKind(previous, next providerAuthFileFingerprint) string {
+	switch {
+	case !previous.exists && next.exists:
+		return "created"
+	case previous.exists && !next.exists:
+		return "deleted"
+	case previous.contentKey != "" && next.contentKey != "":
+		return "content_changed"
+	default:
+		return "metadata_changed"
+	}
 }
 
 func providerAuthFileChanged(previous, next providerAuthFileFingerprint) bool {

--- a/services/tuttid/service/agent/provider_auth_watcher.go
+++ b/services/tuttid/service/agent/provider_auth_watcher.go
@@ -219,10 +219,14 @@ type ProviderAuthWatcher struct {
 	// Called from the watcher goroutine; implementations must not block for
 	// long.
 	OnChange func(providers []string)
+	// OnClose releases resources attached to the watcher, such as persistent
+	// provider processes owned by the same composition root.
+	OnClose func()
 
-	stopOnce sync.Once
-	stop     chan struct{}
-	done     chan struct{}
+	stopOnce      sync.Once
+	closeHookOnce sync.Once
+	stop          chan struct{}
+	done          chan struct{}
 }
 
 type providerAuthFileFingerprint struct {
@@ -260,6 +264,11 @@ func (w *ProviderAuthWatcher) Close() {
 		close(w.stop)
 	})
 	<-w.done
+	w.closeHookOnce.Do(func() {
+		if w.OnClose != nil {
+			w.OnClose()
+		}
+	})
 }
 
 func (w *ProviderAuthWatcher) interval() time.Duration {

--- a/services/tuttid/service/agent/provider_auth_watcher_test.go
+++ b/services/tuttid/service/agent/provider_auth_watcher_test.go
@@ -54,6 +54,35 @@ func TestChangedProvidersTreatsCreateAndDeleteAsChanges(t *testing.T) {
 	}
 }
 
+func TestChangedProviderAuthFilesReportsExactPathAndKind(t *testing.T) {
+	path := "/tmp/codex/config.toml"
+	secondPath := "/tmp/codex/auth.json"
+	entries := []ProviderAuthWatchEntry{{
+		Provider: agentprovider.Codex,
+		Paths:    []string{secondPath, path},
+	}}
+	previous := map[string]providerAuthFileFingerprint{
+		path:       {exists: true, size: 10},
+		secondPath: {exists: true, size: 10},
+	}
+	next := map[string]providerAuthFileFingerprint{
+		path:       {exists: true, size: 20},
+		secondPath: {exists: true, size: 20},
+	}
+	changes := changedProviderAuthFiles(entries, previous, next)
+	if len(changes) != 2 {
+		t.Fatalf("changes = %#v, want both changed files", changes)
+	}
+	for _, change := range changes {
+		if change.Provider != agentprovider.Codex || change.Kind != "metadata_changed" {
+			t.Fatalf("change = %#v, want codex metadata_changed", change)
+		}
+	}
+	if changes[0].Path != secondPath || changes[1].Path != path {
+		t.Fatalf("changes = %#v, want sorted auth then config paths", changes)
+	}
+}
+
 func TestProviderAuthWatcherReportsFileRewrites(t *testing.T) {
 	dir := t.TempDir()
 	authPath := filepath.Join(dir, "auth.json")

--- a/services/tuttid/service/agent/provider_auth_watcher_test.go
+++ b/services/tuttid/service/agent/provider_auth_watcher_test.go
@@ -152,6 +152,25 @@ func TestProviderAuthWatcherStartWithoutCallbackIsInert(_ *testing.T) {
 	watcher.Close()
 }
 
+func TestProviderAuthWatcherCloseRunsHookOnce(t *testing.T) {
+	closeCalls := 0
+	watcher := &ProviderAuthWatcher{
+		Entries: []ProviderAuthWatchEntry{
+			{Provider: agentprovider.Codex, Paths: []string{filepath.Join(t.TempDir(), "auth.json")}},
+		},
+		OnChange: func([]string) {},
+		OnClose: func() {
+			closeCalls++
+		},
+	}
+	watcher.Start()
+	watcher.Close()
+	watcher.Close()
+	if closeCalls != 1 {
+		t.Fatalf("OnClose calls = %d, want one", closeCalls)
+	}
+}
+
 func TestDefaultProviderAuthWatchEntriesCoverCredentialBackedCatalogs(t *testing.T) {
 	home := t.TempDir()
 	configDir := filepath.Join(home, "opencode-config")
@@ -177,6 +196,11 @@ func TestDefaultProviderAuthWatchEntriesCoverCredentialBackedCatalogs(t *testing
 	} {
 		if !containsString(codexPaths, want) {
 			t.Fatalf("codex paths = %v, want %q", codexPaths, want)
+		}
+	}
+	for _, entry := range entries {
+		if entry.Provider == agentprovider.Codex && entry.ContentFingerprint == nil {
+			t.Fatal("codex auth watch entry must fingerprint full file content")
 		}
 	}
 	if len(byProvider[agentprovider.ClaudeCode]) == 0 {

--- a/services/tuttid/service/agent/service_create.go
+++ b/services/tuttid/service/agent/service_create.go
@@ -237,7 +237,8 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 		RuntimeContext:         stampAgentExtensionComposerScope(input.RuntimeContext, input.ProviderTargetRef, cwd, runtimeSettings),
 		Speed:                  stringPointer(runtimeSettings.Speed),
 		ConversationDetailMode: input.ConversationDetailMode, Visible: input.Visible,
-		RailPlacement: input.RailPlacement,
+		RailPlacement:              input.RailPlacement,
+		RailPlacementAuthoritative: input.RailPlacementAuthoritative,
 	}
 	if err := s.applyInitialTuttiModeActivation(ctx, workspaceID, input.AgentSessionID, input.InitialTuttiModeActivation); err != nil {
 		return createSessionFailureResult(input, err)

--- a/services/tuttid/service/agent/service_session.go
+++ b/services/tuttid/service/agent/service_session.go
@@ -144,10 +144,31 @@ func (s *Service) initializeRuntimeSession(
 	session ProviderRuntimeSession,
 	railPlacement *agenthost.RailPlacement,
 ) (PersistedSession, error) {
+	return s.initializeRuntimeSessionWithRailAuthority(ctx, session, railPlacement, false)
+}
+
+func (s *Service) initializeRuntimeSessionWithRailAuthority(
+	ctx context.Context,
+	session ProviderRuntimeSession,
+	railPlacement *agenthost.RailPlacement,
+	railPlacementAuthoritative bool,
+) (PersistedSession, error) {
 	if s == nil || s.SessionInitializer == nil {
 		return PersistedSession{}, fmt.Errorf("initialize workspace agent session: session initializer is unavailable")
 	}
-	persisted, err := s.SessionInitializer.InitializeRuntimeSession(ctx, session, railPlacement)
+	var (
+		persisted PersistedSession
+		err       error
+	)
+	if initializer, ok := s.SessionInitializer.(sessionInitializerWithRailAuthority); ok {
+		persisted, err = initializer.InitializeRuntimeSessionWithRailAuthority(
+			ctx, session, railPlacement, railPlacementAuthoritative,
+		)
+	} else if railPlacementAuthoritative {
+		return PersistedSession{}, fmt.Errorf("initialize workspace agent session: session initializer does not support authoritative rail placement")
+	} else {
+		persisted, err = s.SessionInitializer.InitializeRuntimeSession(ctx, session, railPlacement)
+	}
 	if err != nil {
 		return PersistedSession{}, fmt.Errorf("initialize workspace agent session: %w", err)
 	}

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -86,6 +86,7 @@ type Service struct {
 	skillOptionsCache              *composerSkillOptionsCache
 	providerAvailabilityCache      *providerAvailabilityCache
 	capabilityCatalogCache         *composerCapabilityCatalogCache
+	capabilityCatalogGroup         singleflight.Group
 	liveModelCache                 *composerLiveModelCache
 	claudeStartupLock              *claudecodeservice.StartupGate
 	liveModelDiscoveryMu           sync.Mutex

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -531,6 +531,15 @@ type SessionInitializer interface {
 	InitializeRuntimeSession(context.Context, ProviderRuntimeSession, *agenthost.RailPlacement) (PersistedSession, error)
 }
 
+// sessionInitializerWithRailAuthority is an optional adapter capability for
+// callers whose explicit rail placement comes from an external canonical
+// authority. The legacy initializer remains valid for ordinary service paths;
+// Host adapters must use this capability when they carry the authoritative
+// placement bit across the service boundary.
+type sessionInitializerWithRailAuthority interface {
+	InitializeRuntimeSessionWithRailAuthority(context.Context, ProviderRuntimeSession, *agenthost.RailPlacement, bool) (PersistedSession, error)
+}
+
 type ChildSessionReader interface {
 	ListChildSessions(context.Context, string, string) ([]PersistedSession, error)
 }

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -745,7 +745,10 @@ type CreateSessionInput struct {
 	ConversationDetailMode string
 	Visible                *bool
 	RailPlacement          *agenthost.RailPlacement
-	ExtraSkills            []SessionSkillBundle
+	// RailPlacementAuthoritative carries an externally canonical project
+	// placement through the legacy service adapter used by conformance tests.
+	RailPlacementAuthoritative bool
+	ExtraSkills                []SessionSkillBundle
 	// ExternalRolloutSourcePath is the absolute path to the original provider
 	// CLI rollout/transcript file this session was imported from, when known.
 	// Populated from the persisted session's RuntimeContext when resuming an

--- a/services/tuttid/service/workspace/app_factory.go
+++ b/services/tuttid/service/workspace/app_factory.go
@@ -123,6 +123,7 @@ type FixAppFactoryJobInput struct {
 type AppFactoryAgentTargetComposerOptionsInput struct {
 	AgentTargetID string
 	Locale        string
+	Section       agentservice.ComposerOptionsSection
 	Settings      agentservice.ComposerSettings
 }
 
@@ -203,13 +204,14 @@ func (s *AppFactoryService) GetAgentTargetComposerOptions(ctx context.Context, w
 	if err := os.MkdirAll(cwd, 0o755); err != nil {
 		return agentservice.ComposerOptions{}, fmt.Errorf("create app factory composer draft dir: %w", err)
 	}
-	includeCapabilityCatalog := false
+	includeCapabilityCatalog := input.Section == agentservice.ComposerOptionsSectionCapabilities
 	return s.AgentSessionService.GetComposerOptions(ctx, agentservice.ComposerOptionsInput{
 		AgentTargetID:            resolvedTarget.ID,
 		Cwd:                      cwd,
 		IncludeCapabilityCatalog: &includeCapabilityCatalog,
 		Locale:                   strings.TrimSpace(input.Locale),
 		Provider:                 resolvedTarget.Provider,
+		Section:                  input.Section,
 		Settings:                 input.Settings,
 		WorkspaceID:              strings.TrimSpace(workspaceID),
 	})

--- a/services/tuttid/wiring_agent_service.go
+++ b/services/tuttid/wiring_agent_service.go
@@ -29,13 +29,13 @@ func startAgentModelInvalidationAuthWatcher(
 	events *eventstreamservice.Service,
 ) *agentservice.ProviderAuthWatcher {
 	// External credential switchers (for example cc-switch) rewrite provider
-	// auth/config files without notifying tuttid. Watch those files so cached
-	// model catalogs are dropped and the GUI hears about it immediately.
+	// auth/config files without notifying tuttid. Watch those files so model
+	// catalogs become stale, provider sessions are closed, and the GUI hears
+	// about it immediately.
 	publisher := eventstreamservice.AgentModelCatalogPublisher{Service: events}
-	return startProviderAuthWatcher(replayComposition, func(providers []string) {
-		modelCatalog.Invalidate(providers...)
-		for _, provider := range providers {
-			sessions.InvalidateLiveComposerModels(provider)
+	publish := func(providers []string, event string) {
+		if len(providers) == 0 {
+			return
 		}
 		if err := publisher.PublishAgentModelCatalogInvalidated(context.Background(), providers); err != nil {
 			slog.Warn("agent model catalog invalidation publish failed",
@@ -45,11 +45,27 @@ func startAgentModelInvalidationAuthWatcher(
 			)
 			return
 		}
-		slog.Info("agent provider auth files changed; model catalog invalidated",
-			"event", "agent.model_catalog.invalidated",
+		slog.Info("agent model catalog invalidation published",
+			"event", event,
 			"providers", providers,
 		)
+	}
+	watcher := startProviderAuthWatcher(replayComposition, func(providers []string) {
+		modelCatalog.Invalidate(providers...)
+		for _, provider := range providers {
+			sessions.InvalidateLiveComposerModels(provider)
+		}
+		publish(providers, "agent.model_catalog.invalidated")
 	})
+	if watcher != nil {
+		modelCatalog.OnRefresh = func(provider string) {
+			publish([]string{provider}, "agent.model_catalog.refreshed")
+		}
+		watcher.OnClose = func() {
+			_ = modelCatalog.Close()
+		}
+	}
+	return watcher
 }
 
 func agentWorkspaceIDs(

--- a/services/tuttid/wiring_agent_service.go
+++ b/services/tuttid/wiring_agent_service.go
@@ -33,7 +33,7 @@ func startAgentModelInvalidationAuthWatcher(
 	// catalogs become stale, provider sessions are closed, and the GUI hears
 	// about it immediately.
 	publisher := eventstreamservice.AgentModelCatalogPublisher{Service: events}
-	publish := func(providers []string, event string) {
+	publish := func(providers []string, event string, changes []agentservice.ProviderAuthChange) {
 		if len(providers) == 0 {
 			return
 		}
@@ -43,29 +43,65 @@ func startAgentModelInvalidationAuthWatcher(
 				"providers", providers,
 				"error", err,
 			)
-			return
 		}
 		slog.Info("agent model catalog invalidation published",
 			"event", event,
 			"providers", providers,
+			"changed_files", providerAuthChangeDiagnostics(changes),
 		)
 	}
-	watcher := startProviderAuthWatcher(replayComposition, func(providers []string) {
-		modelCatalog.Invalidate(providers...)
-		for _, provider := range providers {
-			sessions.InvalidateLiveComposerModels(provider)
-		}
-		publish(providers, "agent.model_catalog.invalidated")
-	})
+	watcher := startProviderAuthWatcher(
+		replayComposition,
+		nil,
+		func(changes []agentservice.ProviderAuthChange) {
+			providers := providerAuthChangeProviders(changes)
+			modelCatalog.Invalidate(providers...)
+			for _, provider := range providers {
+				sessions.InvalidateLiveComposerModels(provider)
+			}
+			publish(providers, "agent.model_catalog.invalidated", changes)
+		},
+	)
 	if watcher != nil {
 		modelCatalog.OnRefresh = func(provider string) {
-			publish([]string{provider}, "agent.model_catalog.refreshed")
+			publish([]string{provider}, "agent.model_catalog.refreshed", nil)
 		}
 		watcher.OnClose = func() {
 			_ = modelCatalog.Close()
 		}
 	}
 	return watcher
+}
+
+func providerAuthChangeProviders(changes []agentservice.ProviderAuthChange) []string {
+	providers := make([]string, 0, len(changes))
+	seen := make(map[string]struct{}, len(changes))
+	for _, change := range changes {
+		if change.Provider == "" {
+			continue
+		}
+		if _, ok := seen[change.Provider]; ok {
+			continue
+		}
+		seen[change.Provider] = struct{}{}
+		providers = append(providers, change.Provider)
+	}
+	return providers
+}
+
+func providerAuthChangeDiagnostics(changes []agentservice.ProviderAuthChange) []map[string]string {
+	if len(changes) == 0 {
+		return nil
+	}
+	result := make([]map[string]string, 0, len(changes))
+	for _, change := range changes {
+		result = append(result, map[string]string{
+			"provider": change.Provider,
+			"path":     change.Path,
+			"kind":     change.Kind,
+		})
+	}
+	return result
 }
 
 func agentWorkspaceIDs(

--- a/services/tuttid/wiring_daemon_api.go
+++ b/services/tuttid/wiring_daemon_api.go
@@ -282,6 +282,9 @@ func buildDaemonAPI(
 	})
 	agentModelCapabilities := agentservice.NewModelCapabilitiesService()
 	agentModelCatalog := agentservice.NewAgentModelCatalog()
+	agentModelCatalog.PersistentPath = filepath.Join(
+		tuttitypes.DefaultStateDir(), "agent-model-catalog", "model-catalog.json",
+	)
 	agentModelCatalog.ModelCapabilities = agentModelCapabilities
 	agentModelCatalog.ProviderCommands = &agentStatusService
 	agentSessionPurgeStore, ok := agentActivityRepo.(agenthost.SessionPurgeStore)


### PR DESCRIPTION
## Summary

- Persist the last successful Codex model catalog and return it immediately after daemon restart while refreshing in the background.
- Keep normal Composer Options requests on the core path; load capabilities only when the user opens the capability UI or starts a slash command.
- Let the model picker request a fresh catalog explicitly, while concurrent callers share one refresh.
- Add provider-side model-list and capability stage timings, bounded model names, and invalidation logs with changed file paths and kinds.
- Add API, activity-core, desktop adapter, UI, daemon, persistence, concurrency, Windows, and troubleshooting coverage.

## Tests

- `pnpm check:changed -- --push-ready` — 29 lanes passed.
- Pre-commit formatting and staged boundary checks passed.

## Runtime notes

- Latest dev Codex cold request: model-list stage `1430ms`, total `1744ms`, 7 models.
- Subsequent Codex core request: `59ms`. Claude Code core requests: `52ms` and `23ms`.
- No capability discovery was recorded during the latest Composer initialization window.
- `changed_files` invalidation fields are implemented but do not yet have a post-change runtime sample; the latest invalidation sample predates this instrumentation.

## Notes

- The PR is behind `main` but remains mergeable; no rebase was performed.
- Native Windows execution remains a CI/manual gate.