### PR TITLE
feat(connectors): implement control plane v2

### DIFF
--- a/apps/desktop/src/renderer/src/features/connector-market/services/internal/desktopConnectorMarketBackend.test.ts
+++ b/apps/desktop/src/renderer/src/features/connector-market/services/internal/desktopConnectorMarketBackend.test.ts
@@ -10,6 +10,7 @@ import { createDesktopConnectorMarketBackend } from "./desktopConnectorMarketBac
 test("desktop connector market backend delegates snapshot reads to the daemon client", async () => {
   let calls = 0;
   const snapshot: ConnectorMarketSnapshot = {
+    contractCohort: "connector-control-plane-v2",
     catalogState: "ready",
     connectors: [],
     operations: [],

--- a/apps/desktop/src/renderer/src/features/connector-market/services/internal/desktopConnectorMarketBackend.ts
+++ b/apps/desktop/src/renderer/src/features/connector-market/services/internal/desktopConnectorMarketBackend.ts
@@ -20,8 +20,8 @@ export function createDesktopConnectorMarketBackend(
     getOperation({ operationId }) {
       return client.getConnectorMarketOperation(operationId);
     },
-    refreshCatalog(input) {
-      return client.refreshConnectorMarket(input);
+    refreshCatalog() {
+      return client.refreshConnectorMarket();
     },
     installConnector({ connectorKey, ...request }) {
       return client.installConnectorMarketConnector(connectorKey, request);

--- a/docs/architecture/connector-market.md
+++ b/docs/architecture/connector-market.md
@@ -72,7 +72,7 @@ The shared Connector modules own:
   replacement, size and digest verification, no-network import, safe
   extraction, release-to-package verification, atomic promotion, and cleanup
 - `connector/market`: the reusable local daemon OpenAPI fragment under
-  `openapi/connector-market.v1.yaml`
+  `openapi/connector-market.v2.yaml`
 - the renderer `ConnectorMarketBackend` contract, module Root/Runtime,
   lifecycle and StartupJobs, Valtio-backed domain services, reusable renderer,
   and connector-market i18n bundle

--- a/docs/conventions/npm-package-release.md
+++ b/docs/conventions/npm-package-release.md
@@ -366,7 +366,7 @@ The stable package entrypoints are:
 @tutti-os/connector-market/authorization
 @tutti-os/connector-market/core
 @tutti-os/connector-market/i18n
-@tutti-os/connector-market/openapi/connector-market.v1.yaml
+@tutti-os/connector-market/openapi/connector-market.v2.yaml
 @tutti-os/connector-market/services
 @tutti-os/connector-market/ui
 @tutti-os/workspace-app-center

--- a/docs/specs/2026-08-03-connector-market-shared-domain.md
+++ b/docs/specs/2026-08-03-connector-market-shared-domain.md
@@ -59,7 +59,7 @@ local daemon OpenAPI fragment.
 
 ### Local Daemon API
 
-`packages/connector/market/openapi/connector-market.v1.yaml` is the shared
+`packages/connector/market/openapi/connector-market.v2.yaml` is the shared
 local daemon fragment. It exposes accepted catalog state, local installation,
 authorization, compatibility, revisions, and durable operations to renderers.
 An installed connector is daemon-global and available to every Agent and the
@@ -70,9 +70,10 @@ its own server and client, and provides transport mapping. The local daemon is
 the authoritative source for renderer state.
 
 Market placement is not part of the immutable release manifest. ZK owns each
-listing's primary category, ranks, and optional featured placement; TSH exposes
-the selected deployment market through category and cursor-paginated item
-endpoints. Tutti forwards that model through daemon-owned category/page APIs.
+listing's primary category, ranks, and optional featured placement; tsh-server
+exposes the selected connector market as one versioned full snapshot. Local
+daemons persist that snapshot and expose daemon-owned category/page projections
+to renderers without making further remote pagination requests.
 The shared Valtio service maintains independent page state for every section,
 and the renderer does not infer category membership from connector keys or
 manifest JSON. `featured` is an overlapping collection, while authoritative

--- a/packages/clients/tuttid-ts/src/connectorMarketClient.ts
+++ b/packages/clients/tuttid-ts/src/connectorMarketClient.ts
@@ -69,9 +69,7 @@ export interface ConnectorMarketClient {
   getConnectorMarketOperation(
     operationId: string
   ): Promise<ConnectorMarketOperation>;
-  refreshConnectorMarket(
-    request: ConnectorMarketMutationRequest
-  ): Promise<ConnectorMarketMutationResponse>;
+  refreshConnectorMarket(): Promise<ConnectorMarketSnapshot>;
   installConnectorMarketConnector(
     connectorKey: string,
     request: ConnectorMarketMutationRequest
@@ -130,9 +128,9 @@ export function createConnectorMarketClient(
         "Get connector market operation request failed."
       );
     },
-    async refreshConnectorMarket(request) {
+    async refreshConnectorMarket() {
       return unwrapConnectorMarketData(
-        await refreshConnectorMarket({ client, body: request }),
+        await refreshConnectorMarket({ client }),
         "Refresh connector market request failed."
       );
     },

--- a/packages/clients/tuttid-ts/src/generated/index.ts
+++ b/packages/clients/tuttid-ts/src/generated/index.ts
@@ -575,6 +575,7 @@ export type {
   ConnectorMarketPageToken,
   ConnectorMarketRelease,
   ConnectorMarketSectionId,
+  ConnectorMarketSecurity,
   ConnectorMarketSnapshot,
   CopyWorkspaceFileEntryData,
   CopyWorkspaceFileEntryError,

--- a/packages/clients/tuttid-ts/src/generated/sdk.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/sdk.gen.ts
@@ -5447,7 +5447,7 @@ export const getConnectorMarket = <ThrowOnError extends boolean = false>(
     ThrowOnError
   >({
     security: [{ scheme: "bearer", type: "http" }],
-    url: "/v1/connector-market",
+    url: "/v2/connector-market",
     ...options
   });
 
@@ -5465,7 +5465,7 @@ export const listConnectorMarketCategories = <
     ThrowOnError
   >({
     security: [{ scheme: "bearer", type: "http" }],
-    url: "/v1/connector-market/categories",
+    url: "/v2/connector-market/categories",
     ...options
   });
 
@@ -5483,7 +5483,7 @@ export const listConnectorMarketCatalog = <
     ThrowOnError
   >({
     security: [{ scheme: "bearer", type: "http" }],
-    url: "/v1/connector-market/catalog",
+    url: "/v2/connector-market/catalog",
     ...options
   });
 
@@ -5501,28 +5501,24 @@ export const getConnectorMarketConnector = <
     ThrowOnError
   >({
     security: [{ scheme: "bearer", type: "http" }],
-    url: "/v1/connector-market/connectors/{connectorKey}",
+    url: "/v2/connector-market/connectors/{connectorKey}",
     ...options
   });
 
 /**
- * Refresh and accept the upstream connector catalog
+ * Synchronize the complete upstream connector catalog snapshot
  */
 export const refreshConnectorMarket = <ThrowOnError extends boolean = false>(
-  options: Options<RefreshConnectorMarketData, ThrowOnError>
+  options?: Options<RefreshConnectorMarketData, ThrowOnError>
 ) =>
-  (options.client ?? client).post<
+  (options?.client ?? client).post<
     RefreshConnectorMarketResponses,
     RefreshConnectorMarketErrors,
     ThrowOnError
   >({
     security: [{ scheme: "bearer", type: "http" }],
-    url: "/v1/connector-market:refresh",
-    ...options,
-    headers: {
-      "Content-Type": "application/json",
-      ...options.headers
-    }
+    url: "/v2/connector-market:refresh",
+    ...options
   });
 
 /**
@@ -5539,7 +5535,7 @@ export const installConnectorMarketConnector = <
     ThrowOnError
   >({
     security: [{ scheme: "bearer", type: "http" }],
-    url: "/v1/connector-market/connectors/{connectorKey}:install",
+    url: "/v2/connector-market/connectors/{connectorKey}:install",
     ...options,
     headers: {
       "Content-Type": "application/json",
@@ -5563,7 +5559,7 @@ export const uninstallConnectorMarketConnector = <
     ThrowOnError
   >({
     security: [{ scheme: "bearer", type: "http" }],
-    url: "/v1/connector-market/connectors/{connectorKey}:uninstall",
+    url: "/v2/connector-market/connectors/{connectorKey}:uninstall",
     ...options,
     headers: {
       "Content-Type": "application/json",
@@ -5585,7 +5581,7 @@ export const startConnectorMarketAuthorization = <
     ThrowOnError
   >({
     security: [{ scheme: "bearer", type: "http" }],
-    url: "/v1/connector-market/connectors/{connectorKey}/authorization:start",
+    url: "/v2/connector-market/connectors/{connectorKey}/authorization:start",
     ...options,
     headers: {
       "Content-Type": "application/json",
@@ -5607,7 +5603,7 @@ export const disconnectConnectorMarketAuthorization = <
     ThrowOnError
   >({
     security: [{ scheme: "bearer", type: "http" }],
-    url: "/v1/connector-market/connectors/{connectorKey}/authorization:disconnect",
+    url: "/v2/connector-market/connectors/{connectorKey}/authorization:disconnect",
     ...options,
     headers: {
       "Content-Type": "application/json",
@@ -5629,7 +5625,7 @@ export const getConnectorMarketOperation = <
     ThrowOnError
   >({
     security: [{ scheme: "bearer", type: "http" }],
-    url: "/v1/connector-market/operations/{operationID}",
+    url: "/v2/connector-market/operations/{operationID}",
     ...options
   });
 

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -4799,6 +4799,7 @@ export type ConnectorMarketCatalogPage = {
 };
 
 export type ConnectorMarketSnapshot = {
+  contractCohort: "connector-control-plane-v2";
   catalogState: ConnectorMarketCatalogState;
   connectors: Array<ConnectorMarketConnector>;
   operations: Array<ConnectorMarketOperation>;
@@ -4812,6 +4813,7 @@ export type ConnectorMarketConnector = {
   installation: ConnectorMarketInstallation;
   authorization: ConnectorMarketAuthorization;
   compatibility: ConnectorMarketCompatibility;
+  security: ConnectorMarketSecurity;
   revision: number;
 };
 
@@ -4875,6 +4877,7 @@ export type ConnectorMarketInstallation = {
   installedVersion?: string;
   installedReleaseId?: string;
   installedReleaseDigest?: string;
+  installedArtifactSha256?: string;
   failureCode?: string;
 };
 
@@ -4888,6 +4891,12 @@ export type ConnectorMarketCompatibility = {
   reason?: string;
 };
 
+export type ConnectorMarketSecurity = {
+  state: "allowed" | "revoked";
+  revocationId?: string;
+  reasonCode?: string;
+};
+
 export type ConnectorMarketOperation = {
   operationId: string;
   clientRequestId: string;
@@ -4897,8 +4906,13 @@ export type ConnectorMarketOperation = {
   stage?: ConnectorMarketOperationStage;
   target?: ConnectorMarketOperationTarget;
   attempt: number;
+  operationVersion: number;
   failureCode?: string;
+  nextAttemptAt?: string;
   createdAt: string;
+  startedAt?: string;
+  finishedAt?: string;
+  terminalAt?: string;
   updatedAt: string;
 };
 
@@ -4976,23 +4990,26 @@ export type ConnectorMarketCompatibilityState =
   | "unsupported_implementation";
 
 export type ConnectorMarketOperationKind =
-  | "refresh_catalog"
   | "install"
   | "uninstall"
+  | "reconcile_runtime"
   | "start_authorization"
   | "disconnect_authorization";
 
 export type ConnectorMarketOperationState =
   | "accepted"
   | "running"
+  | "outcome_unknown"
   | "completed"
-  | "failed";
+  | "failed"
+  | "cancelled";
 
 export type ConnectorMarketOperationStage =
   | "accepted"
-  | "refreshing"
   | "installing"
   | "installed"
+  | "activated"
+  | "finalizing"
   | "deactivating"
   | "authorizing"
   | "disconnecting"
@@ -5009,6 +5026,7 @@ export type ConnectorMarketErrorCode =
   | "connector_implementation_unsupported"
   | "connector_market_upstream_unavailable"
   | "connector_install_failed"
+  | "release_revoked"
   | "connector_authorization_failed"
   | "connector_market_unavailable";
 
@@ -16837,7 +16855,7 @@ export type GetConnectorMarketData = {
   body?: never;
   path?: never;
   query?: never;
-  url: "/v1/connector-market";
+  url: "/v2/connector-market";
 };
 
 export type GetConnectorMarketErrors = {
@@ -16872,7 +16890,7 @@ export type ListConnectorMarketCategoriesData = {
   body?: never;
   path?: never;
   query?: never;
-  url: "/v1/connector-market/categories";
+  url: "/v2/connector-market/categories";
 };
 
 export type ListConnectorMarketCategoriesErrors = {
@@ -16907,7 +16925,7 @@ export type ListConnectorMarketCatalogData = {
     pageSize?: number;
     pageToken?: string;
   };
-  url: "/v1/connector-market/catalog";
+  url: "/v2/connector-market/catalog";
 };
 
 export type ListConnectorMarketCatalogErrors = {
@@ -16944,7 +16962,7 @@ export type GetConnectorMarketConnectorData = {
     connectorKey: string;
   };
   query?: never;
-  url: "/v1/connector-market/connectors/{connectorKey}";
+  url: "/v2/connector-market/connectors/{connectorKey}";
 };
 
 export type GetConnectorMarketConnectorErrors = {
@@ -16980,25 +16998,17 @@ export type GetConnectorMarketConnectorResponse =
   GetConnectorMarketConnectorResponses[keyof GetConnectorMarketConnectorResponses];
 
 export type RefreshConnectorMarketData = {
-  body: ConnectorMarketMutationRequest;
+  body?: never;
   path?: never;
   query?: never;
-  url: "/v1/connector-market:refresh";
+  url: "/v2/connector-market:refresh";
 };
 
 export type RefreshConnectorMarketErrors = {
   /**
-   * Invalid connector-market request
-   */
-  400: ConnectorMarketError;
-  /**
    * Daemon authorization is required
    */
   401: ConnectorMarketError;
-  /**
-   * Revision conflict or operation already in progress
-   */
-  409: ConnectorMarketError;
   /**
    * Connector-market capability is temporarily unavailable
    */
@@ -17010,9 +17020,9 @@ export type RefreshConnectorMarketError =
 
 export type RefreshConnectorMarketResponses = {
   /**
-   * Refresh operation accepted
+   * Refreshed connector market snapshot
    */
-  202: ConnectorMarketMutationResponse;
+  200: ConnectorMarketSnapshot;
 };
 
 export type RefreshConnectorMarketResponse =
@@ -17024,7 +17034,7 @@ export type InstallConnectorMarketConnectorData = {
     connectorKey: string;
   };
   query?: never;
-  url: "/v1/connector-market/connectors/{connectorKey}:install";
+  url: "/v2/connector-market/connectors/{connectorKey}:install";
 };
 
 export type InstallConnectorMarketConnectorErrors = {
@@ -17073,7 +17083,7 @@ export type UninstallConnectorMarketConnectorData = {
     connectorKey: string;
   };
   query?: never;
-  url: "/v1/connector-market/connectors/{connectorKey}:uninstall";
+  url: "/v2/connector-market/connectors/{connectorKey}:uninstall";
 };
 
 export type UninstallConnectorMarketConnectorErrors = {
@@ -17118,7 +17128,7 @@ export type StartConnectorMarketAuthorizationData = {
     connectorKey: string;
   };
   query?: never;
-  url: "/v1/connector-market/connectors/{connectorKey}/authorization:start";
+  url: "/v2/connector-market/connectors/{connectorKey}/authorization:start";
 };
 
 export type StartConnectorMarketAuthorizationErrors = {
@@ -17163,7 +17173,7 @@ export type DisconnectConnectorMarketAuthorizationData = {
     connectorKey: string;
   };
   query?: never;
-  url: "/v1/connector-market/connectors/{connectorKey}/authorization:disconnect";
+  url: "/v2/connector-market/connectors/{connectorKey}/authorization:disconnect";
 };
 
 export type DisconnectConnectorMarketAuthorizationErrors = {
@@ -17208,7 +17218,7 @@ export type GetConnectorMarketOperationData = {
     operationID: string;
   };
   query?: never;
-  url: "/v1/connector-market/operations/{operationID}";
+  url: "/v2/connector-market/operations/{operationID}";
 };
 
 export type GetConnectorMarketOperationErrors = {

--- a/packages/clients/tuttid-ts/src/index.test.ts
+++ b/packages/clients/tuttid-ts/src/index.test.ts
@@ -210,6 +210,7 @@ test("shared tuttid client manages workspace deleted Agent sessions", async () =
 
 test("shared tuttid client reads and refreshes daemon-owned desktop admission", async () => {
   const snapshot = {
+    contractCohort: "connector-control-plane-v2" as const,
     featureAvailability: {
       fetchedAt: null,
       keys: ["workspace.example"],
@@ -2484,6 +2485,7 @@ test("shared tuttid client preserves connector market read and install routes", 
       kind: "install" as const,
       state: "accepted" as const,
       attempt: 0,
+      operationVersion: 1,
       createdAt: "2026-08-03T00:00:00Z",
       updatedAt: "2026-08-03T00:00:00Z"
     },
@@ -2508,7 +2510,7 @@ test("shared tuttid client preserves connector market read and install routes", 
     authorization: null,
     body: null,
     method: "GET",
-    path: "/v1/connector-market",
+    path: "/v2/connector-market",
     query: {}
   });
   assertRequest(requests[1]!, {
@@ -2518,7 +2520,7 @@ test("shared tuttid client preserves connector market read and install routes", 
       expectedRevision: 7
     },
     method: "POST",
-    path: "/v1/connector-market/connectors/notion:install",
+    path: "/v2/connector-market/connectors/notion:install",
     query: {}
   });
 });
@@ -2583,14 +2585,14 @@ test("shared tuttid connector client preserves category and cursor pagination", 
     authorization: null,
     body: null,
     method: "GET",
-    path: "/v1/connector-market/categories",
+    path: "/v2/connector-market/categories",
     query: {}
   });
   assertRequest(requests[1]!, {
     authorization: null,
     body: null,
     method: "GET",
-    path: "/v1/connector-market/catalog",
+    path: "/v2/connector-market/catalog",
     query: {
       pageSize: "20",
       pageToken: "cursor-1",

--- a/packages/connector/daemon/catalog_source.go
+++ b/packages/connector/daemon/catalog_source.go
@@ -15,13 +15,13 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	market "github.com/tutti-os/tutti/packages/connector/host"
 )
 
-const connectorCatalogPath = "/v1/market/items"
-const connectorCategoriesPath = "/v1/market/categories"
+const connectorCatalogPath = "/v1/market/catalog"
 const maxCatalogResponseBytes = 8 << 20
 
 type RequestAuthorizer func(*http.Request) error
@@ -42,9 +42,12 @@ type CatalogSource struct {
 	httpClient         *http.Client
 	authorizeRequest   RequestAuthorizer
 	executionTarget    string
+	mu                 sync.RWMutex
+	latest             *market.CatalogSnapshot
 }
 
 var _ market.CatalogSource = (*CatalogSource)(nil)
+var _ market.CatalogChangeSource = (*CatalogSource)(nil)
 
 func NewCatalogSource(config CatalogSourceConfig) (*CatalogSource, error) {
 	baseURL, err := url.Parse(strings.TrimSpace(config.BaseURL))
@@ -77,106 +80,127 @@ func NewCatalogSource(config CatalogSourceConfig) (*CatalogSource, error) {
 }
 
 func (source *CatalogSource) Refresh(ctx context.Context) (market.CatalogSnapshot, error) {
-	categories, err := source.ListCategories(ctx)
-	if err != nil {
+	var payload wireConnectorCatalogSnapshot
+	if _, err := source.getJSON(ctx, connectorCatalogPath, url.Values{"itemType": {"connector"}}, &payload); err != nil {
 		return market.CatalogSnapshot{}, err
 	}
-	releases := make([]market.Release, 0)
-	seen := make(map[string]struct{})
-	primarySections := 0
-	for _, category := range categories {
-		if category.Kind != "category" {
-			continue
+	if payload.SchemaVersion != "2" || payload.Scope.ItemType != "connector" || payload.Scope.MarketType != source.expectedMarketType ||
+		payload.CatalogRevision == 0 || !validPrefixedCatalogDigest(payload.SnapshotDigest) {
+		return market.CatalogSnapshot{}, errors.New("connector market catalog identity is invalid")
+	}
+	if _, err := time.Parse(time.RFC3339Nano, payload.GeneratedAt); err != nil {
+		return market.CatalogSnapshot{}, errors.New("connector market catalog generatedAt is invalid")
+	}
+	categories := make([]market.CatalogCategory, 0, len(payload.Categories))
+	for _, category := range payload.Categories {
+		categories = append(categories, market.CatalogCategory{CategoryID: category.CategoryID, Kind: category.Kind, SortOrder: category.SortOrder, ItemCount: int64(category.ItemCount)})
+	}
+	releases := make([]market.Release, 0, len(payload.Items))
+	entries := make([]market.CatalogEntry, 0, len(payload.Items))
+	seen := make(map[string]struct{}, len(payload.Items))
+	for _, item := range payload.Items {
+		publishedAt, err := time.Parse(time.RFC3339Nano, item.PublishedAt)
+		if err != nil || item.Artifact == nil || item.ArtifactDigest != "sha256:"+item.Artifact.SHA256 {
+			return market.CatalogSnapshot{}, errors.New("connector market catalog item identity is invalid")
 		}
-		primarySections++
-		pageToken := ""
-		seenPageTokens := make(map[string]struct{})
-		for {
-			page, pageErr := source.ListPage(ctx, market.CatalogSourcePageQuery{SectionID: category.CategoryID, PageSize: 100, PageToken: pageToken})
-			if pageErr != nil {
-				return market.CatalogSnapshot{}, pageErr
-			}
-			for _, entry := range page.Entries {
-				if _, exists := seen[entry.Release.ConnectorKey]; exists {
-					return market.CatalogSnapshot{}, errors.New("connector market catalog contains duplicate primary placements")
-				}
-				seen[entry.Release.ConnectorKey] = struct{}{}
-				releases = append(releases, entry.Release)
-			}
-			if page.NextPageToken == "" {
-				break
-			}
-			if _, exists := seenPageTokens[page.NextPageToken]; exists {
-				return market.CatalogSnapshot{}, errors.New("connector market catalog returned a cyclic page token")
-			}
-			seenPageTokens[page.NextPageToken] = struct{}{}
-			pageToken = page.NextPageToken
+		item.PublishedAtMS = wireInt64(publishedAt.UnixMilli())
+		release, err := source.mapItem(item.wireMarketItem)
+		if err != nil {
+			return market.CatalogSnapshot{}, err
 		}
+		if _, duplicate := seen[release.ConnectorKey]; duplicate {
+			return market.CatalogSnapshot{}, errors.New("connector market catalog contains duplicate active connectors")
+		}
+		seen[release.ConnectorKey] = struct{}{}
+		releases = append(releases, release)
+		entries = append(entries, market.CatalogEntry{CategoryID: item.CategoryID, Featured: item.Featured, Release: release})
 	}
-	if primarySections == 0 {
-		return market.CatalogSnapshot{}, errors.New("connector market catalog returned no primary categories")
+	revocations := make([]market.CatalogRevocation, 0, len(payload.Revocations))
+	for _, revocation := range payload.Revocations {
+		effectiveAt, err := time.Parse(time.RFC3339Nano, revocation.EffectiveAt)
+		if err != nil || !validPrefixedCatalogDigest(revocation.ArtifactDigest) || strings.TrimSpace(revocation.RevocationID) == "" || strings.TrimSpace(revocation.ReasonCode) == "" {
+			return market.CatalogSnapshot{}, errors.New("connector market catalog revocation is invalid")
+		}
+		revocations = append(revocations, market.CatalogRevocation{ArtifactDigest: revocation.ArtifactDigest,
+			RevocationID: revocation.RevocationID, ConnectorKey: revocation.ItemKey, Version: revocation.Version,
+			ReasonCode: revocation.ReasonCode, EffectiveAt: effectiveAt})
 	}
-	revisionHash := sha256.New()
-	for _, release := range releases {
-		_, _ = io.WriteString(revisionHash, release.ConnectorKey)
-		_, _ = io.WriteString(revisionHash, "\x00")
-		_, _ = io.WriteString(revisionHash, release.ReleaseDigest)
-		_, _ = io.WriteString(revisionHash, "\n")
-	}
-	return market.CatalogSnapshot{SourceRevision: hex.EncodeToString(revisionHash.Sum(nil)), Releases: releases}, nil
+	result := market.CatalogSnapshot{CatalogRevision: payload.CatalogRevision, SnapshotDigest: payload.SnapshotDigest,
+		SourceRevision: strconv.FormatUint(payload.CatalogRevision, 10) + ":" + payload.SnapshotDigest,
+		Categories:     categories, Entries: entries, Releases: releases, Revocations: revocations}
+	source.mu.Lock()
+	source.latest = &result
+	source.mu.Unlock()
+	return result, nil
 }
 
 func (source *CatalogSource) ListCategories(ctx context.Context) ([]market.CatalogCategory, error) {
-	var payload wireMarketCategoriesResponse
-	if _, err := source.getJSON(ctx, connectorCategoriesPath, url.Values{"itemType": {"connector"}}, &payload); err != nil {
+	snapshot, err := source.cachedSnapshot(ctx)
+	if err != nil {
 		return nil, err
 	}
-	if payload.MarketType != source.expectedMarketType {
-		return nil, errors.New("connector market type does not match configured market")
-	}
-	categories := make([]market.CatalogCategory, 0, len(payload.Categories))
-	seen := make(map[string]struct{}, len(payload.Categories))
-	for _, category := range payload.Categories {
-		if strings.TrimSpace(category.CategoryID) == "" || (category.Kind != "category" && category.Kind != "featured") || category.ItemCount < 0 {
-			return nil, errors.New("connector market category is invalid")
-		}
-		if _, exists := seen[category.CategoryID]; exists {
-			return nil, errors.New("connector market category is duplicated")
-		}
-		seen[category.CategoryID] = struct{}{}
-		categories = append(categories, market.CatalogCategory{CategoryID: category.CategoryID, Kind: category.Kind, SortOrder: category.SortOrder, ItemCount: int64(category.ItemCount)})
-	}
-	return categories, nil
+	return append([]market.CatalogCategory(nil), snapshot.Categories...), nil
 }
 
 func (source *CatalogSource) ListPage(ctx context.Context, input market.CatalogSourcePageQuery) (market.CatalogSourcePage, error) {
-	query := url.Values{
-		"itemType":  {"connector"},
-		"sectionId": {strings.TrimSpace(input.SectionID)},
-		"pageSize":  {strconv.Itoa(input.PageSize)},
-	}
-	if token := strings.TrimSpace(input.PageToken); token != "" {
-		query.Set("pageToken", token)
-	}
-	var payload wireMarketResponse
-	if _, err := source.getJSON(ctx, connectorCatalogPath, query, &payload); err != nil {
+	snapshot, err := source.cachedSnapshot(ctx)
+	if err != nil {
 		return market.CatalogSourcePage{}, err
 	}
-	if payload.MarketType != source.expectedMarketType {
-		return market.CatalogSourcePage{}, errors.New("connector market type does not match configured market")
-	}
-	entries := make([]market.CatalogEntry, 0, len(payload.Items))
-	for _, item := range payload.Items {
-		release, err := source.mapItem(item)
-		if err != nil {
-			return market.CatalogSourcePage{}, err
+	entries := make([]market.CatalogEntry, 0, len(snapshot.Entries))
+	for _, entry := range snapshot.Entries {
+		if (input.SectionID == "featured" && entry.Featured) || (input.SectionID != "featured" && entry.CategoryID == input.SectionID) {
+			entries = append(entries, entry)
 		}
-		if strings.TrimSpace(item.CategoryID) == "" {
-			return market.CatalogSourcePage{}, errors.New("connector market item category is missing")
-		}
-		entries = append(entries, market.CatalogEntry{CategoryID: item.CategoryID, Featured: item.Featured, Release: release})
 	}
-	return market.CatalogSourcePage{SectionID: strings.TrimSpace(input.SectionID), Entries: entries, NextPageToken: payload.NextPageToken}, nil
+	offset := 0
+	if input.PageToken != "" {
+		offset, err = strconv.Atoi(input.PageToken)
+		if err != nil || offset < 0 || offset > len(entries) {
+			return market.CatalogSourcePage{}, errors.New("connector market page token is invalid")
+		}
+	}
+	end := min(offset+input.PageSize, len(entries))
+	next := ""
+	if end < len(entries) {
+		next = strconv.Itoa(end)
+	}
+	return market.CatalogSourcePage{SectionID: strings.TrimSpace(input.SectionID), Entries: entries[offset:end], NextPageToken: next}, nil
+}
+
+func (source *CatalogSource) cachedSnapshot(ctx context.Context) (*market.CatalogSnapshot, error) {
+	source.mu.RLock()
+	snapshot := source.latest
+	source.mu.RUnlock()
+	if snapshot != nil {
+		return snapshot, nil
+	}
+	refreshed, err := source.Refresh(ctx)
+	return &refreshed, err
+}
+
+func (source *CatalogSource) WaitForCatalogChange(ctx context.Context, afterRevision uint64) error {
+	for {
+		var head struct {
+			SchemaVersion   string `json:"schemaVersion"`
+			CatalogRevision uint64 `json:"catalogRevision"`
+			SnapshotDigest  string `json:"snapshotDigest"`
+		}
+		query := url.Values{
+			"itemType":      {"connector"},
+			"afterRevision": {strconv.FormatUint(afterRevision, 10)},
+			"waitSeconds":   {"30"},
+		}
+		if _, err := source.getJSON(ctx, connectorCatalogPath, query, &head); err != nil {
+			return err
+		}
+		if head.SchemaVersion != "2" || !validPrefixedCatalogDigest(head.SnapshotDigest) || head.CatalogRevision < afterRevision {
+			return errors.New("connector market catalog change response is invalid")
+		}
+		if head.CatalogRevision > afterRevision {
+			return nil
+		}
+	}
 }
 
 func (source *CatalogSource) getJSON(ctx context.Context, requestPath string, query url.Values, target any) ([]byte, error) {
@@ -302,15 +326,35 @@ func (source *CatalogSource) resolveManifestImplementation(manifest wireConnecto
 	}
 }
 
-type wireMarketResponse struct {
-	MarketType    string           `json:"marketType"`
-	Items         []wireMarketItem `json:"items"`
-	NextPageToken string           `json:"nextPageToken"`
+type wireConnectorCatalogSnapshot struct {
+	SchemaVersion   string                           `json:"schemaVersion"`
+	Scope           wireConnectorCatalogScope        `json:"scope"`
+	CatalogRevision uint64                           `json:"catalogRevision"`
+	SnapshotDigest  string                           `json:"snapshotDigest"`
+	GeneratedAt     string                           `json:"generatedAt"`
+	Categories      []wireMarketCategory             `json:"categories"`
+	Items           []wireConnectorCatalogItem       `json:"items"`
+	Revocations     []wireConnectorCatalogRevocation `json:"revocations"`
 }
 
-type wireMarketCategoriesResponse struct {
-	MarketType string               `json:"marketType"`
-	Categories []wireMarketCategory `json:"categories"`
+type wireConnectorCatalogScope struct {
+	MarketType string `json:"marketType"`
+	ItemType   string `json:"itemType"`
+}
+
+type wireConnectorCatalogItem struct {
+	wireMarketItem
+	ArtifactDigest string `json:"artifactDigest"`
+	PublishedAt    string `json:"publishedAt"`
+}
+
+type wireConnectorCatalogRevocation struct {
+	ArtifactDigest string `json:"artifactDigest"`
+	RevocationID   string `json:"revocationId"`
+	ItemKey        string `json:"itemKey"`
+	Version        string `json:"version"`
+	ReasonCode     string `json:"reasonCode"`
+	EffectiveAt    string `json:"effectiveAt"`
 }
 
 type wireMarketCategory struct {
@@ -437,4 +481,8 @@ func isSHA256Hex(value string) bool {
 		}
 	}
 	return true
+}
+
+func validPrefixedCatalogDigest(value string) bool {
+	return strings.HasPrefix(value, "sha256:") && isSHA256Hex(strings.TrimPrefix(value, "sha256:"))
 }

--- a/packages/connector/daemon/catalog_source_test.go
+++ b/packages/connector/daemon/catalog_source_test.go
@@ -21,28 +21,26 @@ func TestCatalogSourceMapsPublishedConnectorItemsWithAdditiveFields(t *testing.T
 			t.Fatalf("request path=%q query=%q", request.URL.Path, request.URL.RawQuery)
 		}
 		writer.Header().Set("Content-Type", "application/json")
-		if request.URL.Path == connectorCategoriesPath {
-			_, _ = writer.Write([]byte(`{
-  "marketType": "overseas",
-  "categories": [
-    {"categoryId": "featured", "kind": "featured", "sortOrder": 10, "itemCount": "1"},
-    {"categoryId": "development", "kind": "category", "sortOrder": 20, "itemCount": "1"}
-  ]
-}`))
-			return
-		}
 		itemCalls++
-		if request.URL.Path != connectorCatalogPath || request.URL.Query().Get("sectionId") != "development" || request.URL.Query().Get("pageSize") != "100" {
+		if request.URL.Path != connectorCatalogPath {
 			t.Fatalf("request path=%q query=%q", request.URL.Path, request.URL.RawQuery)
 		}
 		_, _ = writer.Write([]byte(`{
-  "marketType": "overseas",
-  "requestId": "request-1",
+	"schemaVersion": "2",
+	"scope": {"marketType": "overseas", "itemType": "connector"},
+	"catalogRevision": 7,
+	"snapshotDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	"generatedAt": "2026-08-14T00:00:00Z",
+	"categories": [
+	  {"categoryId": "featured", "kind": "featured", "sortOrder": 10, "itemCount": "1"},
+	  {"categoryId": "development", "kind": "category", "sortOrder": 20, "itemCount": "1"}
+	],
   "items": [{
     "itemType": "connector",
     "itemKey": "github",
     "version": "1.0.0",
     "commitSha": "0123456789abcdef",
+	"artifactDigest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
     "publisher": {"name": "Tutti"},
     "artifact": {
       "key": "connectors/github/1.0.0.zip",
@@ -74,11 +72,11 @@ func TestCatalogSourceMapsPublishedConnectorItemsWithAdditiveFields(t *testing.T
         }
       }
     },
-    "publishedAtMs": "1785801600000",
+	"publishedAt": "2026-08-04T00:00:00Z",
     "categoryId": "development",
     "featured": true
   }],
-  "nextPageToken": ""
+	"revocations": []
 }`))
 	}))
 	defer server.Close()
@@ -115,8 +113,8 @@ func TestCatalogSourceMapsPublishedConnectorItemsWithAdditiveFields(t *testing.T
 		page.Entries[0].Release.Version != "1.0.0" || page.Entries[0].Release.Artifact.SHA256 != strings.Repeat("c", 64) {
 		t.Fatalf("page=%#v error=%v", page, err)
 	}
-	if itemCalls != 2 {
-		t.Fatalf("market item requests = %d, want 2", itemCalls)
+	if itemCalls != 1 {
+		t.Fatalf("market catalog requests = %d, want 1", itemCalls)
 	}
 }
 
@@ -269,11 +267,11 @@ func TestCatalogSourceRejectsInvalidConfiguration(t *testing.T) {
 
 func TestCatalogSourcePreservesGatewayBasePath(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		if request.URL.Path != "/api/desktop/v1/market/categories" {
+		if request.URL.Path != "/api/desktop/v1/market/catalog" {
 			t.Fatalf("request path = %q", request.URL.Path)
 		}
 		writer.Header().Set("Content-Type", "application/json")
-		_, _ = writer.Write([]byte(`{"marketType":"overseas","categories":[]}`))
+		_, _ = writer.Write([]byte(`{"schemaVersion":"2","scope":{"marketType":"overseas","itemType":"connector"},"catalogRevision":1,"snapshotDigest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","generatedAt":"2026-08-14T00:00:00Z","categories":[],"items":[],"revocations":[]}`))
 	}))
 	defer server.Close()
 

--- a/packages/connector/daemon/host.go
+++ b/packages/connector/daemon/host.go
@@ -1,3 +1,5 @@
+//revive:disable:file-length-limit
+
 package daemon
 
 import (
@@ -9,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
 	market "github.com/tutti-os/tutti/packages/connector/host"
 )
 
@@ -24,6 +25,7 @@ type HostConfig struct {
 	AuthorizationEvents      market.AuthorizationEventSource
 	AuthorizationReadiness   *market.AuthorizationReadinessGate
 	RuntimeBindings          market.RuntimeBindingResolver
+	OperationScopes          market.OperationScopeResolver
 	Compatibility            market.CompatibilityEvaluator
 	ImplementationRegistry   market.ImplementationRegistry
 	Outbox                   market.ChangedEventOutbox
@@ -52,12 +54,15 @@ type Host struct {
 	authorizationScopeWake     chan struct{}
 	runtimeRecoveryDone        chan struct{}
 	runtimeRecoveryWake        chan struct{}
+	catalogRefreshWake         chan struct{}
+	catalogChangeDone          chan struct{}
 	closeOnce                  sync.Once
 	bootstrapMu                sync.Mutex
 	bootstrapped               bool
 	bootstrapScope             market.OperationScope
 	refreshWorkerStarted       bool
 	repository                 market.Repository
+	catalogSource              market.CatalogSource
 	implementationHost         market.ImplementationHost
 	activationGate             *activationGateHost
 	publicationGate            capabilityPublicationGate
@@ -94,6 +99,7 @@ func NewHost(parent context.Context, config HostConfig) (*Host, error) {
 		AuthorizationSnapshots:   config.AuthorizationSnapshots,
 		AuthorizationReadiness:   config.AuthorizationReadiness,
 		RuntimeBindings:          config.RuntimeBindings,
+		OperationScopes:          config.OperationScopes,
 		Compatibility:            config.Compatibility,
 		Scheduler:                scheduler,
 		ImplementationRegistry:   config.ImplementationRegistry,
@@ -118,7 +124,10 @@ func NewHost(parent context.Context, config HostConfig) (*Host, error) {
 		authorizationScopeWake:  make(chan struct{}, 1),
 		runtimeRecoveryDone:     make(chan struct{}),
 		runtimeRecoveryWake:     make(chan struct{}, 1),
+		catalogRefreshWake:      make(chan struct{}, 1),
+		catalogChangeDone:       make(chan struct{}),
 		repository:              config.Repository,
+		catalogSource:           config.CatalogSource,
 		implementationHost:      config.ImplementationHost,
 		activationGate:          activationGate,
 		publication:             config.Publication,
@@ -128,6 +137,7 @@ func NewHost(parent context.Context, config HostConfig) (*Host, error) {
 		authorizationDirty:      make(map[string]map[string]struct{}),
 		runtimeRecoveryPending:  make(map[string]struct{}),
 	}
+	go host.runCatalogChangeWorker(hostContext)
 	if snapshotStore, ok := config.AuthorizationProjections.(market.AuthorizationSnapshotStore); ok {
 		host.authorizationSnapshotStore = snapshotStore
 	}
@@ -318,6 +328,13 @@ func (host *Host) BootstrapForScope(ctx context.Context, scope market.OperationS
 	host.activationGate.markRecovered()
 	host.bootstrapped = true
 	committed = true
+	if err := host.convergeRevokedInstallations(ctx, scope); err != nil {
+		// Bootstrap is already safe: revoked runtime bindings are fail-closed.
+		// Keep catalog convergence level-triggered until the lifecycle claim is
+		// available and the deterministic uninstall can be accepted.
+		slog.Warn("revoked connector uninstall convergence deferred", "error", err)
+		host.NotifyCatalogDirty()
+	}
 	if reconcileFailures != nil {
 		slog.Warn("connector market bootstrap completed with unavailable connectors", "error", reconcileFailures)
 	}
@@ -665,35 +682,48 @@ func (host *Host) recoverAndWait(ctx context.Context) error {
 }
 
 func (host *Host) refreshAndWait(ctx context.Context) error {
+	if err := host.Application.SyncCatalog(ctx); err != nil {
+		return err
+	}
+	host.bootstrapMu.Lock()
+	bootstrapped, scope := host.bootstrapped, host.bootstrapScope
+	host.bootstrapMu.Unlock()
+	if !bootstrapped {
+		return nil
+	}
+	return host.convergeRevokedInstallations(ctx, scope)
+}
+
+func (host *Host) convergeRevokedInstallations(ctx context.Context, scope market.OperationScope) error {
 	snapshot, err := host.Application.Snapshot(ctx)
 	if err != nil {
 		return err
 	}
-	result, err := host.Application.RefreshCatalog(ctx, market.Mutation{
-		ClientRequestID: "daemon-refresh-" + uuid.NewString(), ExpectedRevision: snapshot.Revision,
-	})
-	if err != nil {
-		return err
-	}
-	ticker := time.NewTicker(25 * time.Millisecond)
-	defer ticker.Stop()
-	for {
-		operation, err := host.Application.GetOperation(ctx, result.Operation.OperationID)
+	var convergenceErr error
+	for _, connector := range snapshot.Connectors {
+		if connector.Security.State != market.SecurityStateRevoked ||
+			connector.Installation.InstalledReleaseDigest == "" ||
+			connector.Installation.State == market.InstallationStateUninstalling {
+			continue
+		}
+		_, err := host.Application.Uninstall(ctx, market.ConnectorMutation{
+			Mutation: market.Mutation{
+				ClientRequestID: fmt.Sprintf(
+					"revocation:%s:%s:%d",
+					connector.Security.RevocationID,
+					connector.Key,
+					connector.Revision,
+				),
+				ExpectedRevision: connector.Revision,
+			},
+			ConnectorKey: connector.Key,
+			AccountID:    scope.AccountID,
+		})
 		if err != nil {
-			return err
-		}
-		switch operation.State {
-		case market.OperationStateCompleted:
-			return nil
-		case market.OperationStateFailed:
-			return fmt.Errorf("connector market refresh failed: %s", operation.FailureCode)
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-ticker.C:
+			convergenceErr = errors.Join(convergenceErr, fmt.Errorf("uninstall revoked connector %s: %w", connector.Key, err))
 		}
 	}
+	return convergenceErr
 }
 
 func (host *Host) waitForOperationTerminal(ctx context.Context, operationID string) (market.Operation, error) {
@@ -718,6 +748,8 @@ func (host *Host) waitForOperationTerminal(ctx context.Context, operationID stri
 
 func (host *Host) runCatalogRefreshWorker() {
 	bootstrapRetry := time.Second
+	// A fresh v2 database has no revision for the long-poll worker to observe.
+	// Pull immediately after bootstrap, then use the normal fallback interval.
 	catalogRetry := time.Duration(0)
 	for {
 		host.bootstrapMu.Lock()
@@ -750,6 +782,8 @@ func (host *Host) runCatalogRefreshWorker() {
 		case <-host.scheduler.ctx.Done():
 			timer.Stop()
 			return
+		case <-host.catalogRefreshWake:
+			timer.Stop()
 		case <-timer.C:
 		}
 		refreshContext, cancel := context.WithTimeout(host.scheduler.ctx, 45*time.Second)
@@ -757,14 +791,58 @@ func (host *Host) runCatalogRefreshWorker() {
 		cancel()
 		if err != nil && !errors.Is(err, context.Canceled) {
 			slog.Warn("connector market scheduled refresh failed", "error", err)
-			if catalogRetry < time.Minute {
-				catalogRetry = time.Minute
-			} else if catalogRetry < 5*time.Minute {
-				catalogRetry *= 2
+			if catalogRetry <= 0 || catalogRetry > 30*time.Second {
+				catalogRetry = time.Second
+			} else {
+				catalogRetry = min(catalogRetry*2, 30*time.Second)
 			}
 			continue
 		}
-		catalogRetry = time.Minute
+		catalogRetry = 10 * time.Minute
+	}
+}
+
+// NotifyCatalogDirty coalesces server dirty notifications into the single
+// refresh controller. The full snapshot remains authoritative; notifications
+// carry no catalog business data and may be delivered more than once.
+func (host *Host) NotifyCatalogDirty() {
+	if host == nil {
+		return
+	}
+	select {
+	case host.catalogRefreshWake <- struct{}{}:
+	default:
+	}
+}
+
+func (host *Host) runCatalogChangeWorker(ctx context.Context) {
+	defer close(host.catalogChangeDone)
+	source, ok := host.catalogSource.(market.CatalogChangeSource)
+	if !ok {
+		return
+	}
+	backoff := time.Second
+	for {
+		snapshot, err := host.repository.CatalogSnapshot(ctx)
+		if err == nil {
+			err = source.WaitForCatalogChange(ctx, snapshot.CatalogRevision)
+		}
+		if err == nil {
+			host.NotifyCatalogDirty()
+			backoff = time.Second
+			continue
+		}
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		timer := time.NewTimer(backoff)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+		backoff = min(backoff*2, 30*time.Second)
 	}
 }
 
@@ -782,6 +860,7 @@ func (host *Host) Close() {
 		<-host.authorizationSyncDone
 		<-host.authorizationEventsDone
 		<-host.runtimeRecoveryDone
+		<-host.catalogChangeDone
 		host.scheduler.Wait()
 	})
 }
@@ -802,7 +881,7 @@ func CatalogOnlyPorts() (
 
 type unavailableReleaseInstaller struct{}
 
-func (unavailableReleaseInstaller) InstallRelease(context.Context, market.InstallReleaseRequest) (market.ReleaseInstallationReceipt, error) {
+func (unavailableReleaseInstaller) PrepareReleaseInstallation(context.Context, market.PrepareReleaseInstallationRequest) (market.ReleaseInstallationReceipt, error) {
 	return market.ReleaseInstallationReceipt{}, errors.New("connector release installation is not registered")
 }
 
@@ -812,7 +891,15 @@ func (unavailableReleaseInstaller) InspectReleaseInstallation(_ context.Context,
 		ReasonCode: "release_installation_manager_unavailable"}, nil
 }
 
-func (unavailableReleaseInstaller) CommitReleaseInstallation(context.Context, market.CommitReleaseInstallationRequest) error {
+func (unavailableReleaseInstaller) ActivateReleaseInstallation(context.Context, market.ReleaseInstallationTransitionRequest) error {
+	return errors.New("connector release installation is not registered")
+}
+
+func (unavailableReleaseInstaller) FinalizeReleaseInstallation(context.Context, market.ReleaseInstallationTransitionRequest) error {
+	return errors.New("connector release installation is not registered")
+}
+
+func (unavailableReleaseInstaller) AbortReleaseInstallation(context.Context, market.ReleaseInstallationTransitionRequest) error {
 	return errors.New("connector release installation is not registered")
 }
 

--- a/packages/connector/daemon/host_test.go
+++ b/packages/connector/daemon/host_test.go
@@ -18,6 +18,8 @@ type activationGateDelegate struct {
 	installationInspections int
 	installationState       market.ReleaseInstallationObservationState
 	deactivations           int
+	uninstalls              int
+	uninstallFailures       int
 	failClosed              int
 	lastReconcile           market.RuntimeReconcileRequest
 }
@@ -35,13 +37,25 @@ func (delegate *activationGateDelegate) InspectReleaseInstallation(
 		ReleaseDigest: request.Release.ReleaseDigest}, nil
 }
 
-func (*activationGateDelegate) InstallRelease(context.Context, market.InstallReleaseRequest) (market.ReleaseInstallationReceipt, error) {
+func (*activationGateDelegate) PrepareReleaseInstallation(context.Context, market.PrepareReleaseInstallationRequest) (market.ReleaseInstallationReceipt, error) {
 	return market.ReleaseInstallationReceipt{}, errors.New("not implemented")
 }
-func (*activationGateDelegate) CommitReleaseInstallation(context.Context, market.CommitReleaseInstallationRequest) error {
+func (*activationGateDelegate) ActivateReleaseInstallation(context.Context, market.ReleaseInstallationTransitionRequest) error {
 	return nil
 }
-func (*activationGateDelegate) UninstallRelease(context.Context, market.UninstallReleaseRequest) error {
+func (*activationGateDelegate) FinalizeReleaseInstallation(context.Context, market.ReleaseInstallationTransitionRequest) error {
+	return nil
+}
+func (*activationGateDelegate) AbortReleaseInstallation(context.Context, market.ReleaseInstallationTransitionRequest) error {
+	return nil
+}
+
+func (delegate *activationGateDelegate) UninstallRelease(context.Context, market.UninstallReleaseRequest) error {
+	delegate.uninstalls++
+	if delegate.uninstallFailures > 0 {
+		delegate.uninstallFailures--
+		return errors.New("simulated uninstall failure")
+	}
 	return nil
 }
 
@@ -145,6 +159,20 @@ type countingCatalogSource struct {
 	refreshErr error
 }
 
+type catalogSourceFunc func(context.Context) (market.CatalogSnapshot, error)
+
+func (source catalogSourceFunc) Refresh(ctx context.Context) (market.CatalogSnapshot, error) {
+	return source(ctx)
+}
+
+func (catalogSourceFunc) ListCategories(context.Context) ([]market.CatalogCategory, error) {
+	return nil, nil
+}
+
+func (catalogSourceFunc) ListPage(context.Context, market.CatalogSourcePageQuery) (market.CatalogSourcePage, error) {
+	return market.CatalogSourcePage{}, nil
+}
+
 func (*countingCatalogSource) ListCategories(context.Context) ([]market.CatalogCategory, error) {
 	return nil, nil
 }
@@ -159,6 +187,188 @@ func (source *countingCatalogSource) Refresh(context.Context) (market.CatalogSna
 		return market.CatalogSnapshot{}, source.refreshErr
 	}
 	return market.CatalogSnapshot{SourceRevision: "source-1", Releases: []market.Release{source.release}}, nil
+}
+
+func TestBootstrapTriggersImmediateFirstCatalogPull(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	store, err := marketdata.Open(ctx, filepath.Join(t.TempDir(), "tuttid.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	refreshed := make(chan struct{}, 1)
+	runtime := &activationGateDelegate{}
+	host, err := NewHost(ctx, HostConfig{
+		Repository: store,
+		CatalogSource: catalogSourceFunc(func(context.Context) (market.CatalogSnapshot, error) {
+			select {
+			case refreshed <- struct{}{}:
+			default:
+			}
+			return market.CatalogSnapshot{
+				CatalogRevision: 1,
+				SnapshotDigest:  "sha256:" + strings.Repeat("e", 64),
+				SourceRevision:  "catalog-1",
+			}, nil
+		}),
+		ReleaseInstallations:   runtime,
+		ImplementationHost:     runtime,
+		Authorization:          unavailableAuthorization{},
+		Compatibility:          rejectingCompatibility{},
+		ImplementationRegistry: market.NewImplementationRegistry(nil),
+		Outbox:                 store,
+		Lifecycle:              store,
+		Publisher:              discardChangedEventPublisher{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(host.Close)
+	if err := host.Bootstrap(ctx); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-refreshed:
+	case <-ctx.Done():
+		t.Fatal("catalog was not pulled immediately after bootstrap")
+	}
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		snapshot, snapshotErr := store.CatalogSnapshot(ctx)
+		if snapshotErr == nil && snapshot.CatalogRevision == 1 {
+			break
+		}
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			t.Fatalf("catalog snapshot = %#v, error = %v", snapshot, snapshotErr)
+		}
+	}
+}
+
+func TestCatalogRefreshAutomaticallyUninstallsRevokedRelease(t *testing.T) {
+	ctx := context.Background()
+	store, err := marketdata.Open(ctx, filepath.Join(t.TempDir(), "tuttid.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	release := hostTestRelease()
+	connector := market.Connector{
+		Key:     release.ConnectorKey,
+		Release: release,
+		Installation: market.Installation{
+			State:                   market.InstallationStateInstalled,
+			InstalledVersion:        release.Version,
+			InstalledReleaseID:      release.ReleaseID,
+			InstalledReleaseDigest:  release.ReleaseDigest,
+			InstalledArtifactSHA256: release.Artifact.SHA256,
+		},
+		Authorization: market.Authorization{State: market.AuthorizationStateNotRequired},
+		Compatibility: market.Compatibility{State: market.CompatibilityStateSupported},
+		Security:      market.Security{State: market.SecurityStateAllowed},
+	}
+	if err := store.Transaction(ctx, func(tx market.Transaction) error {
+		return tx.SaveConnector(connector)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	source := &countingCatalogSource{release: release}
+	runtime := &activationGateDelegate{uninstallFailures: 1}
+	host, err := NewHost(ctx, HostConfig{
+		Repository: store,
+		CatalogSource: catalogSourceFunc(func(context.Context) (market.CatalogSnapshot, error) {
+			snapshot, sourceErr := source.Refresh(ctx)
+			snapshot.CatalogRevision = 2
+			snapshot.SnapshotDigest = "sha256:" + strings.Repeat("d", 64)
+			snapshot.Revocations = []market.CatalogRevocation{{
+				ArtifactDigest: "sha256:" + release.Artifact.SHA256,
+				RevocationID:   "security-incident-1",
+				ConnectorKey:   release.ConnectorKey,
+				Version:        release.Version,
+				ReasonCode:     "security_incident",
+				EffectiveAt:    time.Now().UTC(),
+			}}
+			return snapshot, sourceErr
+		}),
+		ReleaseInstallations:   runtime,
+		ImplementationHost:     runtime,
+		Authorization:          unavailableAuthorization{},
+		Compatibility:          rejectingCompatibility{},
+		ImplementationRegistry: market.NewImplementationRegistry(nil),
+		Outbox:                 store,
+		Lifecycle:              store,
+		Publisher:              discardChangedEventPublisher{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	host.refreshWorkerStarted = true
+	host.bootstrapMu.Lock()
+	host.bootstrapped = true
+	host.bootstrapMu.Unlock()
+	t.Cleanup(host.Close)
+
+	// Hold the gate until the accepted operation exposes its frozen scope. This
+	// keeps the test independent of the randomly generated daemon boot epoch.
+	host.activationGate.mu.Lock()
+	if err := host.refreshAndWait(ctx); err != nil {
+		host.activationGate.mu.Unlock()
+		t.Fatal(err)
+	}
+	accepted, err := store.Snapshot(ctx)
+	if err != nil {
+		host.activationGate.mu.Unlock()
+		t.Fatal(err)
+	}
+	if len(accepted.Operations) != 1 {
+		host.activationGate.mu.Unlock()
+		t.Fatalf("accepted revocation operations = %#v", accepted.Operations)
+	}
+	host.activationGate.scope = accepted.Operations[0].Scope
+	host.activationGate.open = true
+	host.activationGate.mu.Unlock()
+	host.scheduler.Wait()
+	failed, err := host.Application.GetConnector(ctx, connector.Key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if failed.Installation.State != market.InstallationStateFailed {
+		t.Fatalf("first uninstall state = %q, want failed", failed.Installation.State)
+	}
+	if err := host.refreshAndWait(ctx); err != nil {
+		t.Fatal(err)
+	}
+	host.scheduler.Wait()
+
+	updated, err := host.Application.GetConnector(ctx, connector.Key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Installation.State != market.InstallationStateNotInstalled {
+		t.Fatalf("installation state = %q, want not_installed", updated.Installation.State)
+	}
+	operations, err := store.Snapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	operationsByRequestID := make(map[string]market.Operation, len(operations.Operations))
+	for _, operation := range operations.Operations {
+		operationsByRequestID[operation.ClientRequestID] = operation
+	}
+	failedRevocation, hasFailedRevocation := operationsByRequestID["revocation:security-incident-1:github:0"]
+	completedRevocation, hasCompletedRevocation := operationsByRequestID["revocation:security-incident-1:github:2"]
+	if len(operations.Operations) != 2 || !hasFailedRevocation || !hasCompletedRevocation ||
+		failedRevocation.Kind != market.OperationKindUninstall || completedRevocation.Kind != market.OperationKindUninstall {
+		t.Fatalf("revocation operations = %#v", operations.Operations)
+	}
+	if runtime.deactivations != 2 || runtime.uninstalls != 2 {
+		t.Fatalf("runtime deactivations = %d, uninstalls = %d, want 2 and 2", runtime.deactivations, runtime.uninstalls)
+	}
 }
 
 type discardChangedEventPublisher struct{}

--- a/packages/connector/daemon/workers.go
+++ b/packages/connector/daemon/workers.go
@@ -12,6 +12,7 @@ import (
 
 type OperationExecutor interface {
 	ExecuteOperation(context.Context, string) error
+	GetOperation(context.Context, string) (market.Operation, error)
 }
 
 type OperationScheduler struct {
@@ -66,8 +67,35 @@ func (scheduler *OperationScheduler) Schedule(_ context.Context, operationID str
 			delete(scheduler.active, operationID)
 			scheduler.mu.Unlock()
 		}()
-		if err := executor.ExecuteOperation(scheduler.ctx, operationID); err != nil {
-			slog.Warn("connector market operation failed", "operationId", operationID, "error", err)
+		for {
+			operation, err := executor.GetOperation(scheduler.ctx, operationID)
+			if err != nil {
+				slog.Warn("connector market operation could not be loaded", "operationId", operationID, "error", err)
+				return
+			}
+			if operation.State.IsTerminal() {
+				return
+			}
+			if operation.NextAttemptAt != nil {
+				delay := time.Until(operation.NextAttemptAt.UTC())
+				if delay > 0 {
+					timer := time.NewTimer(delay)
+					select {
+					case <-scheduler.ctx.Done():
+						timer.Stop()
+						return
+					case <-timer.C:
+					}
+				}
+			}
+			err = executor.ExecuteOperation(scheduler.ctx, operationID)
+			if errors.Is(err, market.ErrOperationOutcomeUnknown) {
+				continue
+			}
+			if err != nil {
+				slog.Warn("connector market operation failed", "operationId", operationID, "error", err)
+			}
+			return
 		}
 	}()
 	return nil

--- a/packages/connector/daemon/workers_test.go
+++ b/packages/connector/daemon/workers_test.go
@@ -29,6 +29,61 @@ func TestOperationSchedulerDeduplicatesActiveOperation(t *testing.T) {
 	}
 }
 
+func TestOperationSchedulerWaitsForPersistedUnknownOutcomeRetry(t *testing.T) {
+	executor := &unknownOutcomeExecutor{retryAt: time.Now().Add(30 * time.Millisecond), completed: make(chan struct{})}
+	scheduler := NewOperationScheduler(context.Background())
+	if err := scheduler.Bind(executor); err != nil {
+		t.Fatal(err)
+	}
+	if err := scheduler.Schedule(context.Background(), "operation-unknown"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-executor.completed:
+	case <-time.After(time.Second):
+		t.Fatal("unknown outcome was not retried")
+	}
+	scheduler.Wait()
+	executor.mu.Lock()
+	defer executor.mu.Unlock()
+	if executor.calls != 2 {
+		t.Fatalf("executor calls = %d, want 2", executor.calls)
+	}
+	if executor.secondAttempt.Before(executor.retryAt) {
+		t.Fatalf("second attempt at %s, before persisted retry time %s", executor.secondAttempt, executor.retryAt)
+	}
+}
+
+type unknownOutcomeExecutor struct {
+	mu            sync.Mutex
+	calls         int
+	retryAt       time.Time
+	secondAttempt time.Time
+	completed     chan struct{}
+}
+
+func (executor *unknownOutcomeExecutor) GetOperation(context.Context, string) (market.Operation, error) {
+	executor.mu.Lock()
+	defer executor.mu.Unlock()
+	if executor.calls == 0 {
+		return market.Operation{State: market.OperationStateAccepted}, nil
+	}
+	retryAt := executor.retryAt
+	return market.Operation{State: market.OperationStateOutcomeUnknown, NextAttemptAt: &retryAt}, nil
+}
+
+func (executor *unknownOutcomeExecutor) ExecuteOperation(context.Context, string) error {
+	executor.mu.Lock()
+	defer executor.mu.Unlock()
+	executor.calls++
+	if executor.calls == 1 {
+		return market.ErrOperationOutcomeUnknown
+	}
+	executor.secondAttempt = time.Now()
+	close(executor.completed)
+	return nil
+}
+
 type blockingExecutor struct {
 	mu      sync.Mutex
 	calls   int
@@ -43,6 +98,10 @@ func (executor *blockingExecutor) ExecuteOperation(context.Context, string) erro
 	close(executor.started)
 	<-executor.release
 	return nil
+}
+
+func (*blockingExecutor) GetOperation(context.Context, string) (market.Operation, error) {
+	return market.Operation{State: market.OperationStateAccepted}, nil
 }
 
 func TestOutboxDispatcherMarksOnlyPublishedEvents(t *testing.T) {

--- a/packages/connector/host/application.go
+++ b/packages/connector/host/application.go
@@ -8,7 +8,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -24,23 +24,32 @@ type ApplicationConfig struct {
 	AuthorizationSnapshots   AuthorizationSnapshotSource
 	AuthorizationReadiness   *AuthorizationReadinessGate
 	RuntimeBindings          RuntimeBindingResolver
+	OperationScopes          OperationScopeResolver
 	Compatibility            CompatibilityEvaluator
 	Scheduler                OperationScheduler
 	ImplementationRegistry   ImplementationRegistry
 	WorkerID                 string
 	BootEpoch                string
+	DeviceID                 string
 	LeaseDuration            time.Duration
 	Now                      func() time.Time
 	NewID                    func() (string, error)
 }
 
 type Application struct {
-	config ApplicationConfig
+	config      ApplicationConfig
+	catalogMu   sync.Mutex
+	catalogSync *catalogSyncExecution
 
 	// executionMu and inFlight provide process-local ownership for operation
 	// execution. Durable recovery remains the repository and adapter contract.
 	executionMu sync.Mutex
 	inFlight    map[string]*operationExecution
+}
+
+type catalogSyncExecution struct {
+	done chan struct{}
+	err  error
 }
 
 type operationExecution struct {
@@ -95,6 +104,9 @@ func NewApplication(config ApplicationConfig) (*Application, error) {
 		}
 		config.BootEpoch = bootEpoch
 	}
+	if strings.TrimSpace(config.DeviceID) == "" {
+		config.DeviceID = "local"
+	}
 	if config.LeaseDuration <= 0 {
 		config.LeaseDuration = 30 * time.Second
 	}
@@ -106,10 +118,11 @@ func (application *Application) Snapshot(ctx context.Context) (Snapshot, error) 
 }
 
 func (application *Application) ListCatalogCategories(ctx context.Context) ([]CatalogCategory, error) {
-	categories, err := application.config.CatalogSource.ListCategories(ctx)
+	snapshot, err := application.config.Repository.CatalogSnapshot(ctx)
 	if err != nil {
-		return nil, preserveCatalogSourceError("connector catalog categories could not be loaded", err)
+		return nil, NewDomainError(ErrorCodeUnavailable, "connector catalog snapshot is unavailable", true, err)
 	}
+	categories := snapshot.Categories
 	seen := make(map[string]struct{}, len(categories))
 	for _, category := range categories {
 		if strings.TrimSpace(category.CategoryID) == "" ||
@@ -131,75 +144,39 @@ func (application *Application) ListCatalogPage(ctx context.Context, query Catal
 	if query.SectionID == "" || query.PageSize < 1 || query.PageSize > 100 {
 		return CatalogPage{}, invalidRequest("sectionId and a pageSize between 1 and 100 are required")
 	}
-	page, err := application.config.CatalogSource.ListPage(ctx, CatalogSourcePageQuery(query))
+	snapshot, err := application.config.Repository.CatalogSnapshot(ctx)
 	if err != nil {
-		return CatalogPage{}, preserveCatalogSourceError("connector catalog page could not be loaded", err)
+		return CatalogPage{}, NewDomainError(ErrorCodeUnavailable, "connector catalog snapshot is unavailable", true, err)
 	}
-	if page.SectionID != query.SectionID {
-		return CatalogPage{}, invalidManifest("connector catalog page section does not match the request", nil)
+	offset := 0
+	if query.PageToken != "" {
+		offset, err = strconv.Atoi(query.PageToken)
+		if err != nil || offset < 0 {
+			return CatalogPage{}, invalidRequest("connector catalog page token is invalid")
+		}
 	}
-	seen := make(map[string]struct{}, len(page.Entries))
-	compatibilityByKey := make(map[string]Compatibility, len(page.Entries))
-	for _, entry := range page.Entries {
-		if strings.TrimSpace(entry.CategoryID) == "" {
-			return CatalogPage{}, invalidManifest("connector catalog item category is required", nil)
+	entries := make([]CatalogEntry, 0, len(snapshot.Entries))
+	for _, entry := range snapshot.Entries {
+		if query.SectionID == "featured" && entry.Featured {
+			entries = append(entries, entry)
+		} else if query.SectionID != "featured" && entry.CategoryID == query.SectionID {
+			entries = append(entries, entry)
 		}
-		if _, exists := seen[entry.Release.ConnectorKey]; exists {
-			return CatalogPage{}, invalidManifest("connector catalog page contains duplicate connectors", nil)
-		}
-		seen[entry.Release.ConnectorKey] = struct{}{}
-		if err := ValidateReleaseShape(entry.Release); err != nil {
-			return CatalogPage{}, err
-		}
-		compatibility, err := application.compatibilityFor(entry.Release.Manifest)
-		if err != nil {
-			return CatalogPage{}, err
-		}
-		compatibilityByKey[entry.Release.ConnectorKey] = compatibility
 	}
-
-	// Browsing is a cache-aside catalog sync. Persisting newly observed releases
-	// makes an item immediately installable without waiting for the background
-	// authoritative refresh; unseen items are never removed by a partial page.
-	var revision uint64
-	err = application.config.Repository.Transaction(ctx, func(tx Transaction) error {
-		revision = tx.Revision()
-		changed := make([]Connector, 0, len(page.Entries))
-		for _, entry := range page.Entries {
-			connector, lookupErr := tx.Connector(entry.Release.ConnectorKey)
-			if lookupErr != nil && !errors.Is(lookupErr, ErrNotFound) {
-				return lookupErr
-			}
-			if errors.Is(lookupErr, ErrNotFound) {
-				connector = newCatalogConnector(entry.Release)
-			}
-			compatibility := compatibilityByKey[entry.Release.ConnectorKey]
-			if lookupErr == nil && reflect.DeepEqual(connector.Release, entry.Release) && reflect.DeepEqual(connector.Compatibility, compatibility) {
-				continue
-			}
-			connector.Release = entry.Release
-			connector.Authorization = authorizationForManifest(connector.Authorization, entry.Release.Manifest.AuthorizationKind)
-			connector.Compatibility = compatibility
-			changed = append(changed, connector)
-		}
-		if len(changed) == 0 {
-			return nil
-		}
-		revision = tx.AdvanceRevision()
-		for _, connector := range changed {
-			connector.Revision = revision
-			if err := tx.SaveConnector(connector); err != nil {
-				return err
-			}
-		}
-		return tx.EnqueueConnectorMarketChanged(ChangedEvent{Revision: revision})
-	})
+	if offset > len(entries) {
+		return CatalogPage{}, invalidRequest("connector catalog page token is invalid")
+	}
+	end := min(offset+query.PageSize, len(entries))
+	nextPageToken := ""
+	if end < len(entries) {
+		nextPageToken = strconv.Itoa(end)
+	}
+	view, err := application.config.Repository.Snapshot(ctx)
 	if err != nil {
 		return CatalogPage{}, err
 	}
-
-	result := CatalogPage{SectionID: page.SectionID, Items: make([]CatalogListing, 0, len(page.Entries)), NextPageToken: page.NextPageToken, Revision: revision}
-	for _, entry := range page.Entries {
+	result := CatalogPage{SectionID: query.SectionID, Items: make([]CatalogListing, 0, end-offset), NextPageToken: nextPageToken, Revision: view.Revision}
+	for _, entry := range entries[offset:end] {
 		connector, err := application.config.Repository.Connector(ctx, entry.Release.ConnectorKey)
 		if err != nil {
 			return CatalogPage{}, err
@@ -228,21 +205,30 @@ func (application *Application) GetOperation(ctx context.Context, operationID st
 
 func (application *Application) RefreshCatalog(
 	ctx context.Context,
-	mutation Mutation,
-) (MutationResult, error) {
-	return application.acceptOperation(ctx, mutation, OperationKindRefreshCatalog, "")
+) (Snapshot, error) {
+	if err := application.SyncCatalog(ctx); err != nil {
+		return Snapshot{}, err
+	}
+	return application.Snapshot(ctx)
 }
 
 func (application *Application) Install(
 	ctx context.Context,
 	mutation ConnectorMutation,
 ) (MutationResult, error) {
+	catalog, err := application.config.Repository.CatalogSnapshot(ctx)
+	if err != nil {
+		return MutationResult{}, NewDomainError(ErrorCodeUnavailable, "connector catalog snapshot is unavailable", true, err)
+	}
 	var target InstallationState
 	result, err := application.acceptConnectorOperation(
 		ctx,
 		mutation,
 		OperationKindInstall,
 		func(connector Connector) (Connector, error) {
+			if catalogRevokesRelease(catalog, connector.Release) {
+				return Connector{}, NewDomainError(ErrorCodeReleaseRevoked, "connector release is revoked", false, nil)
+			}
 			if connector.Compatibility.State != CompatibilityStateSupported {
 				return Connector{}, NewDomainError(
 					ErrorCodeIncompatible,
@@ -629,9 +615,10 @@ func (application *Application) executeOperation(ctx context.Context, operationI
 			operation.LeaseToken,
 		)
 	}()
-	if operation.State == OperationStateCompleted || operation.State == OperationStateFailed {
+	if operation.State.IsTerminal() {
 		return nil
 	}
+	wasOutcomeUnknown := operation.State == OperationStateOutcomeUnknown
 	operation, err = application.markOperationRunning(executionContext, operation.OperationID)
 	if err != nil {
 		return err
@@ -639,12 +626,18 @@ func (application *Application) executeOperation(ctx context.Context, operationI
 
 	var executeErr error
 	switch operation.Kind {
-	case OperationKindRefreshCatalog:
-		executeErr = application.executeRefresh(executionContext, operation)
 	case OperationKindInstall:
-		executeErr = application.executeInstall(executionContext, operation)
+		if wasOutcomeUnknown {
+			executeErr = application.recoverInstallOutcome(executionContext, operation)
+		} else {
+			executeErr = application.executeInstall(executionContext, operation)
+		}
 	case OperationKindUninstall:
-		executeErr = application.executeUninstall(executionContext, operation)
+		if wasOutcomeUnknown {
+			executeErr = application.recoverUninstallOutcome(executionContext, operation)
+		} else {
+			executeErr = application.executeUninstall(executionContext, operation)
+		}
 	case OperationKindReconcileRuntime:
 		executeErr = application.executeRuntimeReconcile(executionContext, operation)
 	case OperationKindDisconnectAuthorization:
@@ -655,13 +648,19 @@ func (application *Application) executeOperation(ctx context.Context, operationI
 		executeErr = invalidRequest(fmt.Sprintf("operation kind %q is not executable", operation.Kind))
 	}
 	if executeErr != nil {
-		code := ErrorCodeInstallFailed
-		if operation.Kind == OperationKindRefreshCatalog {
-			code = errorCodeOr(executeErr, ErrorCodeUpstreamUnavailable)
+		if errors.Is(executeErr, ErrOperationOutcomeUnknown) {
+			unknownContext, cancelUnknown := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+			unknownErr := application.markOperationOutcomeUnknown(unknownContext, operation.OperationID)
+			cancelUnknown()
+			if unknownErr != nil {
+				return errors.Join(executeErr, fmt.Errorf("record unknown connector operation outcome: %w", unknownErr))
+			}
+			return executeErr
 		}
+		code := errorCodeOr(executeErr, ErrorCodeInstallFailed)
 		if operation.Kind == OperationKindStartAuthorization ||
 			operation.Kind == OperationKindDisconnectAuthorization {
-			code = ErrorCodeAuthorizationFailed
+			code = errorCodeOr(executeErr, ErrorCodeAuthorizationFailed)
 		}
 		terminalContext, cancelTerminal := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 		terminalErr := application.failOperation(terminalContext, operation.OperationID, code)
@@ -672,6 +671,28 @@ func (application *Application) executeOperation(ctx context.Context, operationI
 		return executeErr
 	}
 	return nil
+}
+
+func (application *Application) markOperationOutcomeUnknown(ctx context.Context, operationID string) error {
+	return application.config.Repository.Transaction(ctx, func(tx Transaction) error {
+		operation, err := tx.Operation(operationID)
+		if err != nil {
+			return err
+		}
+		if operation.State.IsTerminal() {
+			return nil
+		}
+		now := application.config.Now().UTC()
+		nextAttempt := now.Add(time.Second)
+		operation.State = OperationStateOutcomeUnknown
+		operation.NextAttemptAt = &nextAttempt
+		operation.UpdatedAt = now
+		if err := tx.SaveOperation(operation); err != nil {
+			return err
+		}
+		revision := tx.AdvanceRevision()
+		return tx.EnqueueConnectorMarketChanged(ChangedEvent{ConnectorKey: operation.ConnectorKey, OperationID: operation.OperationID, Revision: revision})
+	})
 }
 
 func (application *Application) renewOperationLease(ctx context.Context, cancel context.CancelFunc, operation Operation, done chan<- error) {
@@ -757,9 +778,17 @@ func (application *Application) adoptRuntimeOperation(ctx context.Context, opera
 			adopted = operation
 			return nil
 		}
+		connector, err := tx.Connector(operation.ConnectorKey)
+		if err != nil {
+			return err
+		}
 		revision := tx.AdvanceRevision()
-		operation.HostGeneration = HostGeneration{BootEpoch: application.config.BootEpoch, Generation: revision}
+		connector.Revision++
+		operation.HostGeneration = HostGeneration{BootEpoch: application.config.BootEpoch, Generation: connector.Revision}
 		operation.UpdatedAt = application.config.Now().UTC()
+		if err := tx.SaveConnector(connector); err != nil {
+			return err
+		}
 		if err := tx.SaveOperation(operation); err != nil {
 			return err
 		}
@@ -781,14 +810,18 @@ func (application *Application) acceptConnectorOperation(
 	if err := validateConnectorMutation(mutation); err != nil {
 		return MutationResult{}, err
 	}
+	scope, err := application.resolveOperationScope(ctx, mutation.AccountID)
+	if err != nil {
+		return MutationResult{}, err
+	}
 	var result MutationResult
-	err := application.config.Repository.Transaction(ctx, func(tx Transaction) error {
+	err = application.config.Repository.Transaction(ctx, func(tx Transaction) error {
 		existing, err := tx.OperationByClientRequestID(mutation.ClientRequestID)
 		if err != nil {
 			return err
 		}
 		if existing != nil {
-			if err := verifyIdempotentOperation(*existing, kind, mutation.ConnectorKey, mutation.AccountID); err != nil {
+			if err := verifyIdempotentOperation(*existing, kind, scope, mutation.ConnectorKey); err != nil {
 				return err
 			}
 			connector, err := tx.Connector(mutation.ConnectorKey)
@@ -798,14 +831,14 @@ func (application *Application) acceptConnectorOperation(
 			result = MutationResult{Connector: &connector, Operation: *existing, Revision: tx.Revision()}
 			return nil
 		}
-		if err := verifyRevision(tx, mutation.ExpectedRevision); err != nil {
-			return err
-		}
-		if err := rejectActiveOperation(tx, mutation.ConnectorKey); err != nil {
+		if err := rejectActiveOperation(tx, kind, scope, mutation.ConnectorKey); err != nil {
 			return err
 		}
 		connector, err := tx.Connector(mutation.ConnectorKey)
 		if err != nil {
+			return err
+		}
+		if err := verifyConnectorRevision(connector, mutation.ExpectedRevision); err != nil {
 			return err
 		}
 		connector, err = transition(connector)
@@ -818,13 +851,15 @@ func (application *Application) acceptConnectorOperation(
 		if err != nil {
 			return NewDomainError(ErrorCodeUnavailable, "connector operation id could not be generated", true, err)
 		}
-		connector.Revision = revision
+		connector.Revision++
 		operation := Operation{
 			OperationID:     operationID,
 			ClientRequestID: mutation.ClientRequestID,
 			ConnectorKey:    mutation.ConnectorKey,
 			Kind:            kind,
-			Scope:           OperationScope{AccountID: strings.TrimSpace(mutation.AccountID)},
+			Scope:           scope,
+			LockClaims:      OperationLockClaims(kind, scope, mutation.ConnectorKey),
+			RequestDigest:   OperationRequestDigest(kind, scope, mutation.ConnectorKey, nil),
 			State:           OperationStateAccepted,
 			Stage:           OperationStageAccepted,
 			Target:          operationTarget(kind, connector),
@@ -832,7 +867,7 @@ func (application *Application) acceptConnectorOperation(
 			UpdatedAt:       now,
 		}
 		if kind == OperationKindInstall || kind == OperationKindUninstall || kind == OperationKindReconcileRuntime {
-			operation.HostGeneration = HostGeneration{BootEpoch: application.config.BootEpoch, Generation: revision}
+			operation.HostGeneration = HostGeneration{BootEpoch: application.config.BootEpoch, Generation: connector.Revision}
 		}
 		if err := tx.SaveConnector(connector); err != nil {
 			return err
@@ -873,8 +908,12 @@ func (application *Application) isIdempotentConnectorOperation(
 	mutation ConnectorMutation,
 	kind OperationKind,
 ) (bool, error) {
+	scope, err := application.resolveOperationScope(ctx, mutation.AccountID)
+	if err != nil {
+		return false, err
+	}
 	var replay bool
-	err := application.config.Repository.Transaction(ctx, func(tx Transaction) error {
+	err = application.config.Repository.Transaction(ctx, func(tx Transaction) error {
 		existing, err := tx.OperationByClientRequestID(mutation.ClientRequestID)
 		if err != nil {
 			return err
@@ -882,7 +921,7 @@ func (application *Application) isIdempotentConnectorOperation(
 		if existing == nil {
 			return nil
 		}
-		if err := verifyIdempotentOperation(*existing, kind, mutation.ConnectorKey, mutation.AccountID); err != nil {
+		if err := verifyIdempotentOperation(*existing, kind, scope, mutation.ConnectorKey); err != nil {
 			return err
 		}
 		replay = true
@@ -891,77 +930,23 @@ func (application *Application) isIdempotentConnectorOperation(
 	return replay, err
 }
 
-func (application *Application) acceptOperation(
-	ctx context.Context,
-	mutation Mutation,
-	kind OperationKind,
-	connectorKey string,
-) (MutationResult, error) {
-	if err := validateMutation(mutation); err != nil {
-		return MutationResult{}, err
+func (application *Application) resolveOperationScope(ctx context.Context, accountID string) (OperationScope, error) {
+	accountID = strings.TrimSpace(accountID)
+	scope := OperationScope{AccountID: accountID, DeviceID: application.config.DeviceID, DesktopBootEpoch: application.config.BootEpoch}
+	if application.config.OperationScopes == nil {
+		return scope, nil
 	}
-	var result MutationResult
-	err := application.config.Repository.Transaction(ctx, func(tx Transaction) error {
-		existing, err := tx.OperationByClientRequestID(mutation.ClientRequestID)
-		if err != nil {
-			return err
-		}
-		if existing != nil {
-			if err := verifyIdempotentOperation(*existing, kind, connectorKey, ""); err != nil {
-				return err
-			}
-			result = MutationResult{Operation: *existing, Revision: tx.Revision()}
-			return nil
-		}
-		if err := verifyRevision(tx, mutation.ExpectedRevision); err != nil {
-			return err
-		}
-		if err := rejectActiveOperation(tx, connectorKey); err != nil {
-			return err
-		}
-		now := application.config.Now().UTC()
-		revision := tx.AdvanceRevision()
-		operationID, err := application.config.NewID()
-		if err != nil {
-			return NewDomainError(ErrorCodeUnavailable, "connector operation id could not be generated", true, err)
-		}
-		operation := Operation{
-			OperationID:     operationID,
-			ClientRequestID: mutation.ClientRequestID,
-			ConnectorKey:    connectorKey,
-			Kind:            kind,
-			State:           OperationStateAccepted,
-			Stage:           OperationStageAccepted,
-			CreatedAt:       now,
-			UpdatedAt:       now,
-		}
-		if kind == OperationKindRefreshCatalog {
-			if err := tx.SetCatalogState(CatalogStateRefreshing); err != nil {
-				return err
-			}
-		}
-		if err := tx.SaveOperation(operation); err != nil {
-			return err
-		}
-		if err := tx.EnqueueConnectorMarketChanged(ChangedEvent{
-			ConnectorKey: connectorKey,
-			OperationID:  operation.OperationID,
-			Revision:     revision,
-		}); err != nil {
-			return err
-		}
-		result = MutationResult{Operation: operation, Revision: revision}
-		return nil
-	})
+	resolved, err := application.config.OperationScopes.ResolveOperationScope(ctx, accountID)
 	if err != nil {
-		return MutationResult{}, err
+		return OperationScope{}, NewDomainError(ErrorCodeUnavailable, "connector execution authority could not be frozen", true, err)
 	}
-	if result.Operation.State == OperationStateAccepted || result.Operation.State == OperationStateRunning {
-		if err := application.config.Scheduler.Schedule(ctx, result.Operation.OperationID); err != nil {
-			return MutationResult{}, NewDomainError(ErrorCodeUnavailable, "connector operation could not be scheduled", true, err)
-		}
+	if strings.TrimSpace(resolved.AccountID) != accountID || resolved.AccountGeneration == 0 ||
+		strings.TrimSpace(resolved.VMAssignmentID) == "" || strings.TrimSpace(resolved.GuestBootID) == "" || strings.TrimSpace(resolved.RuntimeEpoch) == "" {
+		return OperationScope{}, invalidOperationReceipt("operation scope resolver returned incomplete execution authority")
 	}
-	return result, nil
+	resolved.DeviceID = application.config.DeviceID
+	resolved.DesktopBootEpoch = application.config.BootEpoch
+	return resolved, nil
 }
 
 func validateMutation(mutation Mutation) error {
@@ -981,28 +966,30 @@ func validateConnectorMutation(mutation ConnectorMutation) error {
 	return nil
 }
 
-func verifyRevision(tx Transaction, expected uint64) error {
-	if tx.Revision() == expected {
+func verifyConnectorRevision(connector Connector, expected uint64) error {
+	if connector.Revision == expected {
 		return nil
 	}
 	return NewDomainError(
 		ErrorCodeRevisionConflict,
-		fmt.Sprintf("expected revision %d but current revision is %d", expected, tx.Revision()),
+		fmt.Sprintf("expected connector revision %d but current connector revision is %d", expected, connector.Revision),
 		true,
 		nil,
 	)
 }
 
-func verifyIdempotentOperation(operation Operation, kind OperationKind, connectorKey, accountID string) error {
+func verifyIdempotentOperation(operation Operation, kind OperationKind, scope OperationScope, connectorKey string) error {
+	expectedDigest := OperationRequestDigest(kind, scope, connectorKey, nil)
 	if operation.Kind != kind || operation.ConnectorKey != connectorKey ||
-		operation.Scope.AccountID != strings.TrimSpace(accountID) {
+		operation.Scope.AccountID != scope.AccountID || operation.Scope.DeviceID != scope.DeviceID ||
+		operation.RequestDigest != expectedDigest {
 		return invalidRequest("clientRequestId was already used for a different connector-market command")
 	}
 	return nil
 }
 
-func rejectActiveOperation(tx Transaction, connectorKey string) error {
-	active, err := tx.ActiveOperation(connectorKey)
+func rejectActiveOperation(tx Transaction, kind OperationKind, scope OperationScope, connectorKey string) error {
+	active, err := tx.ActiveOperation(kind, scope, connectorKey)
 	if err != nil {
 		return err
 	}

--- a/packages/connector/host/application_execution.go
+++ b/packages/connector/host/application_execution.go
@@ -1,3 +1,5 @@
+//revive:disable:file-length-limit
+
 package host
 
 import (
@@ -9,13 +11,40 @@ import (
 	"time"
 )
 
-func (application *Application) executeRefresh(ctx context.Context, operation Operation) error {
-	if _, err := application.updateOperationStage(ctx, operation.OperationID, OperationStageRefreshing, nil); err != nil {
-		return err
+// SyncCatalog replaces the complete local Last-Known-Good snapshot without
+// entering the connector operation/claim subsystem. Catalog has its own
+// revision and serialization boundary; a failed pull leaves the previous
+// snapshot and connector projection intact.
+func (application *Application) SyncCatalog(ctx context.Context) error {
+	application.catalogMu.Lock()
+	if current := application.catalogSync; current != nil {
+		application.catalogMu.Unlock()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-current.done:
+			return current.err
+		}
 	}
+	execution := &catalogSyncExecution{done: make(chan struct{})}
+	application.catalogSync = execution
+	application.catalogMu.Unlock()
+
+	execution.err = application.syncCatalogOnce(ctx)
+	application.catalogMu.Lock()
+	application.catalogSync = nil
+	close(execution.done)
+	application.catalogMu.Unlock()
+	return execution.err
+}
+
+func (application *Application) syncCatalogOnce(ctx context.Context) error {
 	catalog, err := application.config.CatalogSource.Refresh(ctx)
 	if err != nil {
 		return preserveCatalogSourceError("connector catalog refresh failed", err)
+	}
+	if err := validateCatalogSnapshot(catalog); err != nil {
+		return err
 	}
 	for _, release := range catalog.Releases {
 		if err := ValidateReleaseShape(release); err != nil {
@@ -25,11 +54,15 @@ func (application *Application) executeRefresh(ctx context.Context, operation Op
 			return invalidManifest("active catalog releases must have available status", nil)
 		}
 	}
-	err = application.config.Repository.Transaction(ctx, func(tx Transaction) error {
-		storedOperation, err := tx.Operation(operation.OperationID)
-		if err != nil {
-			return err
-		}
+	current, currentErr := application.config.Repository.CatalogSnapshot(ctx)
+	if currentErr == nil && current.CatalogRevision == catalog.CatalogRevision &&
+		current.SnapshotDigest == catalog.SnapshotDigest && current.SourceRevision == catalog.SourceRevision {
+		return nil
+	}
+	if currentErr != nil && !errors.Is(currentErr, ErrNotFound) {
+		return currentErr
+	}
+	return application.config.Repository.Transaction(ctx, func(tx Transaction) error {
 		existing, err := tx.Connectors()
 		if err != nil {
 			return err
@@ -48,12 +81,12 @@ func (application *Application) executeRefresh(ctx context.Context, operation Op
 			}
 			connector.Authorization = authorizationForManifest(connector.Authorization, release.Manifest.AuthorizationKind)
 			connector.Release = release
-			compatibility, err := application.compatibilityFor(release.Manifest)
-			if err != nil {
-				return err
+			connector.Security = securityForInstallation(catalog, connector.Installation)
+			compatibility, compatibilityErr := application.compatibilityFor(release.Manifest)
+			if compatibilityErr != nil {
+				return compatibilityErr
 			}
 			connector.Compatibility = compatibility
-			connector.Revision = revision
 			if err := tx.SaveConnector(connector); err != nil {
 				return err
 			}
@@ -68,34 +101,70 @@ func (application *Application) executeRefresh(ctx context.Context, operation Op
 				}
 				continue
 			}
-			connector.Compatibility = Compatibility{
-				State:  CompatibilityStateUnsupportedVersion,
-				Reason: "removed_from_catalog",
-			}
-			connector.Revision = revision
+			connector.Compatibility = Compatibility{State: CompatibilityStateUnsupportedVersion, Reason: "removed_from_catalog"}
+			connector.Security = securityForInstallation(catalog, connector.Installation)
 			if err := tx.SaveConnector(connector); err != nil {
 				return err
 			}
 		}
-		storedOperation.State = OperationStateCompleted
-		storedOperation.Stage = OperationStageCompleted
-		storedOperation.UpdatedAt = application.config.Now().UTC()
-		if err := tx.SaveOperation(storedOperation); err != nil {
+		if err := tx.SaveCatalogRevision(catalog.SourceRevision); err != nil {
 			return err
 		}
-		if err := tx.SaveCatalogRevision(catalog.SourceRevision); err != nil {
+		if err := tx.SaveCatalogSnapshot(catalog); err != nil {
 			return err
 		}
 		if err := tx.SetCatalogState(CatalogStateReady); err != nil {
 			return err
 		}
-		return tx.EnqueueConnectorMarketChanged(ChangedEvent{
-			OperationID: storedOperation.OperationID,
-			Revision:    revision,
-		})
+		return tx.EnqueueConnectorMarketChanged(ChangedEvent{Revision: revision})
 	})
-	if err != nil {
-		return err
+}
+
+func validateCatalogSnapshot(catalog CatalogSnapshot) error {
+	if catalog.CatalogRevision == 0 || !remoteBindingContractHashPattern.MatchString(catalog.SnapshotDigest) ||
+		strings.TrimSpace(catalog.SourceRevision) == "" {
+		return invalidManifest("connector catalog snapshot identity is invalid", nil)
+	}
+	categories := make(map[string]struct{}, len(catalog.Categories))
+	for _, category := range catalog.Categories {
+		if strings.TrimSpace(category.CategoryID) == "" ||
+			(category.Kind != "category" && category.Kind != "featured") || category.ItemCount < 0 {
+			return invalidManifest("connector catalog snapshot category is invalid", nil)
+		}
+		if _, duplicate := categories[category.CategoryID]; duplicate {
+			return invalidManifest("connector catalog snapshot contains duplicate categories", nil)
+		}
+		categories[category.CategoryID] = struct{}{}
+	}
+	releases := make(map[string]Release, len(catalog.Releases))
+	for _, release := range catalog.Releases {
+		if err := ValidateReleaseShape(release); err != nil {
+			return err
+		}
+		if _, duplicate := releases[release.ConnectorKey]; duplicate {
+			return invalidManifest("connector catalog snapshot contains conflicting active releases", nil)
+		}
+		releases[release.ConnectorKey] = release
+	}
+	for _, entry := range catalog.Entries {
+		if _, exists := categories[entry.CategoryID]; !exists {
+			return invalidManifest("connector catalog snapshot entry category is unknown", nil)
+		}
+		if release, exists := releases[entry.Release.ConnectorKey]; !exists || release.ReleaseDigest != entry.Release.ReleaseDigest {
+			return invalidManifest("connector catalog snapshot entry release is unknown", nil)
+		}
+	}
+	revocations := make(map[string]struct{}, len(catalog.Revocations))
+	for _, revocation := range catalog.Revocations {
+		if !remoteBindingContractHashPattern.MatchString(revocation.ArtifactDigest) ||
+			strings.TrimSpace(revocation.RevocationID) == "" || strings.TrimSpace(revocation.ReasonCode) == "" ||
+			revocation.EffectiveAt.IsZero() {
+			return invalidManifest("connector catalog snapshot revocation is invalid", nil)
+		}
+		if _, duplicate := revocations[revocation.RevocationID]; duplicate {
+			return invalidManifest("connector catalog snapshot contains duplicate revocations", nil)
+		}
+		revocations[revocation.RevocationID] = struct{}{}
 	}
 	return nil
 }
@@ -105,6 +174,9 @@ func (application *Application) executeInstall(ctx context.Context, operation Op
 	if err != nil {
 		return err
 	}
+	if err := application.rejectRevokedRelease(ctx, release); err != nil {
+		return err
+	}
 	if err := application.config.ImplementationRegistry.Validate(release.Manifest); err != nil {
 		return err
 	}
@@ -112,7 +184,7 @@ func (application *Application) executeInstall(ctx context.Context, operation Op
 	if err != nil {
 		return err
 	}
-	installed, installErr := application.config.ReleaseInstallations.InstallRelease(ctx, InstallReleaseRequest{
+	installed, installErr := application.config.ReleaseInstallations.PrepareReleaseInstallation(ctx, PrepareReleaseInstallationRequest{
 		OperationID: operation.OperationID,
 		Scope:       operation.Scope,
 		Generation:  operation.HostGeneration,
@@ -124,6 +196,9 @@ func (application *Application) executeInstall(ctx context.Context, operation Op
 	if err := validateReleaseInstallationReceipt(operation, release, installed); err != nil {
 		return err
 	}
+	if err := application.rejectRevokedRelease(ctx, release); err != nil {
+		return err
+	}
 	operation, err = application.updateOperationStage(
 		ctx,
 		operation.OperationID,
@@ -133,26 +208,48 @@ func (application *Application) executeInstall(ctx context.Context, operation Op
 	if err != nil {
 		return err
 	}
-	// The physical owner must publish the verified installation before the
-	// repository projects installed. If desktopd crashes after this commit but
-	// before the transaction below, bootstrap calibration sees an extra physical
-	// installation and the user can safely retry. The inverse ordering can leave
-	// durable installed truth pointing at an uncommitted VM candidate.
-	if err := application.config.ReleaseInstallations.CommitReleaseInstallation(ctx, CommitReleaseInstallationRequest{
+	// Activate switches execution to the candidate but must retain the previous
+	// active release as a rollback slot. The operation claim remains held until
+	// repository projection and Finalize both succeed.
+	transition := ReleaseInstallationTransitionRequest{
 		OperationID: operation.OperationID, Scope: operation.Scope, Generation: operation.HostGeneration,
 		Release: release, Receipt: installed,
-	}); err != nil {
-		return NewDomainError(ErrorCodeInstallFailed, "connector release installation commit failed", true, err)
 	}
-	if err := application.completeConnectorOperation(ctx, operation.OperationID, func(connector Connector) Connector {
+	if err := application.config.ReleaseInstallations.ActivateReleaseInstallation(ctx, transition); err != nil {
+		return NewDomainError(ErrorCodeInstallFailed, "connector release installation activation failed", true, err)
+	}
+	if _, err := application.updateOperationStage(ctx, operation.OperationID, OperationStageActivated, nil); err != nil {
+		return err
+	}
+	if err := application.projectConnectorOperation(ctx, operation.OperationID, func(connector Connector) Connector {
 		connector.Installation = Installation{
-			State:                  InstallationStateInstalled,
-			InstalledVersion:       release.Version,
-			InstalledReleaseID:     release.ReleaseID,
-			InstalledReleaseDigest: release.ReleaseDigest,
+			State:                   InstallationStateInstalled,
+			InstalledVersion:        release.Version,
+			InstalledReleaseID:      release.ReleaseID,
+			InstalledReleaseDigest:  release.ReleaseDigest,
+			InstalledArtifactSHA256: release.Artifact.SHA256,
 		}
+		connector.Security = Security{State: SecurityStateAllowed}
 		return connector
 	}); err != nil {
+		projected, inspectErr := application.installationProjectionMatches(ctx, operation.ConnectorKey, release.ReleaseDigest)
+		if inspectErr != nil {
+			return OutcomeUnknown(errors.Join(err, inspectErr))
+		}
+		if !projected {
+			if abortErr := application.config.ReleaseInstallations.AbortReleaseInstallation(context.WithoutCancel(ctx), transition); abortErr != nil {
+				return OutcomeUnknown(errors.Join(err, abortErr))
+			}
+			return err
+		}
+	}
+	if _, err := application.updateOperationStage(ctx, operation.OperationID, OperationStageFinalizing, nil); err != nil {
+		return err
+	}
+	if err := application.config.ReleaseInstallations.FinalizeReleaseInstallation(ctx, transition); err != nil {
+		return NewDomainError(ErrorCodeInstallFailed, "connector release installation finalization failed", true, err)
+	}
+	if err := application.completeProjectedConnectorOperation(ctx, operation.OperationID); err != nil {
 		return err
 	}
 	// Runtime publication is a distinct durable operation. Failure to enqueue it
@@ -162,16 +259,102 @@ func (application *Application) executeInstall(ctx context.Context, operation Op
 	return nil
 }
 
-func (application *Application) schedulePostInstallRuntimeReconcile(ctx context.Context, operation Operation) error {
-	connector, err := application.config.Repository.Connector(ctx, operation.ConnectorKey)
+func (application *Application) rejectRevokedRelease(ctx context.Context, release Release) error {
+	snapshot, err := application.config.Repository.CatalogSnapshot(ctx)
+	if err != nil {
+		return NewDomainError(ErrorCodeUnavailable, "connector catalog snapshot is unavailable", true, err)
+	}
+	if catalogRevokesRelease(snapshot, release) {
+		return NewDomainError(ErrorCodeReleaseRevoked, "connector release is revoked", false, nil)
+	}
+	return nil
+}
+
+func catalogRevokesRelease(snapshot CatalogSnapshot, release Release) bool {
+	digest := "sha256:" + strings.ToLower(strings.TrimSpace(release.Artifact.SHA256))
+	for _, revocation := range snapshot.Revocations {
+		if strings.EqualFold(strings.TrimSpace(revocation.ArtifactDigest), digest) {
+			return true
+		}
+	}
+	return false
+}
+
+func securityForInstallation(snapshot CatalogSnapshot, installation Installation) Security {
+	artifactSHA := strings.ToLower(strings.TrimSpace(installation.InstalledArtifactSHA256))
+	if artifactSHA == "" {
+		return Security{State: SecurityStateAllowed}
+	}
+	for _, revocation := range snapshot.Revocations {
+		if strings.EqualFold(strings.TrimSpace(revocation.ArtifactDigest), "sha256:"+artifactSHA) {
+			return Security{State: SecurityStateRevoked, RevocationID: revocation.RevocationID, ReasonCode: revocation.ReasonCode}
+		}
+	}
+	return Security{State: SecurityStateAllowed}
+}
+
+func (application *Application) recoverInstallOutcome(ctx context.Context, operation Operation) error {
+	release, err := frozenRelease(operation)
 	if err != nil {
 		return err
 	}
-	_, err = application.ReconcileRuntime(ctx, ConnectorMutation{
-		Mutation:     Mutation{ClientRequestID: operation.ClientRequestID + "/runtime", ExpectedRevision: connector.Revision},
-		ConnectorKey: operation.ConnectorKey,
-		AccountID:    operation.Scope.AccountID,
+	observation, err := application.config.ReleaseInstallations.InspectReleaseInstallation(ctx, InspectReleaseInstallationRequest{
+		OperationID: operation.OperationID, Scope: operation.Scope, Generation: operation.HostGeneration, Release: release,
 	})
+	if err != nil {
+		return OutcomeUnknown(err)
+	}
+	if observation.ConnectorKey != release.ConnectorKey || observation.ReleaseDigest != release.ReleaseDigest {
+		return invalidOperationReceipt("installation inspection returned a mismatched release")
+	}
+	switch observation.State {
+	case ReleaseInstallationPresent:
+		if err := application.rejectRevokedRelease(ctx, release); err != nil {
+			return err
+		}
+		if observation.Receipt == nil {
+			return invalidOperationReceipt("installation inspection returned no receipt")
+		}
+		if err := validateReleaseInstallationReceipt(operation, release, *observation.Receipt); err != nil {
+			return err
+		}
+		if _, err := application.updateOperationStage(ctx, operation.OperationID, OperationStageInstalled, func(current *Operation) {
+			current.Execution.ReleaseInstallation = observation.Receipt
+		}); err != nil {
+			return err
+		}
+		transition := ReleaseInstallationTransitionRequest{
+			OperationID: operation.OperationID, Scope: operation.Scope, Generation: operation.HostGeneration,
+			Release: release, Receipt: *observation.Receipt,
+		}
+		if err := application.config.ReleaseInstallations.ActivateReleaseInstallation(ctx, transition); err != nil {
+			return OutcomeUnknown(err)
+		}
+		if err := application.projectConnectorOperation(ctx, operation.OperationID, func(connector Connector) Connector {
+			connector.Installation = Installation{State: InstallationStateInstalled, InstalledVersion: release.Version, InstalledReleaseID: release.ReleaseID,
+				InstalledReleaseDigest: release.ReleaseDigest, InstalledArtifactSHA256: release.Artifact.SHA256}
+			connector.Security = Security{State: SecurityStateAllowed}
+			return connector
+		}); err != nil {
+			return OutcomeUnknown(err)
+		}
+		if err := application.config.ReleaseInstallations.FinalizeReleaseInstallation(ctx, transition); err != nil {
+			return OutcomeUnknown(err)
+		}
+		return application.completeProjectedConnectorOperation(ctx, operation.OperationID)
+	case ReleaseInstallationAbsent:
+		return application.executeInstall(ctx, operation)
+	case ReleaseInstallationIndeterminate:
+		return OutcomeUnknown(errors.New(observation.ReasonCode))
+	case ReleaseInstallationInvalid:
+		return NewDomainError(ErrorCodeInstallFailed, "connector release installation is invalid", false, errors.New(observation.ReasonCode))
+	default:
+		return invalidOperationReceipt("installation inspection returned an invalid state")
+	}
+}
+
+func (application *Application) schedulePostInstallRuntimeReconcile(ctx context.Context, operation Operation) error {
+	_, err := application.EnsureRuntimeReconcile(ctx, operation.Scope, operation.ConnectorKey)
 	return err
 }
 
@@ -226,6 +409,34 @@ func (application *Application) executeUninstall(ctx context.Context, operation 
 	return application.completeUninstall(ctx, operation.OperationID)
 }
 
+func (application *Application) recoverUninstallOutcome(ctx context.Context, operation Operation) error {
+	release, err := frozenRelease(operation)
+	if err != nil {
+		return err
+	}
+	observation, err := application.config.ReleaseInstallations.InspectReleaseInstallation(ctx, InspectReleaseInstallationRequest{
+		OperationID: operation.OperationID, Scope: operation.Scope, Generation: operation.HostGeneration, Release: release,
+	})
+	if err != nil {
+		return OutcomeUnknown(err)
+	}
+	if observation.ConnectorKey != release.ConnectorKey || observation.ReleaseDigest != release.ReleaseDigest {
+		return invalidOperationReceipt("uninstall inspection returned a mismatched release")
+	}
+	switch observation.State {
+	case ReleaseInstallationAbsent:
+		return application.completeUninstall(ctx, operation.OperationID)
+	case ReleaseInstallationPresent:
+		return application.executeUninstall(ctx, operation)
+	case ReleaseInstallationIndeterminate:
+		return OutcomeUnknown(errors.New(observation.ReasonCode))
+	case ReleaseInstallationInvalid:
+		return NewDomainError(ErrorCodeInstallFailed, "connector release installation is invalid", false, errors.New(observation.ReasonCode))
+	default:
+		return invalidOperationReceipt("uninstall inspection returned an invalid state")
+	}
+}
+
 func (application *Application) completeUninstall(ctx context.Context, operationID string) error {
 	return application.config.Repository.Transaction(ctx, func(tx Transaction) error {
 		operation, err := tx.Operation(operationID)
@@ -245,9 +456,13 @@ func (application *Application) completeUninstall(ctx context.Context, operation
 		// a separate lifecycle: remote authorization is projected from the account
 		// snapshot, while local providers are disconnected only through the explicit
 		// DisconnectAuthorization operation.
-		connector.Revision = revision
+		connector.Revision++
+		now := application.config.Now().UTC()
 		operation.State, operation.Stage, operation.FailureCode = OperationStateCompleted, OperationStageCompleted, ""
-		operation.UpdatedAt = application.config.Now().UTC()
+		operation.NextAttemptAt = nil
+		operation.FinishedAt = &now
+		operation.TerminalAt = &now
+		operation.UpdatedAt = now
 		if err := tx.SaveConnector(connector); err != nil {
 			return err
 		}
@@ -456,9 +671,14 @@ func (application *Application) markOperationRunning(ctx context.Context, operat
 			return nil
 		}
 		revision := tx.AdvanceRevision()
+		now := application.config.Now().UTC()
 		operation.State = OperationStateRunning
 		operation.Attempt++
-		operation.UpdatedAt = application.config.Now().UTC()
+		operation.NextAttemptAt = nil
+		if operation.StartedAt == nil {
+			operation.StartedAt = &now
+		}
+		operation.UpdatedAt = now
 		if err := tx.SaveOperation(operation); err != nil {
 			return err
 		}
@@ -533,9 +753,54 @@ func (application *Application) completeConnectorOperation(
 		}
 		revision := tx.AdvanceRevision()
 		connector = update(connector)
-		connector.Revision = revision
+		connector.Revision++
+		now := application.config.Now().UTC()
 		operation.State = OperationStateCompleted
 		operation.Stage = OperationStageCompleted
+		operation.FailureCode = ""
+		operation.NextAttemptAt = nil
+		operation.FinishedAt = &now
+		operation.TerminalAt = &now
+		operation.UpdatedAt = now
+		if err := tx.SaveConnector(connector); err != nil {
+			return err
+		}
+		if err := tx.SaveOperation(operation); err != nil {
+			return err
+		}
+		return tx.EnqueueConnectorMarketChanged(ChangedEvent{
+			ConnectorKey: connector.Key,
+			OperationID:  operation.OperationID,
+			Revision:     revision,
+		})
+	})
+}
+
+// projectConnectorOperation commits business truth while deliberately keeping
+// the physical execution claim. The caller must Finalize the physical
+// transition before completing the operation and releasing that claim.
+func (application *Application) projectConnectorOperation(
+	ctx context.Context,
+	operationID string,
+	update func(Connector) Connector,
+) error {
+	return application.config.Repository.Transaction(ctx, func(tx Transaction) error {
+		operation, err := tx.Operation(operationID)
+		if err != nil {
+			return err
+		}
+		if operation.State == OperationStateCompleted {
+			return nil
+		}
+		connector, err := tx.Connector(operation.ConnectorKey)
+		if err != nil {
+			return err
+		}
+		revision := tx.AdvanceRevision()
+		connector = update(connector)
+		connector.Revision++
+		operation.State = OperationStateRunning
+		operation.Stage = OperationStageActivated
 		operation.FailureCode = ""
 		operation.UpdatedAt = application.config.Now().UTC()
 		if err := tx.SaveConnector(connector); err != nil {
@@ -546,6 +811,47 @@ func (application *Application) completeConnectorOperation(
 		}
 		return tx.EnqueueConnectorMarketChanged(ChangedEvent{
 			ConnectorKey: connector.Key,
+			OperationID:  operation.OperationID,
+			Revision:     revision,
+		})
+	})
+}
+
+func (application *Application) installationProjectionMatches(
+	ctx context.Context,
+	connectorKey, releaseDigest string,
+) (bool, error) {
+	connector, err := application.config.Repository.Connector(ctx, connectorKey)
+	if err != nil {
+		return false, err
+	}
+	return connector.Installation.State == InstallationStateInstalled &&
+		connector.Installation.InstalledReleaseDigest == releaseDigest, nil
+}
+
+func (application *Application) completeProjectedConnectorOperation(ctx context.Context, operationID string) error {
+	return application.config.Repository.Transaction(ctx, func(tx Transaction) error {
+		operation, err := tx.Operation(operationID)
+		if err != nil {
+			return err
+		}
+		if operation.State == OperationStateCompleted {
+			return nil
+		}
+		revision := tx.AdvanceRevision()
+		now := application.config.Now().UTC()
+		operation.State = OperationStateCompleted
+		operation.Stage = OperationStageCompleted
+		operation.FailureCode = ""
+		operation.NextAttemptAt = nil
+		operation.FinishedAt = &now
+		operation.TerminalAt = &now
+		operation.UpdatedAt = now
+		if err := tx.SaveOperation(operation); err != nil {
+			return err
+		}
+		return tx.EnqueueConnectorMarketChanged(ChangedEvent{
+			ConnectorKey: operation.ConnectorKey,
 			OperationID:  operation.OperationID,
 			Revision:     revision,
 		})
@@ -578,10 +884,16 @@ func (application *Application) completeAuthorizationStart(
 		if projectDeviceState {
 			connector.Authorization = Authorization{State: session.State}
 		}
-		connector.Revision = revision
+		if projectDeviceState {
+			connector.Revision++
+		}
 		if operation.State != OperationStateCompleted {
+			now := application.config.Now().UTC()
 			operation.State = OperationStateCompleted
 			operation.Stage = OperationStageCompleted
+			operation.NextAttemptAt = nil
+			operation.FinishedAt = &now
+			operation.TerminalAt = &now
 		}
 		operation.Execution.AuthorizationSession = &session
 		operation.UpdatedAt = application.config.Now().UTC()
@@ -626,7 +938,7 @@ func (application *Application) completeAuthorizationObservation(
 		}
 		revision := tx.AdvanceRevision()
 		connector.Authorization = Authorization{State: target, FailureCode: failureCode}
-		connector.Revision = revision
+		connector.Revision++
 		if err := tx.SaveConnector(connector); err != nil {
 			return err
 		}
@@ -644,16 +956,15 @@ func (application *Application) failOperation(ctx context.Context, operationID s
 			return nil
 		}
 		revision := tx.AdvanceRevision()
+		now := application.config.Now().UTC()
 		operation.State = OperationStateFailed
 		operation.Stage = OperationStageFailed
 		operation.FailureCode = string(code)
-		operation.UpdatedAt = application.config.Now().UTC()
-		if operation.Kind == OperationKindRefreshCatalog {
-			// Preserve the last-known-good connector projection on refresh failure.
-			if err := tx.SetCatalogState(CatalogStateStale); err != nil {
-				return err
-			}
-		} else if operation.ConnectorKey != "" {
+		operation.NextAttemptAt = nil
+		operation.FinishedAt = &now
+		operation.TerminalAt = &now
+		operation.UpdatedAt = now
+		if operation.ConnectorKey != "" {
 			connector, err := tx.Connector(operation.ConnectorKey)
 			if err != nil && !errors.Is(err, ErrNotFound) {
 				return err
@@ -675,7 +986,7 @@ func (application *Application) failOperation(ctx context.Context, operationID s
 					connector.Authorization.State = AuthorizationStateFailed
 					connector.Authorization.FailureCode = string(code)
 				}
-				connector.Revision = revision
+				connector.Revision++
 				if err := tx.SaveConnector(connector); err != nil {
 					return err
 				}
@@ -723,6 +1034,7 @@ func newCatalogConnector(release Release) Connector {
 		Installation:  Installation{State: InstallationStateNotInstalled},
 		Authorization: initialAuthorization(release.Manifest.AuthorizationKind),
 		Compatibility: Compatibility{State: CompatibilityStateSupported},
+		Security:      Security{State: SecurityStateAllowed},
 	}
 }
 

--- a/packages/connector/host/application_installation_calibration.go
+++ b/packages/connector/host/application_installation_calibration.go
@@ -119,7 +119,7 @@ func (application *Application) applyInstallationObservation(
 		}
 		revision := tx.AdvanceRevision()
 		connector.Installation = next
-		connector.Revision = revision
+		connector.Revision++
 		if err := tx.SaveConnector(connector); err != nil {
 			return err
 		}

--- a/packages/connector/host/application_runtime_execution.go
+++ b/packages/connector/host/application_runtime_execution.go
@@ -54,6 +54,10 @@ func (application *Application) resolveRuntimeBinding(
 		clear(binding.CredentialBrokerGrant)
 		return RuntimeBinding{}, invalidOperationReceipt("runtime binding resolver returned invalid intent")
 	}
+	if connector.Security.State == SecurityStateRevoked {
+		binding.Enabled = false
+		clear(binding.CredentialBrokerGrant)
+	}
 	return binding, nil
 }
 

--- a/packages/connector/host/application_scoped_runtime.go
+++ b/packages/connector/host/application_scoped_runtime.go
@@ -27,13 +27,20 @@ func (application *Application) EnsureRuntimeReconcile(
 ) (EnsureRuntimeReconcileResult, error) {
 	connectorKey = strings.TrimSpace(connectorKey)
 	scope.AccountID = strings.TrimSpace(scope.AccountID)
+	if application.config.OperationScopes != nil && (scope.VMAssignmentID == "" || scope.GuestBootID == "" || scope.RuntimeEpoch == "") {
+		resolved, err := application.resolveOperationScope(ctx, scope.AccountID)
+		if err != nil {
+			return EnsureRuntimeReconcileResult{}, err
+		}
+		scope = resolved
+	}
 	if connectorKey == "" {
 		return EnsureRuntimeReconcileResult{}, invalidRequest("connectorKey is required")
 	}
 	var result MutationResult
 	created := false
 	err := application.config.Repository.Transaction(ctx, func(tx Transaction) error {
-		active, err := tx.ActiveOperation(connectorKey)
+		active, err := tx.ActiveOperation(OperationKindReconcileRuntime, scope, connectorKey)
 		if err != nil {
 			return err
 		}
@@ -67,17 +74,19 @@ func (application *Application) EnsureRuntimeReconcile(
 			return NewDomainError(ErrorCodeUnavailable, "connector operation id could not be generated", true, err)
 		}
 		revision := tx.AdvanceRevision()
-		connector.Revision = revision
+		connector.Revision++
 		operation := Operation{
 			OperationID:     operationID,
 			ClientRequestID: "ensure-runtime-reconcile/" + operationID,
 			ConnectorKey:    connectorKey,
 			Kind:            OperationKindReconcileRuntime,
 			Scope:           scope,
+			LockClaims:      OperationLockClaims(OperationKindReconcileRuntime, scope, connectorKey),
+			RequestDigest:   OperationRequestDigest(OperationKindReconcileRuntime, scope, connectorKey, nil),
 			State:           OperationStateAccepted,
 			Stage:           OperationStageAccepted,
 			Target:          operationTarget(OperationKindReconcileRuntime, connector),
-			HostGeneration:  HostGeneration{BootEpoch: application.config.BootEpoch, Generation: revision},
+			HostGeneration:  HostGeneration{BootEpoch: application.config.BootEpoch, Generation: connector.Revision},
 			CreatedAt:       now,
 			UpdatedAt:       now,
 		}
@@ -195,33 +204,14 @@ func (application *Application) projectAuthorizationAndScheduleRuntime(
 	state AuthorizationState,
 	failureCode string,
 ) error {
-	remote, err := application.projectAuthorization(ctx, scope, connectorKey, connectionID, state, failureCode)
+	_, err := application.projectAuthorization(ctx, scope, connectorKey, connectionID, state, failureCode)
 	if err != nil || application.config.AuthorizationProjections == nil || strings.TrimSpace(scope.AccountID) == "" {
 		return err
 	}
 	if state == AuthorizationStatePending {
 		return nil
 	}
-	deviceSnapshot, err := application.Snapshot(ctx)
-	if err != nil {
-		return err
-	}
-	requestID, err := application.config.NewID()
-	if err != nil {
-		return err
-	}
-	requestPrefix := "authorization-projection/"
-	if remote {
-		requestPrefix = "authorization-snapshot/"
-	}
-	_, err = application.ReconcileRuntime(ctx, ConnectorMutation{
-		Mutation: Mutation{
-			ClientRequestID:  requestPrefix + requestID,
-			ExpectedRevision: deviceSnapshot.Revision,
-		},
-		ConnectorKey: strings.TrimSpace(connectorKey),
-		AccountID:    strings.TrimSpace(scope.AccountID),
-	})
+	_, err = application.EnsureRuntimeReconcile(ctx, scope, strings.TrimSpace(connectorKey))
 	return err
 }
 
@@ -442,11 +432,8 @@ func (application *Application) recordDirectRuntimeGeneration(
 		if connector.Revision >= generation {
 			return nil
 		}
-		revision := tx.Revision()
-		for revision < generation {
-			revision = tx.AdvanceRevision()
-		}
-		connector.Revision = revision
+		revision := tx.AdvanceRevision()
+		connector.Revision = generation
 		if err := tx.SaveConnector(connector); err != nil {
 			return err
 		}
@@ -457,6 +444,7 @@ func (application *Application) recordDirectRuntimeGeneration(
 			ConnectorKey:    connector.Key,
 			Kind:            OperationKindReconcileRuntime,
 			Scope:           scope,
+			RequestDigest:   OperationRequestDigest(OperationKindReconcileRuntime, scope, connector.Key, nil),
 			State:           OperationStateCompleted,
 			Stage:           OperationStageCompleted,
 			Target:          operationTarget(OperationKindReconcileRuntime, connector),

--- a/packages/connector/host/application_test.go
+++ b/packages/connector/host/application_test.go
@@ -142,7 +142,7 @@ func TestApplicationClientRequestIDIsReusableOnlyAfterTerminalRetention(t *testi
 	// A caller reusing that key after the documented window starts a new
 	// operation and must provide the current revision like any fresh command.
 	delete(repository.operations, accepted.Operation.OperationID)
-	command.ExpectedRevision = repository.revision
+	command.ExpectedRevision = repository.connectors[command.ConnectorKey].Revision
 	afterRetention, err := application.Install(context.Background(), command)
 	if err != nil {
 		t.Fatal(err)
@@ -187,7 +187,7 @@ func TestApplicationExecutesAcceptedInstall(t *testing.T) {
 func TestApplicationDoesNotProjectInstalledBeforePhysicalCommit(t *testing.T) {
 	repository := newMemoryRepository(testConnector("github"))
 	scheduler := &memoryScheduler{}
-	physicalCommitErr := errors.New("physical commit unavailable")
+	physicalCommitErr := OutcomeUnknown(errors.New("physical commit transport unavailable"))
 	installationHost := &memoryInstallRuntime{installationCommitErr: physicalCommitErr}
 	application := newTestApplication(t, repository, scheduler, installationHost, CatalogSnapshot{})
 	accepted, err := application.Install(context.Background(), ConnectorMutation{
@@ -196,8 +196,8 @@ func TestApplicationDoesNotProjectInstalledBeforePhysicalCommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := application.ExecuteOperation(context.Background(), accepted.Operation.OperationID); err == nil {
-		t.Fatal("physical commit failure was accepted")
+	if err := application.ExecuteOperation(context.Background(), accepted.Operation.OperationID); !errors.Is(err, ErrOperationOutcomeUnknown) {
+		t.Fatalf("physical commit error = %v, want unknown outcome", err)
 	}
 	connector, err := repository.Connector(context.Background(), "github")
 	if err != nil {
@@ -205,6 +205,13 @@ func TestApplicationDoesNotProjectInstalledBeforePhysicalCommit(t *testing.T) {
 	}
 	if connector.Installation.State == InstallationStateInstalled {
 		t.Fatalf("installation projected before physical commit: %#v", connector.Installation)
+	}
+	operation, err := repository.Operation(context.Background(), accepted.Operation.OperationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if operation.State != OperationStateOutcomeUnknown || operation.NextAttemptAt == nil {
+		t.Fatalf("operation after ambiguous physical commit = %#v", operation)
 	}
 }
 
@@ -560,7 +567,7 @@ func TestApplicationAuthorizationObservationReconcilesWithoutChangingInstallatio
 	expired := connected
 	expired.State = AuthorizationStateExpired
 	accepted, err = application.ObserveAuthorization(context.Background(), ConnectorMutation{
-		Mutation:     Mutation{ClientRequestID: "authorization-expired", ExpectedRevision: repository.revision},
+		Mutation:     Mutation{ClientRequestID: "authorization-expired", ExpectedRevision: repository.connectors["github"].Revision},
 		ConnectorKey: "github", AccountID: "account-1",
 	}, expired)
 	if err != nil {
@@ -696,12 +703,8 @@ func TestApplicationLocalUninstallKeepsRemoteProjectionAndReusesItAfterReinstall
 		t.Fatalf("uninstalled connector reconciles = %d, want 0", runtime.reconciles)
 	}
 
-	snapshot, err := application.Snapshot(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
 	install, err := application.Install(context.Background(), ConnectorMutation{
-		Mutation:     Mutation{ClientRequestID: "reinstall-tencent-docs", ExpectedRevision: snapshot.Revision},
+		Mutation:     Mutation{ClientRequestID: "reinstall-tencent-docs", ExpectedRevision: repository.connectors[connector.Key].Revision},
 		ConnectorKey: connector.Key, AccountID: "account-1",
 	})
 	if err != nil {
@@ -1346,18 +1349,11 @@ func TestApplicationRefreshRejectsUnknownImplementation(t *testing.T) {
 	repository := newMemoryRepository()
 	scheduler := &memoryScheduler{}
 	application := newTestApplication(t, repository, scheduler, &memoryInstallRuntime{}, CatalogSnapshot{
-		SourceRevision: "catalog-2",
-		Releases:       []Release{testReleaseWithImplementation("future-connector", "2.0.0", "future_runtime")},
+		CatalogRevision: 2, SnapshotDigest: "sha256:" + strings.Repeat("b", 64), SourceRevision: "catalog-2",
+		Releases: []Release{testReleaseWithImplementation("future-connector", "2.0.0", "future_runtime")},
 	})
-	accepted, err := application.RefreshCatalog(context.Background(), Mutation{
-		ClientRequestID:  "refresh-1",
-		ExpectedRevision: 0,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := application.ExecuteOperation(context.Background(), accepted.Operation.OperationID); err == nil {
-		t.Fatal("ExecuteOperation() expected strict manifest rejection")
+	if _, err := application.RefreshCatalog(context.Background()); err == nil {
+		t.Fatal("RefreshCatalog() expected strict manifest rejection")
 	}
 }
 
@@ -1378,14 +1374,60 @@ func TestApplicationRejectsStaleRevisionBeforeMutation(t *testing.T) {
 	}
 }
 
-func TestApplicationCatalogPageCachesNewConnectorForImmediateInstall(t *testing.T) {
-	repository := newMemoryRepository()
-	release := testReleaseWithImplementation("github", "1.0.0", ImplementationKindManagedStdio)
-	source := catalogSourceStub{page: CatalogSourcePage{
-		SectionID:     "development",
-		Entries:       []CatalogEntry{{CategoryID: "development", Release: release}},
-		NextPageToken: "next-page",
+func TestApplicationRejectsRevokedReleaseBeforeInstallAdmission(t *testing.T) {
+	connector := testConnector("github")
+	repository := newMemoryRepository(connector)
+	repository.catalogSnapshot.Revocations = []CatalogRevocation{{
+		ArtifactDigest: "sha256:" + connector.Release.Artifact.SHA256,
+		RevocationID:   "revoke-github-1", ConnectorKey: connector.Key, Version: connector.Release.Version,
+		ReasonCode: "security_incident", EffectiveAt: time.Now().UTC(),
 	}}
+	application := newTestApplication(t, repository, &memoryScheduler{}, &memoryInstallRuntime{}, CatalogSnapshot{})
+	_, err := application.Install(context.Background(), ConnectorMutation{
+		Mutation: Mutation{ClientRequestID: "install-revoked", ExpectedRevision: connector.Revision}, ConnectorKey: connector.Key,
+	})
+	var domainError *DomainError
+	if !errors.As(err, &domainError) || domainError.Code != ErrorCodeReleaseRevoked || domainError.Retryable {
+		t.Fatalf("error = %#v, want non-retryable release_revoked", err)
+	}
+	if len(repository.operations) != 0 {
+		t.Fatalf("revoked install created operation: %#v", repository.operations)
+	}
+}
+
+func TestCatalogRefreshDoesNotInvalidateConnectorMutationRevision(t *testing.T) {
+	connector := testConnector("github")
+	repository := newMemoryRepository(connector)
+	updatedRelease := testReleaseWithImplementation("github", "2.0.0", ImplementationKindManagedStdio)
+	scheduler := &memoryScheduler{}
+	application := newTestApplicationWithCatalogSource(t, repository, scheduler, &memoryInstallRuntime{}, catalogSourceStub{
+		snapshot: CatalogSnapshot{CatalogRevision: 2, SnapshotDigest: "sha256:" + strings.Repeat("b", 64), SourceRevision: "catalog-2", Releases: []Release{updatedRelease}},
+	})
+
+	if _, err := application.RefreshCatalog(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := repository.connectors[connector.Key].Revision; got != 0 {
+		t.Fatalf("catalog refresh changed connector mutation revision to %d", got)
+	}
+	accepted, err := application.Install(context.Background(), ConnectorMutation{
+		Mutation: Mutation{ClientRequestID: "install-after-refresh", ExpectedRevision: 0}, ConnectorKey: connector.Key,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if accepted.Operation.Target == nil || accepted.Operation.Target.ReleaseDigest != updatedRelease.ReleaseDigest {
+		t.Fatalf("install target = %#v", accepted.Operation.Target)
+	}
+}
+
+func TestApplicationCatalogPageReadsOnlyPersistedSnapshot(t *testing.T) {
+	release := testReleaseWithImplementation("github", "1.0.0", ImplementationKindManagedStdio)
+	repository := newMemoryRepository(newCatalogConnector(release))
+	repository.revision = 1
+	repository.catalogSnapshot.Categories = []CatalogCategory{{CategoryID: "development", Kind: "category", ItemCount: 1}}
+	repository.catalogSnapshot.Entries = []CatalogEntry{{CategoryID: "development", Release: release}}
+	source := failingCatalogSource{pageError: errors.New("remote source must not be called while browsing")}
 	application := newTestApplicationWithCatalogSource(t, repository, &memoryScheduler{}, &memoryInstallRuntime{}, source)
 
 	page, err := application.ListCatalogPage(context.Background(), CatalogPageQuery{
@@ -1394,11 +1436,8 @@ func TestApplicationCatalogPageCachesNewConnectorForImmediateInstall(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	if page.Revision != 1 || page.NextPageToken != "next-page" || len(page.Items) != 1 || page.Items[0].Connector.Key != "github" {
+	if page.Revision != 1 || page.NextPageToken != "" || len(page.Items) != 1 || page.Items[0].Connector.Key != "github" {
 		t.Fatalf("page = %#v", page)
-	}
-	if _, err := repository.Connector(context.Background(), "github"); err != nil {
-		t.Fatalf("cached connector: %v", err)
 	}
 
 	repeated, err := application.ListCatalogPage(context.Background(), CatalogPageQuery{SectionID: "development", PageSize: 20})
@@ -1410,15 +1449,15 @@ func TestApplicationCatalogPageCachesNewConnectorForImmediateInstall(t *testing.
 	}
 }
 
-func TestApplicationCatalogPagePreservesManifestErrors(t *testing.T) {
+func TestApplicationCatalogPageReportsMissingLocalSnapshot(t *testing.T) {
 	repository := newMemoryRepository()
-	sourceError := invalidManifest("permission scope is invalid", nil)
+	repository.catalogSnapshotErr = ErrNotFound
 	application := newTestApplicationWithCatalogSource(
 		t,
 		repository,
 		&memoryScheduler{},
 		&memoryInstallRuntime{},
-		failingCatalogSource{pageError: sourceError},
+		failingCatalogSource{},
 	)
 
 	_, err := application.ListCatalogPage(context.Background(), CatalogPageQuery{
@@ -1428,29 +1467,7 @@ func TestApplicationCatalogPagePreservesManifestErrors(t *testing.T) {
 	if !errors.As(err, &domainError) {
 		t.Fatalf("error = %v, want DomainError", err)
 	}
-	if domainError.Code != ErrorCodeInvalidManifest || domainError.Retryable {
-		t.Fatalf("domain error = %#v", domainError)
-	}
-}
-
-func TestApplicationCatalogPageClassifiesTransportErrorsAsRetryable(t *testing.T) {
-	repository := newMemoryRepository()
-	application := newTestApplicationWithCatalogSource(
-		t,
-		repository,
-		&memoryScheduler{},
-		&memoryInstallRuntime{},
-		failingCatalogSource{pageError: errors.New("request timeout")},
-	)
-
-	_, err := application.ListCatalogPage(context.Background(), CatalogPageQuery{
-		SectionID: "development", PageSize: 20,
-	})
-	var domainError *DomainError
-	if !errors.As(err, &domainError) {
-		t.Fatalf("error = %v, want DomainError", err)
-	}
-	if domainError.Code != ErrorCodeUpstreamUnavailable || !domainError.Retryable {
+	if domainError.Code != ErrorCodeUnavailable || !domainError.Retryable {
 		t.Fatalf("domain error = %#v", domainError)
 	}
 }
@@ -1464,23 +1481,13 @@ func TestApplicationRefreshPreservesManifestFailureCode(t *testing.T) {
 		&memoryInstallRuntime{},
 		failingCatalogSource{refreshError: invalidManifest("permission scope is invalid", nil)},
 	)
-	accepted, err := application.RefreshCatalog(context.Background(), Mutation{
-		ClientRequestID: "refresh-invalid-manifest", ExpectedRevision: 0,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = application.ExecuteOperation(context.Background(), accepted.Operation.OperationID)
+	_, err := application.RefreshCatalog(context.Background())
 	var domainError *DomainError
 	if !errors.As(err, &domainError) || domainError.Code != ErrorCodeInvalidManifest {
 		t.Fatalf("error = %#v, want invalid manifest", err)
 	}
-	operation, err := application.GetOperation(context.Background(), accepted.Operation.OperationID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if operation.State != OperationStateFailed || operation.FailureCode != string(ErrorCodeInvalidManifest) {
-		t.Fatalf("operation = %#v", operation)
+	if len(repository.operations) != 0 {
+		t.Fatalf("catalog refresh created operations: %#v", repository.operations)
 	}
 }
 
@@ -1805,9 +1812,9 @@ func (host *memoryInstallRuntime) Prepare(_ context.Context, request PrepareArti
 	}, nil
 }
 
-func (host *memoryInstallRuntime) InstallRelease(
+func (host *memoryInstallRuntime) PrepareReleaseInstallation(
 	ctx context.Context,
-	request InstallReleaseRequest,
+	request PrepareReleaseInstallationRequest,
 ) (ReleaseInstallationReceipt, error) {
 	prepared, err := host.Prepare(ctx, PrepareArtifactRequest(request))
 	if err != nil {
@@ -1839,8 +1846,16 @@ func (host *memoryInstallRuntime) UninstallRelease(ctx context.Context, request 
 		ReleaseDigest: request.Release.ReleaseDigest})
 }
 
-func (host *memoryInstallRuntime) CommitReleaseInstallation(context.Context, CommitReleaseInstallationRequest) error {
+func (host *memoryInstallRuntime) ActivateReleaseInstallation(context.Context, ReleaseInstallationTransitionRequest) error {
 	return host.installationCommitErr
+}
+
+func (*memoryInstallRuntime) FinalizeReleaseInstallation(context.Context, ReleaseInstallationTransitionRequest) error {
+	return nil
+}
+
+func (*memoryInstallRuntime) AbortReleaseInstallation(context.Context, ReleaseInstallationTransitionRequest) error {
+	return nil
 }
 
 type runtimeBindingResolverStub struct {
@@ -1922,7 +1937,7 @@ func newBlockingInstallerWithError(err error) *blockingInstaller {
 	}
 }
 
-func (installer *blockingInstaller) InstallRelease(ctx context.Context, request InstallReleaseRequest) (ReleaseInstallationReceipt, error) {
+func (installer *blockingInstaller) PrepareReleaseInstallation(ctx context.Context, request PrepareReleaseInstallationRequest) (ReleaseInstallationReceipt, error) {
 	installer.installs.Add(1)
 	installer.once.Do(func() { close(installer.started) })
 	select {
@@ -2039,6 +2054,8 @@ type memoryRepository struct {
 	revision                         uint64
 	catalogState                     CatalogState
 	sourceRevision                   string
+	catalogSnapshot                  CatalogSnapshot
+	catalogSnapshotErr               error
 	connectors                       map[string]Connector
 	operations                       map[string]Operation
 	events                           []ChangedEvent
@@ -2053,8 +2070,10 @@ type memoryRepository struct {
 func newMemoryRepository(connectors ...Connector) *memoryRepository {
 	repository := &memoryRepository{
 		catalogState: CatalogStateStale,
-		connectors:   map[string]Connector{},
-		operations:   map[string]Operation{},
+		catalogSnapshot: CatalogSnapshot{CatalogRevision: 1, SnapshotDigest: "sha256:" + strings.Repeat("a", 64),
+			SourceRevision: "1:sha256:" + strings.Repeat("a", 64)},
+		connectors: map[string]Connector{},
+		operations: map[string]Operation{},
 	}
 	for _, connector := range connectors {
 		repository.connectors[connector.Key] = connector
@@ -2074,6 +2093,7 @@ func (repository *memoryRepository) Snapshot(_ context.Context) (Snapshot, error
 		operations = append(operations, operation)
 	}
 	return Snapshot{
+		ContractCohort: ConnectorControlPlaneContractCohort,
 		CatalogState:   repository.catalogState,
 		Connectors:     connectors,
 		Operations:     operations,
@@ -2196,6 +2216,13 @@ func (repository *memoryRepository) InstalledRelease(_ context.Context, connecto
 	return Release{}, ErrNotFound
 }
 
+func (repository *memoryRepository) CatalogSnapshot(context.Context) (CatalogSnapshot, error) {
+	if repository.catalogSnapshotErr != nil {
+		return CatalogSnapshot{}, repository.catalogSnapshotErr
+	}
+	return repository.catalogSnapshot, nil
+}
+
 func (repository *memoryRepository) Transaction(ctx context.Context, fn func(Transaction) error) error {
 	if repository.rejectCanceledTransactionContext && ctx.Err() != nil {
 		return ctx.Err()
@@ -2213,12 +2240,13 @@ func (repository *memoryRepository) Transaction(ctx context.Context, fn func(Tra
 		return err
 	}
 	transaction := &memoryTransaction{
-		revision:       repository.revision,
-		catalogState:   repository.catalogState,
-		sourceRevision: repository.sourceRevision,
-		connectors:     cloneConnectors(repository.connectors),
-		operations:     cloneOperations(repository.operations),
-		events:         append([]ChangedEvent(nil), repository.events...),
+		revision:        repository.revision,
+		catalogState:    repository.catalogState,
+		sourceRevision:  repository.sourceRevision,
+		catalogSnapshot: repository.catalogSnapshot,
+		connectors:      cloneConnectors(repository.connectors),
+		operations:      cloneOperations(repository.operations),
+		events:          append([]ChangedEvent(nil), repository.events...),
 	}
 	if err := fn(transaction); err != nil {
 		return err
@@ -2226,6 +2254,7 @@ func (repository *memoryRepository) Transaction(ctx context.Context, fn func(Tra
 	repository.revision = transaction.revision
 	repository.catalogState = transaction.catalogState
 	repository.sourceRevision = transaction.sourceRevision
+	repository.catalogSnapshot = transaction.catalogSnapshot
 	repository.connectors = transaction.connectors
 	repository.operations = transaction.operations
 	repository.events = transaction.events
@@ -2235,7 +2264,7 @@ func (repository *memoryRepository) Transaction(ctx context.Context, fn func(Tra
 func (repository *memoryRepository) RecoverableOperations(context.Context) ([]Operation, error) {
 	var operations []Operation
 	for _, operation := range repository.operations {
-		if operation.State == OperationStateAccepted || operation.State == OperationStateRunning {
+		if !operation.State.IsTerminal() {
 			operations = append(operations, operation)
 		}
 	}
@@ -2243,12 +2272,13 @@ func (repository *memoryRepository) RecoverableOperations(context.Context) ([]Op
 }
 
 type memoryTransaction struct {
-	revision       uint64
-	catalogState   CatalogState
-	sourceRevision string
-	connectors     map[string]Connector
-	operations     map[string]Operation
-	events         []ChangedEvent
+	revision        uint64
+	catalogState    CatalogState
+	sourceRevision  string
+	catalogSnapshot CatalogSnapshot
+	connectors      map[string]Connector
+	operations      map[string]Operation
+	events          []ChangedEvent
 }
 
 func (transaction *memoryTransaction) Revision() uint64 { return transaction.revision }
@@ -2292,10 +2322,14 @@ func (transaction *memoryTransaction) OperationByClientRequestID(clientRequestID
 	return nil, nil
 }
 
-func (transaction *memoryTransaction) ActiveOperation(connectorKey string) (*Operation, error) {
+func (transaction *memoryTransaction) ActiveOperation(kind OperationKind, scope OperationScope, connectorKey string) (*Operation, error) {
+	wanted := OperationLockClaims(kind, scope, connectorKey)
 	for _, operation := range transaction.operations {
-		if (connectorKey == "" || operation.ConnectorKey == "" || operation.ConnectorKey == connectorKey) &&
-			(operation.State == OperationStateAccepted || operation.State == OperationStateRunning) {
+		claims := operation.LockClaims
+		if len(claims) == 0 {
+			claims = OperationLockClaims(operation.Kind, operation.Scope, operation.ConnectorKey)
+		}
+		if claimsOverlap(wanted, claims) && !operation.State.IsTerminal() {
 			copy := operation
 			return &copy, nil
 		}
@@ -2303,8 +2337,24 @@ func (transaction *memoryTransaction) ActiveOperation(connectorKey string) (*Ope
 	return nil, nil
 }
 
+func claimsOverlap(left, right []string) bool {
+	for _, leftClaim := range left {
+		for _, rightClaim := range right {
+			if leftClaim == rightClaim {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (transaction *memoryTransaction) SaveCatalogRevision(sourceRevision string) error {
 	transaction.sourceRevision = sourceRevision
+	return nil
+}
+
+func (transaction *memoryTransaction) SaveCatalogSnapshot(snapshot CatalogSnapshot) error {
+	transaction.catalogSnapshot = snapshot
 	return nil
 }
 

--- a/packages/connector/host/errors.go
+++ b/packages/connector/host/errors.go
@@ -6,9 +6,17 @@ import (
 )
 
 var (
-	ErrNotFound           = errors.New("connector market resource not found")
-	ErrOperationLeaseLost = errors.New("connector market operation lease lost")
+	ErrNotFound                = errors.New("connector market resource not found")
+	ErrOperationLeaseLost      = errors.New("connector market operation lease lost")
+	ErrOperationOutcomeUnknown = errors.New("connector operation outcome is unknown")
 )
+
+func OutcomeUnknown(cause error) error {
+	if cause == nil {
+		return ErrOperationOutcomeUnknown
+	}
+	return fmt.Errorf("%w: %v", ErrOperationOutcomeUnknown, cause)
+}
 
 type ErrorCode string
 
@@ -22,6 +30,7 @@ const (
 	ErrorCodeUnsupportedImplementation ErrorCode = "connector_implementation_unsupported"
 	ErrorCodeUpstreamUnavailable       ErrorCode = "connector_market_upstream_unavailable"
 	ErrorCodeInstallFailed             ErrorCode = "connector_install_failed"
+	ErrorCodeReleaseRevoked            ErrorCode = "release_revoked"
 	ErrorCodeAuthorizationFailed       ErrorCode = "connector_authorization_failed"
 	ErrorCodeUnavailable               ErrorCode = "connector_market_unavailable"
 )

--- a/packages/connector/host/operation_identity.go
+++ b/packages/connector/host/operation_identity.go
@@ -1,0 +1,21 @@
+package host
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+)
+
+func OperationRequestDigest(kind OperationKind, scope OperationScope, connectorKey string, target *OperationTarget) string {
+	// External VM/runtime fence facts are resolved by the Host and are not part
+	// of the caller's idempotency identity. They remain frozen on Operation.Scope.
+	requestScope := OperationScope{AccountID: scope.AccountID, DeviceID: scope.DeviceID}
+	payload, _ := json.Marshal(struct {
+		Kind         OperationKind    `json:"kind"`
+		Scope        OperationScope   `json:"scope"`
+		ConnectorKey string           `json:"connectorKey"`
+		Target       *OperationTarget `json:"target,omitempty"`
+	}{Kind: kind, Scope: requestScope, ConnectorKey: connectorKey, Target: target})
+	sum := sha256.Sum256(payload)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}

--- a/packages/connector/host/ports.go
+++ b/packages/connector/host/ports.go
@@ -17,6 +17,13 @@ type CatalogSource interface {
 	Refresh(context.Context) (CatalogSnapshot, error)
 }
 
+// CatalogChangeSource is an optional low-bandwidth invalidation channel. It
+// returns only after the server catalog advances beyond afterRevision; callers
+// must still pull and validate the complete snapshot.
+type CatalogChangeSource interface {
+	WaitForCatalogChange(ctx context.Context, afterRevision uint64) error
+}
+
 type CatalogSourcePageQuery struct {
 	SectionID string
 	PageSize  int
@@ -62,8 +69,22 @@ type CatalogPage struct {
 }
 
 type CatalogSnapshot struct {
-	SourceRevision string
-	Releases       []Release
+	CatalogRevision uint64              `json:"catalogRevision"`
+	SnapshotDigest  string              `json:"snapshotDigest"`
+	SourceRevision  string              `json:"sourceRevision"`
+	Categories      []CatalogCategory   `json:"categories"`
+	Entries         []CatalogEntry      `json:"entries"`
+	Releases        []Release           `json:"releases"`
+	Revocations     []CatalogRevocation `json:"revocations"`
+}
+
+type CatalogRevocation struct {
+	ArtifactDigest string    `json:"artifactDigest"`
+	RevocationID   string    `json:"revocationId"`
+	ConnectorKey   string    `json:"connectorKey"`
+	Version        string    `json:"version"`
+	ReasonCode     string    `json:"reasonCode"`
+	EffectiveAt    time.Time `json:"effectiveAt"`
 }
 
 type Repository interface {
@@ -81,6 +102,7 @@ type Repository interface {
 	Transaction(ctx context.Context, fn func(Transaction) error) error
 	RecoverableOperations(ctx context.Context) ([]Operation, error)
 	InstalledRelease(ctx context.Context, connectorKey, releaseDigest string) (Release, error)
+	CatalogSnapshot(ctx context.Context) (CatalogSnapshot, error)
 }
 
 type Transaction interface {
@@ -90,8 +112,9 @@ type Transaction interface {
 	Connector(connectorKey string) (Connector, error)
 	Operation(operationID string) (Operation, error)
 	OperationByClientRequestID(clientRequestID string) (*Operation, error)
-	ActiveOperation(connectorKey string) (*Operation, error)
+	ActiveOperation(kind OperationKind, scope OperationScope, connectorKey string) (*Operation, error)
 	SaveCatalogRevision(sourceRevision string) error
+	SaveCatalogSnapshot(CatalogSnapshot) error
 	SetCatalogState(state CatalogState) error
 	SaveConnector(Connector) error
 	DeleteConnector(connectorKey string) error
@@ -108,13 +131,15 @@ type Transaction interface {
 // Installation never implies capability publication. Runtime activation is a
 // separate ImplementationHost reconcile driven by authorization state.
 type ReleaseInstallationManager interface {
-	InstallRelease(ctx context.Context, request InstallReleaseRequest) (ReleaseInstallationReceipt, error)
+	PrepareReleaseInstallation(ctx context.Context, request PrepareReleaseInstallationRequest) (ReleaseInstallationReceipt, error)
 	InspectReleaseInstallation(ctx context.Context, request InspectReleaseInstallationRequest) (ReleaseInstallationObservation, error)
-	CommitReleaseInstallation(ctx context.Context, request CommitReleaseInstallationRequest) error
+	ActivateReleaseInstallation(ctx context.Context, request ReleaseInstallationTransitionRequest) error
+	FinalizeReleaseInstallation(ctx context.Context, request ReleaseInstallationTransitionRequest) error
+	AbortReleaseInstallation(ctx context.Context, request ReleaseInstallationTransitionRequest) error
 	UninstallRelease(ctx context.Context, request UninstallReleaseRequest) error
 }
 
-type InstallReleaseRequest struct {
+type PrepareReleaseInstallationRequest struct {
 	OperationID string
 	Scope       OperationScope
 	Generation  HostGeneration
@@ -152,10 +177,12 @@ type ReleaseInstallationObservation struct {
 	Receipt       *ReleaseInstallationReceipt         `json:"receipt,omitempty"`
 }
 
-// CommitReleaseInstallation is invoked only after installed truth is durable
-// in the business repository. Cross-machine hosts use it to promote a cached
-// candidate to current; same-machine installers may implement it as a no-op.
-type CommitReleaseInstallationRequest struct {
+// ReleaseInstallationTransitionRequest identifies one frozen, idempotent
+// Prepare -> Activate -> Finalize transition. Activate must retain the previous
+// active release as a rollback slot. Finalize may retire that slot only after
+// the Host repository has durably projected the new installed truth. Abort
+// restores the slot when projection fails before Finalize.
+type ReleaseInstallationTransitionRequest struct {
 	OperationID string
 	Scope       OperationScope
 	Generation  HostGeneration
@@ -386,6 +413,13 @@ type CompatibilityEvaluator interface {
 
 type OperationScheduler interface {
 	Schedule(ctx context.Context, operationID string) error
+}
+
+// OperationScopeResolver freezes external execution authority at admission.
+// Cross-machine hosts must return the exact VM/account/runtime incarnation
+// that every retry of the durable operation is required to use.
+type OperationScopeResolver interface {
+	ResolveOperationScope(ctx context.Context, accountID string) (OperationScope, error)
 }
 
 type ChangedEvent struct {

--- a/packages/connector/host/service.go
+++ b/packages/connector/host/service.go
@@ -17,7 +17,7 @@ type Service interface {
 	ListCatalogPage(ctx context.Context, query CatalogPageQuery) (CatalogPage, error)
 	GetConnector(ctx context.Context, connectorKey string) (Connector, error)
 	GetOperation(ctx context.Context, operationID string) (Operation, error)
-	RefreshCatalog(ctx context.Context, mutation Mutation) (MutationResult, error)
+	RefreshCatalog(ctx context.Context) (Snapshot, error)
 	Install(ctx context.Context, mutation ConnectorMutation) (MutationResult, error)
 	Uninstall(ctx context.Context, mutation ConnectorMutation) (MutationResult, error)
 	ReconcileRuntime(ctx context.Context, mutation ConnectorMutation) (MutationResult, error)

--- a/packages/connector/host/types.go
+++ b/packages/connector/host/types.go
@@ -2,6 +2,7 @@ package host
 
 import (
 	"encoding/json"
+	"strings"
 	"time"
 )
 
@@ -56,7 +57,6 @@ const (
 type OperationKind string
 
 const (
-	OperationKindRefreshCatalog          OperationKind = "refresh_catalog"
 	OperationKindInstall                 OperationKind = "install"
 	OperationKindUninstall               OperationKind = "uninstall"
 	OperationKindReconcileRuntime        OperationKind = "reconcile_runtime"
@@ -67,19 +67,26 @@ const (
 type OperationState string
 
 const (
-	OperationStateAccepted  OperationState = "accepted"
-	OperationStateRunning   OperationState = "running"
-	OperationStateCompleted OperationState = "completed"
-	OperationStateFailed    OperationState = "failed"
+	OperationStateAccepted       OperationState = "accepted"
+	OperationStateRunning        OperationState = "running"
+	OperationStateOutcomeUnknown OperationState = "outcome_unknown"
+	OperationStateCompleted      OperationState = "completed"
+	OperationStateFailed         OperationState = "failed"
+	OperationStateCancelled      OperationState = "cancelled"
 )
+
+func (state OperationState) IsTerminal() bool {
+	return state == OperationStateCompleted || state == OperationStateFailed || state == OperationStateCancelled
+}
 
 type OperationStage string
 
 const (
 	OperationStageAccepted      OperationStage = "accepted"
-	OperationStageRefreshing    OperationStage = "refreshing"
 	OperationStageInstalling    OperationStage = "installing"
 	OperationStageInstalled     OperationStage = "installed"
+	OperationStageActivated     OperationStage = "activated"
+	OperationStageFinalizing    OperationStage = "finalizing"
 	OperationStageDeactivating  OperationStage = "deactivating"
 	OperationStageAuthorizing   OperationStage = "authorizing"
 	OperationStageDisconnecting OperationStage = "disconnecting"
@@ -244,11 +251,25 @@ type RemoteStreamableHTTPImplementation struct {
 }
 
 type Installation struct {
-	State                  InstallationState `json:"state"`
-	InstalledVersion       string            `json:"installedVersion,omitempty"`
-	InstalledReleaseID     string            `json:"installedReleaseId,omitempty"`
-	InstalledReleaseDigest string            `json:"installedReleaseDigest,omitempty"`
-	FailureCode            string            `json:"failureCode,omitempty"`
+	State                   InstallationState `json:"state"`
+	InstalledVersion        string            `json:"installedVersion,omitempty"`
+	InstalledReleaseID      string            `json:"installedReleaseId,omitempty"`
+	InstalledReleaseDigest  string            `json:"installedReleaseDigest,omitempty"`
+	InstalledArtifactSHA256 string            `json:"installedArtifactSha256,omitempty"`
+	FailureCode             string            `json:"failureCode,omitempty"`
+}
+
+type SecurityState string
+
+const (
+	SecurityStateAllowed SecurityState = "allowed"
+	SecurityStateRevoked SecurityState = "revoked"
+)
+
+type Security struct {
+	State        SecurityState `json:"state"`
+	RevocationID string        `json:"revocationId,omitempty"`
+	ReasonCode   string        `json:"reasonCode,omitempty"`
 }
 
 type Authorization struct {
@@ -267,35 +288,75 @@ type Connector struct {
 	Installation  Installation  `json:"installation"`
 	Authorization Authorization `json:"authorization"`
 	Compatibility Compatibility `json:"compatibility"`
+	Security      Security      `json:"security"`
 	Revision      uint64        `json:"revision"`
 }
 
 type Operation struct {
-	OperationID     string             `json:"operationId"`
-	ClientRequestID string             `json:"clientRequestId"`
-	ConnectorKey    string             `json:"connectorKey,omitempty"`
-	Kind            OperationKind      `json:"kind"`
-	Scope           OperationScope     `json:"scope,omitempty"`
-	State           OperationState     `json:"state"`
-	Stage           OperationStage     `json:"stage,omitempty"`
-	Target          *OperationTarget   `json:"target,omitempty"`
-	HostGeneration  HostGeneration     `json:"hostGeneration,omitempty"`
-	Execution       OperationExecution `json:"execution,omitempty"`
-	Attempt         uint32             `json:"attempt"`
-	LeaseOwner      string             `json:"leaseOwner,omitempty"`
-	LeaseToken      uint64             `json:"leaseToken,omitempty"`
-	LeaseExpiresAt  *time.Time         `json:"leaseExpiresAt,omitempty"`
-	FailureCode     string             `json:"failureCode,omitempty"`
-	CreatedAt       time.Time          `json:"createdAt"`
-	UpdatedAt       time.Time          `json:"updatedAt"`
+	OperationID      string             `json:"operationId"`
+	ClientRequestID  string             `json:"clientRequestId"`
+	ConnectorKey     string             `json:"connectorKey,omitempty"`
+	Kind             OperationKind      `json:"kind"`
+	Scope            OperationScope     `json:"scope,omitempty"`
+	RequestDigest    string             `json:"requestDigest"`
+	LockClaims       []string           `json:"lockClaims,omitempty"`
+	State            OperationState     `json:"state"`
+	Stage            OperationStage     `json:"stage,omitempty"`
+	Target           *OperationTarget   `json:"target,omitempty"`
+	HostGeneration   HostGeneration     `json:"hostGeneration,omitempty"`
+	Execution        OperationExecution `json:"execution,omitempty"`
+	Attempt          uint32             `json:"attempt"`
+	OperationVersion uint64             `json:"operationVersion"`
+	LeaseOwner       string             `json:"leaseOwner,omitempty"`
+	LeaseToken       uint64             `json:"leaseToken,omitempty"`
+	LeaseExpiresAt   *time.Time         `json:"leaseExpiresAt,omitempty"`
+	FailureCode      string             `json:"failureCode,omitempty"`
+	NextAttemptAt    *time.Time         `json:"nextAttemptAt,omitempty"`
+	CreatedAt        time.Time          `json:"createdAt"`
+	StartedAt        *time.Time         `json:"startedAt,omitempty"`
+	FinishedAt       *time.Time         `json:"finishedAt,omitempty"`
+	TerminalAt       *time.Time         `json:"terminalAt,omitempty"`
+	UpdatedAt        time.Time          `json:"updatedAt"`
 }
 
-// OperationScope freezes the external authority under which a durable
-// operation was accepted. AccountID is intentionally the only persisted
-// authority fact: short-lived artifact and credential grants belong to ports
-// and must never be serialized into an operation.
+// OperationScope freezes the durable authority/incarnation facts under which
+// an operation was accepted. Short-lived artifact and credential grants still
+// belong to ports and must never be serialized into an operation.
 type OperationScope struct {
-	AccountID string `json:"accountId,omitempty"`
+	AccountID         string `json:"accountId,omitempty"`
+	DeviceID          string `json:"deviceId,omitempty"`
+	VMAssignmentID    string `json:"vmAssignmentId,omitempty"`
+	AccountGeneration uint64 `json:"accountGeneration,omitempty"`
+	DesktopBootEpoch  string `json:"desktopBootEpoch,omitempty"`
+	GuestBootID       string `json:"guestBootId,omitempty"`
+	RuntimeEpoch      string `json:"runtimeEpoch,omitempty"`
+}
+
+const (
+	ConnectorExecutionClaimPrefix     = "connector_execution:"
+	ConnectorAuthorizationClaimPrefix = "connector_authorization:"
+)
+
+func OperationLockClaims(kind OperationKind, scope OperationScope, connectorKey string) []string {
+	connectorKey = strings.TrimSpace(connectorKey)
+	if connectorKey == "" {
+		return nil
+	}
+	switch kind {
+	case OperationKindStartAuthorization, OperationKindDisconnectAuthorization:
+		return []string{ConnectorAuthorizationClaimPrefix + strings.TrimSpace(scope.AccountID) + ":" + connectorKey}
+	case OperationKindInstall, OperationKindUninstall, OperationKindReconcileRuntime:
+		authority := strings.TrimSpace(scope.VMAssignmentID)
+		if authority == "" {
+			authority = strings.TrimSpace(scope.DeviceID)
+		}
+		if authority == "" {
+			authority = "local"
+		}
+		return []string{ConnectorExecutionClaimPrefix + authority + ":" + connectorKey}
+	default:
+		return nil
+	}
 }
 
 // OperationTarget freezes the exact release identity at command acceptance so
@@ -516,12 +577,15 @@ type AuthorizationObservation struct {
 }
 
 type Snapshot struct {
+	ContractCohort string       `json:"contractCohort"`
 	CatalogState   CatalogState `json:"catalogState"`
 	Connectors     []Connector  `json:"connectors"`
 	Operations     []Operation  `json:"operations"`
 	Revision       uint64       `json:"revision"`
 	SourceRevision string       `json:"sourceRevision,omitempty"`
 }
+
+const ConnectorControlPlaneContractCohort = "connector-control-plane-v2"
 
 type Mutation struct {
 	ClientRequestID  string `json:"clientRequestId"`

--- a/packages/connector/market/README.md
+++ b/packages/connector/market/README.md
@@ -5,7 +5,7 @@ shared by Tutti and other approved desktop daemon hosts such as TSH.
 
 The package owns the TypeScript and renderer side of the shared boundary:
 
-- `openapi/connector-market.v1.yaml`: the HTTP fragment composed by each host
+- `openapi/connector-market.v2.yaml`: the breaking v2 HTTP fragment composed by each host
   daemon's aggregate OpenAPI document
 - `contracts`: host-neutral backend, event, domain, and error contracts
 - `authorization`: the declarative authorization adapter and replaceable
@@ -119,7 +119,7 @@ Inside this repository, the aggregate document may use a repository path:
 
 ```yaml
 x-tutti-openapi-fragments:
-  - packages/connector/market/openapi/connector-market.v1.yaml
+  - packages/connector/market/openapi/connector-market.v2.yaml
 ```
 
 External hosts install an exact released package version and resolve the
@@ -128,7 +128,7 @@ exported fragment through package exports:
 ```yaml
 x-tutti-openapi-fragments:
   - package: "@tutti-os/connector-market"
-    path: "openapi/connector-market.v1.yaml"
+    path: "openapi/connector-market.v2.yaml"
 ```
 
 Do not copy the fragment into another repository or reference a Tutti worktree.

--- a/packages/connector/market/openapi/connector-market.v2.yaml
+++ b/packages/connector/market/openapi/connector-market.v2.yaml
@@ -1,12 +1,12 @@
 openapi: 3.0.3
 info:
   title: Connector Market API Fragment
-  version: 1.0.0
+  version: 2.0.0
   description: Host-neutral connector catalog, installation, authorization, and global Agent-access contract.
 tags:
   - name: connector-market
 paths:
-  /v1/connector-market:
+  /v2/connector-market:
     get:
       operationId: getConnectorMarket
       tags: [connector-market]
@@ -24,7 +24,7 @@ paths:
           $ref: "#/components/responses/ConnectorMarketUnauthorizedError"
         "503":
           $ref: "#/components/responses/ConnectorMarketUnavailableError"
-  /v1/connector-market/categories:
+  /v2/connector-market/categories:
     get:
       operationId: listConnectorMarketCategories
       tags: [connector-market]
@@ -40,7 +40,7 @@ paths:
           $ref: "#/components/responses/ConnectorMarketUnauthorizedError"
         "503":
           $ref: "#/components/responses/ConnectorMarketUnavailableError"
-  /v1/connector-market/catalog:
+  /v2/connector-market/catalog:
     get:
       operationId: listConnectorMarketCatalog
       tags: [connector-market]
@@ -62,7 +62,7 @@ paths:
           $ref: "#/components/responses/ConnectorMarketUnauthorizedError"
         "503":
           $ref: "#/components/responses/ConnectorMarketUnavailableError"
-  /v1/connector-market/connectors/{connectorKey}:
+  /v2/connector-market/connectors/{connectorKey}:
     parameters:
       - $ref: "#/components/parameters/ConnectorMarketConnectorKey"
     get:
@@ -84,33 +84,23 @@ paths:
           $ref: "#/components/responses/ConnectorMarketNotFoundError"
         "503":
           $ref: "#/components/responses/ConnectorMarketUnavailableError"
-  /v1/connector-market:refresh:
+  /v2/connector-market:refresh:
     post:
       operationId: refreshConnectorMarket
       tags: [connector-market]
-      summary: Refresh and accept the upstream connector catalog
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ConnectorMarketMutationRequest"
+      summary: Synchronize the complete upstream connector catalog snapshot
       responses:
-        "202":
-          description: Refresh operation accepted
+        "200":
+          description: Refreshed connector market snapshot
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ConnectorMarketMutationResponse"
-        "400":
-          $ref: "#/components/responses/ConnectorMarketInvalidRequestError"
+                $ref: "#/components/schemas/ConnectorMarketSnapshot"
         "401":
           $ref: "#/components/responses/ConnectorMarketUnauthorizedError"
-        "409":
-          $ref: "#/components/responses/ConnectorMarketConflictError"
         "503":
           $ref: "#/components/responses/ConnectorMarketUnavailableError"
-  /v1/connector-market/connectors/{connectorKey}:install:
+  /v2/connector-market/connectors/{connectorKey}:install:
     parameters:
       - $ref: "#/components/parameters/ConnectorMarketConnectorKey"
     post:
@@ -142,7 +132,7 @@ paths:
           $ref: "#/components/responses/ConnectorMarketUnprocessableError"
         "503":
           $ref: "#/components/responses/ConnectorMarketUnavailableError"
-  /v1/connector-market/connectors/{connectorKey}:uninstall:
+  /v2/connector-market/connectors/{connectorKey}:uninstall:
     parameters:
       - $ref: "#/components/parameters/ConnectorMarketConnectorKey"
     post:
@@ -176,7 +166,7 @@ paths:
           $ref: "#/components/responses/ConnectorMarketConflictError"
         "503":
           $ref: "#/components/responses/ConnectorMarketUnavailableError"
-  /v1/connector-market/connectors/{connectorKey}/authorization:start:
+  /v2/connector-market/connectors/{connectorKey}/authorization:start:
     parameters:
       - $ref: "#/components/parameters/ConnectorMarketConnectorKey"
     post:
@@ -206,7 +196,7 @@ paths:
           $ref: "#/components/responses/ConnectorMarketConflictError"
         "503":
           $ref: "#/components/responses/ConnectorMarketUnavailableError"
-  /v1/connector-market/connectors/{connectorKey}/authorization:disconnect:
+  /v2/connector-market/connectors/{connectorKey}/authorization:disconnect:
     parameters:
       - $ref: "#/components/parameters/ConnectorMarketConnectorKey"
     post:
@@ -236,7 +226,7 @@ paths:
           $ref: "#/components/responses/ConnectorMarketConflictError"
         "503":
           $ref: "#/components/responses/ConnectorMarketUnavailableError"
-  /v1/connector-market/operations/{operationID}:
+  /v2/connector-market/operations/{operationID}:
     parameters:
       - $ref: "#/components/parameters/ConnectorMarketOperationID"
     get:
@@ -395,8 +385,11 @@ components:
     ConnectorMarketSnapshot:
       type: object
       additionalProperties: false
-      required: [catalogState, connectors, operations, revision]
+      required: [contractCohort, catalogState, connectors, operations, revision]
       properties:
+        contractCohort:
+          type: string
+          enum: [connector-control-plane-v2]
         catalogState:
           $ref: "#/components/schemas/ConnectorMarketCatalogState"
         connectors:
@@ -417,7 +410,15 @@ components:
       type: object
       additionalProperties: false
       required:
-        [key, release, installation, authorization, compatibility, revision]
+        [
+          key,
+          release,
+          installation,
+          authorization,
+          compatibility,
+          security,
+          revision
+        ]
       properties:
         key:
           type: string
@@ -429,6 +430,8 @@ components:
           $ref: "#/components/schemas/ConnectorMarketAuthorization"
         compatibility:
           $ref: "#/components/schemas/ConnectorMarketCompatibility"
+        security:
+          $ref: "#/components/schemas/ConnectorMarketSecurity"
         revision:
           type: integer
           format: int64
@@ -587,6 +590,9 @@ components:
         installedReleaseDigest:
           type: string
           pattern: "^[a-f0-9]{64}$"
+        installedArtifactSha256:
+          type: string
+          pattern: "^[a-f0-9]{64}$"
         failureCode:
           type: string
     ConnectorMarketAuthorization:
@@ -607,6 +613,18 @@ components:
           $ref: "#/components/schemas/ConnectorMarketCompatibilityState"
         reason:
           type: string
+    ConnectorMarketSecurity:
+      type: object
+      additionalProperties: false
+      required: [state]
+      properties:
+        state:
+          type: string
+          enum: [allowed, revoked]
+        revocationId:
+          type: string
+        reasonCode:
+          type: string
     ConnectorMarketOperation:
       type: object
       additionalProperties: false
@@ -617,6 +635,7 @@ components:
           kind,
           state,
           attempt,
+          operationVersion,
           createdAt,
           updatedAt
         ]
@@ -639,9 +658,25 @@ components:
           type: integer
           format: int32
           minimum: 0
+        operationVersion:
+          type: integer
+          format: int64
+          minimum: 0
         failureCode:
           type: string
+        nextAttemptAt:
+          type: string
+          format: date-time
         createdAt:
+          type: string
+          format: date-time
+        startedAt:
+          type: string
+          format: date-time
+        finishedAt:
+          type: string
+          format: date-time
+        terminalAt:
           type: string
           format: date-time
         updatedAt:
@@ -773,21 +808,22 @@ components:
     ConnectorMarketOperationKind:
       type: string
       enum:
-        - refresh_catalog
         - install
         - uninstall
+        - reconcile_runtime
         - start_authorization
         - disconnect_authorization
     ConnectorMarketOperationState:
       type: string
-      enum: [accepted, running, completed, failed]
+      enum: [accepted, running, outcome_unknown, completed, failed, cancelled]
     ConnectorMarketOperationStage:
       type: string
       enum:
         - accepted
-        - refreshing
         - installing
         - installed
+        - activated
+        - finalizing
         - deactivating
         - authorizing
         - disconnecting
@@ -805,5 +841,6 @@ components:
         - connector_implementation_unsupported
         - connector_market_upstream_unavailable
         - connector_install_failed
+        - release_revoked
         - connector_authorization_failed
         - connector_market_unavailable

--- a/packages/connector/market/package.json
+++ b/packages/connector/market/package.json
@@ -10,7 +10,7 @@
     "./contracts": "./src/contracts/index.ts",
     "./core": "./src/services/core/index.ts",
     "./i18n": "./src/i18n/index.ts",
-    "./openapi/connector-market.v1.yaml": "./openapi/connector-market.v1.yaml",
+    "./openapi/connector-market.v2.yaml": "./openapi/connector-market.v2.yaml",
     "./renderer": "./src/renderer/index.ts",
     "./services": "./src/services/index.ts",
     "./ui": "./src/ui/index.ts"
@@ -77,7 +77,7 @@
         "types": "./dist/i18n/index.d.ts",
         "import": "./dist/i18n/index.js"
       },
-      "./openapi/connector-market.v1.yaml": "./openapi/connector-market.v1.yaml",
+      "./openapi/connector-market.v2.yaml": "./openapi/connector-market.v2.yaml",
       "./renderer": {
         "types": "./dist/renderer/index.d.ts",
         "import": "./dist/renderer/index.js"

--- a/packages/connector/market/src/contracts/backend.ts
+++ b/packages/connector/market/src/contracts/backend.ts
@@ -4,7 +4,6 @@ import type {
   ConnectorAuthorizationResult,
   ConnectorMarketCatalogPage,
   ConnectorMarketCategory,
-  ConnectorMarketMutationInput,
   ConnectorMarketSnapshot,
   ConnectorMutationInput,
   ConnectorMutationResult,
@@ -21,9 +20,7 @@ export interface ConnectorMarketBackend {
   }): Promise<ConnectorMarketCatalogPage>;
   getConnector(input: { connectorKey: string }): Promise<Connector>;
   getOperation(input: { operationId: string }): Promise<ConnectorOperation>;
-  refreshCatalog(
-    input: ConnectorMarketMutationInput
-  ): Promise<ConnectorMutationResult>;
+  refreshCatalog(): Promise<ConnectorMarketSnapshot>;
   installConnector(
     input: ConnectorMutationInput
   ): Promise<ConnectorMutationResult>;

--- a/packages/connector/market/src/contracts/domain.ts
+++ b/packages/connector/market/src/contracts/domain.ts
@@ -24,23 +24,26 @@ export type ConnectorCompatibilityState =
 export type ConnectorCatalogState = "ready" | "refreshing" | "stale" | "failed";
 
 export type ConnectorOperationKind =
-  | "refresh_catalog"
   | "install"
   | "uninstall"
+  | "reconcile_runtime"
   | "start_authorization"
   | "disconnect_authorization";
 
 export type ConnectorOperationState =
   | "accepted"
   | "running"
+  | "outcome_unknown"
   | "completed"
-  | "failed";
+  | "failed"
+  | "cancelled";
 
 export type ConnectorOperationStage =
   | "accepted"
-  | "refreshing"
   | "installing"
   | "installed"
+  | "activated"
+  | "finalizing"
   | "deactivating"
   | "authorizing"
   | "disconnecting"
@@ -156,7 +159,14 @@ export interface ConnectorInstallation {
   installedVersion?: string;
   installedReleaseId?: string;
   installedReleaseDigest?: string;
+  installedArtifactSha256?: string;
   failureCode?: string;
+}
+
+export interface ConnectorSecurity {
+  state: "allowed" | "revoked";
+  revocationId?: string;
+  reasonCode?: string;
 }
 
 export interface ConnectorAuthorization {
@@ -175,6 +185,7 @@ export interface Connector {
   installation: ConnectorInstallation;
   authorization: ConnectorAuthorization;
   compatibility: ConnectorCompatibility;
+  security: ConnectorSecurity;
   revision: number;
 }
 
@@ -187,8 +198,13 @@ export interface ConnectorOperation {
   stage?: ConnectorOperationStage;
   target?: ConnectorOperationTarget;
   attempt: number;
+  operationVersion: number;
   failureCode?: string;
+  nextAttemptAt?: string;
   createdAt: string;
+  startedAt?: string;
+  finishedAt?: string;
+  terminalAt?: string;
   updatedAt: string;
 }
 
@@ -201,6 +217,7 @@ export interface ConnectorOperationTarget {
 }
 
 export interface ConnectorMarketSnapshot {
+  contractCohort: "connector-control-plane-v2";
   catalogState: ConnectorCatalogState;
   connectors: Connector[];
   operations: ConnectorOperation[];

--- a/packages/connector/market/src/services/connectorMarketService.interface.ts
+++ b/packages/connector/market/src/services/connectorMarketService.interface.ts
@@ -21,7 +21,6 @@ export interface ConnectorMarketSectionState extends ConnectorMarketCategory {
 export interface ConnectorMarketStoreState {
   loadState: ConnectorMarketLoadState;
   catalogState: ConnectorCatalogState;
-  catalogOperation: ConnectorOperation | null;
   catalogSections: ConnectorMarketSectionState[];
   connectorsByKey: Record<string, Connector>;
   connectorKeys: string[];

--- a/packages/connector/market/src/services/connectorMarketService.test.ts
+++ b/packages/connector/market/src/services/connectorMarketService.test.ts
@@ -51,6 +51,7 @@ function connector(key: string, revision: number): Connector {
     installation: { state: "not_installed" },
     authorization: { state: "not_required" },
     compatibility: { state: "supported" },
+    security: { state: "allowed" },
     revision
   };
 }
@@ -60,6 +61,7 @@ function snapshot(
   connectors: Connector[]
 ): ConnectorMarketSnapshot {
   return {
+    contractCohort: "connector-control-plane-v2",
     catalogState: "ready",
     connectors,
     operations: [],
@@ -286,29 +288,17 @@ test("coalesces concurrent catalog refreshes", async () => {
         calls += 1;
         return refresh.promise;
       }
-    }),
-    createRequestId: () => "request-1"
+    })
   });
 
   const first = service.refreshCatalog();
   const second = service.refreshCatalog();
   assert.equal(calls, 1);
-  refresh.resolve({
-    operation: {
-      operationId: "operation-1",
-      clientRequestId: "request-1",
-      kind: "refresh_catalog",
-      state: "accepted",
-      attempt: 0,
-      createdAt: "2026-08-03T00:00:00Z",
-      updatedAt: "2026-08-03T00:00:00Z"
-    },
-    revision: 1
-  });
+  refresh.resolve(snapshot(1, []));
   await Promise.all([first, second]);
 
   assert.equal(service.dataStore.revision, 1);
-  assert.equal(service.dataStore.catalogOperation?.operationId, "operation-1");
+  assert.equal(service.dataStore.catalogState, "ready");
   service.dispose();
 });
 
@@ -334,6 +324,7 @@ test("rejects overlapping mutations for one connector", async () => {
       kind: "install",
       state: "accepted",
       attempt: 0,
+      operationVersion: 1,
       createdAt: "2026-08-03T00:00:00Z",
       updatedAt: "2026-08-03T00:00:00Z"
     },
@@ -396,6 +387,7 @@ test("installs one connector with the current catalog revision", async () => {
             kind: "install",
             state: "accepted",
             attempt: 0,
+            operationVersion: 1,
             createdAt: "2026-08-03T00:00:00Z",
             updatedAt: "2026-08-03T00:00:00Z"
           },
@@ -451,6 +443,7 @@ test("uninstalls one connector and tracks the durable operation to completion", 
             state: "accepted",
             stage: "accepted",
             attempt: 0,
+            operationVersion: 1,
             createdAt: "2026-08-11T00:00:00Z",
             updatedAt: "2026-08-11T00:00:00Z"
           },
@@ -465,6 +458,7 @@ test("uninstalls one connector and tracks the durable operation to completion", 
         state: "completed",
         stage: "completed",
         attempt: 1,
+        operationVersion: 1,
         createdAt: "2026-08-11T00:00:00Z",
         updatedAt: "2026-08-11T00:00:01Z"
       }),
@@ -570,6 +564,7 @@ test("polls an accepted connector operation to terminal state when its event is 
           state: "accepted",
           stage: "accepted",
           attempt: 0,
+          operationVersion: 1,
           createdAt: "2026-08-03T00:00:00Z",
           updatedAt: "2026-08-03T00:00:00Z"
         },
@@ -585,6 +580,7 @@ test("polls an accepted connector operation to terminal state when its event is 
           state: operationReads === 1 ? "running" : "completed",
           stage: operationReads === 1 ? "installing" : "completed",
           attempt: 1,
+          operationVersion: 1,
           createdAt: "2026-08-03T00:00:00Z",
           updatedAt: `2026-08-03T00:00:0${operationReads}Z`
         };
@@ -644,6 +640,7 @@ test("stops operation polling after a permanent read error and reconciles once",
           state: "accepted",
           stage: "accepted",
           attempt: 0,
+          operationVersion: 1,
           createdAt: "2026-08-03T00:00:00Z",
           updatedAt: "2026-08-03T00:00:00Z"
         },
@@ -685,126 +682,51 @@ test("stops operation polling after a permanent read error and reconciles once",
   service.dispose();
 });
 
-test("reconciles refresh completion from the local snapshot without reloading remote categories", async () => {
+test("applies synchronous refresh and reloads catalog sections", async () => {
   let categoryCalls = 0;
   let snapshotCalls = 0;
-  const completedRefreshOperation: ConnectorOperation = {
-    operationId: "operation-refresh-terminal",
-    clientRequestId: "request-refresh-terminal",
-    kind: "refresh_catalog",
-    state: "completed",
-    stage: "completed",
-    attempt: 1,
-    createdAt: "2026-08-03T00:00:00Z",
-    updatedAt: "2026-08-03T00:00:01Z"
-  };
   const service = new ConnectorMarketService({
     backend: backendWith({
-      refreshCatalog: async () => ({
-        operation: {
-          operationId: "operation-refresh-terminal",
-          clientRequestId: "request-refresh-terminal",
-          kind: "refresh_catalog",
-          state: "accepted",
-          stage: "accepted",
-          attempt: 0,
-          createdAt: "2026-08-03T00:00:00Z",
-          updatedAt: "2026-08-03T00:00:00Z"
-        },
-        revision: 1
-      }),
-      getOperation: async () => completedRefreshOperation,
+      refreshCatalog: async () => snapshot(2, [connector("github", 2)]),
       getSnapshot: async () => {
         snapshotCalls += 1;
-        if (snapshotCalls === 1) {
-          throw {
-            code: "connector_market_unavailable",
-            message: "local snapshot temporarily unavailable",
-            retryable: true
-          };
-        }
-        return {
-          ...snapshot(2, [connector("github", 2)]),
-          operations: [completedRefreshOperation]
-        };
+        return snapshot(2, [connector("github", 2)]);
       },
       listCategories: async () => {
         categoryCalls += 1;
-        throw new Error("remote categories unavailable");
+        return [];
       }
-    }),
-    waitForOperationPoll: async () => undefined
+    })
   });
 
   await service.refreshCatalog();
-  await waitFor(() => service.dataStore.catalogState === "ready");
 
-  assert.equal(categoryCalls, 0);
-  assert.equal(snapshotCalls, 2);
-  assert.equal(service.dataStore.catalogOperation?.state, "completed");
+  assert.equal(categoryCalls, 1);
+  assert.equal(snapshotCalls, 1);
   assert.equal(service.dataStore.revision, 2);
   service.dispose();
 });
 
-test("keeps the authoritative refresh operation after a permanent read error", async () => {
-  const completedRefreshOperation: ConnectorOperation = {
-    operationId: "operation-refresh-forbidden",
-    clientRequestId: "request-refresh-forbidden",
-    kind: "refresh_catalog",
-    state: "completed",
-    stage: "completed",
-    attempt: 1,
-    createdAt: "2026-08-03T00:00:00Z",
-    updatedAt: "2026-08-03T00:00:01Z"
-  };
-  let operationReads = 0;
-  let snapshotReads = 0;
-  let pollWaits = 0;
+test("reports synchronous refresh failures without creating operation state", async () => {
   const service = new ConnectorMarketService({
     backend: backendWith({
-      refreshCatalog: async () => ({
-        operation: {
-          ...completedRefreshOperation,
-          state: "accepted",
-          stage: "accepted",
-          attempt: 0,
-          updatedAt: "2026-08-03T00:00:00Z"
-        },
-        revision: 1
-      }),
-      getOperation: async () => {
-        operationReads += 1;
+      refreshCatalog: async () => {
         throw {
-          code: "connector_market_forbidden",
-          message: "refresh operation read forbidden",
-          retryable: false
-        };
-      },
-      getSnapshot: async () => {
-        snapshotReads += 1;
-        return {
-          ...snapshot(2, [connector("github", 2)]),
-          operations: [completedRefreshOperation]
+          code: "connector_market_upstream_unavailable",
+          message: "catalog unavailable",
+          retryable: true
         };
       }
-    }),
-    waitForOperationPoll: async () => {
-      pollWaits += 1;
-    }
+    })
   });
 
-  await service.refreshCatalog();
-  await waitFor(
-    () => service.dataStore.catalogOperation?.state === "completed"
-  );
+  await assert.rejects(service.refreshCatalog());
 
-  assert.equal(operationReads, 1);
-  assert.equal(snapshotReads, 1);
-  assert.equal(pollWaits, 0);
+  assert.equal(service.dataStore.catalogState, "failed");
   assert.deepEqual(service.dataStore.lastError, {
-    code: "connector_market_forbidden",
-    message: "refresh operation read forbidden",
-    retryable: false
+    code: "connector_market_upstream_unavailable",
+    message: "catalog unavailable",
+    retryable: true
   });
   service.dispose();
 });
@@ -1317,6 +1239,7 @@ test("reconciles connector-scoped events without reloading the catalog", async (
     state: "running",
     stage: "installing",
     attempt: 1,
+    operationVersion: 1,
     createdAt: "2026-08-03T00:00:00Z",
     updatedAt: "2026-08-03T00:00:01Z"
   };
@@ -1581,6 +1504,7 @@ function operation(kind: "start_authorization", revision: number) {
     kind,
     state: "accepted" as const,
     attempt: 0,
+    operationVersion: 1,
     createdAt: "2026-08-03T00:00:00Z",
     updatedAt: "2026-08-03T00:00:00Z"
   };

--- a/packages/connector/market/src/services/connectorMarketService.ts
+++ b/packages/connector/market/src/services/connectorMarketService.ts
@@ -148,14 +148,12 @@ export class ConnectorMarketService implements IConnectorMarketService {
     const generation = this.dataGeneration;
     this.dataStore.catalogState = "refreshing";
     const promise = this.dependencies.backend
-      .refreshCatalog({
-        clientRequestId: this.createRequestId(),
-        expectedRevision: this.dataStore.revision
-      })
-      .then((result) => {
+      .refreshCatalog()
+      .then(async (snapshot) => {
         if (this.isCurrent(generation)) {
-          applyConnectorMutationResult(this.dataStore, result);
-          this.trackOperation(result.operation);
+          applyConnectorMarketSnapshot(this.dataStore, snapshot);
+          this.reconcileUninstallNotificationStates(snapshot.operations);
+          await this.load(false);
         }
       })
       .catch((error) => {
@@ -213,7 +211,7 @@ export class ConnectorMarketService implements IConnectorMarketService {
         this.dependencies.backend.installConnector({
           connectorKey,
           clientRequestId: this.createRequestId(),
-          expectedRevision: this.dataStore.revision
+          expectedRevision: this.connectorRevision(connectorKey)
         }),
       true
     );
@@ -227,7 +225,7 @@ export class ConnectorMarketService implements IConnectorMarketService {
       this.dependencies.backend.uninstallConnector({
         connectorKey,
         clientRequestId: this.createRequestId(),
-        expectedRevision: this.dataStore.revision
+        expectedRevision: this.connectorRevision(connectorKey)
       })
     );
     if (!result) {
@@ -291,7 +289,7 @@ export class ConnectorMarketService implements IConnectorMarketService {
       clientRequestId: this.createRequestId(),
       ...(secret ? { secret } : {})
     };
-    let expectedRevision = this.dataStore.revision;
+    let expectedRevision = this.connectorRevision(connectorKey);
     const openedAuthorizationUrls = new Set<string>();
     let recoveredRevisionConflict = false;
     try {
@@ -331,7 +329,7 @@ export class ConnectorMarketService implements IConnectorMarketService {
           }
           applyConnectorMarketSnapshot(this.dataStore, next);
           this.reconcileUninstallNotificationStates(next.operations);
-          expectedRevision = this.dataStore.revision;
+          expectedRevision = this.connectorRevision(connectorKey);
           if (this.authorizationState(connectorKey) === "connected") {
             await this.waitForAuthorizationOperation(connectorKey);
             return;
@@ -388,9 +386,13 @@ export class ConnectorMarketService implements IConnectorMarketService {
       this.dependencies.backend.disconnectAuthorization({
         connectorKey,
         clientRequestId: this.createRequestId(),
-        expectedRevision: this.dataStore.revision
+        expectedRevision: this.connectorRevision(connectorKey)
       })
     );
+  }
+
+  private connectorRevision(connectorKey: string): number {
+    return this.dataStore.connectorsByKey[connectorKey]?.revision ?? 0;
   }
 
   dispose(): void {
@@ -858,8 +860,6 @@ export class ConnectorMarketService implements IConnectorMarketService {
     if (operation.connectorKey) {
       this.dataStore.operationsByConnectorKey[operation.connectorKey] =
         operation;
-    } else if (operation.kind === "refresh_catalog") {
-      this.dataStore.catalogOperation = operation;
     }
     const notification =
       this.dataStore.pendingUninstallNotificationsByOperationId[

--- a/packages/connector/market/src/services/connectorMarketState.ts
+++ b/packages/connector/market/src/services/connectorMarketState.ts
@@ -13,7 +13,6 @@ export function createConnectorMarketStoreState(): ConnectorMarketStoreState {
   return {
     loadState: "idle",
     catalogState: "stale",
-    catalogOperation: null,
     catalogSections: [],
     connectorsByKey: {},
     connectorKeys: [],
@@ -32,7 +31,6 @@ export function clearConnectorMarketStoreState(
   const initial = createConnectorMarketStoreState();
   state.loadState = initial.loadState;
   state.catalogState = initial.catalogState;
-  state.catalogOperation = initial.catalogOperation;
   state.catalogSections = initial.catalogSections;
   state.connectorsByKey = initial.connectorsByKey;
   state.connectorKeys = initial.connectorKeys;
@@ -111,6 +109,9 @@ export function applyConnectorMarketSnapshot(
   state: ConnectorMarketStoreState,
   next: ConnectorMarketSnapshot
 ): void {
+  if (next.contractCohort !== "connector-control-plane-v2") {
+    throw new Error("unsupported connector control-plane contract cohort");
+  }
   if (next.revision < state.revision) {
     return;
   }
@@ -119,19 +120,12 @@ export function applyConnectorMarketSnapshot(
   );
   state.connectorKeys = next.connectors.map((connector) => connector.key);
   state.operationsByConnectorKey = {};
-  state.catalogOperation = null;
   for (const operation of next.operations) {
     if (operation.connectorKey) {
       const current = state.operationsByConnectorKey[operation.connectorKey];
       if (!current || isNewerConnectorOperation(operation, current)) {
         state.operationsByConnectorKey[operation.connectorKey] = operation;
       }
-    } else if (
-      operation.kind === "refresh_catalog" &&
-      (!state.catalogOperation ||
-        isNewerConnectorOperation(operation, state.catalogOperation))
-    ) {
-      state.catalogOperation = operation;
     }
   }
   state.catalogState = next.catalogState;
@@ -153,8 +147,6 @@ export function applyConnectorMutationResult(
   if (result.operation.connectorKey) {
     state.operationsByConnectorKey[result.operation.connectorKey] =
       result.operation;
-  } else if (result.operation.kind === "refresh_catalog") {
-    state.catalogOperation = result.operation;
   }
   state.revision = result.revision;
   state.lastError = null;

--- a/packages/connector/market/src/services/core/connectorMarketRuntime.test.ts
+++ b/packages/connector/market/src/services/core/connectorMarketRuntime.test.ts
@@ -214,6 +214,7 @@ function connector(key: string, overrides: Partial<Connector> = {}): Connector {
   const value: Connector = {
     authorization: { state: "not_required" },
     compatibility: { state: "supported" },
+    security: { state: "allowed" },
     installation: { state: "not_installed" },
     key,
     release: {
@@ -255,7 +256,13 @@ function snapshot(
   revision: number,
   connectors: Connector[]
 ): ConnectorMarketSnapshot {
-  return { catalogState: "ready", connectors, operations: [], revision };
+  return {
+    contractCohort: "connector-control-plane-v2",
+    catalogState: "ready",
+    connectors,
+    operations: [],
+    revision
+  };
 }
 
 function backendWith(

--- a/packages/connector/market/src/services/view/connectorMarketViewBuilder.test.ts
+++ b/packages/connector/market/src/services/view/connectorMarketViewBuilder.test.ts
@@ -207,6 +207,7 @@ test("keeps a physical repair in the available segment until installation comple
   ];
   market.operationsByConnectorKey[connector.key] = {
     attempt: 1,
+    operationVersion: 1,
     clientRequestId: "repair-github",
     connectorKey: connector.key,
     createdAt: "2026-08-11T00:00:00Z",
@@ -292,6 +293,7 @@ test("exposes disconnect directly for an authorized connector", () => {
   market.connectorsByKey[connector.key] = connector;
   market.operationsByConnectorKey[connector.key] = {
     attempt: 1,
+    operationVersion: 1,
     clientRequestId: "authorize",
     connectorKey: connector.key,
     createdAt: "2026-08-06T00:00:00Z",
@@ -369,6 +371,7 @@ test("disables uninstall controls while one connector mutation is active", () =>
   market.connectorsByKey[connector.key] = connector;
   market.operationsByConnectorKey[connector.key] = {
     attempt: 1,
+    operationVersion: 1,
     clientRequestId: "update-github",
     connectorKey: connector.key,
     createdAt: "2026-08-11T00:00:00Z",
@@ -461,6 +464,7 @@ function connectorFixture(): Connector {
   return {
     authorization: { state: "disconnected" },
     compatibility: { state: "supported" },
+    security: { state: "allowed" },
     installation: { state: "not_installed" },
     key: "github",
     release: {

--- a/packages/connector/market/src/services/view/connectorMarketViewBuilder.ts
+++ b/packages/connector/market/src/services/view/connectorMarketViewBuilder.ts
@@ -158,7 +158,9 @@ function buildConnectorCardView(
   const updating =
     connector.installation.state === "updating" ||
     (installed && !currentReleaseInstalled && pendingInstallation);
-  const unavailable = connector.compatibility.state !== "supported";
+  const unavailable =
+    connector.compatibility.state !== "supported" ||
+    connector.security.state === "revoked";
   const connected = connector.authorization.state === "connected";
   const requiresAuthorization = !["connected", "not_required"].includes(
     connector.authorization.state
@@ -232,6 +234,13 @@ function buildConnectorDialogView(
   const canUninstall = connectorCanUninstall(connector, mutationBusy);
   if (requestKind === "uninstall_confirmation") {
     return canUninstall ? { ...base, kind: "uninstall_confirmation" } : null;
+  }
+  if (connector.security.state === "revoked") {
+    return {
+      ...base,
+      kind: "blocked",
+      reason: connector.security.reasonCode ?? "release_revoked"
+    };
   }
   if (connector.compatibility.state !== "supported") {
     return {

--- a/packages/connector/runtime/release_installer.go
+++ b/packages/connector/runtime/release_installer.go
@@ -30,9 +30,9 @@ func NewReleaseInstaller(
 	return &ReleaseInstaller{artifacts: artifacts, cli: cli}, nil
 }
 
-func (installer *ReleaseInstaller) InstallRelease(
+func (installer *ReleaseInstaller) PrepareReleaseInstallation(
 	ctx context.Context,
-	request market.InstallReleaseRequest,
+	request market.PrepareReleaseInstallationRequest,
 ) (market.ReleaseInstallationReceipt, error) {
 	if installer == nil || installer.artifacts == nil {
 		return market.ReleaseInstallationReceipt{}, errors.New("connector release installer is unavailable")
@@ -176,12 +176,16 @@ func (installer *ReleaseInstaller) UninstallRelease(
 	return errors.Join(cleanupErrors...)
 }
 
-func (*ReleaseInstaller) CommitReleaseInstallation(
-	context.Context,
-	market.CommitReleaseInstallationRequest,
-) error {
-	// Same-machine preparation already atomically published its latest verified
-	// archive. Remote adapters defer candidate promotion until this callback.
+func (*ReleaseInstaller) ActivateReleaseInstallation(context.Context, market.ReleaseInstallationTransitionRequest) error {
+	// Same-machine preparation already atomically publishes verified bytes.
+	return nil
+}
+
+func (*ReleaseInstaller) FinalizeReleaseInstallation(context.Context, market.ReleaseInstallationTransitionRequest) error {
+	return nil
+}
+
+func (*ReleaseInstaller) AbortReleaseInstallation(context.Context, market.ReleaseInstallationTransitionRequest) error {
 	return nil
 }
 

--- a/packages/connector/runtime/release_installer_test.go
+++ b/packages/connector/runtime/release_installer_test.go
@@ -59,7 +59,7 @@ func TestReleaseInstallerDoesNotActivateRuntime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	receipt, err := installer.InstallRelease(context.Background(), market.InstallReleaseRequest{
+	receipt, err := installer.PrepareReleaseInstallation(context.Background(), market.PrepareReleaseInstallationRequest{
 		OperationID: "install-1", Release: release,
 	})
 	if err != nil {
@@ -130,13 +130,13 @@ func TestReleaseInstallerUninstallRemovesEveryConnectorRelease(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	firstReceipt, err := installer.InstallRelease(context.Background(), market.InstallReleaseRequest{
+	firstReceipt, err := installer.PrepareReleaseInstallation(context.Background(), market.PrepareReleaseInstallationRequest{
 		OperationID: "install-v1", Release: first,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	secondReceipt, err := installer.InstallRelease(context.Background(), market.InstallReleaseRequest{
+	secondReceipt, err := installer.PrepareReleaseInstallation(context.Background(), market.PrepareReleaseInstallationRequest{
 		OperationID: "install-v2", Release: second,
 	})
 	if err != nil {

--- a/packages/connector/store-sqlite/lifecycle.go
+++ b/packages/connector/store-sqlite/lifecycle.go
@@ -6,167 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 
 	market "github.com/tutti-os/tutti/packages/connector/host"
 )
 
 const maxLifecycleCleanupBatchSize = 500
-
-func (store *Store) migrateLifecycle(ctx context.Context) error {
-	if _, err := store.db.ExecContext(ctx, `ALTER TABLE connector_market_operations ADD COLUMN updated_at_unix_ms INTEGER NOT NULL DEFAULT 0`); err != nil &&
-		!isDuplicateColumnError(err) {
-		return fmt.Errorf("migrate connector market operation update timestamp: %w", err)
-	}
-	if err := store.backfillLifecycleColumns(ctx); err != nil {
-		return err
-	}
-	statements := []string{
-		`CREATE INDEX IF NOT EXISTS connector_market_operations_terminal_cleanup
-ON connector_market_operations(updated_at_unix_ms, operation_id)
-WHERE state IN ('completed', 'failed')`,
-		`CREATE INDEX IF NOT EXISTS connector_market_outbox_published_cleanup
-ON connector_market_outbox(published_at_unix_ms, sequence)
-WHERE published_at_unix_ms IS NOT NULL`,
-	}
-	for _, statement := range statements {
-		if _, err := store.db.ExecContext(ctx, statement); err != nil {
-			return fmt.Errorf("migrate connector market lifecycle index: %w", err)
-		}
-	}
-	return nil
-}
-
-func isDuplicateColumnError(err error) bool {
-	return err != nil && strings.Contains(strings.ToLower(err.Error()), "duplicate column")
-}
-
-func (store *Store) backfillLifecycleColumns(ctx context.Context) error {
-	tx, err := store.db.BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = tx.Rollback() }()
-	rows, err := tx.QueryContext(ctx, `
-SELECT operation_id, operation_json FROM connector_market_operations
-WHERE updated_at_unix_ms = 0`)
-	if err != nil {
-		return err
-	}
-	type timestampBackfill struct {
-		operationID string
-		updatedAtMS int64
-	}
-	var updates []timestampBackfill
-	for rows.Next() {
-		var operationID, payload string
-		if err := rows.Scan(&operationID, &payload); err != nil {
-			_ = rows.Close()
-			return err
-		}
-		operation, err := decodeOperation(payload)
-		if err != nil {
-			_ = rows.Close()
-			return err
-		}
-		updates = append(updates, timestampBackfill{operationID: operationID, updatedAtMS: operation.UpdatedAt.UTC().UnixMilli()})
-	}
-	if err := rows.Close(); err != nil {
-		return err
-	}
-	if err := rows.Err(); err != nil {
-		return err
-	}
-	for _, update := range updates {
-		if _, err := tx.ExecContext(ctx, `UPDATE connector_market_operations SET updated_at_unix_ms = ? WHERE operation_id = ? AND updated_at_unix_ms = 0`,
-			update.updatedAtMS, update.operationID); err != nil {
-			return err
-		}
-	}
-	if err := backfillInstalledReleaseEvidence(ctx, tx); err != nil {
-		return err
-	}
-	return tx.Commit()
-}
-
-func backfillInstalledReleaseEvidence(ctx context.Context, tx *sql.Tx) error {
-	rows, err := tx.QueryContext(ctx, `SELECT connector_json FROM connector_market_connectors`)
-	if err != nil {
-		return err
-	}
-	var connectors []market.Connector
-	for rows.Next() {
-		var payload string
-		if err := rows.Scan(&payload); err != nil {
-			_ = rows.Close()
-			return err
-		}
-		connector, err := decodeConnector(payload)
-		if err != nil {
-			_ = rows.Close()
-			return err
-		}
-		connectors = append(connectors, connector)
-	}
-	if err := rows.Close(); err != nil {
-		return err
-	}
-	if err := rows.Err(); err != nil {
-		return err
-	}
-	for _, connector := range connectors {
-		digest := connector.Installation.InstalledReleaseDigest
-		if digest == "" {
-			continue
-		}
-		var storedDigest string
-		err := tx.QueryRowContext(ctx, `SELECT release_digest FROM connector_market_installed_releases WHERE connector_key = ?`, connector.Key).Scan(&storedDigest)
-		if err == nil && storedDigest == digest {
-			continue
-		}
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
-			return err
-		}
-		release, found, err := legacyInstalledReleaseEvidence(ctx, tx, connector, digest)
-		if err != nil {
-			return err
-		}
-		if !found {
-			return fmt.Errorf("backfill installed connector release %q for %q: %w", digest, connector.Key, market.ErrNotFound)
-		}
-		if err := saveInstalledReleaseOn(ctx, tx, release); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func legacyInstalledReleaseEvidence(ctx context.Context, tx *sql.Tx, connector market.Connector, digest string) (market.Release, bool, error) {
-	if connector.Release.ReleaseDigest == digest {
-		return connector.Release, true, nil
-	}
-	rows, err := tx.QueryContext(ctx, `SELECT operation_json FROM connector_market_operations
-WHERE connector_key = ? AND kind = ? AND state = ? ORDER BY updated_at_unix_ms DESC`,
-		connector.Key, market.OperationKindInstall, market.OperationStateCompleted)
-	if err != nil {
-		return market.Release{}, false, err
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var payload string
-		if err := rows.Scan(&payload); err != nil {
-			return market.Release{}, false, err
-		}
-		operation, err := decodeOperation(payload)
-		if err != nil {
-			return market.Release{}, false, err
-		}
-		if operation.Target != nil && operation.Target.Release != nil && operation.Target.ReleaseDigest == digest {
-			return *operation.Target.Release, true, nil
-		}
-	}
-	return market.Release{}, false, rows.Err()
-}
 
 func saveInstalledReleaseEvidenceOn(ctx context.Context, tx *sql.Tx, operation market.Operation) error {
 	if operation.State != market.OperationStateCompleted {
@@ -216,10 +60,10 @@ func (store *Store) CleanupLifecycle(ctx context.Context, request market.Lifecyc
 DELETE FROM connector_market_operations
 WHERE operation_id IN (
   SELECT operation_id FROM connector_market_operations
-  WHERE state IN ('completed', 'failed') AND updated_at_unix_ms <= ?
+  WHERE state IN ('completed', 'failed', 'cancelled') AND updated_at_unix_ms <= ?
   ORDER BY updated_at_unix_ms, operation_id LIMIT ?
 )
-AND state IN ('completed', 'failed') AND updated_at_unix_ms <= ?`,
+AND state IN ('completed', 'failed', 'cancelled') AND updated_at_unix_ms <= ?`,
 		request.TerminalOperationsUpdatedThrough.UTC().UnixMilli(), request.BatchSize,
 		request.TerminalOperationsUpdatedThrough.UTC().UnixMilli())
 	if err != nil {

--- a/packages/connector/store-sqlite/lifecycle_test.go
+++ b/packages/connector/store-sqlite/lifecycle_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -372,7 +373,7 @@ func TestStoreCompletedLocalUninstallDeletesReleaseEvidenceButKeepsAuthorization
 	}
 }
 
-func TestStoreMigrationBackfillsLifecycleTimestampAndInstalledReleaseEvidence(t *testing.T) {
+func TestStoreRejectsLegacyLifecycleDatabase(t *testing.T) {
 	ctx := context.Background()
 	databasePath := filepath.Join(t.TempDir(), "tuttid.db")
 	legacy, err := sql.Open("sqlite", databasePath)
@@ -441,28 +442,15 @@ operation_id, client_request_id, connector_key, kind, state, lease_owner, lease_
 		t.Fatal(err)
 	}
 
-	store, err := Open(ctx, databasePath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer store.Close()
-	var updatedAtMS int64
-	if err := store.db.QueryRowContext(ctx, `SELECT updated_at_unix_ms FROM connector_market_operations WHERE operation_id = ?`, operation.OperationID).Scan(&updatedAtMS); err != nil {
-		t.Fatal(err)
-	}
-	if updatedAtMS != operation.UpdatedAt.UnixMilli() {
-		t.Fatalf("migrated updated timestamp = %d, want %d", updatedAtMS, operation.UpdatedAt.UnixMilli())
-	}
-	release, err := store.InstalledRelease(ctx, connector.Key, installedRelease.ReleaseDigest)
-	if err != nil || release.ReleaseDigest != installedRelease.ReleaseDigest {
-		t.Fatalf("migrated installed release = %#v, error = %v", release, err)
+	if _, err := Open(ctx, databasePath); err == nil || !strings.Contains(err.Error(), "legacy connector market SQLite is unsupported") {
+		t.Fatalf("Open(legacy) error = %v", err)
 	}
 }
 
 func lifecycleTestOperation(operationID, connectorKey string, state market.OperationState, updatedAt time.Time) market.Operation {
 	return market.Operation{
 		OperationID: operationID, ClientRequestID: "request-" + operationID, ConnectorKey: connectorKey,
-		Kind: market.OperationKindRefreshCatalog, State: state, Stage: market.OperationStageCompleted,
+		Kind: market.OperationKindReconcileRuntime, State: state, Stage: market.OperationStageCompleted,
 		CreatedAt: updatedAt.Add(-time.Minute), UpdatedAt: updatedAt,
 	}
 }

--- a/packages/connector/store-sqlite/store.go
+++ b/packages/connector/store-sqlite/store.go
@@ -1,3 +1,5 @@
+//revive:disable:file-length-limit
+
 package storesqlite
 
 import (
@@ -80,9 +82,23 @@ func (store *Store) Close() error {
 }
 
 func (store *Store) migrate(ctx context.Context) error {
+	var schemaMarkerCount, legacyTableCount int
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'connector_control_plane_schema'`).Scan(&schemaMarkerCount); err != nil {
+		return fmt.Errorf("inspect connector control-plane schema marker: %w", err)
+	}
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name LIKE 'connector_market_%'`).Scan(&legacyTableCount); err != nil {
+		return fmt.Errorf("inspect legacy connector tables: %w", err)
+	}
+	if schemaMarkerCount == 0 && legacyTableCount > 0 {
+		return errors.New("legacy connector market SQLite is unsupported; open a fresh connector-control-plane-v2 database")
+	}
 	statements := []string{
-		`DROP TABLE IF EXISTS connector_market_catalog_trust`,
-		`DROP TABLE IF EXISTS connector_market_security_revocations`,
+		`CREATE TABLE IF NOT EXISTS connector_control_plane_schema (
+  schema_version INTEGER PRIMARY KEY CHECK (schema_version = 2),
+  contract_cohort TEXT NOT NULL CHECK (contract_cohort = 'connector-control-plane-v2')
+)`,
+		`INSERT INTO connector_control_plane_schema (schema_version, contract_cohort)
+VALUES (2, 'connector-control-plane-v2') ON CONFLICT(schema_version) DO NOTHING`,
 		`CREATE TABLE IF NOT EXISTS connector_market_metadata (
   id INTEGER PRIMARY KEY CHECK (id = 1),
   revision INTEGER NOT NULL,
@@ -94,6 +110,12 @@ VALUES (1, 0, 'stale', '') ON CONFLICT(id) DO NOTHING`,
 		`CREATE TABLE IF NOT EXISTS connector_market_connectors (
   connector_key TEXT PRIMARY KEY,
   connector_json TEXT NOT NULL
+)`,
+		`CREATE TABLE IF NOT EXISTS connector_market_catalog_snapshot (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  catalog_revision INTEGER NOT NULL CHECK (catalog_revision > 0),
+  snapshot_digest TEXT NOT NULL,
+  snapshot_json TEXT NOT NULL
 )`,
 		`CREATE TABLE IF NOT EXISTS connector_market_installed_releases (
   connector_key TEXT PRIMARY KEY,
@@ -115,16 +137,25 @@ VALUES (1, 0, 'stale', '') ON CONFLICT(id) DO NOTHING`,
   client_request_id TEXT NOT NULL UNIQUE,
   connector_key TEXT NOT NULL,
   kind TEXT NOT NULL,
-  state TEXT NOT NULL,
+  state TEXT NOT NULL CHECK (state IN ('accepted', 'running', 'outcome_unknown', 'completed', 'failed', 'cancelled')),
+  request_digest TEXT NOT NULL,
+  operation_version INTEGER NOT NULL CHECK (operation_version >= 0),
   lease_owner TEXT NOT NULL,
-	lease_token INTEGER NOT NULL DEFAULT 0,
+  lease_token INTEGER NOT NULL DEFAULT 0,
   lease_expires_at_unix_ms INTEGER,
-	updated_at_unix_ms INTEGER NOT NULL DEFAULT 0,
+  next_attempt_at_unix_ms INTEGER,
+  updated_at_unix_ms INTEGER NOT NULL,
   operation_json TEXT NOT NULL
 )`,
-		`CREATE UNIQUE INDEX IF NOT EXISTS connector_market_one_active_operation
-ON connector_market_operations(connector_key)
-WHERE state IN ('accepted', 'running')`,
+		`CREATE INDEX IF NOT EXISTS connector_market_operations_dispatch
+ON connector_market_operations(state, next_attempt_at_unix_ms, lease_expires_at_unix_ms, operation_id)
+WHERE state IN ('accepted', 'running', 'outcome_unknown')`,
+		`CREATE TABLE IF NOT EXISTS connector_market_resource_claims (
+  resource_key TEXT PRIMARY KEY,
+  operation_id TEXT NOT NULL UNIQUE,
+  acquired_at_unix_ms INTEGER NOT NULL,
+  FOREIGN KEY (operation_id) REFERENCES connector_market_operations(operation_id) ON DELETE CASCADE
+)`,
 		`CREATE TABLE IF NOT EXISTS connector_market_outbox (
   sequence INTEGER PRIMARY KEY AUTOINCREMENT,
   revision INTEGER NOT NULL,
@@ -133,17 +164,27 @@ WHERE state IN ('accepted', 'running')`,
 )`,
 		`CREATE INDEX IF NOT EXISTS connector_market_outbox_pending
 ON connector_market_outbox(published_at_unix_ms, sequence)`,
+		`CREATE INDEX IF NOT EXISTS connector_market_operations_terminal_cleanup
+ON connector_market_operations(updated_at_unix_ms, operation_id)
+WHERE state IN ('completed', 'failed', 'cancelled')`,
+		`CREATE INDEX IF NOT EXISTS connector_market_outbox_published_cleanup
+ON connector_market_outbox(published_at_unix_ms, sequence)
+WHERE published_at_unix_ms IS NOT NULL`,
 	}
 	for _, statement := range statements {
 		if _, err := store.db.ExecContext(ctx, statement); err != nil {
 			return fmt.Errorf("migrate connector market store: %w", err)
 		}
 	}
-	if _, err := store.db.ExecContext(ctx, `ALTER TABLE connector_market_operations ADD COLUMN lease_token INTEGER NOT NULL DEFAULT 0`); err != nil &&
-		!strings.Contains(strings.ToLower(err.Error()), "duplicate column") {
-		return fmt.Errorf("migrate connector market operation lease token: %w", err)
+	var version int
+	var cohort string
+	if err := store.db.QueryRowContext(ctx, `SELECT schema_version, contract_cohort FROM connector_control_plane_schema`).Scan(&version, &cohort); err != nil {
+		return fmt.Errorf("read connector control-plane schema identity: %w", err)
 	}
-	return store.migrateLifecycle(ctx)
+	if version != 2 || cohort != "connector-control-plane-v2" {
+		return fmt.Errorf("unsupported connector control-plane schema identity: version=%d cohort=%q", version, cohort)
+	}
+	return nil
 }
 
 func (store *Store) Snapshot(ctx context.Context) (market.Snapshot, error) {
@@ -153,6 +194,7 @@ func (store *Store) Snapshot(ctx context.Context) (market.Snapshot, error) {
 	}
 	defer func() { _ = tx.Rollback() }()
 	var result market.Snapshot
+	result.ContractCohort = market.ConnectorControlPlaneContractCohort
 	if err := tx.QueryRowContext(ctx, `
 SELECT revision, catalog_state, source_revision
 FROM connector_market_metadata WHERE id = ?`, metadataID).
@@ -213,7 +255,7 @@ func (store *Store) ClaimOperation(
 UPDATE connector_market_operations
 SET lease_owner = ?, lease_token = lease_token + 1, lease_expires_at_unix_ms = ?
 WHERE operation_id = ?
-  AND state IN ('accepted', 'running')
+  AND state IN ('accepted', 'running', 'outcome_unknown')
   AND (
     lease_owner = '' OR lease_expires_at_unix_ms IS NULL OR
     lease_expires_at_unix_ms <= ? OR lease_owner = ?
@@ -332,10 +374,22 @@ WHERE connector_key = ? AND release_digest = ?`, connectorKey, releaseDigest).Sc
 	return release, nil
 }
 
+func (store *Store) CatalogSnapshot(ctx context.Context) (market.CatalogSnapshot, error) {
+	var payload string
+	if err := store.db.QueryRowContext(ctx, `SELECT snapshot_json FROM connector_market_catalog_snapshot WHERE id = 1`).Scan(&payload); err != nil {
+		return market.CatalogSnapshot{}, mapNotFound(err)
+	}
+	var snapshot market.CatalogSnapshot
+	if err := json.Unmarshal([]byte(payload), &snapshot); err != nil {
+		return market.CatalogSnapshot{}, fmt.Errorf("decode connector catalog snapshot: %w", err)
+	}
+	return snapshot, nil
+}
+
 func (store *Store) RecoverableOperations(ctx context.Context) ([]market.Operation, error) {
 	rows, err := store.db.QueryContext(ctx, `
 SELECT operation_json FROM connector_market_operations
-WHERE state IN ('accepted', 'running')
+WHERE state IN ('accepted', 'running', 'outcome_unknown')
 ORDER BY operation_id`)
 	if err != nil {
 		return nil, err
@@ -551,17 +605,19 @@ SELECT operation_json FROM connector_market_operations WHERE client_request_id =
 	return &operation, err
 }
 
-func (transaction *transaction) ActiveOperation(connectorKey string) (*market.Operation, error) {
-	var payload string
-	query := `
-SELECT operation_json FROM connector_market_operations
-WHERE connector_key IN ('', ?) AND state IN ('accepted', 'running') LIMIT 1`
-	arguments := []any{connectorKey}
-	if strings.TrimSpace(connectorKey) == "" {
-		query = `SELECT operation_json FROM connector_market_operations WHERE state IN ('accepted', 'running') LIMIT 1`
-		arguments = nil
+func (transaction *transaction) ActiveOperation(kind market.OperationKind, scope market.OperationScope, connectorKey string) (*market.Operation, error) {
+	claims := market.OperationLockClaims(kind, scope, connectorKey)
+	if len(claims) == 0 {
+		return nil, nil
 	}
-	if err := transaction.tx.QueryRowContext(transaction.ctx, query, arguments...).Scan(&payload); err != nil {
+	var payload string
+	if err := transaction.tx.QueryRowContext(transaction.ctx, `
+SELECT operation.operation_json
+FROM connector_market_resource_claims claim
+JOIN connector_market_operations operation ON operation.operation_id = claim.operation_id
+WHERE claim.resource_key = ?
+  AND operation.state IN ('accepted', 'running', 'outcome_unknown')
+LIMIT 1`, claims[0]).Scan(&payload); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}
@@ -574,6 +630,21 @@ WHERE connector_key IN ('', ?) AND state IN ('accepted', 'running') LIMIT 1`
 func (transaction *transaction) SaveCatalogRevision(sourceRevision string) error {
 	_, err := transaction.tx.ExecContext(transaction.ctx, `
 UPDATE connector_market_metadata SET source_revision = ? WHERE id = ?`, sourceRevision, metadataID)
+	return err
+}
+
+func (transaction *transaction) SaveCatalogSnapshot(snapshot market.CatalogSnapshot) error {
+	payload, err := json.Marshal(snapshot)
+	if err != nil {
+		return err
+	}
+	_, err = transaction.tx.ExecContext(transaction.ctx, `
+INSERT INTO connector_market_catalog_snapshot (id, catalog_revision, snapshot_digest, snapshot_json)
+VALUES (1, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+  catalog_revision = excluded.catalog_revision,
+  snapshot_digest = excluded.snapshot_digest,
+  snapshot_json = excluded.snapshot_json`, snapshot.CatalogRevision, snapshot.SnapshotDigest, string(payload))
 	return err
 }
 
@@ -682,6 +753,18 @@ SELECT operation_json FROM connector_market_operations WHERE operation_id = ?`, 
 }
 
 func saveOperationOn(ctx context.Context, tx *sql.Tx, operation market.Operation) error {
+	var currentVersion uint64
+	err := tx.QueryRowContext(ctx, `SELECT operation_version FROM connector_market_operations WHERE operation_id = ?`, operation.OperationID).Scan(&currentVersion)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+	operation.OperationVersion = currentVersion + 1
+	if operation.RequestDigest == "" {
+		operation.RequestDigest = market.OperationRequestDigest(operation.Kind, operation.Scope, operation.ConnectorKey, nil)
+	}
+	if len(operation.LockClaims) == 0 {
+		operation.LockClaims = market.OperationLockClaims(operation.Kind, operation.Scope, operation.ConnectorKey)
+	}
 	payload, err := json.Marshal(operation)
 	if err != nil {
 		return err
@@ -690,16 +773,23 @@ func saveOperationOn(ctx context.Context, tx *sql.Tx, operation market.Operation
 	if operation.LeaseExpiresAt != nil {
 		leaseExpiresAt = operation.LeaseExpiresAt.UTC().UnixMilli()
 	}
+	var nextAttemptAt any
+	if operation.NextAttemptAt != nil {
+		nextAttemptAt = operation.NextAttemptAt.UTC().UnixMilli()
+	}
 	result, err := tx.ExecContext(ctx, `
 INSERT INTO connector_market_operations (
-  operation_id, client_request_id, connector_key, kind, state,
-  lease_owner, lease_token, lease_expires_at_unix_ms, updated_at_unix_ms, operation_json
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  operation_id, client_request_id, connector_key, kind, state, request_digest, operation_version,
+  lease_owner, lease_token, lease_expires_at_unix_ms, next_attempt_at_unix_ms, updated_at_unix_ms, operation_json
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(operation_id) DO UPDATE SET
   state = excluded.state,
+  request_digest = excluded.request_digest,
+  operation_version = excluded.operation_version,
   lease_owner = excluded.lease_owner,
 	lease_token = excluded.lease_token,
   lease_expires_at_unix_ms = excluded.lease_expires_at_unix_ms,
+	next_attempt_at_unix_ms = excluded.next_attempt_at_unix_ms,
 	updated_at_unix_ms = excluded.updated_at_unix_ms,
 	operation_json = excluded.operation_json
 WHERE excluded.lease_token = 0 OR (
@@ -707,7 +797,8 @@ WHERE excluded.lease_token = 0 OR (
   connector_market_operations.lease_token = excluded.lease_token
 )`,
 		operation.OperationID, operation.ClientRequestID, operation.ConnectorKey,
-		operation.Kind, operation.State, operation.LeaseOwner, operation.LeaseToken, leaseExpiresAt,
+		operation.Kind, operation.State, operation.RequestDigest, operation.OperationVersion,
+		operation.LeaseOwner, operation.LeaseToken, leaseExpiresAt, nextAttemptAt,
 		operation.UpdatedAt.UTC().UnixMilli(), string(payload))
 	if err != nil {
 		return err
@@ -718,6 +809,28 @@ WHERE excluded.lease_token = 0 OR (
 	}
 	if operation.LeaseToken > 0 && changed != 1 {
 		return market.ErrOperationLeaseLost
+	}
+	if operation.State.IsTerminal() {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM connector_market_resource_claims WHERE operation_id = ?`, operation.OperationID); err != nil {
+			return err
+		}
+	} else {
+		for _, resourceKey := range operation.LockClaims {
+			if _, err := tx.ExecContext(ctx, `
+INSERT INTO connector_market_resource_claims (resource_key, operation_id, acquired_at_unix_ms)
+VALUES (?, ?, ?)
+ON CONFLICT(resource_key) DO UPDATE SET operation_id = excluded.operation_id
+WHERE connector_market_resource_claims.operation_id = excluded.operation_id`, resourceKey, operation.OperationID, operation.CreatedAt.UTC().UnixMilli()); err != nil {
+				return err
+			}
+			var owner string
+			if err := tx.QueryRowContext(ctx, `SELECT operation_id FROM connector_market_resource_claims WHERE resource_key = ?`, resourceKey).Scan(&owner); err != nil {
+				return err
+			}
+			if owner != operation.OperationID {
+				return fmt.Errorf("connector resource %q is claimed by operation %q", resourceKey, owner)
+			}
+		}
 	}
 	return saveInstalledReleaseEvidenceOn(ctx, tx, operation)
 }

--- a/packages/connector/store-sqlite/store_test.go
+++ b/packages/connector/store-sqlite/store_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -40,7 +41,7 @@ func TestConnectorMarketSQLiteDSNUsesWindowsFileURI(t *testing.T) {
 	}
 }
 
-func TestStoreMigrationDropsLegacyTrustTables(t *testing.T) {
+func TestStoreRejectsLegacyConnectorTables(t *testing.T) {
 	ctx := context.Background()
 	databasePath := filepath.Join(t.TempDir(), "tuttid.db")
 	legacy, err := sql.Open("sqlite", databasePath)
@@ -60,19 +61,8 @@ func TestStoreMigrationDropsLegacyTrustTables(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	store, err := Open(ctx, databasePath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer store.Close()
-	for _, table := range []string{"connector_market_catalog_trust", "connector_market_security_revocations"} {
-		var count int
-		if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?`, table).Scan(&count); err != nil {
-			t.Fatal(err)
-		}
-		if count != 0 {
-			t.Fatalf("legacy table %q still exists", table)
-		}
+	if _, err := Open(ctx, databasePath); err == nil || !strings.Contains(err.Error(), "legacy connector market SQLite is unsupported") {
+		t.Fatalf("Open(legacy) error = %v", err)
 	}
 }
 
@@ -118,6 +108,101 @@ func TestStorePersistsRevisionOperationBindingAndOutboxAtomically(t *testing.T) 
 	}
 	if len(entries) != 1 || entries[0].Event.Revision != 1 {
 		t.Fatalf("outbox = %#v", entries)
+	}
+}
+
+func TestStoreAtomicallyReplacesFullCatalogSnapshot(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(ctx, filepath.Join(t.TempDir(), "connector-control-plane-v2.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	release := testConnector().Release
+	snapshot := market.CatalogSnapshot{
+		CatalogRevision: 9, SnapshotDigest: "sha256:" + strings.Repeat("d", 64), SourceRevision: "9:sha256:" + strings.Repeat("d", 64),
+		Categories: []market.CatalogCategory{{CategoryID: "development", Kind: "category", ItemCount: 1}},
+		Entries:    []market.CatalogEntry{{CategoryID: "development", Release: release}},
+		Releases:   []market.Release{release},
+		Revocations: []market.CatalogRevocation{{ArtifactDigest: "sha256:" + strings.Repeat("e", 64), RevocationID: "revoke-1",
+			ConnectorKey: "old", Version: "0.9.0", ReasonCode: "malware", EffectiveAt: time.Unix(2, 0).UTC()}},
+	}
+	if err := store.Transaction(ctx, func(tx market.Transaction) error {
+		if err := tx.SaveCatalogSnapshot(snapshot); err != nil {
+			return err
+		}
+		return tx.SaveCatalogRevision(snapshot.SourceRevision)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	stored, err := store.CatalogSnapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.CatalogRevision != 9 || stored.SnapshotDigest != snapshot.SnapshotDigest || len(stored.Entries) != 1 || len(stored.Revocations) != 1 {
+		t.Fatalf("catalog snapshot = %#v", stored)
+	}
+}
+
+func TestStoreResourceClaimsSerializeOnlyConflictingPhysicalWork(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(ctx, filepath.Join(t.TempDir(), "connector-control-plane-v2.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	now := time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC)
+	connectorKey := "github"
+	executionScope := market.OperationScope{DeviceID: "device-1", AccountID: "account-1"}
+	install := market.Operation{
+		OperationID: "install-1", ClientRequestID: "request-install-1", ConnectorKey: connectorKey,
+		Kind: market.OperationKindInstall, Scope: executionScope, State: market.OperationStateAccepted,
+		Stage: market.OperationStageAccepted, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := store.Transaction(ctx, func(tx market.Transaction) error { return tx.SaveOperation(install) }); err != nil {
+		t.Fatalf("save install claim: %v", err)
+	}
+	authorization := market.Operation{
+		OperationID: "authorize-1", ClientRequestID: "request-authorize-1", ConnectorKey: connectorKey,
+		Kind: market.OperationKindStartAuthorization, Scope: executionScope, State: market.OperationStateAccepted,
+		Stage: market.OperationStageAccepted, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := store.Transaction(ctx, func(tx market.Transaction) error { return tx.SaveOperation(authorization) }); err != nil {
+		t.Fatalf("authorization should not conflict with execution: %v", err)
+	}
+	runtimeReconcile := market.Operation{
+		OperationID: "runtime-1", ClientRequestID: "request-runtime-1", ConnectorKey: connectorKey,
+		Kind: market.OperationKindReconcileRuntime, Scope: executionScope, State: market.OperationStateAccepted,
+		Stage: market.OperationStageAccepted, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := store.Transaction(ctx, func(tx market.Transaction) error { return tx.SaveOperation(runtimeReconcile) }); err == nil {
+		t.Fatal("runtime reconcile acquired the execution claim while install was active")
+	}
+	install.State = market.OperationStateOutcomeUnknown
+	install.UpdatedAt = now.Add(time.Second)
+	if err := store.Transaction(ctx, func(tx market.Transaction) error { return tx.SaveOperation(install) }); err != nil {
+		t.Fatalf("persist outcome_unknown: %v", err)
+	}
+	if err := store.Transaction(ctx, func(tx market.Transaction) error {
+		active, err := tx.ActiveOperation(market.OperationKindReconcileRuntime, executionScope, connectorKey)
+		if err != nil {
+			return err
+		}
+		if active == nil || active.OperationID != install.OperationID {
+			return fmt.Errorf("execution claim owner = %#v", active)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	install.State = market.OperationStateFailed
+	install.Stage = market.OperationStageFailed
+	install.UpdatedAt = now.Add(2 * time.Second)
+	if err := store.Transaction(ctx, func(tx market.Transaction) error { return tx.SaveOperation(install) }); err != nil {
+		t.Fatalf("finish install: %v", err)
+	}
+	if err := store.Transaction(ctx, func(tx market.Transaction) error { return tx.SaveOperation(runtimeReconcile) }); err != nil {
+		t.Fatalf("runtime reconcile did not acquire released execution claim: %v", err)
 	}
 }
 

--- a/services/tuttid/api/daemon_connector_market.go
+++ b/services/tuttid/api/daemon_connector_market.go
@@ -128,31 +128,25 @@ func (api DaemonAPI) GetConnectorMarketConnector(
 
 func (api DaemonAPI) RefreshConnectorMarket(
 	ctx context.Context,
-	request tuttigenerated.RefreshConnectorMarketRequestObject,
+	_ tuttigenerated.RefreshConnectorMarketRequestObject,
 ) (tuttigenerated.RefreshConnectorMarketResponseObject, error) {
 	if api.ConnectorMarketService == nil {
 		return tuttigenerated.RefreshConnectorMarket503JSONResponse{ConnectorMarketUnavailableErrorJSONResponse: connectorMarketUnavailableError()}, nil
 	}
-	mutation, err := connectorMarketMutation(request.Body)
+	snapshot, err := api.ConnectorMarketService.RefreshCatalog(ctx)
 	if err != nil {
-		return tuttigenerated.RefreshConnectorMarket400JSONResponse{ConnectorMarketInvalidRequestErrorJSONResponse: invalidConnectorMarketResponse(connectorMarketErrorPayload(err))}, nil
-	}
-	result, err := api.ConnectorMarketService.RefreshCatalog(ctx, mutation)
-	if err != nil {
-		payload, status := connectorMarketError(err)
-		if status == 409 {
-			return tuttigenerated.RefreshConnectorMarket409JSONResponse{ConnectorMarketConflictErrorJSONResponse: conflictConnectorMarketResponse(payload)}, nil
-		}
-		if status == 400 {
-			return tuttigenerated.RefreshConnectorMarket400JSONResponse{ConnectorMarketInvalidRequestErrorJSONResponse: invalidConnectorMarketResponse(payload)}, nil
-		}
+		payload, _ := connectorMarketError(err)
 		return tuttigenerated.RefreshConnectorMarket503JSONResponse{ConnectorMarketUnavailableErrorJSONResponse: unavailableConnectorMarketResponse(payload)}, nil
 	}
-	projected, err := projectConnectorMarket[tuttigenerated.ConnectorMarketMutationResponse](result)
+	if err := api.overlayConnectorAuthorizationProjections(ctx, snapshot.Connectors); err != nil {
+		payload, _ := connectorMarketError(err)
+		return tuttigenerated.RefreshConnectorMarket503JSONResponse{ConnectorMarketUnavailableErrorJSONResponse: unavailableConnectorMarketResponse(payload)}, nil
+	}
+	projected, err := projectConnectorMarket[tuttigenerated.ConnectorMarketSnapshot](snapshot)
 	if err != nil {
 		return nil, err
 	}
-	return tuttigenerated.RefreshConnectorMarket202JSONResponse(projected), nil
+	return tuttigenerated.RefreshConnectorMarket200JSONResponse(projected), nil
 }
 
 func (api DaemonAPI) InstallConnectorMarketConnector(
@@ -433,7 +427,8 @@ func connectorMarketError(err error) (tuttigenerated.ConnectorMarketError, int) 
 		return payload, 404
 	case market.ErrorCodeRevisionConflict, market.ErrorCodeOperationInProgress:
 		return payload, 409
-	case market.ErrorCodeIncompatible, market.ErrorCodeInvalidManifest, market.ErrorCodeUnsupportedImplementation:
+	case market.ErrorCodeIncompatible, market.ErrorCodeInvalidManifest, market.ErrorCodeUnsupportedImplementation,
+		market.ErrorCodeReleaseRevoked:
 		return payload, 422
 	default:
 		return payload, 503

--- a/services/tuttid/api/daemon_connector_market_test.go
+++ b/services/tuttid/api/daemon_connector_market_test.go
@@ -13,6 +13,7 @@ import (
 type stubConnectorMarketService struct {
 	market.Service
 	snapshotFn   func(context.Context) (market.Snapshot, error)
+	refreshFn    func(context.Context) (market.Snapshot, error)
 	categoriesFn func(context.Context) ([]market.CatalogCategory, error)
 	pageFn       func(context.Context, market.CatalogPageQuery) (market.CatalogPage, error)
 	installFn    func(context.Context, market.ConnectorMutation) (market.MutationResult, error)
@@ -29,6 +30,10 @@ func (service stubConnectorMarketService) GetAuthorizationProjection(ctx context
 
 func (service stubConnectorMarketService) Snapshot(ctx context.Context) (market.Snapshot, error) {
 	return service.snapshotFn(ctx)
+}
+
+func (service stubConnectorMarketService) RefreshCatalog(ctx context.Context) (market.Snapshot, error) {
+	return service.refreshFn(ctx)
 }
 
 func (service stubConnectorMarketService) Install(ctx context.Context, mutation market.ConnectorMutation) (market.MutationResult, error) {
@@ -51,6 +56,7 @@ func TestDaemonAPIConnectorMarketSnapshotHidesImplementationConfig(t *testing.T)
 	service := stubConnectorMarketService{
 		snapshotFn: func(_ context.Context) (market.Snapshot, error) {
 			return market.Snapshot{
+				ContractCohort: market.ConnectorControlPlaneContractCohort,
 				CatalogState:   market.CatalogStateReady,
 				Connectors:     []market.Connector{connectorMarketTestConnector()},
 				Operations:     []market.Operation{},
@@ -62,7 +68,7 @@ func TestDaemonAPIConnectorMarketSnapshotHidesImplementationConfig(t *testing.T)
 	mux := http.NewServeMux()
 	RegisterRoutes(mux, NewRoutes(DaemonAPI{ConnectorMarketService: service}))
 
-	recorder := performGeneratedRouteRequest(t, mux, http.MethodGet, "/v1/connector-market", nil)
+	recorder := performGeneratedRouteRequest(t, mux, http.MethodGet, "/v2/connector-market", nil)
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d; body: %s", recorder.Code, http.StatusOK, recorder.Body.String())
 	}
@@ -90,7 +96,7 @@ func TestDaemonAPIConnectorMarketSnapshotHidesImplementationConfig(t *testing.T)
 func TestDaemonAPIConnectorMarketOverlaysAccountAuthorizationProjection(t *testing.T) {
 	service := stubConnectorMarketService{
 		snapshotFn: func(context.Context) (market.Snapshot, error) {
-			return market.Snapshot{Connectors: []market.Connector{connectorMarketTestConnector()}}, nil
+			return market.Snapshot{ContractCohort: market.ConnectorControlPlaneContractCohort, Connectors: []market.Connector{connectorMarketTestConnector()}}, nil
 		},
 		projectionFn: func(_ context.Context, accountID, connectorKey string) (market.AuthorizationProjection, error) {
 			if accountID != "account-1" || connectorKey != "notion" {
@@ -103,7 +109,7 @@ func TestDaemonAPIConnectorMarketOverlaysAccountAuthorizationProjection(t *testi
 	RegisterRoutes(mux, NewRoutes(DaemonAPI{ConnectorMarketService: service, ConnectorMarketScope: func() market.OperationScope {
 		return market.OperationScope{AccountID: "account-1"}
 	}}))
-	recorder := performGeneratedRouteRequest(t, mux, http.MethodGet, "/v1/connector-market", nil)
+	recorder := performGeneratedRouteRequest(t, mux, http.MethodGet, "/v2/connector-market", nil)
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("status = %d body=%s", recorder.Code, recorder.Body.String())
 	}
@@ -157,7 +163,7 @@ func TestDaemonAPIConnectorMarketInstallMapsUnsupportedImplementation(t *testing
 	mux := http.NewServeMux()
 	RegisterRoutes(mux, NewRoutes(DaemonAPI{ConnectorMarketService: service}))
 
-	recorder := performGeneratedRouteRequest(t, mux, http.MethodPost, "/v1/connector-market/connectors/notion:install", map[string]any{
+	recorder := performGeneratedRouteRequest(t, mux, http.MethodPost, "/v2/connector-market/connectors/notion:install", map[string]any{
 		"clientRequestId":  "request-1",
 		"expectedRevision": 7,
 	})
@@ -198,7 +204,7 @@ func TestDaemonAPIConnectorMarketUninstallPreservesMutationScope(t *testing.T) {
 		},
 	}))
 
-	recorder := performGeneratedRouteRequest(t, mux, http.MethodPost, "/v1/connector-market/connectors/notion:uninstall", map[string]any{
+	recorder := performGeneratedRouteRequest(t, mux, http.MethodPost, "/v2/connector-market/connectors/notion:uninstall", map[string]any{
 		"clientRequestId":  "request-uninstall-1",
 		"expectedRevision": 7,
 	})
@@ -212,16 +218,28 @@ func TestDaemonAPIConnectorMarketUninstallPreservesMutationScope(t *testing.T) {
 	}
 }
 
-func TestDaemonAPIConnectorMarketRefreshRejectsNegativeRevision(t *testing.T) {
+func TestDaemonAPIConnectorMarketRefreshReturnsSynchronizedSnapshot(t *testing.T) {
+	service := stubConnectorMarketService{refreshFn: func(context.Context) (market.Snapshot, error) {
+		return market.Snapshot{
+			ContractCohort: market.ConnectorControlPlaneContractCohort,
+			CatalogState:   market.CatalogStateReady,
+			Connectors:     []market.Connector{},
+			Operations:     []market.Operation{},
+			Revision:       8,
+			SourceRevision: "catalog-2",
+		}, nil
+	}}
 	mux := http.NewServeMux()
-	RegisterRoutes(mux, NewRoutes(DaemonAPI{ConnectorMarketService: stubConnectorMarketService{}}))
+	RegisterRoutes(mux, NewRoutes(DaemonAPI{ConnectorMarketService: service}))
 
-	recorder := performGeneratedRouteRequest(t, mux, http.MethodPost, "/v1/connector-market:refresh", map[string]any{
-		"clientRequestId":  "request-1",
-		"expectedRevision": -1,
-	})
-	if recorder.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want %d; body: %s", recorder.Code, http.StatusBadRequest, recorder.Body.String())
+	recorder := performGeneratedRouteRequest(t, mux, http.MethodPost, "/v2/connector-market:refresh", nil)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	var response tuttigenerated.ConnectorMarketSnapshot
+	decodeGeneratedRouteResponse(t, recorder, &response)
+	if response.ContractCohort != market.ConnectorControlPlaneContractCohort || response.Revision != 8 {
+		t.Fatalf("response = %#v", response)
 	}
 }
 
@@ -245,11 +263,11 @@ func TestDaemonAPIConnectorMarketServesCategoriesAndCursorPage(t *testing.T) {
 	mux := http.NewServeMux()
 	RegisterRoutes(mux, NewRoutes(DaemonAPI{ConnectorMarketService: service}))
 
-	categories := performGeneratedRouteRequest(t, mux, http.MethodGet, "/v1/connector-market/categories", nil)
+	categories := performGeneratedRouteRequest(t, mux, http.MethodGet, "/v2/connector-market/categories", nil)
 	if categories.Code != http.StatusOK {
 		t.Fatalf("categories status = %d; body: %s", categories.Code, categories.Body.String())
 	}
-	page := performGeneratedRouteRequest(t, mux, http.MethodGet, "/v1/connector-market/catalog?sectionId=development&pageSize=20&pageToken=cursor-1", nil)
+	page := performGeneratedRouteRequest(t, mux, http.MethodGet, "/v2/connector-market/catalog?sectionId=development&pageSize=20&pageToken=cursor-1", nil)
 	if page.Code != http.StatusOK {
 		t.Fatalf("page status = %d; body: %s", page.Code, page.Body.String())
 	}
@@ -300,6 +318,7 @@ func connectorMarketTestConnector() market.Connector {
 		Installation:  market.Installation{State: market.InstallationStateNotInstalled},
 		Authorization: market.Authorization{State: market.AuthorizationStateDisconnected},
 		Compatibility: market.Compatibility{State: market.CompatibilityStateSupported},
+		Security:      market.Security{State: market.SecurityStateAllowed},
 		Revision:      7,
 	}
 }

--- a/services/tuttid/api/generated/server.gen.go
+++ b/services/tuttid/api/generated/server.gen.go
@@ -98,36 +98,6 @@ type ServerInterface interface {
 	// Invoke one registered CLI command
 	// (POST /v1/cli/commands/{commandID}/invoke)
 	InvokeCliCommand(w http.ResponseWriter, r *http.Request, commandID CliCommandID)
-	// Get the authoritative connector-market snapshot
-	// (GET /v1/connector-market)
-	GetConnectorMarket(w http.ResponseWriter, r *http.Request)
-	// List one server-owned connector-market section
-	// (GET /v1/connector-market/catalog)
-	ListConnectorMarketCatalog(w http.ResponseWriter, r *http.Request, params ListConnectorMarketCatalogParams)
-	// List server-owned connector-market sections
-	// (GET /v1/connector-market/categories)
-	ListConnectorMarketCategories(w http.ResponseWriter, r *http.Request)
-	// Get one connector projection
-	// (GET /v1/connector-market/connectors/{connectorKey})
-	GetConnectorMarketConnector(w http.ResponseWriter, r *http.Request, connectorKey ConnectorMarketConnectorKey)
-	// Disconnect connector authorization
-	// (POST /v1/connector-market/connectors/{connectorKey}/authorization:disconnect)
-	DisconnectConnectorMarketAuthorization(w http.ResponseWriter, r *http.Request, connectorKey ConnectorMarketConnectorKey)
-	// Start connector authorization
-	// (POST /v1/connector-market/connectors/{connectorKey}/authorization:start)
-	StartConnectorMarketAuthorization(w http.ResponseWriter, r *http.Request, connectorKey ConnectorMarketConnectorKey)
-	// Install or update one connector
-	// (POST /v1/connector-market/connectors/{connectorKey}:install)
-	InstallConnectorMarketConnector(w http.ResponseWriter, r *http.Request, connectorKey ConnectorMarketConnectorKey)
-	// Uninstall one connector from this device
-	// (POST /v1/connector-market/connectors/{connectorKey}:uninstall)
-	UninstallConnectorMarketConnector(w http.ResponseWriter, r *http.Request, connectorKey ConnectorMarketConnectorKey)
-	// Get one durable connector-market operation
-	// (GET /v1/connector-market/operations/{operationID})
-	GetConnectorMarketOperation(w http.ResponseWriter, r *http.Request, operationID ConnectorMarketOperationID)
-	// Refresh and accept the upstream connector catalog
-	// (POST /v1/connector-market:refresh)
-	RefreshConnectorMarket(w http.ResponseWriter, r *http.Request)
 	// Read the daemon-owned desktop update admission snapshot
 	// (GET /v1/desktop-update-admission)
 	GetDesktopUpdateAdmissionSnapshot(w http.ResponseWriter, r *http.Request)
@@ -785,6 +755,36 @@ type ServerInterface interface {
 	// Decide one Tutti-owned workflow checkpoint
 	// (POST /v1/workspaces/{workspaceID}/workflows/{workflowID}/checkpoints/{checkpointID}/decision)
 	DecideWorkspaceWorkflowCheckpoint(w http.ResponseWriter, r *http.Request, workspaceID WorkspaceID, workflowID openapi_types.UUID, checkpointID openapi_types.UUID)
+	// Get the authoritative connector-market snapshot
+	// (GET /v2/connector-market)
+	GetConnectorMarket(w http.ResponseWriter, r *http.Request)
+	// List one server-owned connector-market section
+	// (GET /v2/connector-market/catalog)
+	ListConnectorMarketCatalog(w http.ResponseWriter, r *http.Request, params ListConnectorMarketCatalogParams)
+	// List server-owned connector-market sections
+	// (GET /v2/connector-market/categories)
+	ListConnectorMarketCategories(w http.ResponseWriter, r *http.Request)
+	// Get one connector projection
+	// (GET /v2/connector-market/connectors/{connectorKey})
+	GetConnectorMarketConnector(w http.ResponseWriter, r *http.Request, connectorKey ConnectorMarketConnectorKey)
+	// Disconnect connector authorization
+	// (POST /v2/connector-market/connectors/{connectorKey}/authorization:disconnect)
+	DisconnectConnectorMarketAuthorization(w http.ResponseWriter, r *http.Request, connectorKey ConnectorMarketConnectorKey)
+	// Start connector authorization
+	// (POST /v2/connector-market/connectors/{connectorKey}/authorization:start)
+	StartConnectorMarketAuthorization(w http.ResponseWriter, r *http.Request, connectorKey ConnectorMarketConnectorKey)
+	// Install or update one connector
+	// (POST /v2/connector-market/connectors/{connectorKey}:install)
+	InstallConnectorMarketConnector(w http.ResponseWriter, r *http.Request, connectorKey ConnectorMarketConnectorKey)
+	// Uninstall one connector from this device
+	// (POST /v2/connector-market/connectors/{connectorKey}:uninstall)
+	UninstallConnectorMarketConnector(w http.ResponseWriter, r *http.Request, connectorKey ConnectorMarketConnectorKey)
+	// Get one durable connector-market operation
+	// (GET /v2/connector-market/operations/{operationID})
+	GetConnectorMarketOperation(w http.ResponseWriter, r *http.Request, operationID ConnectorMarketOperationID)
+	// Synchronize the complete upstream connector catalog snapshot
+	// (POST /v2/connector-market:refresh)
+	RefreshConnectorMarket(w http.ResponseWriter, r *http.Request)
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -1629,323 +1629,6 @@ func (siw *ServerInterfaceWrapper) InvokeCliCommand(w http.ResponseWriter, r *ht
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.InvokeCliCommand(w, r, commandID)
-	}))
-
-	for _, middleware := range siw.HandlerMiddlewares {
-		handler = middleware(handler)
-	}
-
-	handler.ServeHTTP(w, r)
-}
-
-// GetConnectorMarket operation middleware
-func (siw *ServerInterfaceWrapper) GetConnectorMarket(w http.ResponseWriter, r *http.Request) {
-
-	ctx := r.Context()
-
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
-
-	r = r.WithContext(ctx)
-
-	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetConnectorMarket(w, r)
-	}))
-
-	for _, middleware := range siw.HandlerMiddlewares {
-		handler = middleware(handler)
-	}
-
-	handler.ServeHTTP(w, r)
-}
-
-// ListConnectorMarketCatalog operation middleware
-func (siw *ServerInterfaceWrapper) ListConnectorMarketCatalog(w http.ResponseWriter, r *http.Request) {
-
-	var err error
-	_ = err
-
-	ctx := r.Context()
-
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
-
-	r = r.WithContext(ctx)
-
-	// Parameter object where we will unmarshal all parameters from the context
-	var params ListConnectorMarketCatalogParams
-
-	// ------------- Required query parameter "sectionId" -------------
-
-	err = runtime.BindQueryParameterWithOptions("form", true, true, "sectionId", r.URL.Query(), &params.SectionId, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
-	if err != nil {
-		var requiredError *runtime.RequiredParameterError
-		if errors.As(err, &requiredError) {
-			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "sectionId"})
-		} else {
-			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "sectionId", Err: err})
-		}
-		return
-	}
-
-	// ------------- Optional query parameter "pageSize" -------------
-
-	err = runtime.BindQueryParameterWithOptions("form", true, false, "pageSize", r.URL.Query(), &params.PageSize, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
-	if err != nil {
-		var requiredError *runtime.RequiredParameterError
-		if errors.As(err, &requiredError) {
-			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "pageSize"})
-		} else {
-			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "pageSize", Err: err})
-		}
-		return
-	}
-
-	// ------------- Optional query parameter "pageToken" -------------
-
-	err = runtime.BindQueryParameterWithOptions("form", true, false, "pageToken", r.URL.Query(), &params.PageToken, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
-	if err != nil {
-		var requiredError *runtime.RequiredParameterError
-		if errors.As(err, &requiredError) {
-			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "pageToken"})
-		} else {
-			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "pageToken", Err: err})
-		}
-		return
-	}
-
-	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.ListConnectorMarketCatalog(w, r, params)
-	}))
-
-	for _, middleware := range siw.HandlerMiddlewares {
-		handler = middleware(handler)
-	}
-
-	handler.ServeHTTP(w, r)
-}
-
-// ListConnectorMarketCategories operation middleware
-func (siw *ServerInterfaceWrapper) ListConnectorMarketCategories(w http.ResponseWriter, r *http.Request) {
-
-	ctx := r.Context()
-
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
-
-	r = r.WithContext(ctx)
-
-	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.ListConnectorMarketCategories(w, r)
-	}))
-
-	for _, middleware := range siw.HandlerMiddlewares {
-		handler = middleware(handler)
-	}
-
-	handler.ServeHTTP(w, r)
-}
-
-// GetConnectorMarketConnector operation middleware
-func (siw *ServerInterfaceWrapper) GetConnectorMarketConnector(w http.ResponseWriter, r *http.Request) {
-
-	var err error
-	_ = err
-
-	// ------------- Path parameter "connectorKey" -------------
-	var connectorKey ConnectorMarketConnectorKey
-
-	err = runtime.BindStyledParameterWithOptions("simple", "connectorKey", r.PathValue("connectorKey"), &connectorKey, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "connectorKey", Err: err})
-		return
-	}
-
-	ctx := r.Context()
-
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
-
-	r = r.WithContext(ctx)
-
-	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetConnectorMarketConnector(w, r, connectorKey)
-	}))
-
-	for _, middleware := range siw.HandlerMiddlewares {
-		handler = middleware(handler)
-	}
-
-	handler.ServeHTTP(w, r)
-}
-
-// DisconnectConnectorMarketAuthorization operation middleware
-func (siw *ServerInterfaceWrapper) DisconnectConnectorMarketAuthorization(w http.ResponseWriter, r *http.Request) {
-
-	var err error
-	_ = err
-
-	// ------------- Path parameter "connectorKey" -------------
-	var connectorKey ConnectorMarketConnectorKey
-
-	err = runtime.BindStyledParameterWithOptions("simple", "connectorKey", r.PathValue("connectorKey"), &connectorKey, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "connectorKey", Err: err})
-		return
-	}
-
-	ctx := r.Context()
-
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
-
-	r = r.WithContext(ctx)
-
-	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.DisconnectConnectorMarketAuthorization(w, r, connectorKey)
-	}))
-
-	for _, middleware := range siw.HandlerMiddlewares {
-		handler = middleware(handler)
-	}
-
-	handler.ServeHTTP(w, r)
-}
-
-// StartConnectorMarketAuthorization operation middleware
-func (siw *ServerInterfaceWrapper) StartConnectorMarketAuthorization(w http.ResponseWriter, r *http.Request) {
-
-	var err error
-	_ = err
-
-	// ------------- Path parameter "connectorKey" -------------
-	var connectorKey ConnectorMarketConnectorKey
-
-	err = runtime.BindStyledParameterWithOptions("simple", "connectorKey", r.PathValue("connectorKey"), &connectorKey, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "connectorKey", Err: err})
-		return
-	}
-
-	ctx := r.Context()
-
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
-
-	r = r.WithContext(ctx)
-
-	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.StartConnectorMarketAuthorization(w, r, connectorKey)
-	}))
-
-	for _, middleware := range siw.HandlerMiddlewares {
-		handler = middleware(handler)
-	}
-
-	handler.ServeHTTP(w, r)
-}
-
-// InstallConnectorMarketConnector operation middleware
-func (siw *ServerInterfaceWrapper) InstallConnectorMarketConnector(w http.ResponseWriter, r *http.Request) {
-
-	var err error
-	_ = err
-
-	// ------------- Path parameter "connectorKey" -------------
-	var connectorKey ConnectorMarketConnectorKey
-
-	err = runtime.BindStyledParameterWithOptions("simple", "connectorKey", r.PathValue("connectorKey"), &connectorKey, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "connectorKey", Err: err})
-		return
-	}
-
-	ctx := r.Context()
-
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
-
-	r = r.WithContext(ctx)
-
-	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.InstallConnectorMarketConnector(w, r, connectorKey)
-	}))
-
-	for _, middleware := range siw.HandlerMiddlewares {
-		handler = middleware(handler)
-	}
-
-	handler.ServeHTTP(w, r)
-}
-
-// UninstallConnectorMarketConnector operation middleware
-func (siw *ServerInterfaceWrapper) UninstallConnectorMarketConnector(w http.ResponseWriter, r *http.Request) {
-
-	var err error
-	_ = err
-
-	// ------------- Path parameter "connectorKey" -------------
-	var connectorKey ConnectorMarketConnectorKey
-
-	err = runtime.BindStyledParameterWithOptions("simple", "connectorKey", r.PathValue("connectorKey"), &connectorKey, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "connectorKey", Err: err})
-		return
-	}
-
-	ctx := r.Context()
-
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
-
-	r = r.WithContext(ctx)
-
-	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.UninstallConnectorMarketConnector(w, r, connectorKey)
-	}))
-
-	for _, middleware := range siw.HandlerMiddlewares {
-		handler = middleware(handler)
-	}
-
-	handler.ServeHTTP(w, r)
-}
-
-// GetConnectorMarketOperation operation middleware
-func (siw *ServerInterfaceWrapper) GetConnectorMarketOperation(w http.ResponseWriter, r *http.Request) {
-
-	var err error
-	_ = err
-
-	// ------------- Path parameter "operationID" -------------
-	var operationID ConnectorMarketOperationID
-
-	err = runtime.BindStyledParameterWithOptions("simple", "operationID", r.PathValue("operationID"), &operationID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "operationID", Err: err})
-		return
-	}
-
-	ctx := r.Context()
-
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
-
-	r = r.WithContext(ctx)
-
-	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetConnectorMarketOperation(w, r, operationID)
-	}))
-
-	for _, middleware := range siw.HandlerMiddlewares {
-		handler = middleware(handler)
-	}
-
-	handler.ServeHTTP(w, r)
-}
-
-// RefreshConnectorMarket operation middleware
-func (siw *ServerInterfaceWrapper) RefreshConnectorMarket(w http.ResponseWriter, r *http.Request) {
-
-	ctx := r.Context()
-
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
-
-	r = r.WithContext(ctx)
-
-	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.RefreshConnectorMarket(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -11218,6 +10901,323 @@ func (siw *ServerInterfaceWrapper) DecideWorkspaceWorkflowCheckpoint(w http.Resp
 	handler.ServeHTTP(w, r)
 }
 
+// GetConnectorMarket operation middleware
+func (siw *ServerInterfaceWrapper) GetConnectorMarket(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetConnectorMarket(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListConnectorMarketCatalog operation middleware
+func (siw *ServerInterfaceWrapper) ListConnectorMarketCatalog(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListConnectorMarketCatalogParams
+
+	// ------------- Required query parameter "sectionId" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, true, "sectionId", r.URL.Query(), &params.SectionId, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "sectionId"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "sectionId", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "pageSize" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "pageSize", r.URL.Query(), &params.PageSize, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "pageSize"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "pageSize", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "pageToken" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "pageToken", r.URL.Query(), &params.PageToken, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "pageToken"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "pageToken", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListConnectorMarketCatalog(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListConnectorMarketCategories operation middleware
+func (siw *ServerInterfaceWrapper) ListConnectorMarketCategories(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListConnectorMarketCategories(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetConnectorMarketConnector operation middleware
+func (siw *ServerInterfaceWrapper) GetConnectorMarketConnector(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "connectorKey" -------------
+	var connectorKey ConnectorMarketConnectorKey
+
+	err = runtime.BindStyledParameterWithOptions("simple", "connectorKey", r.PathValue("connectorKey"), &connectorKey, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "connectorKey", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetConnectorMarketConnector(w, r, connectorKey)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DisconnectConnectorMarketAuthorization operation middleware
+func (siw *ServerInterfaceWrapper) DisconnectConnectorMarketAuthorization(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "connectorKey" -------------
+	var connectorKey ConnectorMarketConnectorKey
+
+	err = runtime.BindStyledParameterWithOptions("simple", "connectorKey", r.PathValue("connectorKey"), &connectorKey, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "connectorKey", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DisconnectConnectorMarketAuthorization(w, r, connectorKey)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// StartConnectorMarketAuthorization operation middleware
+func (siw *ServerInterfaceWrapper) StartConnectorMarketAuthorization(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "connectorKey" -------------
+	var connectorKey ConnectorMarketConnectorKey
+
+	err = runtime.BindStyledParameterWithOptions("simple", "connectorKey", r.PathValue("connectorKey"), &connectorKey, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "connectorKey", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.StartConnectorMarketAuthorization(w, r, connectorKey)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// InstallConnectorMarketConnector operation middleware
+func (siw *ServerInterfaceWrapper) InstallConnectorMarketConnector(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "connectorKey" -------------
+	var connectorKey ConnectorMarketConnectorKey
+
+	err = runtime.BindStyledParameterWithOptions("simple", "connectorKey", r.PathValue("connectorKey"), &connectorKey, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "connectorKey", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.InstallConnectorMarketConnector(w, r, connectorKey)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UninstallConnectorMarketConnector operation middleware
+func (siw *ServerInterfaceWrapper) UninstallConnectorMarketConnector(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "connectorKey" -------------
+	var connectorKey ConnectorMarketConnectorKey
+
+	err = runtime.BindStyledParameterWithOptions("simple", "connectorKey", r.PathValue("connectorKey"), &connectorKey, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "connectorKey", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UninstallConnectorMarketConnector(w, r, connectorKey)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetConnectorMarketOperation operation middleware
+func (siw *ServerInterfaceWrapper) GetConnectorMarketOperation(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "operationID" -------------
+	var operationID ConnectorMarketOperationID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "operationID", r.PathValue("operationID"), &operationID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "operationID", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetConnectorMarketOperation(w, r, operationID)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// RefreshConnectorMarket operation middleware
+func (siw *ServerInterfaceWrapper) RefreshConnectorMarket(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.RefreshConnectorMarket(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 type UnescapedCookieParamError struct {
 	ParamName string
 	Err       error
@@ -11364,16 +11364,6 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc(http.MethodPatch+" "+options.BaseURL+"/v1/agent-targets/{agentTargetID}/enabled", wrapper.SetSystemAgentTargetEnabled)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/v1/cli/capabilities", wrapper.ListCliCapabilities)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/v1/cli/commands/{commandID}/invoke", wrapper.InvokeCliCommand)
-	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/v1/connector-market", wrapper.GetConnectorMarket)
-	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/v1/connector-market/catalog", wrapper.ListConnectorMarketCatalog)
-	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/v1/connector-market/categories", wrapper.ListConnectorMarketCategories)
-	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/v1/connector-market/connectors/{connectorKey}", wrapper.GetConnectorMarketConnector)
-	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/v1/connector-market/connectors/{connectorKey}/authorization:disconnect", wrapper.DisconnectConnectorMarketAuthorization)
-	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/v1/connector-market/connectors/{connectorKey}/authorization:start", wrapper.StartConnectorMarketAuthorization)
-	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/v1/connector-market/connectors/{connectorKey}:install", wrapper.InstallConnectorMarketConnector)
-	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/v1/connector-market/connectors/{connectorKey}:uninstall", wrapper.UninstallConnectorMarketConnector)
-	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/v1/connector-market/operations/{operationID}", wrapper.GetConnectorMarketOperation)
-	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/v1/connector-market:refresh", wrapper.RefreshConnectorMarket)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/v1/desktop-update-admission", wrapper.GetDesktopUpdateAdmissionSnapshot)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/v1/desktop-update-admission/refresh", wrapper.RefreshDesktopUpdateAdmission)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/v1/desktop-update-admission/startup", wrapper.GetDesktopUpdateAdmissionStartup)
@@ -11593,6 +11583,16 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/v1/workspaces/{workspaceID}/workflows", wrapper.ListWorkspaceWorkflows)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/v1/workspaces/{workspaceID}/workflows/{workflowID}", wrapper.GetWorkspaceWorkflow)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/v1/workspaces/{workspaceID}/workflows/{workflowID}/checkpoints/{checkpointID}/decision", wrapper.DecideWorkspaceWorkflowCheckpoint)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/v2/connector-market", wrapper.GetConnectorMarket)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/v2/connector-market/catalog", wrapper.ListConnectorMarketCatalog)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/v2/connector-market/categories", wrapper.ListConnectorMarketCategories)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/v2/connector-market/connectors/{connectorKey}", wrapper.GetConnectorMarketConnector)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/v2/connector-market/connectors/{connectorKey}/authorization:disconnect", wrapper.DisconnectConnectorMarketAuthorization)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/v2/connector-market/connectors/{connectorKey}/authorization:start", wrapper.StartConnectorMarketAuthorization)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/v2/connector-market/connectors/{connectorKey}:install", wrapper.InstallConnectorMarketConnector)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/v2/connector-market/connectors/{connectorKey}:uninstall", wrapper.UninstallConnectorMarketConnector)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/v2/connector-market/operations/{operationID}", wrapper.GetConnectorMarketOperation)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/v2/connector-market:refresh", wrapper.RefreshConnectorMarket)
 
 	return m
 }
@@ -13876,884 +13876,6 @@ type InvokeCliCommand503JSONResponse struct {
 }
 
 func (response InvokeCliCommand503JSONResponse) VisitInvokeCliCommandResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(503)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type GetConnectorMarketRequestObject struct {
-}
-
-type GetConnectorMarketResponseObject interface {
-	VisitGetConnectorMarketResponse(w http.ResponseWriter) error
-}
-
-type GetConnectorMarket200JSONResponse ConnectorMarketSnapshot
-
-func (response GetConnectorMarket200JSONResponse) VisitGetConnectorMarketResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type GetConnectorMarket400JSONResponse struct {
-	ConnectorMarketInvalidRequestErrorJSONResponse
-}
-
-func (response GetConnectorMarket400JSONResponse) VisitGetConnectorMarketResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(400)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type GetConnectorMarket401JSONResponse struct {
-	ConnectorMarketUnauthorizedErrorJSONResponse
-}
-
-func (response GetConnectorMarket401JSONResponse) VisitGetConnectorMarketResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(401)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type GetConnectorMarket503JSONResponse struct {
-	ConnectorMarketUnavailableErrorJSONResponse
-}
-
-func (response GetConnectorMarket503JSONResponse) VisitGetConnectorMarketResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(503)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type ListConnectorMarketCatalogRequestObject struct {
-	Params ListConnectorMarketCatalogParams
-}
-
-type ListConnectorMarketCatalogResponseObject interface {
-	VisitListConnectorMarketCatalogResponse(w http.ResponseWriter) error
-}
-
-type ListConnectorMarketCatalog200JSONResponse ConnectorMarketCatalogPage
-
-func (response ListConnectorMarketCatalog200JSONResponse) VisitListConnectorMarketCatalogResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type ListConnectorMarketCatalog400JSONResponse struct {
-	ConnectorMarketInvalidRequestErrorJSONResponse
-}
-
-func (response ListConnectorMarketCatalog400JSONResponse) VisitListConnectorMarketCatalogResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(400)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type ListConnectorMarketCatalog401JSONResponse struct {
-	ConnectorMarketUnauthorizedErrorJSONResponse
-}
-
-func (response ListConnectorMarketCatalog401JSONResponse) VisitListConnectorMarketCatalogResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(401)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type ListConnectorMarketCatalog503JSONResponse struct {
-	ConnectorMarketUnavailableErrorJSONResponse
-}
-
-func (response ListConnectorMarketCatalog503JSONResponse) VisitListConnectorMarketCatalogResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(503)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type ListConnectorMarketCategoriesRequestObject struct {
-}
-
-type ListConnectorMarketCategoriesResponseObject interface {
-	VisitListConnectorMarketCategoriesResponse(w http.ResponseWriter) error
-}
-
-type ListConnectorMarketCategories200JSONResponse ConnectorMarketCategoriesResponse
-
-func (response ListConnectorMarketCategories200JSONResponse) VisitListConnectorMarketCategoriesResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type ListConnectorMarketCategories401JSONResponse struct {
-	ConnectorMarketUnauthorizedErrorJSONResponse
-}
-
-func (response ListConnectorMarketCategories401JSONResponse) VisitListConnectorMarketCategoriesResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(401)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type ListConnectorMarketCategories503JSONResponse struct {
-	ConnectorMarketUnavailableErrorJSONResponse
-}
-
-func (response ListConnectorMarketCategories503JSONResponse) VisitListConnectorMarketCategoriesResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(503)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type GetConnectorMarketConnectorRequestObject struct {
-	ConnectorKey ConnectorMarketConnectorKey `json:"connectorKey"`
-}
-
-type GetConnectorMarketConnectorResponseObject interface {
-	VisitGetConnectorMarketConnectorResponse(w http.ResponseWriter) error
-}
-
-type GetConnectorMarketConnector200JSONResponse ConnectorMarketConnector
-
-func (response GetConnectorMarketConnector200JSONResponse) VisitGetConnectorMarketConnectorResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type GetConnectorMarketConnector400JSONResponse struct {
-	ConnectorMarketInvalidRequestErrorJSONResponse
-}
-
-func (response GetConnectorMarketConnector400JSONResponse) VisitGetConnectorMarketConnectorResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(400)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type GetConnectorMarketConnector401JSONResponse struct {
-	ConnectorMarketUnauthorizedErrorJSONResponse
-}
-
-func (response GetConnectorMarketConnector401JSONResponse) VisitGetConnectorMarketConnectorResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(401)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type GetConnectorMarketConnector404JSONResponse struct {
-	ConnectorMarketNotFoundErrorJSONResponse
-}
-
-func (response GetConnectorMarketConnector404JSONResponse) VisitGetConnectorMarketConnectorResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(404)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type GetConnectorMarketConnector503JSONResponse struct {
-	ConnectorMarketUnavailableErrorJSONResponse
-}
-
-func (response GetConnectorMarketConnector503JSONResponse) VisitGetConnectorMarketConnectorResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(503)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type DisconnectConnectorMarketAuthorizationRequestObject struct {
-	ConnectorKey ConnectorMarketConnectorKey `json:"connectorKey"`
-	Body         *DisconnectConnectorMarketAuthorizationJSONRequestBody
-}
-
-type DisconnectConnectorMarketAuthorizationResponseObject interface {
-	VisitDisconnectConnectorMarketAuthorizationResponse(w http.ResponseWriter) error
-}
-
-type DisconnectConnectorMarketAuthorization202JSONResponse ConnectorMarketMutationResponse
-
-func (response DisconnectConnectorMarketAuthorization202JSONResponse) VisitDisconnectConnectorMarketAuthorizationResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(202)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type DisconnectConnectorMarketAuthorization400JSONResponse struct {
-	ConnectorMarketInvalidRequestErrorJSONResponse
-}
-
-func (response DisconnectConnectorMarketAuthorization400JSONResponse) VisitDisconnectConnectorMarketAuthorizationResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(400)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type DisconnectConnectorMarketAuthorization401JSONResponse struct {
-	ConnectorMarketUnauthorizedErrorJSONResponse
-}
-
-func (response DisconnectConnectorMarketAuthorization401JSONResponse) VisitDisconnectConnectorMarketAuthorizationResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(401)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type DisconnectConnectorMarketAuthorization404JSONResponse struct {
-	ConnectorMarketNotFoundErrorJSONResponse
-}
-
-func (response DisconnectConnectorMarketAuthorization404JSONResponse) VisitDisconnectConnectorMarketAuthorizationResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(404)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type DisconnectConnectorMarketAuthorization409JSONResponse struct {
-	ConnectorMarketConflictErrorJSONResponse
-}
-
-func (response DisconnectConnectorMarketAuthorization409JSONResponse) VisitDisconnectConnectorMarketAuthorizationResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(409)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type DisconnectConnectorMarketAuthorization503JSONResponse struct {
-	ConnectorMarketUnavailableErrorJSONResponse
-}
-
-func (response DisconnectConnectorMarketAuthorization503JSONResponse) VisitDisconnectConnectorMarketAuthorizationResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(503)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type StartConnectorMarketAuthorizationRequestObject struct {
-	ConnectorKey ConnectorMarketConnectorKey `json:"connectorKey"`
-	Body         *StartConnectorMarketAuthorizationJSONRequestBody
-}
-
-type StartConnectorMarketAuthorizationResponseObject interface {
-	VisitStartConnectorMarketAuthorizationResponse(w http.ResponseWriter) error
-}
-
-type StartConnectorMarketAuthorization200JSONResponse ConnectorMarketAuthorizationResponse
-
-func (response StartConnectorMarketAuthorization200JSONResponse) VisitStartConnectorMarketAuthorizationResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type StartConnectorMarketAuthorization400JSONResponse struct {
-	ConnectorMarketInvalidRequestErrorJSONResponse
-}
-
-func (response StartConnectorMarketAuthorization400JSONResponse) VisitStartConnectorMarketAuthorizationResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(400)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type StartConnectorMarketAuthorization401JSONResponse struct {
-	ConnectorMarketUnauthorizedErrorJSONResponse
-}
-
-func (response StartConnectorMarketAuthorization401JSONResponse) VisitStartConnectorMarketAuthorizationResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(401)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type StartConnectorMarketAuthorization404JSONResponse struct {
-	ConnectorMarketNotFoundErrorJSONResponse
-}
-
-func (response StartConnectorMarketAuthorization404JSONResponse) VisitStartConnectorMarketAuthorizationResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(404)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type StartConnectorMarketAuthorization409JSONResponse struct {
-	ConnectorMarketConflictErrorJSONResponse
-}
-
-func (response StartConnectorMarketAuthorization409JSONResponse) VisitStartConnectorMarketAuthorizationResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(409)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type StartConnectorMarketAuthorization503JSONResponse struct {
-	ConnectorMarketUnavailableErrorJSONResponse
-}
-
-func (response StartConnectorMarketAuthorization503JSONResponse) VisitStartConnectorMarketAuthorizationResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(503)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type InstallConnectorMarketConnectorRequestObject struct {
-	ConnectorKey ConnectorMarketConnectorKey `json:"connectorKey"`
-	Body         *InstallConnectorMarketConnectorJSONRequestBody
-}
-
-type InstallConnectorMarketConnectorResponseObject interface {
-	VisitInstallConnectorMarketConnectorResponse(w http.ResponseWriter) error
-}
-
-type InstallConnectorMarketConnector202JSONResponse ConnectorMarketMutationResponse
-
-func (response InstallConnectorMarketConnector202JSONResponse) VisitInstallConnectorMarketConnectorResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(202)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type InstallConnectorMarketConnector400JSONResponse struct {
-	ConnectorMarketInvalidRequestErrorJSONResponse
-}
-
-func (response InstallConnectorMarketConnector400JSONResponse) VisitInstallConnectorMarketConnectorResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(400)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type InstallConnectorMarketConnector401JSONResponse struct {
-	ConnectorMarketUnauthorizedErrorJSONResponse
-}
-
-func (response InstallConnectorMarketConnector401JSONResponse) VisitInstallConnectorMarketConnectorResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(401)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type InstallConnectorMarketConnector404JSONResponse struct {
-	ConnectorMarketNotFoundErrorJSONResponse
-}
-
-func (response InstallConnectorMarketConnector404JSONResponse) VisitInstallConnectorMarketConnectorResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(404)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type InstallConnectorMarketConnector409JSONResponse struct {
-	ConnectorMarketConflictErrorJSONResponse
-}
-
-func (response InstallConnectorMarketConnector409JSONResponse) VisitInstallConnectorMarketConnectorResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(409)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type InstallConnectorMarketConnector422JSONResponse struct {
-	ConnectorMarketUnprocessableErrorJSONResponse
-}
-
-func (response InstallConnectorMarketConnector422JSONResponse) VisitInstallConnectorMarketConnectorResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(422)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type InstallConnectorMarketConnector503JSONResponse struct {
-	ConnectorMarketUnavailableErrorJSONResponse
-}
-
-func (response InstallConnectorMarketConnector503JSONResponse) VisitInstallConnectorMarketConnectorResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(503)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type UninstallConnectorMarketConnectorRequestObject struct {
-	ConnectorKey ConnectorMarketConnectorKey `json:"connectorKey"`
-	Body         *UninstallConnectorMarketConnectorJSONRequestBody
-}
-
-type UninstallConnectorMarketConnectorResponseObject interface {
-	VisitUninstallConnectorMarketConnectorResponse(w http.ResponseWriter) error
-}
-
-type UninstallConnectorMarketConnector202JSONResponse ConnectorMarketMutationResponse
-
-func (response UninstallConnectorMarketConnector202JSONResponse) VisitUninstallConnectorMarketConnectorResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(202)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type UninstallConnectorMarketConnector400JSONResponse struct {
-	ConnectorMarketInvalidRequestErrorJSONResponse
-}
-
-func (response UninstallConnectorMarketConnector400JSONResponse) VisitUninstallConnectorMarketConnectorResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(400)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type UninstallConnectorMarketConnector401JSONResponse struct {
-	ConnectorMarketUnauthorizedErrorJSONResponse
-}
-
-func (response UninstallConnectorMarketConnector401JSONResponse) VisitUninstallConnectorMarketConnectorResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(401)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type UninstallConnectorMarketConnector404JSONResponse struct {
-	ConnectorMarketNotFoundErrorJSONResponse
-}
-
-func (response UninstallConnectorMarketConnector404JSONResponse) VisitUninstallConnectorMarketConnectorResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(404)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type UninstallConnectorMarketConnector409JSONResponse struct {
-	ConnectorMarketConflictErrorJSONResponse
-}
-
-func (response UninstallConnectorMarketConnector409JSONResponse) VisitUninstallConnectorMarketConnectorResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(409)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type UninstallConnectorMarketConnector503JSONResponse struct {
-	ConnectorMarketUnavailableErrorJSONResponse
-}
-
-func (response UninstallConnectorMarketConnector503JSONResponse) VisitUninstallConnectorMarketConnectorResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(503)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type GetConnectorMarketOperationRequestObject struct {
-	OperationID ConnectorMarketOperationID `json:"operationID"`
-}
-
-type GetConnectorMarketOperationResponseObject interface {
-	VisitGetConnectorMarketOperationResponse(w http.ResponseWriter) error
-}
-
-type GetConnectorMarketOperation200JSONResponse ConnectorMarketOperation
-
-func (response GetConnectorMarketOperation200JSONResponse) VisitGetConnectorMarketOperationResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type GetConnectorMarketOperation400JSONResponse struct {
-	ConnectorMarketInvalidRequestErrorJSONResponse
-}
-
-func (response GetConnectorMarketOperation400JSONResponse) VisitGetConnectorMarketOperationResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(400)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type GetConnectorMarketOperation401JSONResponse struct {
-	ConnectorMarketUnauthorizedErrorJSONResponse
-}
-
-func (response GetConnectorMarketOperation401JSONResponse) VisitGetConnectorMarketOperationResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(401)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type GetConnectorMarketOperation404JSONResponse struct {
-	ConnectorMarketNotFoundErrorJSONResponse
-}
-
-func (response GetConnectorMarketOperation404JSONResponse) VisitGetConnectorMarketOperationResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(404)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type GetConnectorMarketOperation503JSONResponse struct {
-	ConnectorMarketUnavailableErrorJSONResponse
-}
-
-func (response GetConnectorMarketOperation503JSONResponse) VisitGetConnectorMarketOperationResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(503)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type RefreshConnectorMarketRequestObject struct {
-	Body *RefreshConnectorMarketJSONRequestBody
-}
-
-type RefreshConnectorMarketResponseObject interface {
-	VisitRefreshConnectorMarketResponse(w http.ResponseWriter) error
-}
-
-type RefreshConnectorMarket202JSONResponse ConnectorMarketMutationResponse
-
-func (response RefreshConnectorMarket202JSONResponse) VisitRefreshConnectorMarketResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(202)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type RefreshConnectorMarket400JSONResponse struct {
-	ConnectorMarketInvalidRequestErrorJSONResponse
-}
-
-func (response RefreshConnectorMarket400JSONResponse) VisitRefreshConnectorMarketResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(400)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type RefreshConnectorMarket401JSONResponse struct {
-	ConnectorMarketUnauthorizedErrorJSONResponse
-}
-
-func (response RefreshConnectorMarket401JSONResponse) VisitRefreshConnectorMarketResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(401)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type RefreshConnectorMarket409JSONResponse struct {
-	ConnectorMarketConflictErrorJSONResponse
-}
-
-func (response RefreshConnectorMarket409JSONResponse) VisitRefreshConnectorMarketResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(409)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type RefreshConnectorMarket503JSONResponse struct {
-	ConnectorMarketUnavailableErrorJSONResponse
-}
-
-func (response RefreshConnectorMarket503JSONResponse) VisitRefreshConnectorMarketResponse(w http.ResponseWriter) error {
 
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(response); err != nil {
@@ -39387,6 +38509,851 @@ func (response DecideWorkspaceWorkflowCheckpoint503JSONResponse) VisitDecideWork
 	return err
 }
 
+type GetConnectorMarketRequestObject struct {
+}
+
+type GetConnectorMarketResponseObject interface {
+	VisitGetConnectorMarketResponse(w http.ResponseWriter) error
+}
+
+type GetConnectorMarket200JSONResponse ConnectorMarketSnapshot
+
+func (response GetConnectorMarket200JSONResponse) VisitGetConnectorMarketResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetConnectorMarket400JSONResponse struct {
+	ConnectorMarketInvalidRequestErrorJSONResponse
+}
+
+func (response GetConnectorMarket400JSONResponse) VisitGetConnectorMarketResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetConnectorMarket401JSONResponse struct {
+	ConnectorMarketUnauthorizedErrorJSONResponse
+}
+
+func (response GetConnectorMarket401JSONResponse) VisitGetConnectorMarketResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetConnectorMarket503JSONResponse struct {
+	ConnectorMarketUnavailableErrorJSONResponse
+}
+
+func (response GetConnectorMarket503JSONResponse) VisitGetConnectorMarketResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(503)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListConnectorMarketCatalogRequestObject struct {
+	Params ListConnectorMarketCatalogParams
+}
+
+type ListConnectorMarketCatalogResponseObject interface {
+	VisitListConnectorMarketCatalogResponse(w http.ResponseWriter) error
+}
+
+type ListConnectorMarketCatalog200JSONResponse ConnectorMarketCatalogPage
+
+func (response ListConnectorMarketCatalog200JSONResponse) VisitListConnectorMarketCatalogResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListConnectorMarketCatalog400JSONResponse struct {
+	ConnectorMarketInvalidRequestErrorJSONResponse
+}
+
+func (response ListConnectorMarketCatalog400JSONResponse) VisitListConnectorMarketCatalogResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListConnectorMarketCatalog401JSONResponse struct {
+	ConnectorMarketUnauthorizedErrorJSONResponse
+}
+
+func (response ListConnectorMarketCatalog401JSONResponse) VisitListConnectorMarketCatalogResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListConnectorMarketCatalog503JSONResponse struct {
+	ConnectorMarketUnavailableErrorJSONResponse
+}
+
+func (response ListConnectorMarketCatalog503JSONResponse) VisitListConnectorMarketCatalogResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(503)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListConnectorMarketCategoriesRequestObject struct {
+}
+
+type ListConnectorMarketCategoriesResponseObject interface {
+	VisitListConnectorMarketCategoriesResponse(w http.ResponseWriter) error
+}
+
+type ListConnectorMarketCategories200JSONResponse ConnectorMarketCategoriesResponse
+
+func (response ListConnectorMarketCategories200JSONResponse) VisitListConnectorMarketCategoriesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListConnectorMarketCategories401JSONResponse struct {
+	ConnectorMarketUnauthorizedErrorJSONResponse
+}
+
+func (response ListConnectorMarketCategories401JSONResponse) VisitListConnectorMarketCategoriesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListConnectorMarketCategories503JSONResponse struct {
+	ConnectorMarketUnavailableErrorJSONResponse
+}
+
+func (response ListConnectorMarketCategories503JSONResponse) VisitListConnectorMarketCategoriesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(503)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetConnectorMarketConnectorRequestObject struct {
+	ConnectorKey ConnectorMarketConnectorKey `json:"connectorKey"`
+}
+
+type GetConnectorMarketConnectorResponseObject interface {
+	VisitGetConnectorMarketConnectorResponse(w http.ResponseWriter) error
+}
+
+type GetConnectorMarketConnector200JSONResponse ConnectorMarketConnector
+
+func (response GetConnectorMarketConnector200JSONResponse) VisitGetConnectorMarketConnectorResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetConnectorMarketConnector400JSONResponse struct {
+	ConnectorMarketInvalidRequestErrorJSONResponse
+}
+
+func (response GetConnectorMarketConnector400JSONResponse) VisitGetConnectorMarketConnectorResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetConnectorMarketConnector401JSONResponse struct {
+	ConnectorMarketUnauthorizedErrorJSONResponse
+}
+
+func (response GetConnectorMarketConnector401JSONResponse) VisitGetConnectorMarketConnectorResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetConnectorMarketConnector404JSONResponse struct {
+	ConnectorMarketNotFoundErrorJSONResponse
+}
+
+func (response GetConnectorMarketConnector404JSONResponse) VisitGetConnectorMarketConnectorResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetConnectorMarketConnector503JSONResponse struct {
+	ConnectorMarketUnavailableErrorJSONResponse
+}
+
+func (response GetConnectorMarketConnector503JSONResponse) VisitGetConnectorMarketConnectorResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(503)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DisconnectConnectorMarketAuthorizationRequestObject struct {
+	ConnectorKey ConnectorMarketConnectorKey `json:"connectorKey"`
+	Body         *DisconnectConnectorMarketAuthorizationJSONRequestBody
+}
+
+type DisconnectConnectorMarketAuthorizationResponseObject interface {
+	VisitDisconnectConnectorMarketAuthorizationResponse(w http.ResponseWriter) error
+}
+
+type DisconnectConnectorMarketAuthorization202JSONResponse ConnectorMarketMutationResponse
+
+func (response DisconnectConnectorMarketAuthorization202JSONResponse) VisitDisconnectConnectorMarketAuthorizationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(202)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DisconnectConnectorMarketAuthorization400JSONResponse struct {
+	ConnectorMarketInvalidRequestErrorJSONResponse
+}
+
+func (response DisconnectConnectorMarketAuthorization400JSONResponse) VisitDisconnectConnectorMarketAuthorizationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DisconnectConnectorMarketAuthorization401JSONResponse struct {
+	ConnectorMarketUnauthorizedErrorJSONResponse
+}
+
+func (response DisconnectConnectorMarketAuthorization401JSONResponse) VisitDisconnectConnectorMarketAuthorizationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DisconnectConnectorMarketAuthorization404JSONResponse struct {
+	ConnectorMarketNotFoundErrorJSONResponse
+}
+
+func (response DisconnectConnectorMarketAuthorization404JSONResponse) VisitDisconnectConnectorMarketAuthorizationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DisconnectConnectorMarketAuthorization409JSONResponse struct {
+	ConnectorMarketConflictErrorJSONResponse
+}
+
+func (response DisconnectConnectorMarketAuthorization409JSONResponse) VisitDisconnectConnectorMarketAuthorizationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(409)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DisconnectConnectorMarketAuthorization503JSONResponse struct {
+	ConnectorMarketUnavailableErrorJSONResponse
+}
+
+func (response DisconnectConnectorMarketAuthorization503JSONResponse) VisitDisconnectConnectorMarketAuthorizationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(503)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type StartConnectorMarketAuthorizationRequestObject struct {
+	ConnectorKey ConnectorMarketConnectorKey `json:"connectorKey"`
+	Body         *StartConnectorMarketAuthorizationJSONRequestBody
+}
+
+type StartConnectorMarketAuthorizationResponseObject interface {
+	VisitStartConnectorMarketAuthorizationResponse(w http.ResponseWriter) error
+}
+
+type StartConnectorMarketAuthorization200JSONResponse ConnectorMarketAuthorizationResponse
+
+func (response StartConnectorMarketAuthorization200JSONResponse) VisitStartConnectorMarketAuthorizationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type StartConnectorMarketAuthorization400JSONResponse struct {
+	ConnectorMarketInvalidRequestErrorJSONResponse
+}
+
+func (response StartConnectorMarketAuthorization400JSONResponse) VisitStartConnectorMarketAuthorizationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type StartConnectorMarketAuthorization401JSONResponse struct {
+	ConnectorMarketUnauthorizedErrorJSONResponse
+}
+
+func (response StartConnectorMarketAuthorization401JSONResponse) VisitStartConnectorMarketAuthorizationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type StartConnectorMarketAuthorization404JSONResponse struct {
+	ConnectorMarketNotFoundErrorJSONResponse
+}
+
+func (response StartConnectorMarketAuthorization404JSONResponse) VisitStartConnectorMarketAuthorizationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type StartConnectorMarketAuthorization409JSONResponse struct {
+	ConnectorMarketConflictErrorJSONResponse
+}
+
+func (response StartConnectorMarketAuthorization409JSONResponse) VisitStartConnectorMarketAuthorizationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(409)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type StartConnectorMarketAuthorization503JSONResponse struct {
+	ConnectorMarketUnavailableErrorJSONResponse
+}
+
+func (response StartConnectorMarketAuthorization503JSONResponse) VisitStartConnectorMarketAuthorizationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(503)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type InstallConnectorMarketConnectorRequestObject struct {
+	ConnectorKey ConnectorMarketConnectorKey `json:"connectorKey"`
+	Body         *InstallConnectorMarketConnectorJSONRequestBody
+}
+
+type InstallConnectorMarketConnectorResponseObject interface {
+	VisitInstallConnectorMarketConnectorResponse(w http.ResponseWriter) error
+}
+
+type InstallConnectorMarketConnector202JSONResponse ConnectorMarketMutationResponse
+
+func (response InstallConnectorMarketConnector202JSONResponse) VisitInstallConnectorMarketConnectorResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(202)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type InstallConnectorMarketConnector400JSONResponse struct {
+	ConnectorMarketInvalidRequestErrorJSONResponse
+}
+
+func (response InstallConnectorMarketConnector400JSONResponse) VisitInstallConnectorMarketConnectorResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type InstallConnectorMarketConnector401JSONResponse struct {
+	ConnectorMarketUnauthorizedErrorJSONResponse
+}
+
+func (response InstallConnectorMarketConnector401JSONResponse) VisitInstallConnectorMarketConnectorResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type InstallConnectorMarketConnector404JSONResponse struct {
+	ConnectorMarketNotFoundErrorJSONResponse
+}
+
+func (response InstallConnectorMarketConnector404JSONResponse) VisitInstallConnectorMarketConnectorResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type InstallConnectorMarketConnector409JSONResponse struct {
+	ConnectorMarketConflictErrorJSONResponse
+}
+
+func (response InstallConnectorMarketConnector409JSONResponse) VisitInstallConnectorMarketConnectorResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(409)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type InstallConnectorMarketConnector422JSONResponse struct {
+	ConnectorMarketUnprocessableErrorJSONResponse
+}
+
+func (response InstallConnectorMarketConnector422JSONResponse) VisitInstallConnectorMarketConnectorResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type InstallConnectorMarketConnector503JSONResponse struct {
+	ConnectorMarketUnavailableErrorJSONResponse
+}
+
+func (response InstallConnectorMarketConnector503JSONResponse) VisitInstallConnectorMarketConnectorResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(503)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UninstallConnectorMarketConnectorRequestObject struct {
+	ConnectorKey ConnectorMarketConnectorKey `json:"connectorKey"`
+	Body         *UninstallConnectorMarketConnectorJSONRequestBody
+}
+
+type UninstallConnectorMarketConnectorResponseObject interface {
+	VisitUninstallConnectorMarketConnectorResponse(w http.ResponseWriter) error
+}
+
+type UninstallConnectorMarketConnector202JSONResponse ConnectorMarketMutationResponse
+
+func (response UninstallConnectorMarketConnector202JSONResponse) VisitUninstallConnectorMarketConnectorResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(202)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UninstallConnectorMarketConnector400JSONResponse struct {
+	ConnectorMarketInvalidRequestErrorJSONResponse
+}
+
+func (response UninstallConnectorMarketConnector400JSONResponse) VisitUninstallConnectorMarketConnectorResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UninstallConnectorMarketConnector401JSONResponse struct {
+	ConnectorMarketUnauthorizedErrorJSONResponse
+}
+
+func (response UninstallConnectorMarketConnector401JSONResponse) VisitUninstallConnectorMarketConnectorResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UninstallConnectorMarketConnector404JSONResponse struct {
+	ConnectorMarketNotFoundErrorJSONResponse
+}
+
+func (response UninstallConnectorMarketConnector404JSONResponse) VisitUninstallConnectorMarketConnectorResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UninstallConnectorMarketConnector409JSONResponse struct {
+	ConnectorMarketConflictErrorJSONResponse
+}
+
+func (response UninstallConnectorMarketConnector409JSONResponse) VisitUninstallConnectorMarketConnectorResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(409)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UninstallConnectorMarketConnector503JSONResponse struct {
+	ConnectorMarketUnavailableErrorJSONResponse
+}
+
+func (response UninstallConnectorMarketConnector503JSONResponse) VisitUninstallConnectorMarketConnectorResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(503)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetConnectorMarketOperationRequestObject struct {
+	OperationID ConnectorMarketOperationID `json:"operationID"`
+}
+
+type GetConnectorMarketOperationResponseObject interface {
+	VisitGetConnectorMarketOperationResponse(w http.ResponseWriter) error
+}
+
+type GetConnectorMarketOperation200JSONResponse ConnectorMarketOperation
+
+func (response GetConnectorMarketOperation200JSONResponse) VisitGetConnectorMarketOperationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetConnectorMarketOperation400JSONResponse struct {
+	ConnectorMarketInvalidRequestErrorJSONResponse
+}
+
+func (response GetConnectorMarketOperation400JSONResponse) VisitGetConnectorMarketOperationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetConnectorMarketOperation401JSONResponse struct {
+	ConnectorMarketUnauthorizedErrorJSONResponse
+}
+
+func (response GetConnectorMarketOperation401JSONResponse) VisitGetConnectorMarketOperationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetConnectorMarketOperation404JSONResponse struct {
+	ConnectorMarketNotFoundErrorJSONResponse
+}
+
+func (response GetConnectorMarketOperation404JSONResponse) VisitGetConnectorMarketOperationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetConnectorMarketOperation503JSONResponse struct {
+	ConnectorMarketUnavailableErrorJSONResponse
+}
+
+func (response GetConnectorMarketOperation503JSONResponse) VisitGetConnectorMarketOperationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(503)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type RefreshConnectorMarketRequestObject struct {
+}
+
+type RefreshConnectorMarketResponseObject interface {
+	VisitRefreshConnectorMarketResponse(w http.ResponseWriter) error
+}
+
+type RefreshConnectorMarket200JSONResponse ConnectorMarketSnapshot
+
+func (response RefreshConnectorMarket200JSONResponse) VisitRefreshConnectorMarketResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type RefreshConnectorMarket401JSONResponse struct {
+	ConnectorMarketUnauthorizedErrorJSONResponse
+}
+
+func (response RefreshConnectorMarket401JSONResponse) VisitRefreshConnectorMarketResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type RefreshConnectorMarket503JSONResponse struct {
+	ConnectorMarketUnavailableErrorJSONResponse
+}
+
+func (response RefreshConnectorMarket503JSONResponse) VisitRefreshConnectorMarketResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(503)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
 // StrictServerInterface represents all server handlers.
 type StrictServerInterface interface {
 	// Start desktop account login
@@ -39467,36 +39434,6 @@ type StrictServerInterface interface {
 	// Invoke one registered CLI command
 	// (POST /v1/cli/commands/{commandID}/invoke)
 	InvokeCliCommand(ctx context.Context, request InvokeCliCommandRequestObject) (InvokeCliCommandResponseObject, error)
-	// Get the authoritative connector-market snapshot
-	// (GET /v1/connector-market)
-	GetConnectorMarket(ctx context.Context, request GetConnectorMarketRequestObject) (GetConnectorMarketResponseObject, error)
-	// List one server-owned connector-market section
-	// (GET /v1/connector-market/catalog)
-	ListConnectorMarketCatalog(ctx context.Context, request ListConnectorMarketCatalogRequestObject) (ListConnectorMarketCatalogResponseObject, error)
-	// List server-owned connector-market sections
-	// (GET /v1/connector-market/categories)
-	ListConnectorMarketCategories(ctx context.Context, request ListConnectorMarketCategoriesRequestObject) (ListConnectorMarketCategoriesResponseObject, error)
-	// Get one connector projection
-	// (GET /v1/connector-market/connectors/{connectorKey})
-	GetConnectorMarketConnector(ctx context.Context, request GetConnectorMarketConnectorRequestObject) (GetConnectorMarketConnectorResponseObject, error)
-	// Disconnect connector authorization
-	// (POST /v1/connector-market/connectors/{connectorKey}/authorization:disconnect)
-	DisconnectConnectorMarketAuthorization(ctx context.Context, request DisconnectConnectorMarketAuthorizationRequestObject) (DisconnectConnectorMarketAuthorizationResponseObject, error)
-	// Start connector authorization
-	// (POST /v1/connector-market/connectors/{connectorKey}/authorization:start)
-	StartConnectorMarketAuthorization(ctx context.Context, request StartConnectorMarketAuthorizationRequestObject) (StartConnectorMarketAuthorizationResponseObject, error)
-	// Install or update one connector
-	// (POST /v1/connector-market/connectors/{connectorKey}:install)
-	InstallConnectorMarketConnector(ctx context.Context, request InstallConnectorMarketConnectorRequestObject) (InstallConnectorMarketConnectorResponseObject, error)
-	// Uninstall one connector from this device
-	// (POST /v1/connector-market/connectors/{connectorKey}:uninstall)
-	UninstallConnectorMarketConnector(ctx context.Context, request UninstallConnectorMarketConnectorRequestObject) (UninstallConnectorMarketConnectorResponseObject, error)
-	// Get one durable connector-market operation
-	// (GET /v1/connector-market/operations/{operationID})
-	GetConnectorMarketOperation(ctx context.Context, request GetConnectorMarketOperationRequestObject) (GetConnectorMarketOperationResponseObject, error)
-	// Refresh and accept the upstream connector catalog
-	// (POST /v1/connector-market:refresh)
-	RefreshConnectorMarket(ctx context.Context, request RefreshConnectorMarketRequestObject) (RefreshConnectorMarketResponseObject, error)
 	// Read the daemon-owned desktop update admission snapshot
 	// (GET /v1/desktop-update-admission)
 	GetDesktopUpdateAdmissionSnapshot(ctx context.Context, request GetDesktopUpdateAdmissionSnapshotRequestObject) (GetDesktopUpdateAdmissionSnapshotResponseObject, error)
@@ -40154,6 +40091,36 @@ type StrictServerInterface interface {
 	// Decide one Tutti-owned workflow checkpoint
 	// (POST /v1/workspaces/{workspaceID}/workflows/{workflowID}/checkpoints/{checkpointID}/decision)
 	DecideWorkspaceWorkflowCheckpoint(ctx context.Context, request DecideWorkspaceWorkflowCheckpointRequestObject) (DecideWorkspaceWorkflowCheckpointResponseObject, error)
+	// Get the authoritative connector-market snapshot
+	// (GET /v2/connector-market)
+	GetConnectorMarket(ctx context.Context, request GetConnectorMarketRequestObject) (GetConnectorMarketResponseObject, error)
+	// List one server-owned connector-market section
+	// (GET /v2/connector-market/catalog)
+	ListConnectorMarketCatalog(ctx context.Context, request ListConnectorMarketCatalogRequestObject) (ListConnectorMarketCatalogResponseObject, error)
+	// List server-owned connector-market sections
+	// (GET /v2/connector-market/categories)
+	ListConnectorMarketCategories(ctx context.Context, request ListConnectorMarketCategoriesRequestObject) (ListConnectorMarketCategoriesResponseObject, error)
+	// Get one connector projection
+	// (GET /v2/connector-market/connectors/{connectorKey})
+	GetConnectorMarketConnector(ctx context.Context, request GetConnectorMarketConnectorRequestObject) (GetConnectorMarketConnectorResponseObject, error)
+	// Disconnect connector authorization
+	// (POST /v2/connector-market/connectors/{connectorKey}/authorization:disconnect)
+	DisconnectConnectorMarketAuthorization(ctx context.Context, request DisconnectConnectorMarketAuthorizationRequestObject) (DisconnectConnectorMarketAuthorizationResponseObject, error)
+	// Start connector authorization
+	// (POST /v2/connector-market/connectors/{connectorKey}/authorization:start)
+	StartConnectorMarketAuthorization(ctx context.Context, request StartConnectorMarketAuthorizationRequestObject) (StartConnectorMarketAuthorizationResponseObject, error)
+	// Install or update one connector
+	// (POST /v2/connector-market/connectors/{connectorKey}:install)
+	InstallConnectorMarketConnector(ctx context.Context, request InstallConnectorMarketConnectorRequestObject) (InstallConnectorMarketConnectorResponseObject, error)
+	// Uninstall one connector from this device
+	// (POST /v2/connector-market/connectors/{connectorKey}:uninstall)
+	UninstallConnectorMarketConnector(ctx context.Context, request UninstallConnectorMarketConnectorRequestObject) (UninstallConnectorMarketConnectorResponseObject, error)
+	// Get one durable connector-market operation
+	// (GET /v2/connector-market/operations/{operationID})
+	GetConnectorMarketOperation(ctx context.Context, request GetConnectorMarketOperationRequestObject) (GetConnectorMarketOperationResponseObject, error)
+	// Synchronize the complete upstream connector catalog snapshot
+	// (POST /v2/connector-market:refresh)
+	RefreshConnectorMarket(ctx context.Context, request RefreshConnectorMarketRequestObject) (RefreshConnectorMarketResponseObject, error)
 }
 
 type StrictHandlerFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request, request any) (any, error)
@@ -40929,305 +40896,6 @@ func (sh *strictHandler) InvokeCliCommand(w http.ResponseWriter, r *http.Request
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
 	} else if validResponse, ok := response.(InvokeCliCommandResponseObject); ok {
 		if err := validResponse.VisitInvokeCliCommandResponse(w); err != nil {
-			sh.options.ResponseErrorHandlerFunc(w, r, err)
-		}
-	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
-	}
-}
-
-// GetConnectorMarket operation middleware
-func (sh *strictHandler) GetConnectorMarket(w http.ResponseWriter, r *http.Request) {
-	var request GetConnectorMarketRequestObject
-
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
-		return sh.ssi.GetConnectorMarket(ctx, request.(GetConnectorMarketRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "GetConnectorMarket")
-	}
-
-	response, err := handler(r.Context(), w, r, request)
-
-	if err != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, err)
-	} else if validResponse, ok := response.(GetConnectorMarketResponseObject); ok {
-		if err := validResponse.VisitGetConnectorMarketResponse(w); err != nil {
-			sh.options.ResponseErrorHandlerFunc(w, r, err)
-		}
-	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
-	}
-}
-
-// ListConnectorMarketCatalog operation middleware
-func (sh *strictHandler) ListConnectorMarketCatalog(w http.ResponseWriter, r *http.Request, params ListConnectorMarketCatalogParams) {
-	var request ListConnectorMarketCatalogRequestObject
-
-	request.Params = params
-
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
-		return sh.ssi.ListConnectorMarketCatalog(ctx, request.(ListConnectorMarketCatalogRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "ListConnectorMarketCatalog")
-	}
-
-	response, err := handler(r.Context(), w, r, request)
-
-	if err != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, err)
-	} else if validResponse, ok := response.(ListConnectorMarketCatalogResponseObject); ok {
-		if err := validResponse.VisitListConnectorMarketCatalogResponse(w); err != nil {
-			sh.options.ResponseErrorHandlerFunc(w, r, err)
-		}
-	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
-	}
-}
-
-// ListConnectorMarketCategories operation middleware
-func (sh *strictHandler) ListConnectorMarketCategories(w http.ResponseWriter, r *http.Request) {
-	var request ListConnectorMarketCategoriesRequestObject
-
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
-		return sh.ssi.ListConnectorMarketCategories(ctx, request.(ListConnectorMarketCategoriesRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "ListConnectorMarketCategories")
-	}
-
-	response, err := handler(r.Context(), w, r, request)
-
-	if err != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, err)
-	} else if validResponse, ok := response.(ListConnectorMarketCategoriesResponseObject); ok {
-		if err := validResponse.VisitListConnectorMarketCategoriesResponse(w); err != nil {
-			sh.options.ResponseErrorHandlerFunc(w, r, err)
-		}
-	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
-	}
-}
-
-// GetConnectorMarketConnector operation middleware
-func (sh *strictHandler) GetConnectorMarketConnector(w http.ResponseWriter, r *http.Request, connectorKey ConnectorMarketConnectorKey) {
-	var request GetConnectorMarketConnectorRequestObject
-
-	request.ConnectorKey = connectorKey
-
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
-		return sh.ssi.GetConnectorMarketConnector(ctx, request.(GetConnectorMarketConnectorRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "GetConnectorMarketConnector")
-	}
-
-	response, err := handler(r.Context(), w, r, request)
-
-	if err != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, err)
-	} else if validResponse, ok := response.(GetConnectorMarketConnectorResponseObject); ok {
-		if err := validResponse.VisitGetConnectorMarketConnectorResponse(w); err != nil {
-			sh.options.ResponseErrorHandlerFunc(w, r, err)
-		}
-	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
-	}
-}
-
-// DisconnectConnectorMarketAuthorization operation middleware
-func (sh *strictHandler) DisconnectConnectorMarketAuthorization(w http.ResponseWriter, r *http.Request, connectorKey ConnectorMarketConnectorKey) {
-	var request DisconnectConnectorMarketAuthorizationRequestObject
-
-	request.ConnectorKey = connectorKey
-
-	var body DisconnectConnectorMarketAuthorizationJSONRequestBody
-	decoder := json.NewDecoder(r.Body)
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&body); err != nil {
-		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
-		return
-	}
-	request.Body = &body
-
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
-		return sh.ssi.DisconnectConnectorMarketAuthorization(ctx, request.(DisconnectConnectorMarketAuthorizationRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "DisconnectConnectorMarketAuthorization")
-	}
-
-	response, err := handler(r.Context(), w, r, request)
-
-	if err != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, err)
-	} else if validResponse, ok := response.(DisconnectConnectorMarketAuthorizationResponseObject); ok {
-		if err := validResponse.VisitDisconnectConnectorMarketAuthorizationResponse(w); err != nil {
-			sh.options.ResponseErrorHandlerFunc(w, r, err)
-		}
-	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
-	}
-}
-
-// StartConnectorMarketAuthorization operation middleware
-func (sh *strictHandler) StartConnectorMarketAuthorization(w http.ResponseWriter, r *http.Request, connectorKey ConnectorMarketConnectorKey) {
-	var request StartConnectorMarketAuthorizationRequestObject
-
-	request.ConnectorKey = connectorKey
-
-	var body StartConnectorMarketAuthorizationJSONRequestBody
-	decoder := json.NewDecoder(r.Body)
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&body); err != nil {
-		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
-		return
-	}
-	request.Body = &body
-
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
-		return sh.ssi.StartConnectorMarketAuthorization(ctx, request.(StartConnectorMarketAuthorizationRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "StartConnectorMarketAuthorization")
-	}
-
-	response, err := handler(r.Context(), w, r, request)
-
-	if err != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, err)
-	} else if validResponse, ok := response.(StartConnectorMarketAuthorizationResponseObject); ok {
-		if err := validResponse.VisitStartConnectorMarketAuthorizationResponse(w); err != nil {
-			sh.options.ResponseErrorHandlerFunc(w, r, err)
-		}
-	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
-	}
-}
-
-// InstallConnectorMarketConnector operation middleware
-func (sh *strictHandler) InstallConnectorMarketConnector(w http.ResponseWriter, r *http.Request, connectorKey ConnectorMarketConnectorKey) {
-	var request InstallConnectorMarketConnectorRequestObject
-
-	request.ConnectorKey = connectorKey
-
-	var body InstallConnectorMarketConnectorJSONRequestBody
-	decoder := json.NewDecoder(r.Body)
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&body); err != nil {
-		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
-		return
-	}
-	request.Body = &body
-
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
-		return sh.ssi.InstallConnectorMarketConnector(ctx, request.(InstallConnectorMarketConnectorRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "InstallConnectorMarketConnector")
-	}
-
-	response, err := handler(r.Context(), w, r, request)
-
-	if err != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, err)
-	} else if validResponse, ok := response.(InstallConnectorMarketConnectorResponseObject); ok {
-		if err := validResponse.VisitInstallConnectorMarketConnectorResponse(w); err != nil {
-			sh.options.ResponseErrorHandlerFunc(w, r, err)
-		}
-	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
-	}
-}
-
-// UninstallConnectorMarketConnector operation middleware
-func (sh *strictHandler) UninstallConnectorMarketConnector(w http.ResponseWriter, r *http.Request, connectorKey ConnectorMarketConnectorKey) {
-	var request UninstallConnectorMarketConnectorRequestObject
-
-	request.ConnectorKey = connectorKey
-
-	var body UninstallConnectorMarketConnectorJSONRequestBody
-	decoder := json.NewDecoder(r.Body)
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&body); err != nil {
-		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
-		return
-	}
-	request.Body = &body
-
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
-		return sh.ssi.UninstallConnectorMarketConnector(ctx, request.(UninstallConnectorMarketConnectorRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "UninstallConnectorMarketConnector")
-	}
-
-	response, err := handler(r.Context(), w, r, request)
-
-	if err != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, err)
-	} else if validResponse, ok := response.(UninstallConnectorMarketConnectorResponseObject); ok {
-		if err := validResponse.VisitUninstallConnectorMarketConnectorResponse(w); err != nil {
-			sh.options.ResponseErrorHandlerFunc(w, r, err)
-		}
-	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
-	}
-}
-
-// GetConnectorMarketOperation operation middleware
-func (sh *strictHandler) GetConnectorMarketOperation(w http.ResponseWriter, r *http.Request, operationID ConnectorMarketOperationID) {
-	var request GetConnectorMarketOperationRequestObject
-
-	request.OperationID = operationID
-
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
-		return sh.ssi.GetConnectorMarketOperation(ctx, request.(GetConnectorMarketOperationRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "GetConnectorMarketOperation")
-	}
-
-	response, err := handler(r.Context(), w, r, request)
-
-	if err != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, err)
-	} else if validResponse, ok := response.(GetConnectorMarketOperationResponseObject); ok {
-		if err := validResponse.VisitGetConnectorMarketOperationResponse(w); err != nil {
-			sh.options.ResponseErrorHandlerFunc(w, r, err)
-		}
-	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
-	}
-}
-
-// RefreshConnectorMarket operation middleware
-func (sh *strictHandler) RefreshConnectorMarket(w http.ResponseWriter, r *http.Request) {
-	var request RefreshConnectorMarketRequestObject
-
-	var body RefreshConnectorMarketJSONRequestBody
-	decoder := json.NewDecoder(r.Body)
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&body); err != nil {
-		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
-		return
-	}
-	request.Body = &body
-
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
-		return sh.ssi.RefreshConnectorMarket(ctx, request.(RefreshConnectorMarketRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "RefreshConnectorMarket")
-	}
-
-	response, err := handler(r.Context(), w, r, request)
-
-	if err != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, err)
-	} else if validResponse, ok := response.(RefreshConnectorMarketResponseObject); ok {
-		if err := validResponse.VisitRefreshConnectorMarketResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
@@ -47950,6 +47618,296 @@ func (sh *strictHandler) DecideWorkspaceWorkflowCheckpoint(w http.ResponseWriter
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
 	} else if validResponse, ok := response.(DecideWorkspaceWorkflowCheckpointResponseObject); ok {
 		if err := validResponse.VisitDecideWorkspaceWorkflowCheckpointResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetConnectorMarket operation middleware
+func (sh *strictHandler) GetConnectorMarket(w http.ResponseWriter, r *http.Request) {
+	var request GetConnectorMarketRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetConnectorMarket(ctx, request.(GetConnectorMarketRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetConnectorMarket")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetConnectorMarketResponseObject); ok {
+		if err := validResponse.VisitGetConnectorMarketResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// ListConnectorMarketCatalog operation middleware
+func (sh *strictHandler) ListConnectorMarketCatalog(w http.ResponseWriter, r *http.Request, params ListConnectorMarketCatalogParams) {
+	var request ListConnectorMarketCatalogRequestObject
+
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.ListConnectorMarketCatalog(ctx, request.(ListConnectorMarketCatalogRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListConnectorMarketCatalog")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ListConnectorMarketCatalogResponseObject); ok {
+		if err := validResponse.VisitListConnectorMarketCatalogResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// ListConnectorMarketCategories operation middleware
+func (sh *strictHandler) ListConnectorMarketCategories(w http.ResponseWriter, r *http.Request) {
+	var request ListConnectorMarketCategoriesRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.ListConnectorMarketCategories(ctx, request.(ListConnectorMarketCategoriesRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListConnectorMarketCategories")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ListConnectorMarketCategoriesResponseObject); ok {
+		if err := validResponse.VisitListConnectorMarketCategoriesResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetConnectorMarketConnector operation middleware
+func (sh *strictHandler) GetConnectorMarketConnector(w http.ResponseWriter, r *http.Request, connectorKey ConnectorMarketConnectorKey) {
+	var request GetConnectorMarketConnectorRequestObject
+
+	request.ConnectorKey = connectorKey
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetConnectorMarketConnector(ctx, request.(GetConnectorMarketConnectorRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetConnectorMarketConnector")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetConnectorMarketConnectorResponseObject); ok {
+		if err := validResponse.VisitGetConnectorMarketConnectorResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// DisconnectConnectorMarketAuthorization operation middleware
+func (sh *strictHandler) DisconnectConnectorMarketAuthorization(w http.ResponseWriter, r *http.Request, connectorKey ConnectorMarketConnectorKey) {
+	var request DisconnectConnectorMarketAuthorizationRequestObject
+
+	request.ConnectorKey = connectorKey
+
+	var body DisconnectConnectorMarketAuthorizationJSONRequestBody
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.DisconnectConnectorMarketAuthorization(ctx, request.(DisconnectConnectorMarketAuthorizationRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "DisconnectConnectorMarketAuthorization")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(DisconnectConnectorMarketAuthorizationResponseObject); ok {
+		if err := validResponse.VisitDisconnectConnectorMarketAuthorizationResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// StartConnectorMarketAuthorization operation middleware
+func (sh *strictHandler) StartConnectorMarketAuthorization(w http.ResponseWriter, r *http.Request, connectorKey ConnectorMarketConnectorKey) {
+	var request StartConnectorMarketAuthorizationRequestObject
+
+	request.ConnectorKey = connectorKey
+
+	var body StartConnectorMarketAuthorizationJSONRequestBody
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.StartConnectorMarketAuthorization(ctx, request.(StartConnectorMarketAuthorizationRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "StartConnectorMarketAuthorization")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(StartConnectorMarketAuthorizationResponseObject); ok {
+		if err := validResponse.VisitStartConnectorMarketAuthorizationResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// InstallConnectorMarketConnector operation middleware
+func (sh *strictHandler) InstallConnectorMarketConnector(w http.ResponseWriter, r *http.Request, connectorKey ConnectorMarketConnectorKey) {
+	var request InstallConnectorMarketConnectorRequestObject
+
+	request.ConnectorKey = connectorKey
+
+	var body InstallConnectorMarketConnectorJSONRequestBody
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.InstallConnectorMarketConnector(ctx, request.(InstallConnectorMarketConnectorRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "InstallConnectorMarketConnector")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(InstallConnectorMarketConnectorResponseObject); ok {
+		if err := validResponse.VisitInstallConnectorMarketConnectorResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// UninstallConnectorMarketConnector operation middleware
+func (sh *strictHandler) UninstallConnectorMarketConnector(w http.ResponseWriter, r *http.Request, connectorKey ConnectorMarketConnectorKey) {
+	var request UninstallConnectorMarketConnectorRequestObject
+
+	request.ConnectorKey = connectorKey
+
+	var body UninstallConnectorMarketConnectorJSONRequestBody
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.UninstallConnectorMarketConnector(ctx, request.(UninstallConnectorMarketConnectorRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "UninstallConnectorMarketConnector")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(UninstallConnectorMarketConnectorResponseObject); ok {
+		if err := validResponse.VisitUninstallConnectorMarketConnectorResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetConnectorMarketOperation operation middleware
+func (sh *strictHandler) GetConnectorMarketOperation(w http.ResponseWriter, r *http.Request, operationID ConnectorMarketOperationID) {
+	var request GetConnectorMarketOperationRequestObject
+
+	request.OperationID = operationID
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetConnectorMarketOperation(ctx, request.(GetConnectorMarketOperationRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetConnectorMarketOperation")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetConnectorMarketOperationResponseObject); ok {
+		if err := validResponse.VisitGetConnectorMarketOperationResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// RefreshConnectorMarket operation middleware
+func (sh *strictHandler) RefreshConnectorMarket(w http.ResponseWriter, r *http.Request) {
+	var request RefreshConnectorMarketRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.RefreshConnectorMarket(ctx, request.(RefreshConnectorMarketRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "RefreshConnectorMarket")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(RefreshConnectorMarketResponseObject); ok {
+		if err := validResponse.VisitRefreshConnectorMarketResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -1460,6 +1460,7 @@ const (
 	ConnectorMarketUpstreamUnavailable ConnectorMarketErrorCode = "connector_market_upstream_unavailable"
 	ConnectorNotFound                  ConnectorMarketErrorCode = "connector_not_found"
 	ConnectorOperationInProgress       ConnectorMarketErrorCode = "connector_operation_in_progress"
+	ReleaseRevoked                     ConnectorMarketErrorCode = "release_revoked"
 )
 
 // Valid indicates whether the value is a known member of the ConnectorMarketErrorCode enum.
@@ -1486,6 +1487,8 @@ func (e ConnectorMarketErrorCode) Valid() bool {
 	case ConnectorNotFound:
 		return true
 	case ConnectorOperationInProgress:
+		return true
+	case ReleaseRevoked:
 		return true
 	default:
 		return false
@@ -1562,7 +1565,7 @@ func (e ConnectorMarketManifestSchemaVersion) Valid() bool {
 const (
 	DisconnectAuthorization ConnectorMarketOperationKind = "disconnect_authorization"
 	Install                 ConnectorMarketOperationKind = "install"
-	RefreshCatalog          ConnectorMarketOperationKind = "refresh_catalog"
+	ReconcileRuntime        ConnectorMarketOperationKind = "reconcile_runtime"
 	StartAuthorization      ConnectorMarketOperationKind = "start_authorization"
 	Uninstall               ConnectorMarketOperationKind = "uninstall"
 )
@@ -1574,7 +1577,7 @@ func (e ConnectorMarketOperationKind) Valid() bool {
 		return true
 	case Install:
 		return true
-	case RefreshCatalog:
+	case ReconcileRuntime:
 		return true
 	case StartAuthorization:
 		return true
@@ -1588,20 +1591,23 @@ func (e ConnectorMarketOperationKind) Valid() bool {
 // Defines values for ConnectorMarketOperationStage.
 const (
 	ConnectorMarketOperationStageAccepted      ConnectorMarketOperationStage = "accepted"
+	ConnectorMarketOperationStageActivated     ConnectorMarketOperationStage = "activated"
 	ConnectorMarketOperationStageAuthorizing   ConnectorMarketOperationStage = "authorizing"
 	ConnectorMarketOperationStageCompleted     ConnectorMarketOperationStage = "completed"
 	ConnectorMarketOperationStageDeactivating  ConnectorMarketOperationStage = "deactivating"
 	ConnectorMarketOperationStageDisconnecting ConnectorMarketOperationStage = "disconnecting"
 	ConnectorMarketOperationStageFailed        ConnectorMarketOperationStage = "failed"
+	ConnectorMarketOperationStageFinalizing    ConnectorMarketOperationStage = "finalizing"
 	ConnectorMarketOperationStageInstalled     ConnectorMarketOperationStage = "installed"
 	ConnectorMarketOperationStageInstalling    ConnectorMarketOperationStage = "installing"
-	ConnectorMarketOperationStageRefreshing    ConnectorMarketOperationStage = "refreshing"
 )
 
 // Valid indicates whether the value is a known member of the ConnectorMarketOperationStage enum.
 func (e ConnectorMarketOperationStage) Valid() bool {
 	switch e {
 	case ConnectorMarketOperationStageAccepted:
+		return true
+	case ConnectorMarketOperationStageActivated:
 		return true
 	case ConnectorMarketOperationStageAuthorizing:
 		return true
@@ -1613,11 +1619,11 @@ func (e ConnectorMarketOperationStage) Valid() bool {
 		return true
 	case ConnectorMarketOperationStageFailed:
 		return true
+	case ConnectorMarketOperationStageFinalizing:
+		return true
 	case ConnectorMarketOperationStageInstalled:
 		return true
 	case ConnectorMarketOperationStageInstalling:
-		return true
-	case ConnectorMarketOperationStageRefreshing:
 		return true
 	default:
 		return false
@@ -1626,10 +1632,12 @@ func (e ConnectorMarketOperationStage) Valid() bool {
 
 // Defines values for ConnectorMarketOperationState.
 const (
-	ConnectorMarketOperationStateAccepted  ConnectorMarketOperationState = "accepted"
-	ConnectorMarketOperationStateCompleted ConnectorMarketOperationState = "completed"
-	ConnectorMarketOperationStateFailed    ConnectorMarketOperationState = "failed"
-	ConnectorMarketOperationStateRunning   ConnectorMarketOperationState = "running"
+	ConnectorMarketOperationStateAccepted       ConnectorMarketOperationState = "accepted"
+	ConnectorMarketOperationStateCancelled      ConnectorMarketOperationState = "cancelled"
+	ConnectorMarketOperationStateCompleted      ConnectorMarketOperationState = "completed"
+	ConnectorMarketOperationStateFailed         ConnectorMarketOperationState = "failed"
+	ConnectorMarketOperationStateOutcomeUnknown ConnectorMarketOperationState = "outcome_unknown"
+	ConnectorMarketOperationStateRunning        ConnectorMarketOperationState = "running"
 )
 
 // Valid indicates whether the value is a known member of the ConnectorMarketOperationState enum.
@@ -1637,9 +1645,13 @@ func (e ConnectorMarketOperationState) Valid() bool {
 	switch e {
 	case ConnectorMarketOperationStateAccepted:
 		return true
+	case ConnectorMarketOperationStateCancelled:
+		return true
 	case ConnectorMarketOperationStateCompleted:
 		return true
 	case ConnectorMarketOperationStateFailed:
+		return true
+	case ConnectorMarketOperationStateOutcomeUnknown:
 		return true
 	case ConnectorMarketOperationStateRunning:
 		return true
@@ -1675,6 +1687,39 @@ func (e ConnectorMarketReleaseStatus) Valid() bool {
 	case ConnectorMarketReleaseStatusAvailable:
 		return true
 	case ConnectorMarketReleaseStatusSuperseded:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ConnectorMarketSecurityState.
+const (
+	Allowed ConnectorMarketSecurityState = "allowed"
+	Revoked ConnectorMarketSecurityState = "revoked"
+)
+
+// Valid indicates whether the value is a known member of the ConnectorMarketSecurityState enum.
+func (e ConnectorMarketSecurityState) Valid() bool {
+	switch e {
+	case Allowed:
+		return true
+	case Revoked:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ConnectorMarketSnapshotContractCohort.
+const (
+	ConnectorControlPlaneV2 ConnectorMarketSnapshotContractCohort = "connector-control-plane-v2"
+)
+
+// Valid indicates whether the value is a known member of the ConnectorMarketSnapshotContractCohort enum.
+func (e ConnectorMarketSnapshotContractCohort) Valid() bool {
+	switch e {
+	case ConnectorControlPlaneV2:
 		return true
 	default:
 		return false
@@ -6197,6 +6242,7 @@ type ConnectorMarketConnector struct {
 	Key           string                       `json:"key"`
 	Release       ConnectorMarketRelease       `json:"release"`
 	Revision      int64                        `json:"revision"`
+	Security      ConnectorMarketSecurity      `json:"security"`
 }
 
 // ConnectorMarketConnectorResponse defines model for ConnectorMarketConnectorResponse.
@@ -6227,11 +6273,12 @@ type ConnectorMarketImplementationKind string
 
 // ConnectorMarketInstallation defines model for ConnectorMarketInstallation.
 type ConnectorMarketInstallation struct {
-	FailureCode            *string                          `json:"failureCode,omitempty"`
-	InstalledReleaseDigest *string                          `json:"installedReleaseDigest,omitempty"`
-	InstalledReleaseId     *string                          `json:"installedReleaseId,omitempty"`
-	InstalledVersion       *string                          `json:"installedVersion,omitempty"`
-	State                  ConnectorMarketInstallationState `json:"state"`
+	FailureCode             *string                          `json:"failureCode,omitempty"`
+	InstalledArtifactSha256 *string                          `json:"installedArtifactSha256,omitempty"`
+	InstalledReleaseDigest  *string                          `json:"installedReleaseDigest,omitempty"`
+	InstalledReleaseId      *string                          `json:"installedReleaseId,omitempty"`
+	InstalledVersion        *string                          `json:"installedVersion,omitempty"`
+	State                   ConnectorMarketInstallationState `json:"state"`
 }
 
 // ConnectorMarketInstallationState defines model for ConnectorMarketInstallationState.
@@ -6273,17 +6320,22 @@ type ConnectorMarketMutationResponse struct {
 
 // ConnectorMarketOperation defines model for ConnectorMarketOperation.
 type ConnectorMarketOperation struct {
-	Attempt         int32                           `json:"attempt"`
-	ClientRequestId string                          `json:"clientRequestId"`
-	ConnectorKey    *string                         `json:"connectorKey,omitempty"`
-	CreatedAt       time.Time                       `json:"createdAt"`
-	FailureCode     *string                         `json:"failureCode,omitempty"`
-	Kind            ConnectorMarketOperationKind    `json:"kind"`
-	OperationId     string                          `json:"operationId"`
-	Stage           *ConnectorMarketOperationStage  `json:"stage,omitempty"`
-	State           ConnectorMarketOperationState   `json:"state"`
-	Target          *ConnectorMarketOperationTarget `json:"target,omitempty"`
-	UpdatedAt       time.Time                       `json:"updatedAt"`
+	Attempt          int32                           `json:"attempt"`
+	ClientRequestId  string                          `json:"clientRequestId"`
+	ConnectorKey     *string                         `json:"connectorKey,omitempty"`
+	CreatedAt        time.Time                       `json:"createdAt"`
+	FailureCode      *string                         `json:"failureCode,omitempty"`
+	FinishedAt       *time.Time                      `json:"finishedAt,omitempty"`
+	Kind             ConnectorMarketOperationKind    `json:"kind"`
+	NextAttemptAt    *time.Time                      `json:"nextAttemptAt,omitempty"`
+	OperationId      string                          `json:"operationId"`
+	OperationVersion int64                           `json:"operationVersion"`
+	Stage            *ConnectorMarketOperationStage  `json:"stage,omitempty"`
+	StartedAt        *time.Time                      `json:"startedAt,omitempty"`
+	State            ConnectorMarketOperationState   `json:"state"`
+	Target           *ConnectorMarketOperationTarget `json:"target,omitempty"`
+	TerminalAt       *time.Time                      `json:"terminalAt,omitempty"`
+	UpdatedAt        time.Time                       `json:"updatedAt"`
 }
 
 // ConnectorMarketOperationKind defines model for ConnectorMarketOperationKind.
@@ -6324,14 +6376,28 @@ type ConnectorMarketReleaseSchemaVersion string
 // ConnectorMarketReleaseStatus defines model for ConnectorMarketRelease.Status.
 type ConnectorMarketReleaseStatus string
 
+// ConnectorMarketSecurity defines model for ConnectorMarketSecurity.
+type ConnectorMarketSecurity struct {
+	ReasonCode   *string                      `json:"reasonCode,omitempty"`
+	RevocationId *string                      `json:"revocationId,omitempty"`
+	State        ConnectorMarketSecurityState `json:"state"`
+}
+
+// ConnectorMarketSecurityState defines model for ConnectorMarketSecurity.State.
+type ConnectorMarketSecurityState string
+
 // ConnectorMarketSnapshot defines model for ConnectorMarketSnapshot.
 type ConnectorMarketSnapshot struct {
-	CatalogState   ConnectorMarketCatalogState `json:"catalogState"`
-	Connectors     []ConnectorMarketConnector  `json:"connectors"`
-	Operations     []ConnectorMarketOperation  `json:"operations"`
-	Revision       int64                       `json:"revision"`
-	SourceRevision *string                     `json:"sourceRevision,omitempty"`
+	CatalogState   ConnectorMarketCatalogState           `json:"catalogState"`
+	Connectors     []ConnectorMarketConnector            `json:"connectors"`
+	ContractCohort ConnectorMarketSnapshotContractCohort `json:"contractCohort"`
+	Operations     []ConnectorMarketOperation            `json:"operations"`
+	Revision       int64                                 `json:"revision"`
+	SourceRevision *string                               `json:"sourceRevision,omitempty"`
 }
+
+// ConnectorMarketSnapshotContractCohort defines model for ConnectorMarketSnapshot.ContractCohort.
+type ConnectorMarketSnapshotContractCohort string
 
 // CopyWorkspaceFileEntryRequest defines model for CopyWorkspaceFileEntryRequest.
 type CopyWorkspaceFileEntryRequest struct {
@@ -10199,13 +10265,6 @@ type ListCliCapabilitiesParams struct {
 	IncludeIntegration *bool `form:"includeIntegration,omitempty" json:"includeIntegration,omitempty"`
 }
 
-// ListConnectorMarketCatalogParams defines parameters for ListConnectorMarketCatalog.
-type ListConnectorMarketCatalogParams struct {
-	SectionId ConnectorMarketSectionID  `form:"sectionId" json:"sectionId"`
-	PageSize  *ConnectorMarketPageSize  `form:"pageSize,omitempty" json:"pageSize,omitempty"`
-	PageToken *ConnectorMarketPageToken `form:"pageToken,omitempty" json:"pageToken,omitempty"`
-}
-
 // ListWorkspaceAgentGeneratedFilesParams defines parameters for ListWorkspaceAgentGeneratedFiles.
 type ListWorkspaceAgentGeneratedFilesParams struct {
 	Query *string `form:"query,omitempty" json:"query,omitempty"`
@@ -10489,6 +10548,13 @@ type ListWorkspaceWorkflowsParams struct {
 // ListWorkspaceWorkflowsParamsCheckpointStatus defines parameters for ListWorkspaceWorkflows.
 type ListWorkspaceWorkflowsParamsCheckpointStatus string
 
+// ListConnectorMarketCatalogParams defines parameters for ListConnectorMarketCatalog.
+type ListConnectorMarketCatalogParams struct {
+	SectionId ConnectorMarketSectionID  `form:"sectionId" json:"sectionId"`
+	PageSize  *ConnectorMarketPageSize  `form:"pageSize,omitempty" json:"pageSize,omitempty"`
+	PageToken *ConnectorMarketPageToken `form:"pageToken,omitempty" json:"pageToken,omitempty"`
+}
+
 // DismissAccountRegistrationCreditsRewardJSONRequestBody defines body for DismissAccountRegistrationCreditsReward for application/json ContentType.
 type DismissAccountRegistrationCreditsRewardJSONRequestBody = DismissAccountRegistrationCreditsRewardRequest
 
@@ -10518,21 +10584,6 @@ type SetSystemAgentTargetEnabledJSONRequestBody = SetSystemAgentTargetEnabledReq
 
 // InvokeCliCommandJSONRequestBody defines body for InvokeCliCommand for application/json ContentType.
 type InvokeCliCommandJSONRequestBody = CliInvokeRequest
-
-// DisconnectConnectorMarketAuthorizationJSONRequestBody defines body for DisconnectConnectorMarketAuthorization for application/json ContentType.
-type DisconnectConnectorMarketAuthorizationJSONRequestBody = ConnectorMarketMutationRequest
-
-// StartConnectorMarketAuthorizationJSONRequestBody defines body for StartConnectorMarketAuthorization for application/json ContentType.
-type StartConnectorMarketAuthorizationJSONRequestBody = ConnectorMarketAuthorizationRequest
-
-// InstallConnectorMarketConnectorJSONRequestBody defines body for InstallConnectorMarketConnector for application/json ContentType.
-type InstallConnectorMarketConnectorJSONRequestBody = ConnectorMarketMutationRequest
-
-// UninstallConnectorMarketConnectorJSONRequestBody defines body for UninstallConnectorMarketConnector for application/json ContentType.
-type UninstallConnectorMarketConnectorJSONRequestBody = ConnectorMarketMutationRequest
-
-// RefreshConnectorMarketJSONRequestBody defines body for RefreshConnectorMarket for application/json ContentType.
-type RefreshConnectorMarketJSONRequestBody = ConnectorMarketMutationRequest
 
 // RefreshDesktopUpdateAdmissionJSONRequestBody defines body for RefreshDesktopUpdateAdmission for application/json ContentType.
 type RefreshDesktopUpdateAdmissionJSONRequestBody = DesktopUpdateAdmissionRefreshRequest
@@ -10821,6 +10872,18 @@ type PutWorkspaceWorkbenchJSONRequestBody = PutWorkspaceWorkbenchRequest
 
 // DecideWorkspaceWorkflowCheckpointJSONRequestBody defines body for DecideWorkspaceWorkflowCheckpoint for application/json ContentType.
 type DecideWorkspaceWorkflowCheckpointJSONRequestBody = DecideWorkspaceWorkflowCheckpointRequest
+
+// DisconnectConnectorMarketAuthorizationJSONRequestBody defines body for DisconnectConnectorMarketAuthorization for application/json ContentType.
+type DisconnectConnectorMarketAuthorizationJSONRequestBody = ConnectorMarketMutationRequest
+
+// StartConnectorMarketAuthorizationJSONRequestBody defines body for StartConnectorMarketAuthorization for application/json ContentType.
+type StartConnectorMarketAuthorizationJSONRequestBody = ConnectorMarketAuthorizationRequest
+
+// InstallConnectorMarketConnectorJSONRequestBody defines body for InstallConnectorMarketConnector for application/json ContentType.
+type InstallConnectorMarketConnectorJSONRequestBody = ConnectorMarketMutationRequest
+
+// UninstallConnectorMarketConnectorJSONRequestBody defines body for UninstallConnectorMarketConnector for application/json ContentType.
+type UninstallConnectorMarketConnectorJSONRequestBody = ConnectorMarketMutationRequest
 
 // AsAgentTargetBuiltinLocalLaunchRef returns the union data inside the AgentTargetLaunchRef as a AgentTargetBuiltinLocalLaunchRef
 func (t AgentTargetLaunchRef) AsAgentTargetBuiltinLocalLaunchRef() (AgentTargetBuiltinLocalLaunchRef, error) {

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -5,7 +5,7 @@ info:
   description: Versioned local daemon API for tutti desktop, CLI, and approved local integrations.
 x-tutti-openapi-fragments:
   - packages/workspace/issue-manager/openapi/issue-manager.v1.yaml
-  - packages/connector/market/openapi/connector-market.v1.yaml
+  - packages/connector/market/openapi/connector-market.v2.yaml
   - services/tuttid/api/openapi/mobile-remote-access.v1.yaml
 servers:
   - url: http://127.0.0.1:4545

--- a/services/tuttid/api/routes.go
+++ b/services/tuttid/api/routes.go
@@ -759,35 +759,35 @@ func RegisterRoutes(mux *http.ServeMux, routes Routes) {
 }
 
 func registerConnectorMarketRoutes(mux *http.ServeMux, wrapper *tuttigenerated.ServerInterfaceWrapper) {
-	mux.HandleFunc("/v1/connector-market", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/v2/connector-market", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			tuttitypes.WriteMethodNotAllowed(w)
 			return
 		}
 		wrapper.GetConnectorMarket(w, r)
 	})
-	mux.HandleFunc("/v1/connector-market/categories", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/v2/connector-market/categories", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			tuttitypes.WriteMethodNotAllowed(w)
 			return
 		}
 		wrapper.ListConnectorMarketCategories(w, r)
 	})
-	mux.HandleFunc("/v1/connector-market/catalog", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/v2/connector-market/catalog", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			tuttitypes.WriteMethodNotAllowed(w)
 			return
 		}
 		wrapper.ListConnectorMarketCatalog(w, r)
 	})
-	mux.HandleFunc("/v1/connector-market:refresh", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/v2/connector-market:refresh", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			tuttitypes.WriteMethodNotAllowed(w)
 			return
 		}
 		wrapper.RefreshConnectorMarket(w, r)
 	})
-	mux.HandleFunc("/v1/connector-market/connectors/{connectorSegment}", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/v2/connector-market/connectors/{connectorSegment}", func(w http.ResponseWriter, r *http.Request) {
 		segment := r.PathValue("connectorSegment")
 		switch {
 		case r.Method == http.MethodGet && !strings.Contains(segment, ":"):
@@ -803,21 +803,21 @@ func registerConnectorMarketRoutes(mux *http.ServeMux, wrapper *tuttigenerated.S
 			tuttitypes.WriteMethodNotAllowed(w)
 		}
 	})
-	mux.HandleFunc("/v1/connector-market/connectors/{connectorKey}/authorization:start", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/v2/connector-market/connectors/{connectorKey}/authorization:start", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			tuttitypes.WriteMethodNotAllowed(w)
 			return
 		}
 		wrapper.StartConnectorMarketAuthorization(w, r)
 	})
-	mux.HandleFunc("/v1/connector-market/connectors/{connectorKey}/authorization:disconnect", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/v2/connector-market/connectors/{connectorKey}/authorization:disconnect", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			tuttitypes.WriteMethodNotAllowed(w)
 			return
 		}
 		wrapper.DisconnectConnectorMarketAuthorization(w, r)
 	})
-	mux.HandleFunc("/v1/connector-market/operations/{operationID}", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/v2/connector-market/operations/{operationID}", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			tuttitypes.WriteMethodNotAllowed(w)
 			return

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -253,7 +253,8 @@ func (w *tuttiWiring) buildWorkspaceModule(ctx context.Context) error {
 		return err
 	}
 	if connectorsEnabled {
-		connectorMarketStore, err := connectormarketdata.Open(ctx, workspacedata.DefaultDBPath())
+		connectorControlPlanePath := filepath.Join(filepath.Dir(workspacedata.DefaultDBPath()), "connector-control-plane-v2.db")
+		connectorMarketStore, err := connectormarketdata.Open(ctx, connectorControlPlanePath)
 		if err != nil {
 			agentRuntime.Close()
 			providerAuthWatcher.Close()


### PR DESCRIPTION
## Summary

Connector catalog refresh previously entered the lifecycle operation manager with an empty connector key, so it could conflict with unrelated installs. This breaking v2 change separates catalog synchronization from connector lifecycle work and makes operation recovery explicit.

- replace incremental refresh operations with a versioned Last-Known-Good catalog snapshot
- add long-poll delivery with immediate first pull and a 10-minute fallback
- use connector-scoped revisions and explicit conflicting lock claims
- persist accepted, running, outcome_unknown, recovering, completed, and failed operation states
- use a fresh v2 SQLite schema with no v1 compatibility path
- fail closed on revocation and schedule deterministic automatic uninstall
- expose only the local Connector Market v2 API

## Verification

- node tools/scripts/generate-openapi.mjs --check
- go test ./packages/connector/host ./packages/connector/daemon ./packages/connector/store-sqlite ./packages/connector/runtime ./services/tuttid/api
- pnpm --filter @tutti-os/connector-market typecheck
- pnpm --filter @tutti-os/connector-market test (57 passed)
- pnpm --filter @tutti-os/client-tuttid-ts typecheck
- pnpm --filter @tutti-os/desktop typecheck
- pnpm check:changed -- --push-ready (30 lanes passed)

## Fallback Three Questions

- Source: long-poll delivery can be interrupted while a desktop is asleep, offline, or reconnecting.
- Why source cannot fully fix it: the current delivery channel does not provide a durable per-device acknowledgement cursor.
- Removal condition: remove the 10-minute fallback after delivery provides durable per-device cursors with monitored completeness.

## Checklist

- [x] If this changes agent lifecycle, platform behavior, safety boundaries, or execution guarantees, I added or updated regression coverage.
- [x] I ran the focused tests/checks for the changed packages.
- [x] I updated architecture or protocol documentation where applicable.
- [x] I checked README variants; no translated README update is required.
- [x] I ran repository push-ready checks.
- [x] The commit includes a DCO Signed-off-by trailer.