### PR TITLE
fix(agent-gui): harden abortable single-flight retries

### DIFF
--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -95,6 +95,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - [Claude Code starts another command after Stop](./agent-session-lifecycle.md#claude-code-starts-another-command-after-stop)
 - [AgentGUI freezes when session history is large](./agent-session-lifecycle.md#agentgui-freezes-when-session-history-is-large)
 - [AgentGUI @ Sessions tab is empty](./agent-session-lifecycle.md#agentgui--sessions-tab-is-empty)
+- [AgentGUI @ browse fails after reopening](./agent-session-lifecycle.md#agentgui--browse-fails-after-reopening)
 - [Fork reports only `agent_session_fork_conflict`](./agent-session-lifecycle.md#fork-reports-only-agent_session_fork_conflict)
 - [Agent diagnostics flood while a turn is streaming](./agent-session-lifecycle.md#agent-diagnostics-flood-while-a-turn-is-streaming)
 - [Codex turn stays working before any reply or tool activity](./agent-session-lifecycle.md#codex-turn-stays-working-before-any-reply-or-tool-activity)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -3110,6 +3110,34 @@ inline data URL instead`. Claude or standard ACP may instead receive no
   [desktopRichTextAtAgentContributors.ts](../../../apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtAgentContributors.ts)
   [agent-gui-node.md](../../architecture/agent-gui-node.md)
 
+### AgentGUI @ browse fails after reopening
+
+- Symptom:
+  The AgentGUI `@` palette opens once, then shows a search failure after the
+  palette is closed and reopened, even though the workspace request itself is
+  healthy.
+- Quick checks:
+  Inspect the AgentGUI lifecycle diagnostics for a `browse.fetch.start` entry
+  followed by `AbortError` on the next open. The failing request usually has
+  the same browse key as the request canceled when the first palette closed.
+- Root cause:
+  A shared browse request was kept in its deduplication map until its promise's
+  asynchronous `finally` cleanup ran. A new consumer could arrive in that
+  window and attach to the already-aborted request, turning expected palette
+  cancellation into a visible search failure.
+- Fix:
+  Use `AbortableSingleFlight` for shared abortable requests. Evict the entry
+  synchronously when its final consumer leaves, and make late cleanup delete
+  only the exact request instance. An operation owner may also abort a stuck
+  request immediately without leaving a retryable stale entry.
+- Validation:
+  Cover concurrent deduplication, one-consumer cancellation, immediate retry
+  after final-consumer cancellation, operation-owner timeout cancellation, and
+  late completion of the old request after a replacement starts.
+- References:
+  [abortableSingleFlight.ts](../../../packages/agent/gui/shared/query/abortableSingleFlight.ts)
+  [AgentMentionSearchCache.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchCache.ts)
+
 ### Agent diagnostics flood while a turn is streaming
 
 - Symptom:

--- a/packages/agent/gui/README.md
+++ b/packages/agent/gui/README.md
@@ -358,6 +358,12 @@ is not a runtime or host capability and has no published package entrypoint.
 In-flight first-page results are fenced to the attached controller generation
 so stale mounts cannot mutate the Engine or cache.
 
+The `@tutti-os/agent-gui/abortable-single-flight` subpath exposes the generic
+`AbortableSingleFlight` lifecycle primitive for host adapters that need to
+coalesce keyed abortable reads while keeping caller cancellation independent.
+The primitive owns only request sharing and cancellation; cache, snapshot, and
+event ownership remain with the host adapter.
+
 Run this boundary check after changing AgentGUI data flow:
 
 ```sh

--- a/packages/agent/gui/abortable-single-flight.ts
+++ b/packages/agent/gui/abortable-single-flight.ts
@@ -1,0 +1,5 @@
+export {
+  AbortableSingleFlight,
+  type AbortableSingleFlightResult,
+  type AbortableSingleFlightStartContext
+} from "./shared/query/abortableSingleFlight";

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchCache.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchCache.ts
@@ -11,6 +11,7 @@ import {
   providerDiagnosticsSummary,
   rawGroupItemCount
 } from "./AgentMentionSearchModel";
+import { AbortableSingleFlight } from "../../shared/query/abortableSingleFlight";
 
 export interface AgentMentionBrowseFetchResult {
   providerDiagnostics: AgentMentionProviderQueryDiagnostic[];
@@ -29,16 +30,9 @@ const sharedAgentMentionBrowseCache = new Map<
   string,
   AgentMentionBrowseCacheEntry
 >();
-interface SharedAgentMentionBrowseFetch {
-  abortController: AbortController;
-  consumers: Set<symbol>;
-  promise: Promise<AgentMentionBrowseFetchResult> | null;
-  settled: boolean;
-}
-
-const sharedAgentMentionBrowseFetches = new Map<
+const sharedAgentMentionBrowseFetches = new AbortableSingleFlight<
   string,
-  SharedAgentMentionBrowseFetch
+  AgentMentionBrowseFetchResult
 >();
 
 // Bound the shared browse cache so long-lived renderer sessions cannot grow it
@@ -140,10 +134,7 @@ export function scheduleAgentMentionIdleTask(task: () => void): () => void {
 
 export function resetAgentMentionSearchBrowseCacheForTests(): void {
   sharedAgentMentionBrowseCache.clear();
-  for (const fetch of sharedAgentMentionBrowseFetches.values()) {
-    fetch.abortController.abort();
-  }
-  sharedAgentMentionBrowseFetches.clear();
+  sharedAgentMentionBrowseFetches.abortAll();
 }
 
 (
@@ -179,33 +170,18 @@ export async function loadAgentMentionBrowseFetchResult(input: {
 }): Promise<AgentMentionBrowseFetchResult> {
   const { cacheKey, reason } = input;
   const browseInput = input.input;
-  let sharedFetch = sharedAgentMentionBrowseFetches.get(cacheKey);
-  if (sharedFetch) {
-    input.logLifecycle("browse.fetch.dedupe", {
-      filter: browseInput.filter,
-      reason,
-      workspaceId: browseInput.workspaceId
-    });
-  } else {
-    const startedAt = input.diagnosticNow();
-    input.logLifecycle("browse.fetch.start", {
-      filter: browseInput.filter,
-      providerIds: input.providerIds,
-      reason,
-      workspaceId: browseInput.workspaceId
-    });
-    const abortController = new AbortController();
-    sharedFetch = {
-      abortController,
-      consumers: new Set(),
-      promise: null,
-      settled: false
-    };
-    const entry = sharedFetch;
-    entry.promise = input
-      .fetchBrowseResult(abortController.signal)
-      .then((result) => {
-        if (abortController.signal.aborted) {
+  const request = sharedAgentMentionBrowseFetches.acquire(
+    cacheKey,
+    ({ signal: abortSignal }) => {
+      const startedAt = input.diagnosticNow();
+      input.logLifecycle("browse.fetch.start", {
+        filter: browseInput.filter,
+        providerIds: input.providerIds,
+        reason,
+        workspaceId: browseInput.workspaceId
+      });
+      return input.fetchBrowseResult(abortSignal).then((result) => {
+        if (abortSignal.aborted) {
           const error = new Error("Mention browse request aborted");
           error.name = "AbortError";
           throw error;
@@ -225,76 +201,18 @@ export async function loadAgentMentionBrowseFetchResult(input: {
           workspaceId: browseInput.workspaceId
         });
         return result;
-      })
-      .finally(() => {
-        entry.settled = true;
-        if (sharedAgentMentionBrowseFetches.get(cacheKey) === entry) {
-          sharedAgentMentionBrowseFetches.delete(cacheKey);
-        }
       });
-    sharedAgentMentionBrowseFetches.set(cacheKey, entry);
+    },
+    input.abortSignal
+  );
+  if (request.shared) {
+    input.logLifecycle("browse.fetch.dedupe", {
+      filter: browseInput.filter,
+      reason,
+      workspaceId: browseInput.workspaceId
+    });
   }
-
-  return consumeSharedBrowseFetch({
-    abortSignal: input.abortSignal,
-    cacheKey,
-    sharedFetch
-  });
-}
-
-function consumeSharedBrowseFetch(input: {
-  abortSignal?: AbortSignal;
-  cacheKey: string;
-  sharedFetch: SharedAgentMentionBrowseFetch;
-}): Promise<AgentMentionBrowseFetchResult> {
-  const consumer = Symbol(input.cacheKey);
-  input.sharedFetch.consumers.add(consumer);
-  const sharedPromise = input.sharedFetch.promise;
-  if (!sharedPromise) {
-    input.sharedFetch.consumers.delete(consumer);
-    return Promise.reject(new Error("Mention browse request was not started"));
-  }
-
-  return new Promise((resolve, reject) => {
-    let finished = false;
-    const finish = (settle: () => void, abortWhenUnused: boolean): void => {
-      if (finished) {
-        return;
-      }
-      finished = true;
-      input.abortSignal?.removeEventListener("abort", onAbort);
-      input.sharedFetch.consumers.delete(consumer);
-      if (
-        abortWhenUnused &&
-        !input.sharedFetch.settled &&
-        input.sharedFetch.consumers.size === 0
-      ) {
-        if (
-          sharedAgentMentionBrowseFetches.get(input.cacheKey) ===
-          input.sharedFetch
-        ) {
-          sharedAgentMentionBrowseFetches.delete(input.cacheKey);
-        }
-        input.sharedFetch.abortController.abort();
-      }
-      settle();
-    };
-    const onAbort = (): void => {
-      const error = new Error("Mention browse request aborted");
-      error.name = "AbortError";
-      finish(() => reject(error), true);
-    };
-
-    if (input.abortSignal?.aborted) {
-      onAbort();
-      return;
-    }
-    input.abortSignal?.addEventListener("abort", onAbort, { once: true });
-    sharedPromise.then(
-      (result) => finish(() => resolve(result), false),
-      (error: unknown) => finish(() => reject(error), false)
-    );
-  });
+  return request.promise;
 }
 
 export function readAgentMentionBrowseCache(input: {

--- a/packages/agent/gui/build/agentGuiBuildEntries.ts
+++ b/packages/agent/gui/build/agentGuiBuildEntries.ts
@@ -9,6 +9,7 @@ export const agentGUIBuildEntries = {
   "dock-icons": "dockIcons.ts",
   layout: "layout.ts",
   "mention-search": "agent-gui/agentGuiNode/AgentMentionSearchController.ts",
+  "abortable-single-flight": "abortable-single-flight.ts",
   "agent-message-center/index": "agent-message-center/index.ts",
   "agent-conversation/index": "agent-conversation/index.ts",
   "agent-conversation/follow-end":
@@ -65,6 +66,7 @@ export const agentGUIDtsEntryGroups = [
     "quick-composer",
     "agents",
     "mention-search",
+    "abortable-single-flight",
     "agent-message-center/index",
     "agent-conversation/index",
     "agent-conversation/follow-end",

--- a/packages/agent/gui/package.json
+++ b/packages/agent/gui/package.json
@@ -15,6 +15,7 @@
     "./dock-icons": "./dockIcons.ts",
     "./layout": "./layout.ts",
     "./mention-search": "./agent-gui/agentGuiNode/AgentMentionSearchController.ts",
+    "./abortable-single-flight": "./abortable-single-flight.ts",
     "./agent-message-center": "./agent-message-center/index.ts",
     "./agent-conversation": "./agent-conversation/index.ts",
     "./agent-conversation/follow-end": "./shared/agentConversation/agentConversationFollowEndController.ts",
@@ -176,6 +177,10 @@
         "types": "./dist/mention-search.d.ts",
         "import": "./dist/mention-search.js"
       },
+      "./abortable-single-flight": {
+        "types": "./dist/abortable-single-flight.d.ts",
+        "import": "./dist/abortable-single-flight.js"
+      },
       "./agent-message-center": {
         "types": "./dist/agent-message-center/index.d.ts",
         "import": "./dist/agent-message-center/index.js"
@@ -335,6 +340,9 @@
         ],
         "mention-search": [
           "./dist/mention-search.d.ts"
+        ],
+        "abortable-single-flight": [
+          "./dist/abortable-single-flight.d.ts"
         ],
         "agent-conversation": [
           "./dist/agent-conversation/index.d.ts"

--- a/packages/agent/gui/shared/query/abortableSingleFlight.spec.ts
+++ b/packages/agent/gui/shared/query/abortableSingleFlight.spec.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { AbortableSingleFlight } from "./abortableSingleFlight";
+
+describe("AbortableSingleFlight", () => {
+  it("shares concurrent callers for the same key", async () => {
+    const pending = deferred<string>();
+    const flight = new AbortableSingleFlight<string, string>();
+    let starts = 0;
+
+    const first = flight.acquire("room-1", () => {
+      starts += 1;
+      return pending.promise;
+    });
+    const second = flight.acquire("room-1", async () => {
+      starts += 1;
+      return "unexpected";
+    });
+
+    expect(first.shared).toBe(false);
+    expect(second.shared).toBe(true);
+    expect(starts).toBe(1);
+    pending.resolve("ready");
+    await expect(Promise.all([first.promise, second.promise])).resolves.toEqual(
+      ["ready", "ready"]
+    );
+  });
+
+  it("only aborts the shared operation after the final caller leaves", async () => {
+    const pending = deferred<string>();
+    const flight = new AbortableSingleFlight<string, string>();
+    let sharedSignal: AbortSignal | undefined;
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    const start = ({ signal }: { signal: AbortSignal }): Promise<string> => {
+      sharedSignal = signal;
+      return pending.promise;
+    };
+
+    const first = flight.acquire("room-1", start, firstController.signal);
+    const second = flight.acquire("room-1", start, secondController.signal);
+    firstController.abort();
+    await expect(first.promise).rejects.toMatchObject({ name: "AbortError" });
+    expect(sharedSignal?.aborted).toBe(false);
+
+    pending.resolve("ready");
+    await expect(second.promise).resolves.toBe("ready");
+  });
+
+  it("evicts an aborted entry before an immediate retry can acquire it", async () => {
+    const first = deferred<string>();
+    const second = deferred<string>();
+    const flight = new AbortableSingleFlight<string, string>();
+    const firstController = new AbortController();
+    let starts = 0;
+
+    const firstRequest = flight.acquire(
+      "room-1",
+      ({ signal }) => {
+        starts += 1;
+        signal.addEventListener(
+          "abort",
+          () => first.reject(new Error("aborted")),
+          { once: true }
+        );
+        return first.promise;
+      },
+      firstController.signal
+    );
+    firstController.abort();
+    await expect(firstRequest.promise).rejects.toMatchObject({
+      name: "AbortError"
+    });
+
+    const retry = flight.acquire("room-1", () => {
+      starts += 1;
+      return second.promise;
+    });
+    expect(retry.shared).toBe(false);
+    expect(starts).toBe(2);
+    second.resolve("retry-ready");
+    await expect(retry.promise).resolves.toBe("retry-ready");
+  });
+
+  it("does not let an old completion remove a replacement entry", async () => {
+    const first = deferred<string>();
+    const second = deferred<string>();
+    const flight = new AbortableSingleFlight<string, string>();
+    const firstController = new AbortController();
+
+    const firstRequest = flight.acquire(
+      "room-1",
+      ({ signal }) => {
+        signal.addEventListener("abort", () => first.resolve("stale"), {
+          once: true
+        });
+        return first.promise;
+      },
+      firstController.signal
+    );
+    firstController.abort();
+    await expect(firstRequest.promise).rejects.toMatchObject({
+      name: "AbortError"
+    });
+
+    const retry = flight.acquire("room-1", () => second.promise);
+    first.resolve("late-stale");
+    await Promise.resolve();
+    const third = flight.acquire("room-1", () => Promise.resolve("unexpected"));
+    expect(third.shared).toBe(true);
+    second.resolve("fresh");
+    await expect(retry.promise).resolves.toBe("fresh");
+    await expect(third.promise).resolves.toBe("fresh");
+  });
+});
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}

--- a/packages/agent/gui/shared/query/abortableSingleFlight.ts
+++ b/packages/agent/gui/shared/query/abortableSingleFlight.ts
@@ -1,0 +1,176 @@
+export interface AbortableSingleFlightResult<TValue> {
+  readonly promise: Promise<TValue>;
+  readonly shared: boolean;
+}
+
+export interface AbortableSingleFlightStartContext {
+  readonly signal: AbortSignal;
+  abort(reason?: unknown): void;
+}
+
+type SingleFlightState = "running" | "settled" | "aborted";
+
+interface SingleFlightEntry<TValue> {
+  readonly abortController: AbortController;
+  readonly consumers: Set<symbol>;
+  rejectStarted?: (reason?: unknown) => void;
+  promise: Promise<TValue>;
+  state: SingleFlightState;
+}
+
+/**
+ * Shares one abortable operation per key while keeping caller cancellation
+ * independent. The underlying operation is aborted only when its final caller
+ * leaves, and that entry is evicted before aborting so an immediate retry can
+ * never acquire the aborted operation.
+ */
+export class AbortableSingleFlight<TKey, TValue> {
+  private readonly entries = new Map<TKey, SingleFlightEntry<TValue>>();
+
+  acquire(
+    key: TKey,
+    start: (context: AbortableSingleFlightStartContext) => Promise<TValue>,
+    signal?: AbortSignal
+  ): AbortableSingleFlightResult<TValue> {
+    if (signal?.aborted) {
+      return {
+        promise: Promise.reject(createAbortError()),
+        shared: false
+      };
+    }
+
+    let entry = this.entries.get(key);
+    let shared = true;
+    if (
+      !entry ||
+      entry.state !== "running" ||
+      entry.abortController.signal.aborted
+    ) {
+      shared = false;
+      entry = this.createEntry(key, start);
+    }
+
+    return {
+      promise: this.subscribe(key, entry, signal),
+      shared
+    };
+  }
+
+  abortAll(reason?: unknown): void {
+    const entries = [...this.entries.values()];
+    this.entries.clear();
+    for (const entry of entries) {
+      this.abortEntry(undefined, entry, reason);
+    }
+  }
+
+  private createEntry(
+    key: TKey,
+    start: (context: AbortableSingleFlightStartContext) => Promise<TValue>
+  ): SingleFlightEntry<TValue> {
+    let resolveStarted!: (value: TValue | PromiseLike<TValue>) => void;
+    let rejectStarted!: (reason?: unknown) => void;
+    const started = new Promise<TValue>((resolve, reject) => {
+      resolveStarted = resolve;
+      rejectStarted = reject;
+    });
+    const abortController = new AbortController();
+    const entry: SingleFlightEntry<TValue> = {
+      abortController,
+      consumers: new Set(),
+      promise: Promise.resolve() as Promise<TValue>,
+      state: "running"
+    };
+    entry.rejectStarted = rejectStarted;
+    entry.promise = started
+      .then((value) => {
+        if (abortController.signal.aborted) {
+          throw abortController.signal.reason ?? createAbortError();
+        }
+        return value;
+      })
+      .finally(() => {
+        entry.state = "settled";
+        if (this.entries.get(key) === entry) {
+          this.entries.delete(key);
+        }
+      });
+    this.entries.set(key, entry);
+
+    try {
+      Promise.resolve(
+        start({
+          signal: abortController.signal,
+          abort: (reason) => this.abortEntry(key, entry, reason)
+        })
+      ).then(resolveStarted, rejectStarted);
+    } catch (error) {
+      rejectStarted(error);
+    }
+    // If every consumer leaves before the operation settles, the shared
+    // promise still needs an explicit rejection handler to avoid an unhandled
+    // rejection while the abandoned operation unwinds.
+    entry.promise.catch(() => undefined);
+    return entry;
+  }
+
+  private subscribe(
+    key: TKey,
+    entry: SingleFlightEntry<TValue>,
+    signal?: AbortSignal
+  ): Promise<TValue> {
+    const consumer = Symbol("single-flight-consumer");
+    entry.consumers.add(consumer);
+    return new Promise<TValue>((resolve, reject) => {
+      let finished = false;
+      const finish = (settle: () => void, abortWhenUnused: boolean): void => {
+        if (finished) {
+          return;
+        }
+        finished = true;
+        signal?.removeEventListener("abort", handleAbort);
+        entry.consumers.delete(consumer);
+        if (abortWhenUnused && entry.consumers.size === 0) {
+          this.abortEntry(key, entry);
+        }
+        settle();
+      };
+      const handleAbort = (): void => {
+        finish(() => reject(createAbortError()), true);
+      };
+
+      if (signal?.aborted) {
+        handleAbort();
+        return;
+      }
+      signal?.addEventListener("abort", handleAbort, { once: true });
+      entry.promise.then(
+        (value) => finish(() => resolve(value), false),
+        (error) => finish(() => reject(error), false)
+      );
+    });
+  }
+
+  private abortEntry(
+    key: TKey | undefined,
+    entry: SingleFlightEntry<TValue>,
+    reason?: unknown
+  ): void {
+    if (entry.state !== "running") {
+      return;
+    }
+    entry.state = "aborted";
+    if (key !== undefined && this.entries.get(key) === entry) {
+      this.entries.delete(key);
+    }
+    const abortReason = reason ?? createAbortError();
+    entry.rejectStarted?.(abortReason);
+    entry.abortController.abort(abortReason);
+  }
+}
+
+function createAbortError(): Error {
+  const error = new Error("Single-flight request was aborted");
+  error.name = "AbortError";
+  return error;
+}

--- a/packages/agent/gui/tsconfig.dts.json
+++ b/packages/agent/gui/tsconfig.dts.json
@@ -20,6 +20,7 @@
     "dockIcons.ts",
     "layout.ts",
     "agent-gui/agentGuiNode/AgentMentionSearchController.ts",
+    "abortable-single-flight.ts",
     "agent-message-center/index.ts",
     "agent-conversation/index.ts",
     "shared/agentConversation/agentConversationFollowEndController.ts",


### PR DESCRIPTION
## What changed

- Add a reusable `AbortableSingleFlight` lifecycle primitive for keyed abortable operations.
- Migrate AgentGUI mention browse fetching to the primitive.
- Evict a request synchronously when its final consumer cancels, while keeping identity-checked late cleanup.
- Expose the primitive through the supported `@tutti-os/agent-gui/abortable-single-flight` public subpath for host adapters.
- Include the new entry in source exports, built exports, TypeScript declaration inputs, and package documentation.

## Why

AgentGUI could reuse an already-aborted browse request when a palette was closed and reopened before the old promise's asynchronous cleanup ran. The result was an expected cancellation surfaced as a visible search failure. TSH has the same lifecycle need for cloud-session reads, so the generic primitive now has one upstream implementation and a stable consumer contract.

## Verification

- `corepack pnpm --filter @tutti-os/agent-gui exec vitest run tsup.dts.config.test.ts shared/query/abortableSingleFlight.spec.ts agent-gui/agentGuiNode/AgentMentionSearchController.spec.ts --pool=threads` (66 tests passed)
- `node --input-type=module -e "import('@tutti-os/agent-gui/abortable-single-flight')"` export check passed from linked TSH Desktop.
- `corepack pnpm check:changed -- --push-ready` (12 lanes passed)

## Risk and scope

This preserves AgentGUI provider query behavior and adds one explicit public package subpath. The corresponding TSH consumer is in [tutti-lab/tsh#2741](https://github.com/tutti-lab/tsh/pull/2741) and must follow the next released Tutti package cohort.