### PR TITLE
fix(agent): accept authoritative external rail placement

### DIFF
--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -153,6 +153,13 @@ and persists its opaque `SectionKey` exactly on first creation. An idempotent
 retry that supplies a placement must use the same placement; project deletion
 or another adapter-side view change never reassigns an existing session to
 `conversations`.
+By default, a new explicit project placement must still exist in the Host's
+local project registry, which fences a stale local selection after project
+deletion. A trusted adapter may set
+`CreateSessionInput.RailPlacementAuthoritative` when an external canonical
+authority already fixed the placement. That opt-in accepts a project absent
+from the local registry, but it applies only to first initialization and never
+allows an existing session's immutable placement to change.
 Before provider startup, Host resolves the final placement from the immutable
 existing session, an explicit caller placement, or the prepared cwd through the
 canonical store. It then installs the prepared cwd in `TUTTI_AGENT_CWD` and the

--- a/packages/agent/host/conformance/authoritative_rail_placement_scenario.go
+++ b/packages/agent/host/conformance/authoritative_rail_placement_scenario.go
@@ -1,0 +1,65 @@
+package conformance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+func runCreateWithAuthoritativeRailPlacement(ctx context.Context, driver Driver) error {
+	if err := driver.Reset(ctx, Fixture{}); err != nil {
+		return err
+	}
+	input := agenthost.CreateSessionInput{
+		AgentSessionID:             "session-authoritative-rail-placement",
+		AgentTargetID:              "target-1",
+		Provider:                   "codex",
+		InitialContent:             []agenthost.PromptContentBlock{{Type: "text", Text: "build in caller-selected project"}},
+		ClientSubmitID:             "create-authoritative-rail-placement-1",
+		RailPlacementAuthoritative: true,
+		RailPlacement: &agenthost.RailPlacement{
+			Version:     1,
+			Kind:        agenthost.RailPlacementKindProject,
+			ProjectPath: "/workspace/caller-project",
+		},
+	}
+	session, turnID, err := driver.Create(ctx, "workspace-1", input)
+	if err != nil {
+		return fmt.Errorf("create with authoritative rail placement: %w", err)
+	}
+	if turnID == "" {
+		return errors.New("create with authoritative rail placement turn is empty")
+	}
+	wantKey := storesqlite.RailSectionKeyForProject("/workspace/caller-project")
+	if session.RailSectionKey != wantKey {
+		return fmt.Errorf(
+			"create with authoritative rail placement key=%q, want %q",
+			session.RailSectionKey,
+			wantKey,
+		)
+	}
+	metrics := driver.Metrics()
+	if err := requireRuntimeRailPlacement(metrics.LastStartEnv, agenthost.RailPlacement{
+		Version: 1, Kind: agenthost.RailPlacementKindProject,
+		ProjectPath: "/workspace/caller-project", SectionKey: wantKey,
+	}); err != nil {
+		return fmt.Errorf("create authoritative runtime: %w", err)
+	}
+	if err := verifyRetriedInitialCreate(ctx, driver, input, session, turnID); err != nil {
+		return err
+	}
+	conflictingRetry := input
+	conflictingPlacement := *input.RailPlacement
+	conflictingPlacement.ProjectPath = "/workspace/other-caller-project"
+	conflictingRetry.RailPlacement = &conflictingPlacement
+	if _, _, err := driver.Create(ctx, "workspace-1", conflictingRetry); !errors.Is(
+		err,
+		agenthost.ErrRailPlacementConflict,
+	) {
+		return fmt.Errorf("authoritative retry with conflicting rail placement error=%v", err)
+	}
+	return nil
+}

--- a/packages/agent/host/conformance/conformance_test.go
+++ b/packages/agent/host/conformance/conformance_test.go
@@ -12,8 +12,8 @@ func TestPublishedScenarioCatalogsHaveUniqueNames(t *testing.T) {
 		scenarios []Scenario
 		wantCount int
 	}{
-		{name: "adapter lifecycle", scenarios: Scenarios(), wantCount: 33},
-		{name: "application core", scenarios: ApplicationCoreScenarios(), wantCount: 28},
+		{name: "adapter lifecycle", scenarios: Scenarios(), wantCount: 34},
+		{name: "application core", scenarios: ApplicationCoreScenarios(), wantCount: 29},
 		{name: "guidance", scenarios: GuidanceScenarios(), wantCount: 3},
 		{name: "resume policy", scenarios: ResumePolicyScenarios(), wantCount: 5},
 		{name: "submission fence", scenarios: SubmissionFenceScenarios(), wantCount: 1},
@@ -110,6 +110,7 @@ func TestScenarioOwnershipIsExplicit(t *testing.T) {
 		"typed initial goal waits for canonical rail initialization",
 		"failed canonical initialization aborts unpublished runtime",
 		"create with explicit rail placement",
+		"create with authoritative rail placement outside local project registry",
 		"resume persisted session",
 		"send input",
 		"send connector-only input",
@@ -145,6 +146,7 @@ func TestScenarioOwnershipIsExplicit(t *testing.T) {
 		"typed initial goal waits for canonical rail initialization",
 		"failed canonical initialization aborts unpublished runtime",
 		"create with explicit rail placement",
+		"create with authoritative rail placement outside local project registry",
 		"resume persisted session",
 		"send input",
 		"send connector-only input",

--- a/packages/agent/host/conformance/scenarios.go
+++ b/packages/agent/host/conformance/scenarios.go
@@ -13,11 +13,15 @@ var (
 		Name: "failed canonical initialization aborts unpublished runtime",
 		run:  runFailedCanonicalInitializationAbortsUnpublishedRuntime,
 	}
-	createWithRailPlacementScenario = Scenario{Name: "create with explicit rail placement", run: runCreateWithRailPlacement}
-	resumePersistedSessionScenario  = Scenario{Name: "resume persisted session", run: runResumePersistedSession}
-	sendInputScenario               = Scenario{Name: "send input", run: runSendInput}
-	sendConnectorOnlyInputScenario  = Scenario{Name: "send connector-only input", run: runSendConnectorOnlyInput}
-	providerAcceptanceScenario      = Scenario{
+	createWithRailPlacementScenario              = Scenario{Name: "create with explicit rail placement", run: runCreateWithRailPlacement}
+	createWithAuthoritativeRailPlacementScenario = Scenario{
+		Name: "create with authoritative rail placement outside local project registry",
+		run:  runCreateWithAuthoritativeRailPlacement,
+	}
+	resumePersistedSessionScenario = Scenario{Name: "resume persisted session", run: runResumePersistedSession}
+	sendInputScenario              = Scenario{Name: "send input", run: runSendInput}
+	sendConnectorOnlyInputScenario = Scenario{Name: "send connector-only input", run: runSendConnectorOnlyInput}
+	providerAcceptanceScenario     = Scenario{
 		Name: "new turns require durable provider acceptance",
 		run:  runNewTurnsRequireDurableProviderAcceptance,
 	}
@@ -73,6 +77,7 @@ func Scenarios() []Scenario {
 		typedInitialGoalRailBarrierScenario,
 		failedCanonicalInitializationScenario,
 		createWithRailPlacementScenario,
+		createWithAuthoritativeRailPlacementScenario,
 		resumePersistedSessionScenario,
 		sendInputScenario,
 		sendConnectorOnlyInputScenario,
@@ -224,6 +229,7 @@ func ApplicationCoreScenarios() []Scenario {
 		typedInitialGoalRailBarrierScenario,
 		failedCanonicalInitializationScenario,
 		createWithRailPlacementScenario,
+		createWithAuthoritativeRailPlacementScenario,
 		resumePersistedSessionScenario,
 		sendInputScenario,
 		sendConnectorOnlyInputScenario,

--- a/packages/agent/host/lifecycle.go
+++ b/packages/agent/host/lifecycle.go
@@ -178,10 +178,7 @@ func (h *Host) createSession(ctx context.Context, workspaceID string, input Crea
 	runtimeCreated := startResult.Created
 	h.observeStep(ctx, "session_create", "runtime_started", workspaceID, session.ID, session.Provider, startedAt, nil)
 	startedAt = h.now()
-	canonicalSession, err := h.store.InitializeRuntimeSession(ctx, RuntimeSessionInitialization{
-		Session:       session,
-		RailPlacement: input.RailPlacement,
-	})
+	canonicalSession, err := h.store.InitializeRuntimeSession(ctx, runtimeSessionInitializationForCreate(session, input))
 	if err != nil {
 		h.observeStep(ctx, "session_create", "session_persisted", workspaceID, session.ID, session.Provider, startedAt, err)
 		return createSessionFailureResult(input, cleanup(err, runtimeCreated, false))

--- a/packages/agent/host/lifecycle_rail_environment.go
+++ b/packages/agent/host/lifecycle_rail_environment.go
@@ -2,6 +2,17 @@ package agenthost
 
 import "context"
 
+func runtimeSessionInitializationForCreate(
+	session ProviderRuntimeSession,
+	input CreateSessionInput,
+) RuntimeSessionInitialization {
+	return RuntimeSessionInitialization{
+		Session:                    session,
+		RailPlacement:              input.RailPlacement,
+		RailPlacementAuthoritative: input.RailPlacementAuthoritative,
+	}
+}
+
 func (h *Host) resolveCreateRuntimeRailEnvironment(
 	ctx context.Context,
 	workspaceID string,
@@ -12,11 +23,12 @@ func (h *Host) resolveCreateRuntimeRailEnvironment(
 		return nil, nil, ErrRuntimeRailPlacementUnavailable
 	}
 	placement, err := h.runtimeRailPlacement.ResolveRuntimeSessionRailPlacement(ctx, ResolveRuntimeSessionRailPlacementInput{
-		WorkspaceID:    workspaceID,
-		AgentSessionID: input.AgentSessionID,
-		Cwd:            prepared.Cwd,
-		RuntimeContext: cloneMap(input.RuntimeContext),
-		RailPlacement:  input.RailPlacement,
+		WorkspaceID:                workspaceID,
+		AgentSessionID:             input.AgentSessionID,
+		Cwd:                        prepared.Cwd,
+		RuntimeContext:             cloneMap(input.RuntimeContext),
+		RailPlacement:              input.RailPlacement,
+		RailPlacementAuthoritative: input.RailPlacementAuthoritative,
 	})
 	if err != nil {
 		return nil, nil, err

--- a/packages/agent/host/ports.go
+++ b/packages/agent/host/ports.go
@@ -26,8 +26,9 @@ type RuntimeSessionRailPlacementResolver interface {
 }
 
 type RuntimeSessionInitialization struct {
-	Session       ProviderRuntimeSession
-	RailPlacement *RailPlacement
+	Session                    ProviderRuntimeSession
+	RailPlacement              *RailPlacement
+	RailPlacementAuthoritative bool
 }
 
 type CanonicalTurnStore interface {

--- a/packages/agent/host/sqlite_workspace_store.go
+++ b/packages/agent/host/sqlite_workspace_store.go
@@ -363,27 +363,28 @@ func (s *SQLiteWorkspaceStore) InitializeRuntimeSession(ctx context.Context, inp
 	}
 	result, err := store.ReportActivityState(ctx, storesqlite.ActivityStateReport{
 		Session: storesqlite.SessionStateReport{
-			WorkspaceID:       workspaceID,
-			AgentSessionID:    sessionID,
-			Kind:              storesqlite.SessionKindRoot,
-			Origin:            canonicalRuntimeSessionOrigin,
-			UserID:            userID,
-			AgentTargetID:     strings.TrimSpace(session.AgentTargetID),
-			Provider:          strings.TrimSpace(session.Provider),
-			ProviderSessionID: strings.TrimSpace(session.ProviderSessionID),
-			Model:             composerSettingsModel(session.Settings),
-			Settings:          composerSettingsPayload(session.Settings),
-			Capabilities:      canonical.CloneCapabilitySnapshot(session.Capabilities),
-			RuntimeContext:    runtimeContext,
-			Cwd:               strings.TrimSpace(session.Cwd),
-			RailPlacement:     railPlacement,
-			Title:             strings.TrimSpace(session.Title),
-			Status:            runtimeLifecycleStatus(session.Status),
-			CurrentPhase:      runtimeLifecyclePhase(session.Status),
-			LastError:         strings.TrimSpace(session.LastError),
-			OccurredAtUnixMS:  occurredAt,
-			StartedAtUnixMS:   session.CreatedAtUnixMS,
-			CreatedAtUnixMS:   session.CreatedAtUnixMS,
+			WorkspaceID:                workspaceID,
+			AgentSessionID:             sessionID,
+			Kind:                       storesqlite.SessionKindRoot,
+			Origin:                     canonicalRuntimeSessionOrigin,
+			UserID:                     userID,
+			AgentTargetID:              strings.TrimSpace(session.AgentTargetID),
+			Provider:                   strings.TrimSpace(session.Provider),
+			ProviderSessionID:          strings.TrimSpace(session.ProviderSessionID),
+			Model:                      composerSettingsModel(session.Settings),
+			Settings:                   composerSettingsPayload(session.Settings),
+			Capabilities:               canonical.CloneCapabilitySnapshot(session.Capabilities),
+			RuntimeContext:             runtimeContext,
+			Cwd:                        strings.TrimSpace(session.Cwd),
+			RailPlacement:              railPlacement,
+			RailPlacementAuthoritative: input.RailPlacementAuthoritative,
+			Title:                      strings.TrimSpace(session.Title),
+			Status:                     runtimeLifecycleStatus(session.Status),
+			CurrentPhase:               runtimeLifecyclePhase(session.Status),
+			LastError:                  strings.TrimSpace(session.LastError),
+			OccurredAtUnixMS:           occurredAt,
+			StartedAtUnixMS:            session.CreatedAtUnixMS,
+			CreatedAtUnixMS:            session.CreatedAtUnixMS,
 		},
 	})
 	if err != nil {
@@ -437,11 +438,12 @@ func (s *SQLiteWorkspaceStore) ResolveRuntimeSessionRailPlacement(
 		}
 	}
 	section, err := store.ResolveAgentSessionRailSection(ctx, storesqlite.ResolveAgentSessionRailSectionInput{
-		WorkspaceID:       workspaceID,
-		AgentSessionID:    agentSessionID,
-		Cwd:               input.Cwd,
-		RuntimeContext:    cloneStringAnyMap(input.RuntimeContext),
-		ExplicitPlacement: explicit,
+		WorkspaceID:                    workspaceID,
+		AgentSessionID:                 agentSessionID,
+		Cwd:                            input.Cwd,
+		RuntimeContext:                 cloneStringAnyMap(input.RuntimeContext),
+		ExplicitPlacement:              explicit,
+		ExplicitPlacementAuthoritative: input.RailPlacementAuthoritative,
 	})
 	if err != nil {
 		if errors.Is(err, storesqlite.ErrRailSectionConflict) {

--- a/packages/agent/host/sqlite_workspace_store_test.go
+++ b/packages/agent/host/sqlite_workspace_store_test.go
@@ -214,6 +214,26 @@ func TestSQLiteWorkspaceStoreResolvesRuntimeRailPlacementFromPreparedCWD(t *test
 	if !errors.Is(err, agenthost.ErrRailPlacementConflict) {
 		t.Fatalf("stale explicit project error = %v, want %v", err, agenthost.ErrRailPlacementConflict)
 	}
+
+	authoritative, err := store.ResolveRuntimeSessionRailPlacement(t.Context(), agenthost.ResolveRuntimeSessionRailPlacementInput{
+		WorkspaceID:                "workspace-1",
+		AgentSessionID:             "session-authoritative-project",
+		Cwd:                        "/workspace/caller-project",
+		RailPlacementAuthoritative: true,
+		RailPlacement: &agenthost.RailPlacement{
+			Version: 1, Kind: agenthost.RailPlacementKindProject,
+			ProjectPath: "/workspace/caller-project",
+		},
+	})
+	if err != nil {
+		t.Fatalf("ResolveRuntimeSessionRailPlacement(authoritative) error = %v", err)
+	}
+	wantAuthoritativeKey := storesqlite.RailSectionKeyForProject("/workspace/caller-project")
+	if authoritative.Kind != agenthost.RailPlacementKindProject ||
+		authoritative.ProjectPath != storesqlite.NormalizeProjectPath("/workspace/caller-project") ||
+		authoritative.SectionKey != wantAuthoritativeKey {
+		t.Fatalf("authoritative placement = %#v, want project %q", authoritative, wantAuthoritativeKey)
+	}
 }
 
 func TestSQLiteWorkspaceStoreProjectsForkTurnIdentitiesThroughProductionPort(t *testing.T) {

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -631,11 +631,12 @@ type RailPlacement struct {
 // runtime context whose canonical rail placement must be known before a
 // provider process starts.
 type ResolveRuntimeSessionRailPlacementInput struct {
-	WorkspaceID    string
-	AgentSessionID string
-	Cwd            string
-	RuntimeContext map[string]any
-	RailPlacement  *RailPlacement
+	WorkspaceID                string
+	AgentSessionID             string
+	Cwd                        string
+	RuntimeContext             map[string]any
+	RailPlacement              *RailPlacement
+	RailPlacementAuthoritative bool
 }
 
 // CreateSessionInput is the provider-neutral create contract. Adapter-only
@@ -676,6 +677,11 @@ type CreateSessionInput struct {
 	ConversationDetailMode string
 	Visible                *bool
 	RailPlacement          *RailPlacement
+	// RailPlacementAuthoritative declares that RailPlacement was selected by
+	// an external canonical authority and may name a project absent from this
+	// Host's local project registry. It applies only to first initialization
+	// and never permits replacing an existing canonical placement.
+	RailPlacementAuthoritative bool
 }
 
 type SendInput struct {

--- a/packages/agent/store-sqlite/activity_transaction.go
+++ b/packages/agent/store-sqlite/activity_transaction.go
@@ -208,6 +208,7 @@ SELECT EXISTS(
 		session.RuntimeContext,
 		input.ImportProjectPath,
 		input.RailPlacement,
+		input.RailPlacementAuthoritative,
 	)
 	if err != nil {
 		return false, false, 0, Session{}, err

--- a/packages/agent/store-sqlite/rail.go
+++ b/packages/agent/store-sqlite/rail.go
@@ -39,6 +39,9 @@ type ResolveAgentSessionRailSectionInput struct {
 	Cwd               string
 	RuntimeContext    map[string]any
 	ExplicitPlacement *RailSection
+	// ExplicitPlacementAuthoritative accepts a new project placement without
+	// requiring it to appear in this store's local project registry.
+	ExplicitPlacementAuthoritative bool
 }
 
 // ResolveAgentSessionRailSection resolves the same existing, explicit, import,
@@ -70,6 +73,7 @@ func (s *Store) ResolveAgentSessionRailSection(
 		input.RuntimeContext,
 		"",
 		input.ExplicitPlacement,
+		input.ExplicitPlacementAuthoritative,
 	)
 	if err != nil {
 		return RailSection{}, err
@@ -105,6 +109,7 @@ func (s *Store) resolveAgentSessionRailSectionTx(
 	runtimeContext map[string]any,
 	importProjectPath string,
 	explicitPlacement *RailSection,
+	explicitPlacementAuthoritative bool,
 ) (RailSection, error) {
 	existingRail, err := getExistingAgentSessionRailSectionTx(ctx, tx, workspaceID, agentSessionID)
 	if err != nil {
@@ -114,7 +119,7 @@ func (s *Store) resolveAgentSessionRailSectionTx(
 	if err != nil {
 		return RailSection{}, err
 	}
-	if !existingRail.Found && hasExplicitRail && explicitRail.Kind == RailSectionKindProject {
+	if !existingRail.Found && hasExplicitRail && explicitRail.Kind == RailSectionKindProject && !explicitPlacementAuthoritative {
 		projectPaths, err := s.listRailProjectPaths(ctx, tx)
 		if err != nil {
 			return RailSection{}, err

--- a/packages/agent/store-sqlite/repository.go
+++ b/packages/agent/store-sqlite/repository.go
@@ -717,15 +717,19 @@ type SessionStateReport struct {
 	ImportProjectPath string
 	// RailPlacement is an explicit caller-selected placement for a newly
 	// created session. The first accepted value is immutable.
-	RailPlacement    *RailSection
-	Title            string
-	Status           string
-	CurrentPhase     string
-	LastError        string
-	OccurredAtUnixMS int64
-	StartedAtUnixMS  int64
-	EndedAtUnixMS    int64
-	CreatedAtUnixMS  int64
+	RailPlacement *RailSection
+	// RailPlacementAuthoritative accepts an explicit project placement even
+	// when it is absent from this store's local project registry. It does not
+	// permit changing an existing session's immutable placement.
+	RailPlacementAuthoritative bool
+	Title                      string
+	Status                     string
+	CurrentPhase               string
+	LastError                  string
+	OccurredAtUnixMS           int64
+	StartedAtUnixMS            int64
+	EndedAtUnixMS              int64
+	CreatedAtUnixMS            int64
 }
 
 type StateReportResult struct {


### PR DESCRIPTION
## Summary
- add a typed Host opt-in for externally authoritative rail placement
- preserve the local stale-project registry fence by default and keep existing rail placement immutable
- cover empty-owner-registry creation, runtime environment propagation, persistence, replay, and conflicting retry

## Tests
- `pnpm check:changed -- --push-ready`
- `go test ./packages/agent/host/... ./packages/agent/store-sqlite/...`

## Notes
- TSH integration will follow after this change is published in a stable Tutti cohort; no dependency overrides or compatibility shims are included
