### PR TITLE
fix: stabilize 0814 mention and queued-submit flows

### DIFF
--- a/packages/agent/activity-core/src/engine/pendingIntents.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.reducer.test.ts
@@ -102,6 +102,33 @@ test("command timeout is uncertain until the same client submit id is durable", 
   assert.deepEqual(confirmed.commands, []);
 });
 
+test("durable confirmation is idempotent and ignores a late command result", () => {
+  const requested = reduce(createInitialPendingIntentsState(), submit()).state;
+  const confirmed = reduce(requested, {
+    type: "message/snapshotReceived",
+    messages: [message("submit-1")]
+  });
+  assert.equal(
+    confirmed.state.submitsByClientSubmitId["submit-1"]?.status,
+    "confirmed"
+  );
+
+  const duplicate = reduce(confirmed.state, {
+    type: "message/snapshotReceived",
+    messages: [message("submit-1")]
+  });
+  assert.equal(duplicate.state, confirmed.state);
+
+  const lateResult = reduce(confirmed.state, {
+    type: "engine/commandResult",
+    commandId: "queue:send:session-1:1",
+    commandType: "queue/sendPrompt",
+    correlationId: "submit-1",
+    outcome: "timedOut"
+  });
+  assert.equal(lateResult.state, confirmed.state);
+});
+
 test("failed submit preserves the structured protocol reason for presentation", () => {
   let state = reduce(createInitialPendingIntentsState(), submit()).state;
   state = reduce(state, {

--- a/packages/agent/activity-core/src/engine/pendingSubmit.reducer.ts
+++ b/packages/agent/activity-core/src/engine/pendingSubmit.reducer.ts
@@ -90,6 +90,11 @@ export function settleSubmitCommand(
   if (!record) {
     return unchanged(state);
   }
+  // A later timeout/failure must not regress a send that already has an
+  // accepted or durable confirmation. Replayed command results are no-ops.
+  if (record.status === "accepted" || record.status === "confirmed") {
+    return unchanged(state);
+  }
   if (intent.outcome === "succeeded") {
     if (!validation || validation.kind === "invalid") {
       return {
@@ -176,10 +181,14 @@ export function confirmFromMessages(
     if (record.turnId && messageTurnId && record.turnId !== messageTurnId) {
       continue;
     }
+    const nextTurnId = record.turnId ?? messageTurnId ?? null;
+    if (record.status === "confirmed" && record.turnId === nextTurnId) {
+      continue;
+    }
     next = replaceSubmit(next, {
       ...record,
       status: "confirmed",
-      turnId: record.turnId ?? messageTurnId ?? null
+      turnId: nextTurnId
     });
   }
   return next === state

--- a/packages/agent/activity-core/src/engine/promptQueue.lookup.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.lookup.ts
@@ -7,7 +7,8 @@ export function promptQueuePromptIdForClientSubmit(
 ): string | null {
   return (
     state.recordsBySessionId[agentSessionId.trim()]?.prompts.find(
-      (prompt) => prompt.clientSubmitId === clientSubmitId.trim()
+      (prompt) =>
+        (prompt.clientSubmitId?.trim() || prompt.id) === clientSubmitId.trim()
     )?.id ?? null
   );
 }

--- a/packages/agent/activity-core/src/engine/promptQueue.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.reducer.test.ts
@@ -58,6 +58,28 @@ test("available canonical lifecycle sends an enqueued prompt immediately", () =>
   );
 });
 
+test("durable message removes an in-flight queued prompt by its prompt identity", () => {
+  const sending = reduce(
+    createInitialPromptQueueState(),
+    enqueue("prompt-1"),
+    canonicalLifecycle("settled", 1, "turn-0")
+  );
+  assert.equal(
+    sending.state.recordsBySessionId["session-1"]?.inFlight?.clientSubmitId,
+    "prompt-1"
+  );
+
+  const confirmed = reduce(
+    sending.state,
+    messagesReceived("prompt-1", "turn-1"),
+    canonicalLifecycle("running", 2, "turn-1")
+  );
+  const record = confirmed.state.recordsBySessionId["session-1"];
+  assert.deepEqual(record?.prompts, []);
+  assert.equal(record?.inFlight, null);
+  assert.equal(record?.deliveryBarrierTurnId, "turn-1");
+});
+
 test("user settings inFlight blocks drain until settings settle to idle", () => {
   let lifecycle = canonicalLifecycle("settled", 1);
   lifecycle = sessionLifecycleReducer(lifecycle, {

--- a/packages/agent/activity-core/src/engine/promptQueue.reducer.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.reducer.ts
@@ -489,14 +489,14 @@ function confirmDeliveredPrompts(
   for (const [agentSessionId, current] of Object.entries(
     state.recordsBySessionId
   )) {
-    const matched = current.prompts.find((prompt) => {
-      const turnId = prompt.clientSubmitId
-        ? confirmedTurnByClientSubmitId.get(prompt.clientSubmitId)
-        : undefined;
-      return Boolean(turnId);
+    const matchingPrompts = current.prompts.filter((prompt) => {
+      const clientSubmitId = prompt.clientSubmitId?.trim() || prompt.id;
+      return confirmedTurnByClientSubmitId.has(clientSubmitId);
     });
-    if (!matched?.clientSubmitId) continue;
-    const turnId = confirmedTurnByClientSubmitId.get(matched.clientSubmitId);
+    if (matchingPrompts.length !== 1) continue;
+    const matched = matchingPrompts[0]!;
+    const clientSubmitId = matched.clientSubmitId?.trim() || matched.id;
+    const turnId = confirmedTurnByClientSubmitId.get(clientSubmitId);
     if (!turnId) continue;
     const record = compactQueueRecord({
       ...current,
@@ -636,6 +636,7 @@ function drainSession(
     {
       ...record,
       inFlight: {
+        clientSubmitId: head.clientSubmitId?.trim() || head.id,
         commandId,
         ...(decision.guidance ? { guidance: true as const } : {}),
         kind: "send",
@@ -664,7 +665,7 @@ function sendCommandFromQueuedPrompt(
     ...clonePromptCapabilityReferences(head.capabilityRefs),
     commandId,
     ...(head.clientSubmitId ? { correlationId: head.clientSubmitId } : {}),
-    clientSubmitId: head.clientSubmitId ?? head.id,
+    clientSubmitId: head.clientSubmitId?.trim() || head.id,
     content: head.runtimeContent ?? head.content,
     ...(head.displayPrompt ? { displayPrompt: head.displayPrompt } : {}),
     ...(guidance ? { guidance: true } : {}),

--- a/packages/agent/activity-core/src/engine/promptQueue.types.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.types.ts
@@ -24,6 +24,7 @@ export interface EngineQueuedPrompt {
 export type PromptQueueSuspendReason = "user_stop";
 
 export interface PromptQueueInFlightCommand {
+  clientSubmitId?: string;
   commandId: string;
   /** Set when the command was dispatched as an active-turn steer. */
   guidance?: true;

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchControllerBase.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchControllerBase.ts
@@ -772,6 +772,7 @@ export class AgentMentionSearchControllerBase {
   ): Promise<AgentMentionBrowseFetchResult> {
     return fetchAgentMentionFilterResult({
       ...input,
+      abortSignal,
       fileLimit: this.fileLimit,
       currentFileSearchLimit: this.currentFileSearchLimit,
       currentIssueSearchLimit: this.currentIssueSearchLimit,

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchIndex.test.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchIndex.test.ts
@@ -6,6 +6,117 @@ import {
 } from "./AgentMentionSearchIndex";
 
 describe("fetchAgentMentionFilterResult provenance filtering", () => {
+  it("keeps ordinary files ready when the optional generated-file provider fails", async () => {
+    const queryProviderMentionItemsById = vi.fn(
+      async (input: AgentMentionProviderQueryInput) => {
+        if (
+          input.providerId ===
+          AGENT_CONTEXT_MENTION_PROVIDER_IDS.agentGeneratedFile
+        ) {
+          throw new Error("generated files unavailable");
+        }
+        return [
+          {
+            directoryPath: "/workspace",
+            entryKind: "file" as const,
+            href: "/workspace/readme.md",
+            kind: "file" as const,
+            name: "readme.md",
+            path: "/workspace/readme.md"
+          }
+        ];
+      }
+    );
+
+    const result = await fetchAgentMentionFilterResult({
+      workspaceId: "workspace-1",
+      currentUserId: "user-1",
+      query: "",
+      filter: "file",
+      sessionCwd: "/workspace",
+      sectionKey: "project:/workspace",
+      includeAgentGeneratedFiles: true,
+      fileLimit: 30,
+      currentFileSearchLimit: 30,
+      currentIssueSearchLimit: 30,
+      provenanceFilter: null,
+      queryProviderMentionItemsById
+    });
+
+    expect(result.rawGroups.opened_files).toEqual([
+      expect.objectContaining({ path: "/workspace/readme.md" })
+    ]);
+    expect(result.rawGroups.agent_generated_files).toEqual([]);
+  });
+
+  it("does not swallow an aborted optional generated-file request", async () => {
+    const error = new Error("aborted");
+    error.name = "AbortError";
+    const queryProviderMentionItemsById = vi.fn(
+      async (input: AgentMentionProviderQueryInput) => {
+        if (
+          input.providerId ===
+          AGENT_CONTEXT_MENTION_PROVIDER_IDS.agentGeneratedFile
+        ) {
+          throw error;
+        }
+        return [];
+      }
+    );
+
+    await expect(
+      fetchAgentMentionFilterResult({
+        workspaceId: "workspace-1",
+        currentUserId: "user-1",
+        query: "",
+        filter: "file",
+        sessionCwd: "/workspace",
+        sectionKey: "project:/workspace",
+        includeAgentGeneratedFiles: true,
+        fileLimit: 30,
+        currentFileSearchLimit: 30,
+        currentIssueSearchLimit: 30,
+        provenanceFilter: null,
+        queryProviderMentionItemsById
+      })
+    ).rejects.toBe(error);
+  });
+
+  it("fails closed when generated files are required by a provenance filter", async () => {
+    const error = new Error("generated files unavailable");
+    const queryProviderMentionItemsById = vi.fn(
+      async (input: AgentMentionProviderQueryInput) => {
+        if (
+          input.providerId ===
+          AGENT_CONTEXT_MENTION_PROVIDER_IDS.agentGeneratedFile
+        ) {
+          throw error;
+        }
+        return [];
+      }
+    );
+
+    await expect(
+      fetchAgentMentionFilterResult({
+        workspaceId: "workspace-1",
+        currentUserId: "user-1",
+        query: "",
+        filter: "file",
+        sessionCwd: "/workspace",
+        sectionKey: "project:/workspace",
+        includeAgentGeneratedFiles: true,
+        fileLimit: 30,
+        currentFileSearchLimit: 30,
+        currentIssueSearchLimit: 30,
+        provenanceFilter: {
+          agentTargetIds: ["agent-1"],
+          memberIds: null
+        },
+        queryProviderMentionItemsById
+      })
+    ).rejects.toBe(error);
+  });
+
   it("queries only the provenance-aware file provider for a member-only constraint", async () => {
     const queryProviderMentionItemsById = vi.fn(
       async (input: AgentMentionProviderQueryInput) =>

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchIndex.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchIndex.ts
@@ -45,6 +45,7 @@ export interface AgentMentionProviderQueryInput {
 export interface AgentMentionProviderGroupedQueryInput extends AgentMentionProviderQueryInput {}
 
 export async function fetchAgentMentionFilterResult(input: {
+  abortSignal?: AbortSignal;
   workspaceId: string;
   currentUserId: string;
   query: string;
@@ -98,9 +99,15 @@ export async function fetchAgentMentionFilterResult(input: {
               provenanceFilter: input.provenanceFilter
             })
           : Promise.resolve([] as AgentContextMentionItem[]);
+      const resolvedAgentGeneratedFileQuery = provenanceFilterActive
+        ? agentGeneratedFileQuery
+        : tolerateOptionalAgentGeneratedFileFailure({
+            abortSignal: input.abortSignal,
+            query: agentGeneratedFileQuery
+          });
       const [fileItems, agentGeneratedFileItems] = await Promise.all([
         fileQuery,
-        agentGeneratedFileQuery
+        resolvedAgentGeneratedFileQuery
       ]);
       const rawGroups = emptyAgentMentionRawGroups();
       rawGroups.opened_files = fileItems.filter((item) => item.kind === "file");
@@ -216,6 +223,22 @@ export async function fetchAgentMentionFilterResult(input: {
       };
     }
   }
+}
+
+function tolerateOptionalAgentGeneratedFileFailure(input: {
+  abortSignal?: AbortSignal;
+  query: Promise<AgentContextMentionItem[]>;
+}): Promise<AgentContextMentionItem[]> {
+  return input.query.catch((error: unknown) => {
+    if (input.abortSignal?.aborted || isAbortError(error)) {
+      throw error;
+    }
+    return [];
+  });
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
 }
 
 export async function queryAgentMentionProviderItems(input: {

--- a/packages/workspace/file-reference/src/ui/internal/reference/ReferenceProvenanceFilterControl.render.test.ts
+++ b/packages/workspace/file-reference/src/ui/internal/reference/ReferenceProvenanceFilterControl.render.test.ts
@@ -20,7 +20,7 @@ const require = createRequire(import.meta.url);
 const { JSDOM } = require("jsdom") as JsdomModule;
 const ts = require("typescript") as TypeScriptModule;
 
-test("provenance filter handles row clicks and disabled option visibility", async () => {
+test("provenance filter keeps its host palette open while filtering", async () => {
   const longMemberLabel = "Alice with a very long display name";
   const moduleDir = dirname(fileURLToPath(import.meta.url));
   const tempDir = mkdtempSync(join(moduleDir, ".filter-render-test-"));
@@ -34,9 +34,12 @@ test("provenance filter handles row clicks and disabled option visibility", asyn
   ).IS_REACT_ACT_ENVIRONMENT;
 
   let root: Root | null = null;
+  let testDocument: Document | null = null;
+  let hostPointerDownOutside: ((event: Event) => void) | null = null;
   try {
     const componentModuleUrl = buildFilterControlRenderModule(tempDir);
     const dom = new JSDOM('<!doctype html><div id="root"></div>');
+    testDocument = dom.window.document;
     globalThis.window = dom.window;
     globalThis.document = dom.window.document;
     globalThis.HTMLElement = dom.window.HTMLElement;
@@ -86,25 +89,25 @@ test("provenance filter handles row clicks and disabled option visibility", asyn
       value: { agentTargetIds: ["codex"], memberIds: null }
     };
     const renderControl = (nextProps: ReferenceProvenanceFilterControlProps) =>
-      createElement(
-        "div",
-        {
-          onClickCapture(event: React.MouseEvent<HTMLDivElement>) {
-            if (
-              event.target instanceof Element &&
-              !event.target.closest(".nodrag")
-            ) {
-              event.stopPropagation();
-            }
-          }
-        },
-        createElement(ReferenceProvenanceFilterControl, nextProps)
-      );
+      createElement(ReferenceProvenanceFilterControl, nextProps);
 
     root = createRoot(container);
     await act(async () => {
       root?.render(renderControl(props));
     });
+
+    let hostPointerDownOutsideCount = 0;
+    hostPointerDownOutside = (event) => {
+      const target = event.target;
+      if (!(target instanceof Node) || !container.contains(target)) {
+        hostPointerDownOutsideCount += 1;
+      }
+    };
+    dom.window.document.addEventListener(
+      "pointerdown",
+      hostPointerDownOutside,
+      true
+    );
 
     assert.doesNotMatch(dom.window.document.body.textContent ?? "", /Cursor/);
     assert.doesNotMatch(dom.window.document.body.textContent ?? "", /Reset/);
@@ -112,12 +115,28 @@ test("provenance filter handles row clicks and disabled option visibility", asyn
       'button[aria-label="Filtered sources"]'
     );
     assert.ok(filterTrigger);
+    assert.equal(filterTrigger.getAttribute("aria-expanded"), "false");
     assert.match(filterTrigger.className, /(?:^|\s)border-0(?:\s|$)/);
     assert.doesNotMatch(
       filterTrigger.className,
       /border-\[var\(--border-focus\)\]/
     );
-    const popover = dom.window.document.querySelector<HTMLElement>(".nodrag");
+    assert.equal(dom.window.document.querySelector('[role="menu"]'), null);
+
+    const triggerPointerDown = new dom.window.MouseEvent("pointerdown", {
+      bubbles: true,
+      cancelable: true
+    });
+    await act(async () => {
+      filterTrigger.dispatchEvent(triggerPointerDown);
+      filterTrigger.click();
+    });
+    assert.equal(triggerPointerDown.defaultPrevented, true);
+    assert.equal(hostPointerDownOutsideCount, 0);
+    assert.equal(filterTrigger.getAttribute("aria-expanded"), "true");
+
+    const popover =
+      dom.window.document.querySelector<HTMLElement>('[role="menu"]');
     assert.ok(popover);
     assert.equal(popover.style.zIndex, "var(--z-panel-popover)");
 
@@ -131,6 +150,8 @@ test("provenance filter handles row clicks and disabled option visibility", asyn
     await act(async () => {
       allAgentsRow.click();
     });
+    assert.equal(hostPointerDownOutsideCount, 0);
+    assert.ok(dom.window.document.querySelector('[role="menu"]'));
 
     const codexRow = [
       ...dom.window.document.querySelectorAll<HTMLElement>(
@@ -196,6 +217,7 @@ test("provenance filter handles row clicks and disabled option visibility", asyn
     });
 
     assert.deepEqual(calls, ["all:agent", "codex", "all:member", "member-1"]);
+    assert.equal(hostPointerDownOutsideCount, 0);
 
     const agentsTab = [
       ...dom.window.document.querySelectorAll<HTMLElement>('[role="tab"]')
@@ -221,7 +243,42 @@ test("provenance filter handles row clicks and disabled option visibility", asyn
     ].find((element) => element.textContent === "Cursor");
     assert.ok(cursorRow);
     assert.equal(cursorRow.getAttribute("aria-disabled"), "true");
+
+    const outside = dom.window.document.createElement("button");
+    dom.window.document.body.append(outside);
+    await act(async () => {
+      outside.dispatchEvent(
+        new dom.window.MouseEvent("pointerdown", {
+          bubbles: true,
+          cancelable: true
+        })
+      );
+    });
+    assert.equal(hostPointerDownOutsideCount, 1);
+    assert.equal(dom.window.document.querySelector('[role="menu"]'), null);
+
+    await act(async () => {
+      filterTrigger.click();
+    });
+    assert.ok(dom.window.document.querySelector('[role="menu"]'));
+    await act(async () => {
+      dom.window.document.dispatchEvent(
+        new dom.window.KeyboardEvent("keydown", {
+          bubbles: true,
+          cancelable: true,
+          key: "Escape"
+        })
+      );
+    });
+    assert.equal(dom.window.document.querySelector('[role="menu"]'), null);
   } finally {
+    if (hostPointerDownOutside && testDocument) {
+      testDocument.removeEventListener(
+        "pointerdown",
+        hostPointerDownOutside,
+        true
+      );
+    }
     if (root) {
       await act(async () => {
         root?.unmount();
@@ -247,26 +304,17 @@ function buildFilterControlRenderModule(tempDir: string): string {
       import { createElement, isValidElement } from "react";
       const h = createElement;
       function cleanProps(props = {}) {
-        const {
-          align,
-          asChild,
-          checked,
-          children,
-          disabled,
-          modal,
-          onCheckedChange,
-          onSelect,
-          onValueChange,
-          preventMouseDownDefault,
-          side,
-          sideOffset,
-          size,
-          segments,
-          tabs,
-          value,
-          variant,
-          ...rest
-        } = props;
+      const {
+        checked,
+        children,
+        disabled,
+        onValueChange,
+        segments,
+        size,
+        value,
+        variant,
+        ...rest
+      } = props;
         return rest;
       }
       function passthrough(tag) {
@@ -280,35 +328,6 @@ function buildFilterControlRenderModule(tempDir: string): string {
       export const Button = passthrough("button");
       export function ChevronDownIcon(props = {}) {
         return h("svg", cleanProps(props));
-      }
-      export const DropdownMenu = passthrough("div");
-      export const DropdownMenuContent = passthrough("div");
-      export const DropdownMenuGroup = passthrough("div");
-      export function DropdownMenuTrigger(props = {}) {
-        return props.asChild && isValidElement(props.children)
-          ? props.children
-          : h("span", cleanProps(props), props.children);
-      }
-      export function DropdownMenuCheckboxItem(props = {}) {
-        const { checked, disabled, onCheckedChange } = props;
-        return h("div", {
-          ...cleanProps(props),
-          "aria-checked": checked === "indeterminate" ? "mixed" : checked,
-          "aria-disabled": disabled || undefined,
-          role: "menuitemcheckbox",
-          onClick: disabled ? undefined : () => onCheckedChange?.(!checked)
-        }, props.children);
-      }
-      export function UnderlineTabs(props = {}) {
-        return h("div", { role: "tablist" }, props.tabs.map((tab) =>
-          h("button", {
-            key: tab.value,
-            "aria-selected": props.value === tab.value,
-            role: "tab",
-            type: "button",
-            onClick: () => props.onValueChange(tab.value)
-          }, tab.label)
-        ));
       }
       export function Checkbox(props = {}) {
         return h("span", cleanProps(props));
@@ -361,13 +380,7 @@ function buildFilterControlRenderModule(tempDir: string): string {
         Button,
         Checkbox,
         ChevronDownIcon,
-        DropdownMenu,
-        DropdownMenuCheckboxItem,
-        DropdownMenuContent,
-        DropdownMenuGroup,
-        DropdownMenuTrigger,
-        SegmentBar,
-        cn
+        SegmentBar
       } from "${uiSystemUrl}";`
     )
     .replace(

--- a/packages/workspace/file-reference/src/ui/internal/reference/ReferenceProvenanceFilterControl.tsx
+++ b/packages/workspace/file-reference/src/ui/internal/reference/ReferenceProvenanceFilterControl.tsx
@@ -1,13 +1,8 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Button,
   Checkbox,
   ChevronDownIcon,
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuTrigger,
   SegmentBar
 } from "@tutti-os/ui-system";
 import type {
@@ -90,6 +85,43 @@ function ReferenceProvenanceOptionLabel({
   );
 }
 
+function ReferenceProvenanceFilterMenuItem({
+  checked,
+  children,
+  disabled = false,
+  onToggle
+}: {
+  checked: boolean | "indeterminate";
+  children: React.ReactNode;
+  disabled?: boolean;
+  onToggle: () => void;
+}) {
+  const handleToggle = () => {
+    if (!disabled) onToggle();
+  };
+
+  return (
+    <div
+      aria-checked={checked === "indeterminate" ? "mixed" : checked}
+      aria-disabled={disabled || undefined}
+      className="flex min-h-7 cursor-pointer items-center gap-2 rounded-md py-1 pr-2 text-left text-xs text-[var(--text-primary)] outline-none hover:bg-[var(--transparency-hover)] focus-visible:bg-[var(--transparency-hover)] data-[disabled=true]:cursor-not-allowed data-[disabled=true]:opacity-50"
+      data-disabled={disabled || undefined}
+      role="menuitemcheckbox"
+      tabIndex={disabled ? -1 : 0}
+      onClick={handleToggle}
+      onKeyDown={(event) => {
+        if (disabled || (event.key !== "Enter" && event.key !== " ")) {
+          return;
+        }
+        event.preventDefault();
+        handleToggle();
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
 export function ReferenceProvenanceFilterControl({
   agentOptions,
   enabledDimensions,
@@ -101,9 +133,11 @@ export function ReferenceProvenanceFilterControl({
   onToggle,
   onToggleAll
 }: ReferenceProvenanceFilterControlProps) {
+  const [open, setOpen] = useState(false);
   const [dimension, setDimension] = useState<ReferenceProvenanceDimension>(
     enabledDimensions[0] ?? "agent"
   );
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const memberOptionsById = useMemo(
     () => new Map(memberOptions.map((option) => [option.id, option])),
     [memberOptions]
@@ -121,34 +155,66 @@ export function ReferenceProvenanceFilterControl({
   const allLabel =
     activeDimension === "agent" ? labels.allAgents : labels.allMembers;
 
+  useEffect(() => {
+    if (!open) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (
+        !(target instanceof Node) ||
+        !containerRef.current?.contains(target)
+      ) {
+        setOpen(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown, true);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown, true);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
   if (enabledDimensions.length === 0) return null;
 
   return (
-    <div className="flex shrink-0 items-center">
-      <DropdownMenu modal={false}>
-        <DropdownMenuTrigger asChild>
-          <Button
-            aria-label={active ? labels.filteredSources : labels.allSources}
-            className="h-7 gap-1.5 border-0 px-2 text-xs hover:bg-transparent aria-expanded:bg-transparent"
-            size="sm"
-            type="button"
-            variant="ghost"
-          >
-            {active ? labels.filteredSources : labels.allSources}
-            <ChevronDownIcon
-              aria-hidden="true"
-              className="size-3 text-[var(--text-tertiary)] transition-transform in-data-[state=open]:rotate-180"
-            />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent
-          align="end"
-          className="nodrag w-60 overflow-hidden p-0"
-          style={
-            popoverElevation === "panel"
-              ? { zIndex: "var(--z-panel-popover)" }
-              : undefined
-          }
+    <div ref={containerRef} className="relative flex shrink-0 items-center">
+      <Button
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label={active ? labels.filteredSources : labels.allSources}
+        className="h-7 gap-1.5 border-0 px-2 text-xs hover:bg-transparent aria-expanded:bg-transparent"
+        size="sm"
+        type="button"
+        variant="ghost"
+        onClick={() => setOpen((current) => !current)}
+        onPointerDown={(event) => event.preventDefault()}
+      >
+        {active ? labels.filteredSources : labels.allSources}
+        <ChevronDownIcon
+          aria-hidden="true"
+          className={`size-3 text-[var(--text-tertiary)] transition-transform${open ? " rotate-180" : ""}`}
+        />
+      </Button>
+      {open ? (
+        <div
+          aria-label={labels.allSources}
+          className="nodrag absolute top-[calc(100%+4px)] right-0 z-50 w-60 overflow-hidden rounded-[8px] border border-[var(--line-1)] bg-[var(--background-fronted)] p-0 shadow-soft"
+          role="menu"
+          style={{
+            zIndex:
+              popoverElevation === "panel"
+                ? "var(--z-panel-popover)"
+                : "var(--z-popover)"
+          }}
+          onPointerDown={(event) => event.preventDefault()}
         >
           {enabledDimensions.length > 1 ? (
             <div className="px-1 pt-1">
@@ -164,8 +230,8 @@ export function ReferenceProvenanceFilterControl({
               />
             </div>
           ) : null}
-          <DropdownMenuGroup className="max-h-72 gap-0.5 overflow-y-auto p-1">
-            <DropdownMenuCheckboxItem
+          <div className="max-h-72 overflow-y-auto p-1">
+            <ReferenceProvenanceFilterMenuItem
               checked={
                 allSelected
                   ? true
@@ -173,9 +239,7 @@ export function ReferenceProvenanceFilterControl({
                     ? "indeterminate"
                     : false
               }
-              className="min-h-7 rounded-md py-1 pr-2 text-xs [&_[data-slot='dropdown-menu-checkbox-item-indicator']]:hidden"
-              onCheckedChange={() => onToggleAll(activeDimension)}
-              onSelect={(event) => event.preventDefault()}
+              onToggle={() => onToggleAll(activeDimension)}
             >
               <span className="min-w-0 flex-1 truncate">{allLabel}</span>
               <Checkbox
@@ -190,15 +254,13 @@ export function ReferenceProvenanceFilterControl({
                 className="pointer-events-none size-4 data-[state=checked]:border-[var(--tutti-purple)] data-[state=checked]:bg-[var(--tutti-purple)] data-[state=indeterminate]:border-[var(--tutti-purple)] data-[state=indeterminate]:bg-[var(--tutti-purple)] [&_[data-slot='checkbox-indicator']>svg]:size-2.5"
                 tabIndex={-1}
               />
-            </DropdownMenuCheckboxItem>
+            </ReferenceProvenanceFilterMenuItem>
             {visibleOptions.map((option) => (
-              <DropdownMenuCheckboxItem
+              <ReferenceProvenanceFilterMenuItem
                 key={option.id}
                 checked={allSelected || selected.includes(option.id)}
-                className="min-h-7 rounded-md py-1 pr-2 text-xs [&_[data-slot='dropdown-menu-checkbox-item-indicator']]:hidden"
                 disabled={option.disabled}
-                onCheckedChange={() => onToggle(activeDimension, option.id)}
-                onSelect={(event) => event.preventDefault()}
+                onToggle={() => onToggle(activeDimension, option.id)}
               >
                 {option.iconUrl ? (
                   <img
@@ -216,13 +278,14 @@ export function ReferenceProvenanceFilterControl({
                   aria-hidden="true"
                   checked={allSelected || selected.includes(option.id)}
                   className="pointer-events-none size-4 data-[state=checked]:border-[var(--tutti-purple)] data-[state=checked]:bg-[var(--tutti-purple)] [&_[data-slot='checkbox-indicator']>svg]:size-2.5"
+                  disabled={option.disabled}
                   tabIndex={-1}
                 />
-              </DropdownMenuCheckboxItem>
+              </ReferenceProvenanceFilterMenuItem>
             ))}
-          </DropdownMenuGroup>
-        </DropdownMenuContent>
-      </DropdownMenu>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- 修复 @ 面板点击“全部来源”后被宿主误判为外部点击而自动收起。
- 隔离可选的 agent-generated-file provider 失败，避免输入 @ 后空格触发整个工作区文件搜索失败；普通文件结果仍可用。
- 统一排队提交的 prompt/clientSubmitId 身份，处理消息先到、命令结果迟到的竞态，避免已发送消息继续留在对话框。

## Tests
- `pnpm check:changed -- --push-ready`（16 lanes）
- `pnpm --filter @tutti-os/agent-activity-core test`（474 passed）
- `pnpm --filter @tutti-os/agent-gui test`（2872 passed）
- `pnpm --filter @tutti-os/workspace-file-reference test`（111 passed）
- 3 个受影响包 typecheck、Oxfmt、Oxlint 通过

## Notes
- 仅覆盖 0814 未解决视图中除负责人转交项之外的 Tutti 侧 3 条 Bug。
- 未运行真实 Electron/E2E 场景。
