### PR TITLE
fix(mobile-remote): disable retired mobile remote access

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFeatureFlagSettings.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFeatureFlagSettings.ts
@@ -4,8 +4,7 @@ import { desktopFeatureFlagsEqual } from "../../../../../../shared/preferences/i
 import {
   AGENT_EXTENSION_ACTIVATION_FLAGS,
   AGENT_QUICK_PROMPT_LIBRARY_FLAG,
-  isFeatureEnabled,
-  MOBILE_REMOTE_ACCESS_SETTINGS_FLAG
+  isFeatureEnabled
 } from "../../../../../../shared/featureFlags/catalog.ts";
 import type { IDesktopPreferencesService as DesktopPreferencesService } from "../../../desktop-preferences/services/desktopPreferencesService.interface.ts";
 import { getActiveLocale } from "../../../../i18n/runtime.ts";
@@ -39,9 +38,6 @@ export function createWorkspaceFeatureFlagSettings(input: {
       const quickPromptLibraryChanged =
         isFeatureEnabled(previousFlags, AGENT_QUICK_PROMPT_LIBRARY_FLAG) !==
         isFeatureEnabled(nextFlags, AGENT_QUICK_PROMPT_LIBRARY_FLAG);
-      const mobileRemoteAccessSettingsChanged =
-        isFeatureEnabled(previousFlags, MOBILE_REMOTE_ACCESS_SETTINGS_FLAG) !==
-        isFeatureEnabled(nextFlags, MOBILE_REMOTE_ACCESS_SETTINGS_FLAG);
       try {
         const activationChanged = AGENT_EXTENSION_ACTIVATION_FLAGS.some(
           (flag) =>
@@ -57,9 +53,7 @@ export function createWorkspaceFeatureFlagSettings(input: {
           title: createTranslator(getActiveLocale()).t(
             quickPromptLibraryChanged
               ? "workspace.settings.developer.quickPromptLibrarySaveFailed"
-              : mobileRemoteAccessSettingsChanged
-                ? "workspace.settings.developer.mobileRemoteAccessSettingsSaveFailed"
-                : "workspace.settings.lab.preferencesSaveFailed"
+              : "workspace.settings.lab.preferencesSaveFailed"
           )
         });
       }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceSettingsService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceSettingsService.test.ts
@@ -11,8 +11,7 @@ import {
   AGENT_EXTENSION_GEMINI_FLAG,
   AGENT_QUICK_PROMPT_LIBRARY_FLAG,
   LAB_CONNECTORS_FLAG,
-  LAB_ENABLED_FLAG,
-  MOBILE_REMOTE_ACCESS_SETTINGS_FLAG
+  LAB_ENABLED_FLAG
 } from "../../../../../../shared/featureFlags/catalog.ts";
 import type { DesktopWorkspaceSettingsClient } from "./adapters/desktopWorkspaceSettingsClient.ts";
 import { WorkspaceSettingsService } from "./workspaceSettingsService.ts";
@@ -621,30 +620,6 @@ test("WorkspaceSettingsService reports a quick prompt specific save failure", as
     notifications.items[0] ===
       "We couldn't update quick-prompt library availability." ||
       notifications.items[0] === "暂时无法更新快捷提示词库可用状态"
-  );
-});
-
-test("WorkspaceSettingsService reports a mobile remote access settings save failure", async () => {
-  const notifications = createNotificationRecorder();
-  const service = new WorkspaceSettingsService(
-    { client: createWorkspaceSettingsClient({}) },
-    createDesktopPreferencesService({
-      onSetFeatureFlags: async () => {
-        throw new Error("preferences unavailable");
-      },
-      state: createPreferencesState({ featureFlags: {} })
-    }),
-    notifications.service
-  );
-
-  await service.changeFeatureFlags({
-    [MOBILE_REMOTE_ACCESS_SETTINGS_FLAG]: true
-  });
-
-  assert.equal(notifications.items.length, 1);
-  assert.ok(
-    notifications.items[0] === "We couldn't update mobile remote access." ||
-      notifications.items[0] === "暂时无法更新手机远程访问设置"
   );
 });
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceConnectionSettingsSection.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceConnectionSettingsSection.tsx
@@ -1,26 +1,12 @@
 import { useEffect } from "react";
-import type { DesktopFeatureFlags } from "@shared/preferences";
 import { LoadingIcon } from "@tutti-os/ui-system";
-import {
-  isFeatureEnabled,
-  MOBILE_REMOTE_ACCESS_SETTINGS_FLAG
-} from "../../../../../shared/featureFlags/catalog.ts";
 import { useTranslation } from "@renderer/i18n";
-import { WorkspaceMobileRemoteSettingsSection } from "./WorkspaceMobileRemoteSettingsSection";
 import { WorkspaceSettingsActionButton } from "./WorkspaceSettingsActionButton";
 import { useAccountService } from "./useAccountService";
 
-export function WorkspaceConnectionSettingsSection({
-  featureFlags
-}: {
-  featureFlags: DesktopFeatureFlags;
-}) {
+export function WorkspaceConnectionSettingsSection() {
   const { t } = useTranslation();
   const { service: accountService, state: accountState } = useAccountService();
-  const mobileRemoteAccessSettingsEnabled = isFeatureEnabled(
-    featureFlags,
-    MOBILE_REMOTE_ACCESS_SETTINGS_FLAG
-  );
 
   useEffect(() => {
     void accountService.refreshUserInfo();
@@ -120,10 +106,6 @@ export function WorkspaceConnectionSettingsSection({
         <p className="m-0 rounded-[6px] bg-[color-mix(in_srgb,var(--state-warning)_16%,transparent)] px-3 py-2 text-[13px] text-[var(--text-primary)]">
           {accountState.error}
         </p>
-      ) : null}
-
-      {user && mobileRemoteAccessSettingsEnabled ? (
-        <WorkspaceMobileRemoteSettingsSection />
       ) : null}
     </div>
   );

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceDeveloperSettingsSection.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceDeveloperSettingsSection.tsx
@@ -40,8 +40,7 @@ import {
   isFeatureEnabled,
   LAB_AGENT_SESSION_FORK_FLAG,
   LAB_CODEX_SAVER_MODE_FLAG,
-  LAB_ENABLED_FLAG,
-  MOBILE_REMOTE_ACCESS_SETTINGS_FLAG
+  LAB_ENABLED_FLAG
 } from "../../../../../shared/featureFlags/catalog.ts";
 import { formatWorkspaceSettingsBytes } from "../services/workspaceSettingsFormat";
 import { useWorkspaceSettingsService } from "./useWorkspaceSettingsService";
@@ -106,10 +105,6 @@ export function WorkspaceDeveloperSettingsSection() {
     pendingFeatureFlags,
     LAB_CODEX_SAVER_MODE_FLAG
   );
-  const mobileRemoteAccessSettingsEnabled = isFeatureEnabled(
-    pendingFeatureFlags,
-    MOBILE_REMOTE_ACCESS_SETTINGS_FLAG
-  );
   const featureFlagsUpdating =
     desktopPreferencesState.changingFeatureFlags !== null;
   const showAppDeveloperSources =
@@ -156,12 +151,6 @@ export function WorkspaceDeveloperSettingsSection() {
     void settingsService.changeFeatureFlags({
       ...pendingFeatureFlags,
       [LAB_CODEX_SAVER_MODE_FLAG]: enabled
-    });
-  };
-  const onMobileRemoteAccessSettingsEnabledChange = (enabled: boolean) => {
-    void settingsService.changeFeatureFlags({
-      ...pendingFeatureFlags,
-      [MOBILE_REMOTE_ACCESS_SETTINGS_FLAG]: enabled
     });
   };
   const onReferenceProvenanceFilterEnabledChange = (enabled: boolean) => {
@@ -381,27 +370,6 @@ export function WorkspaceDeveloperSettingsSection() {
           checked={quickPromptLibraryEnabled}
           disabled={featureFlagsUpdating}
           onCheckedChange={onQuickPromptLibraryEnabledChange}
-        />
-      </div>
-
-      <div className="flex w-full items-center justify-between gap-4 max-[560px]:flex-col max-[560px]:items-stretch">
-        <div className="flex min-w-0 flex-1 flex-col gap-1 max-[560px]:w-full">
-          <strong className="text-[13px] font-semibold text-[var(--text-primary)]">
-            {t("workspace.settings.developer.mobileRemoteAccessSettingsLabel")}
-          </strong>
-          <p className="m-0 text-[13px] leading-[1.3] text-[var(--text-secondary)]">
-            {t(
-              "workspace.settings.developer.mobileRemoteAccessSettingsDescription"
-            )}
-          </p>
-        </div>
-        <Switch
-          aria-label={t(
-            "workspace.settings.developer.mobileRemoteAccessSettingsLabel"
-          )}
-          checked={mobileRemoteAccessSettingsEnabled}
-          disabled={featureFlagsUpdating}
-          onCheckedChange={onMobileRemoteAccessSettingsEnabledChange}
         />
       </div>
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.test.ts
@@ -75,23 +75,16 @@ test("workspace settings places enabled signed-in Connectors between Agent Runti
   assert.doesNotMatch(runtimeTabSource, /WorkspaceAgentsSection/);
 });
 
-test("workspace settings shows Connection with mobile remote access settings", () => {
-  assert.match(
-    panelSource,
-    /\.\.\.\(mobileRemoteAccessSettingsEnabled[\s\S]{0,220}id: "connection" as const/
-  );
+test("workspace settings keeps account Connection without mobile remote access", () => {
+  assert.match(panelSource, /id: "connection" as const/);
   assert.match(
     panelSource,
     /activeSection === "connection"[\s\S]{0,220}<WorkspaceConnectionSettingsSection/
   );
-  assert.match(
-    panelSource,
-    /!mobileRemoteAccessSettingsEnabled[\s\S]{0,120}activeSection === "connection"[\s\S]{0,120}selectSection\("general"\)/
-  );
   assert.match(connectionSectionSource, /accountService\.refreshUserInfo\(\)/);
-  assert.match(
+  assert.doesNotMatch(
     connectionSectionSource,
-    /user && mobileRemoteAccessSettingsEnabled[\s\S]{0,120}<WorkspaceMobileRemoteSettingsSection/
+    /WorkspaceMobileRemoteSettingsSection/
   );
 });
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
@@ -94,7 +94,6 @@ import {
   LAB_CONNECTORS_FLAG,
   LAB_WORKBENCH_SHORTCUTS_FLAG,
   LAB_AUTOMATION_RULES_FLAG,
-  MOBILE_REMOTE_ACCESS_SETTINGS_FLAG,
   resolveDesktopWorkspaceUiMode
 } from "../../../../../shared/featureFlags/catalog.ts";
 import { resolveWorkspaceAgentGuiLabel } from "../services/workspaceAgentProviderCatalog";
@@ -215,11 +214,6 @@ export function WorkspaceSettingsPanel({
     pendingFeatureFlags,
     LAB_AUTOMATION_RULES_FLAG
   );
-  const mobileRemoteAccessSettingsEnabled = isFeatureEnabled(
-    pendingFeatureFlags,
-    MOBILE_REMOTE_ACCESS_SETTINGS_FLAG
-  );
-
   useEffect(() => {
     if (settingsState.open) {
       settingsService.syncWorkspace({ id: workspace.id });
@@ -231,19 +225,6 @@ export function WorkspaceSettingsPanel({
       settingsService.selectSection("general");
     }
   }, [labSectionVisible, settingsService, settingsState.activeSection]);
-
-  useEffect(() => {
-    if (
-      !mobileRemoteAccessSettingsEnabled &&
-      settingsState.activeSection === "connection"
-    ) {
-      settingsService.selectSection("general");
-    }
-  }, [
-    mobileRemoteAccessSettingsEnabled,
-    settingsService,
-    settingsState.activeSection
-  ]);
 
   useEffect(() => {
     if (!automationRulesEnabled && settingsState.agentTab === "automation") {
@@ -333,14 +314,10 @@ export function WorkspaceSettingsPanel({
               id: "appearance" as const,
               label: t("workspace.settings.nav.appearance")
             },
-            ...(mobileRemoteAccessSettingsEnabled
-              ? [
-                  {
-                    id: "connection" as const,
-                    label: t("workspace.settings.nav.connection")
-                  }
-                ]
-              : []),
+            {
+              id: "connection" as const,
+              label: t("workspace.settings.nav.connection")
+            },
             {
               id: "deletedConversations" as const,
               label: t("workspace.settings.nav.deletedConversations")
@@ -620,12 +597,7 @@ export function WorkspaceSettingsPanel({
                 }}
               />
             ) : settingsState.activeSection === "connection" ? (
-              <WorkspaceConnectionSettingsSection
-                featureFlags={
-                  desktopPreferencesState.changingFeatureFlags ??
-                  desktopPreferencesState.featureFlags
-                }
-              />
+              <WorkspaceConnectionSettingsSection />
             ) : settingsState.activeSection === "deletedConversations" ? (
               <WorkspaceDeletedConversationsSection
                 changingRetentionDays={

--- a/apps/desktop/src/shared/featureFlags/catalog.test.ts
+++ b/apps/desktop/src/shared/featureFlags/catalog.test.ts
@@ -91,7 +91,7 @@ test("isFeatureEnabled falls back to catalog default when key absent", () => {
       { [MOBILE_REMOTE_ACCESS_SETTINGS_FLAG]: true },
       MOBILE_REMOTE_ACCESS_SETTINGS_FLAG
     ),
-    true
+    false
   );
 });
 

--- a/apps/desktop/src/shared/featureFlags/catalog.ts
+++ b/apps/desktop/src/shared/featureFlags/catalog.ts
@@ -216,6 +216,11 @@ export function isFeatureEnabled(
   flags: DesktopFeatureFlags,
   key: string
 ): boolean {
+  // Keep the durable key for old profiles, but do not expose or activate the
+  // retired mobile remote access capability.
+  if (key === MOBILE_REMOTE_ACCESS_SETTINGS_FLAG) {
+    return false;
+  }
   if (Object.prototype.hasOwnProperty.call(flags, key)) {
     return flags[key] === true;
   }

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -512,8 +512,9 @@ Google Play 账号。以下事项等正式分发前再处理：
 - Personal `tuttid` 已接入设备注册、QR challenge、Desktop confirm、配对列表和撤销；
 - Personal 配对 API 已进入生成的 Go/TypeScript daemon client，账号 cookie 和设备私钥不会返回给 UI。
 - Desktop 设置页已接入二维码创建、配对码复制、轮询确认和撤销；
-- Desktop owner host 仅在持久化的 `mobile.remoteAccessSettings` 能力开关开启时
-  轮询配对和 DeviceLink attempt 控制面；关闭会停止 discovery 并断开已有远程链路；
+- Desktop owner host 的 mobile remote access 当前已停用；持久化的
+  `mobile.remoteAccessSettings` 键仅为旧 profile 保留，desktop daemon 会忽略它，
+  不再轮询配对和 DeviceLink attempt 控制面；
 - `apps/mobile` 已接入平台原生浏览器认证 GitHub 登录和邮箱验证码登录、Android Keystore
   设备身份、设备列表、内置 ZXing 二维码扫描或手动粘贴配对码，以及 challenge
   claim/poll；

--- a/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
+++ b/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
@@ -1,6 +1,6 @@
 # Mobile AgentGUI And DeviceLink Design
 
-Status: accepted product direction; Personal direct-lane MVP in implementation
+Status: accepted product direction; Personal direct-lane MVP currently disabled
 
 ## Implementation progress (2026-08-11)
 
@@ -264,12 +264,10 @@ Cookie，也不新增移动端账号实体。Android 在浏览器 provider 支�
 5. tsh-server 校验同账号和 challenge 状态；
 6. Desktop 显式确认配对。
 
-Desktop 的账号登录入口与手机远程访问入口独立发布。Tutti Agent 及工作区账号菜单
-默认显示且不再提供独立的开发者可见性开关。独立持久化的
-`mobile.remoteAccessSettings` feature flag 控制手机远程访问能力和「连接」设置入口；
-关闭时 `tuttid` owner host 不得轮询账号、配对或 DeviceLink attempt 控制面，并关闭
-已有远程链路；开启时立即开始 owner-side discovery。「连接」页承载账号登录、退出、
-刷新、手机配对和远程访问能力。该开关不创建第二套登录态、设备实体或协议能力。
+Desktop 的账号登录入口与手机远程访问入口独立发布。手机远程访问当前已停用；
+`mobile.remoteAccessSettings` 仅作为旧 profile 的持久化兼容键保留，desktop daemon
+会强制忽略它，不启动 owner-side discovery，也不提供手机配对 UI。「连接」页仍承载
+账号登录、退出和刷新。该开关不创建第二套登录态、设备实体或协议能力。
 
 QR 不包含 bearer token、私钥、原始候选或可长期使用的连接凭据。
 

--- a/services/tuttid/biz/preferences/feature_flags.go
+++ b/services/tuttid/biz/preferences/feature_flags.go
@@ -10,9 +10,16 @@ var capabilityFlagDefaults = map[string]bool{
 	FeatureFlagMobileRemoteAccess:    false,
 }
 
-// IsCapabilityFlagEnabled resolves daemon-enforced feature behavior. Stored
-// values win and unknown or absent keys fail closed.
+var permanentlyDisabledCapabilityFlags = map[string]struct{}{
+	FeatureFlagMobileRemoteAccess: {},
+}
+
+// IsCapabilityFlagEnabled resolves daemon-enforced feature behavior. Permanently
+// disabled capabilities stay off even when an old profile stores them as true.
 func IsCapabilityFlagEnabled(flags map[string]bool, key string) bool {
+	if _, disabled := permanentlyDisabledCapabilityFlags[key]; disabled {
+		return false
+	}
 	if enabled, ok := flags[key]; ok {
 		return enabled
 	}

--- a/services/tuttid/biz/preferences/feature_flags_test.go
+++ b/services/tuttid/biz/preferences/feature_flags_test.go
@@ -17,14 +17,14 @@ func TestAgentSessionRecordingCapabilityFlagFailsClosed(t *testing.T) {
 	}
 }
 
-func TestMobileRemoteAccessCapabilityFlagFailsClosed(t *testing.T) {
+func TestMobileRemoteAccessCapabilityFlagIsPermanentlyDisabled(t *testing.T) {
 	if IsCapabilityFlagEnabled(nil, FeatureFlagMobileRemoteAccess) {
-		t.Fatal("absent mobile remote access flag must resolve false")
+		t.Fatal("absent mobile remote access flag must remain disabled")
 	}
-	if !IsCapabilityFlagEnabled(
+	if IsCapabilityFlagEnabled(
 		map[string]bool{FeatureFlagMobileRemoteAccess: true},
 		FeatureFlagMobileRemoteAccess,
 	) {
-		t.Fatal("stored mobile remote access true must win")
+		t.Fatal("stored mobile remote access true must be ignored")
 	}
 }

--- a/services/tuttid/wiring_mobile_remote_test.go
+++ b/services/tuttid/wiring_mobile_remote_test.go
@@ -56,7 +56,7 @@ func TestStartMobileRemoteHostFollowsPersistedPreference(t *testing.T) {
 		wantStarts int
 		wantCloses int
 	}{
-		{name: "enabled", flags: map[string]bool{preferencesbiz.FeatureFlagMobileRemoteAccess: true}, wantStarts: 1},
+		{name: "stored enabled value is ignored", flags: map[string]bool{preferencesbiz.FeatureFlagMobileRemoteAccess: true}, wantCloses: 1},
 		{name: "disabled", wantCloses: 1},
 		{name: "read failure fails closed", getErr: errors.New("read failed"), wantCloses: 1},
 	} {
@@ -90,7 +90,7 @@ func TestStartMobileRemoteHostFollowsPersistedPreference(t *testing.T) {
 	}
 }
 
-func TestMobileRemoteHostTracksPreferenceChanges(t *testing.T) {
+func TestMobileRemoteHostRemainsDisabledWhenPreferenceChanges(t *testing.T) {
 	store := &mobileRemotePreferencesStore{}
 	preferences := &preferencesservice.Service{Store: store}
 	host := &recordingMobileRemoteHost{}
@@ -106,15 +106,15 @@ func TestMobileRemoteHostTracksPreferenceChanges(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if host.starts != 1 || host.closes != 1 {
-		t.Fatalf("enabled lifecycle calls = start %d, close %d; want start 1, close 1", host.starts, host.closes)
+	if host.starts != 0 || host.closes != 1 {
+		t.Fatalf("enabled lifecycle calls = start %d, close %d; want start 0, close 1", host.starts, host.closes)
 	}
 
 	if _, err := preferences.Put(context.Background(), preferencesservice.PutInput{}); err != nil {
 		t.Fatal(err)
 	}
-	if host.starts != 1 || host.closes != 2 {
-		t.Fatalf("disabled lifecycle calls = start %d, close %d; want start 1, close 2", host.starts, host.closes)
+	if host.starts != 0 || host.closes != 1 {
+		t.Fatalf("disabled lifecycle calls = start %d, close %d; want start 0, close 1", host.starts, host.closes)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Permanently disable `mobile.remoteAccessSettings` in `tuttid`, including profiles that already persist it as `true`.
- Remove the desktop mobile-remote toggle and pairing UI while retaining the account Connection page.
- Keep the durable flag and API implementation for compatibility, and document the retired state.

## Motivation

The mobile-remote owner host polls the control plane every two seconds. This capability is retired, so the background polling should stop without requiring users to clean up old profiles.

## Validation

- `go test ./biz/preferences .` — passed
- Focused desktop tests (62 tests) — passed
- `pnpm --filter @tutti-os/desktop typecheck` — passed
- `pnpm build:go` — passed
- `pnpm --filter @tutti-os/desktop build` — passed
- `pnpm check:changed -- --push-ready` / pre-push could not complete because the local environment uses golangci-lint v1 while the repository config requires v2.
- The full Go suite also reported unrelated existing process-tree/workspace test failures.