### PR TITLE
fix(windows): make workflow revision publishing portable

### DIFF
--- a/services/tuttid/data/workspace/workflow_revision_directory_sync_nonwindows.go
+++ b/services/tuttid/data/workspace/workflow_revision_directory_sync_nonwindows.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package workspace
+
+import (
+	"fmt"
+	"os"
+)
+
+func syncWorkflowRevisionDirectory(path string) error {
+	directory, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open workspace workflow revision directory: %w", err)
+	}
+	defer directory.Close()
+	if err := directory.Sync(); err != nil {
+		return fmt.Errorf("sync workspace workflow revision directory: %w", err)
+	}
+	return nil
+}

--- a/services/tuttid/data/workspace/workflow_revision_directory_sync_windows.go
+++ b/services/tuttid/data/workspace/workflow_revision_directory_sync_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package workspace
+
+// Windows does not provide portable directory fsync through os.File. The
+// revision file itself is synced before publication.
+func syncWorkflowRevisionDirectory(string) error {
+	return nil
+}

--- a/services/tuttid/data/workspace/workflow_revision_files.go
+++ b/services/tuttid/data/workspace/workflow_revision_files.go
@@ -115,15 +115,3 @@ func digestWorkflowRevision(raw []byte) string {
 	hash := sha256.Sum256(raw)
 	return fmt.Sprintf("%x", hash[:])
 }
-
-func syncWorkflowRevisionDirectory(path string) error {
-	directory, err := os.Open(path)
-	if err != nil {
-		return fmt.Errorf("open workspace workflow revision directory: %w", err)
-	}
-	defer directory.Close()
-	if err := directory.Sync(); err != nil {
-		return fmt.Errorf("sync workspace workflow revision directory: %w", err)
-	}
-	return nil
-}

--- a/services/tuttid/data/workspace/workflow_revision_files_windows_test.go
+++ b/services/tuttid/data/workspace/workflow_revision_files_windows_test.go
@@ -1,0 +1,38 @@
+//go:build windows
+
+package workspace
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWorkflowRevisionFilesPublishesContentOnWindows(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	files := WorkflowRevisionFiles{StateDir: stateDir}
+	raw := []byte("windows revision")
+
+	documentPath, digest, err := files.Write("workflow-windows", raw)
+	if err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	stored, err := files.Read("workflow-windows", documentPath, digest)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if !bytes.Equal(stored, raw) {
+		t.Fatalf("Read() = %q, want %q", stored, raw)
+	}
+
+	directory := filepath.Dir(filepath.Join(stateDir, documentPath))
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		t.Fatalf("ReadDir() error = %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != digest+".md" {
+		t.Fatalf("revision directory entries = %v, want only %q", entries, digest+".md")
+	}
+}


### PR DESCRIPTION
## Summary

- split workflow revision directory syncing by platform
- keep file-level fsync before publication on Windows, where directory fsync is unsupported
- add Windows regression coverage for revision publication and read-back

## Root cause

`WorkflowRevisionFiles.Write` atomically publishes a content-addressed revision file, then calls `os.File.Sync()` on its containing directory. On Windows, directory sync returns `Access is denied`, so `plan propose` and `plan revise` fail before their workflow metadata mutation is committed.

This mirrors the platform split already used for managed issue attachments.

## Impact

Windows Tutti Mode plan proposal and revision persistence. No API or schema changes.

## Validation

- `go test ./services/tuttid/data/workspace -run 'TestWorkflowRevisionFiles|TestSyncWorkflowRevisionDirectoryIsPortableOnWindows' -count=1`
- `go test ./services/tuttid/service/tuttimodeplan -run '^TestService(Propose|Revise)' -count=1`
- `go test ./services/tuttid/service/cli/providers/tuttimodeplan -count=1`
- `GOOS=linux go test ./services/tuttid/data/workspace -run '^$' -count=1 -c`

The full `tuttimodeplan` package has one pre-existing Windows path test failure in `TestValidatePlanExecutionIsolation`; the same failure reproduces on unmodified `origin/main`.