### PR TITLE
fix(agent): classify undispatched exact guidance

### DIFF
--- a/packages/agent/activity-core/src/engine/promptQueue.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.reducer.test.ts
@@ -584,6 +584,33 @@ test("no-active-turn send failure reconciles before retrying queued prompt", () 
   assert.equal(reconciled.commands[0]?.type, "queue/sendPrompt");
 });
 
+test("session no-active-turn app error reconciles before retrying queued prompt", () => {
+  const available = canonicalLifecycle("settled", 1);
+  const sending = reduce(
+    createInitialPromptQueueState(),
+    enqueue("prompt-1"),
+    available
+  );
+  const failed = reduce(
+    sending.state,
+    commandResult(
+      commandId(sending.commands[0]),
+      "queue/sendPrompt",
+      "failed",
+      { errorCode: "agent.session_no_active_turn" }
+    ),
+    available
+  );
+
+  assert.equal(failed.commands.length, 1);
+  assert.equal(failed.commands[0]?.type, "session/reconcile");
+  assert.equal(
+    failed.state.recordsBySessionId["session-1"]?.failedPromptId,
+    null
+  );
+  assert.equal(failed.state.recordsBySessionId["session-1"]?.inFlight, null);
+});
+
 test("timeout confirmation waits for its exact canonical turn to settle", () => {
   const available = canonicalLifecycle("settled", 1, "turn-0");
   const first = reduce(

--- a/packages/agent/activity-core/src/engine/promptQueue.reducer.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.reducer.ts
@@ -470,12 +470,20 @@ function settleQueueCommand(
 }
 
 function isNoActiveTurnSendFailure(intent: EngineIntent): boolean {
+  if (
+    intent.type !== "engine/commandResult" ||
+    intent.commandType !== "queue/sendPrompt" ||
+    intent.outcome !== "failed"
+  ) {
+    return false;
+  }
+  const errorReason = intent.errorReason?.trim();
+  const errorCode = intent.errorCode?.trim();
   return (
-    intent.type === "engine/commandResult" &&
-    intent.commandType === "queue/sendPrompt" &&
-    intent.outcome === "failed" &&
-    (intent.errorReason?.trim() === "agent.no_active_turn" ||
-      intent.errorCode?.trim() === "agent.no_active_turn")
+    errorReason === "agent.no_active_turn" ||
+    errorCode === "agent.no_active_turn" ||
+    errorReason === "agent.session_no_active_turn" ||
+    errorCode === "agent.session_no_active_turn"
   );
 }
 

--- a/packages/agent/daemon/runtime/adapter.go
+++ b/packages/agent/daemon/runtime/adapter.go
@@ -333,6 +333,25 @@ type ActiveTurnGuidanceAdapter interface {
 	GuideActiveTurn(context.Context, Session, []PromptContentBlock, string, string, EventSink, CommandSnapshotSink) ([]activityshared.Event, error)
 }
 
+// ActiveTurnGuidanceProviderDispatchAdapter adds the provider-dispatch verdict
+// needed to distinguish adapter-local preflight failures from a request whose
+// provider acknowledgement is unknown. Adapters that do not implement this
+// optional seam retain the conservative legacy behavior: any returned error is
+// treated as outcome_unknown.
+type ActiveTurnGuidanceProviderDispatchAdapter interface {
+	ActiveTurnGuidanceAdapter
+	GuideActiveTurnWithProviderDispatch(
+		context.Context,
+		Session,
+		[]PromptContentBlock,
+		string,
+		string,
+		EventSink,
+		CommandSnapshotSink,
+		ProviderDispatchSink,
+	) ([]activityshared.Event, error)
+}
+
 type ResumeProbeAdapter interface {
 	CanResume(Session) bool
 }

--- a/packages/agent/daemon/runtime/claude_sdk_execution.go
+++ b/packages/agent/daemon/runtime/claude_sdk_execution.go
@@ -509,14 +509,45 @@ func (a *ClaudeCodeSDKAdapter) GuideActiveTurn(
 	emit EventSink,
 	_ CommandSnapshotSink,
 ) ([]activityshared.Event, error) {
+	return a.GuideActiveTurnWithProviderDispatch(
+		ctx,
+		session,
+		content,
+		displayPrompt,
+		turnID,
+		emit,
+		nil,
+		nil,
+	)
+}
+
+func (a *ClaudeCodeSDKAdapter) GuideActiveTurnWithProviderDispatch(
+	ctx context.Context,
+	session Session,
+	content []PromptContentBlock,
+	displayPrompt string,
+	turnID string,
+	emit EventSink,
+	_ CommandSnapshotSink,
+	reportDispatch ProviderDispatchSink,
+) ([]activityshared.Event, error) {
+	reportNotDispatched := func() {
+		if reportDispatch != nil {
+			reportDispatch(ProviderDispatchResult{
+				Disposition: DispatchDispositionNotDispatched,
+			})
+		}
+	}
 	adapterSession := a.getSession(session.AgentSessionID)
 	if adapterSession == nil {
+		reportNotDispatched()
 		return nil, ErrSessionDisconnected
 	}
 	session.ProviderSessionID = adapterSession.providerSessionID
 	explicitDisplayPrompt, visibleText := explicitAndVisiblePromptText(content, displayPrompt)
 	providerContent, err := materializeProviderPromptImagesAtBoundary(ctx, content, a.promptImageMaterializer)
 	if err != nil {
+		reportNotDispatched()
 		return nil, err
 	}
 	events := []activityshared.Event{
@@ -527,6 +558,7 @@ func (a *ClaudeCodeSDKAdapter) GuideActiveTurn(
 		}),
 	}
 	if err := a.startClaudeSDKReader(session.AgentSessionID, adapterSession); err != nil {
+		reportNotDispatched()
 		return events, err
 	}
 	ctx, cancel := context.WithTimeout(ctx, claudeSDKGoalCommandTimeout)
@@ -540,7 +572,17 @@ func (a *ClaudeCodeSDKAdapter) GuideActiveTurn(
 			"content":        promptContentForClaudeSDK(providerContent, visibleText),
 		},
 	}); err != nil {
+		if reportDispatch != nil {
+			reportDispatch(ProviderDispatchResult{
+				Disposition: DispatchDispositionOutcomeUnknown,
+			})
+		}
 		return events, err
+	}
+	if reportDispatch != nil {
+		reportDispatch(ProviderDispatchResult{
+			Disposition: DispatchDispositionAppliedWithoutProviderTurn,
+		})
 	}
 	if emit != nil {
 		emit(events)

--- a/packages/agent/daemon/runtime/claude_sdk_settings_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_settings_test.go
@@ -2,6 +2,7 @@ package agentruntime
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -57,11 +58,14 @@ func TestClaudeCodeSDKAdapterGuideActiveTurnSendsSidecarGuide(t *testing.T) {
 		err    error
 	}
 	results := make(chan guidanceResult, 1)
+	dispatches := make(chan ProviderDispatchResult, 1)
 	go func() {
-		events, err := adapter.GuideActiveTurn(context.Background(), session, []PromptContentBlock{
+		events, err := adapter.GuideActiveTurnWithProviderDispatch(context.Background(), session, []PromptContentBlock{
 			{Type: "text", Text: "guide current turn"},
 			{Type: "image", MimeType: "image/png", URL: imageURL},
-		}, "", "turn-guidance", nil, nil)
+		}, "", "turn-guidance", nil, nil, func(result ProviderDispatchResult) {
+			dispatches <- result
+		})
 		results <- guidanceResult{events: events, err: err}
 	}()
 
@@ -95,6 +99,68 @@ func TestClaudeCodeSDKAdapterGuideActiveTurnSendsSidecarGuide(t *testing.T) {
 	}
 	if guidance, ok := messages[0].Payload.Metadata["guidance"].(bool); !ok || !guidance {
 		t.Fatalf("guidance metadata = %#v, want guidance=true", messages[0].Payload.Metadata)
+	}
+	if dispatch := <-dispatches; dispatch.Disposition != DispatchDispositionAppliedWithoutProviderTurn {
+		t.Fatalf("guidance dispatch = %#v, want applied", dispatch)
+	}
+}
+
+func TestClaudeCodeSDKAdapterGuidancePreflightFailureIsNotDispatched(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	dispatches := make(chan ProviderDispatchResult, 1)
+	_, err := adapter.GuideActiveTurnWithProviderDispatch(
+		t.Context(),
+		standardTestSession(ProviderClaudeCode),
+		textPrompt("guide current turn"),
+		"",
+		"turn-guidance",
+		nil,
+		nil,
+		func(result ProviderDispatchResult) { dispatches <- result },
+	)
+	if !errors.Is(err, ErrSessionDisconnected) {
+		t.Fatalf("GuideActiveTurn error = %v, want ErrSessionDisconnected", err)
+	}
+	if dispatch := <-dispatches; dispatch.Disposition != DispatchDispositionNotDispatched {
+		t.Fatalf("guidance dispatch = %#v, want not dispatched", dispatch)
+	}
+}
+
+func TestClaudeCodeSDKAdapterGuidanceFailureAfterSendIsOutcomeUnknown(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	conn := newBlockingClaudeSDKConnection()
+	defer func() { _ = conn.Close() }()
+	adapter.storeSession(session.AgentSessionID, &claudeSDKAdapterSession{
+		conn:             conn,
+		reader:           &claudeSDKLineReader{conn: conn},
+		pendingRequests:  make(map[string]*pendingInteractiveRequest),
+		pendingResponses: make(map[string]chan claudeSDKSidecarEvent),
+		liveState:        newClaudeSDKLiveState(),
+	})
+	ctx, cancel := context.WithCancel(t.Context())
+	dispatches := make(chan ProviderDispatchResult, 1)
+	done := make(chan error, 1)
+	go func() {
+		_, err := adapter.GuideActiveTurnWithProviderDispatch(
+			ctx,
+			session,
+			textPrompt("guide current turn"),
+			"",
+			"turn-guidance",
+			nil,
+			nil,
+			func(result ProviderDispatchResult) { dispatches <- result },
+		)
+		done <- err
+	}()
+	waitForClaudeSDKSentRequest(t, conn, "guide")
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("GuideActiveTurn error = %v, want context canceled", err)
+	}
+	if dispatch := <-dispatches; dispatch.Disposition != DispatchDispositionOutcomeUnknown {
+		t.Fatalf("guidance dispatch = %#v, want outcome unknown", dispatch)
 	}
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_guidance_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_guidance_test.go
@@ -124,6 +124,27 @@ func TestCodexAppServerAdapterGuideActiveTurnUsesTurnSteer(t *testing.T) {
 	}
 }
 
+func TestCodexAppServerAdapterGuidancePreflightFailureIsNotDispatched(t *testing.T) {
+	adapter := NewCodexAppServerAdapter(nil)
+	dispatches := make(chan ProviderDispatchResult, 1)
+	_, err := adapter.GuideActiveTurnWithProviderDispatch(
+		t.Context(),
+		standardTestSession(ProviderCodex),
+		textPrompt("guide current turn"),
+		"",
+		"turn-guidance",
+		nil,
+		nil,
+		func(result ProviderDispatchResult) { dispatches <- result },
+	)
+	if !errors.Is(err, ErrSessionDisconnected) {
+		t.Fatalf("GuideActiveTurn error = %v, want ErrSessionDisconnected", err)
+	}
+	if dispatch := <-dispatches; dispatch.Disposition != DispatchDispositionNotDispatched {
+		t.Fatalf("guidance dispatch = %#v, want not dispatched", dispatch)
+	}
+}
+
 func TestCodexAppServerAdapterGuideMaterializesRemoteImageAtProviderBoundary(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/codex_appserver_turn.go
+++ b/packages/agent/daemon/runtime/codex_appserver_turn.go
@@ -115,8 +115,38 @@ func (a *CodexAppServerAdapter) GuideActiveTurn(
 	emit EventSink,
 	emitCommands CommandSnapshotSink,
 ) ([]activityshared.Event, error) {
+	return a.GuideActiveTurnWithProviderDispatch(
+		ctx,
+		session,
+		content,
+		displayPrompt,
+		turnID,
+		emit,
+		emitCommands,
+		nil,
+	)
+}
+
+func (a *CodexAppServerAdapter) GuideActiveTurnWithProviderDispatch(
+	ctx context.Context,
+	session Session,
+	content []PromptContentBlock,
+	displayPrompt string,
+	turnID string,
+	emit EventSink,
+	emitCommands CommandSnapshotSink,
+	reportDispatch ProviderDispatchSink,
+) ([]activityshared.Event, error) {
+	reportNotDispatched := func() {
+		if reportDispatch != nil {
+			reportDispatch(ProviderDispatchResult{
+				Disposition: DispatchDispositionNotDispatched,
+			})
+		}
+	}
 	appSession := a.getSession(session.AgentSessionID)
 	if appSession == nil || appSession.client == nil {
+		reportNotDispatched()
 		return nil, ErrSessionDisconnected
 	}
 	activeTurnID := a.sessionActiveTurnID(session.AgentSessionID)
@@ -131,12 +161,23 @@ func (a *CodexAppServerAdapter) GuideActiveTurn(
 		var err error
 		providerContent, err = materializeProviderPromptImagesAtBoundary(ctx, providerContent, a.promptImageMaterializer)
 		if err != nil {
+			reportNotDispatched()
 			return nil, err
 		}
-		return a.steerActiveTurn(
+		events, err := a.steerActiveTurn(
 			ctx, appSession, session, content, providerContent,
 			explicitDisplayPrompt, visibleText, turnID, activeTurnID, emit,
 		)
+		if err != nil {
+			if reportDispatch != nil {
+				reportDispatch(ProviderDispatchResult{
+					Disposition: DispatchDispositionOutcomeUnknown,
+				})
+			}
+			return events, err
+		}
+		reportCodexAppliedWithoutProviderTurn(reportDispatch)
+		return events, nil
 	}
 	// The canonical root turn remains active while child sessions drain even
 	// after the provider's root turn has ended. Guidance in that window starts
@@ -145,9 +186,10 @@ func (a *CodexAppServerAdapter) GuideActiveTurn(
 	if a.sessionActiveTurn(session.AgentSessionID) != nil {
 		// The provider turn exists but turn/started has not supplied its id yet;
 		// starting another turn would race the existing one.
+		reportNotDispatched()
 		return nil, ErrSessionNoActiveTurn
 	}
-	return a.startGuidanceContinuation(
+	events, err := a.startGuidanceContinuation(
 		ctx,
 		session,
 		content,
@@ -156,6 +198,12 @@ func (a *CodexAppServerAdapter) GuideActiveTurn(
 		emit,
 		emitCommands,
 	)
+	if err != nil {
+		reportNotDispatched()
+		return events, err
+	}
+	reportCodexAppliedWithoutProviderTurn(reportDispatch)
+	return events, nil
 }
 
 func (appTurn *codexAppServerActiveTurn) markTerminated() {

--- a/packages/agent/daemon/runtime/codex_appserver_turn_timeout_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_turn_timeout_test.go
@@ -277,11 +277,22 @@ func TestCodexAppServerAdapterTurnSteerTimesOut(t *testing.T) {
 	transport.server.mu.Unlock()
 
 	startedAt := time.Now()
-	_, err := adapter.Exec(context.Background(), session, []PromptContentBlock{{
-		Type: "text", Text: "new guidance",
-	}}, "", "turn-guidance", nil, nil)
+	dispatches := make(chan ProviderDispatchResult, 1)
+	_, err := adapter.GuideActiveTurnWithProviderDispatch(
+		context.Background(),
+		session,
+		[]PromptContentBlock{{Type: "text", Text: "new guidance"}},
+		"",
+		"turn-guidance",
+		nil,
+		nil,
+		func(result ProviderDispatchResult) { dispatches <- result },
+	)
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("steered Exec error = %v, want deadline exceeded", err)
+	}
+	if dispatch := <-dispatches; dispatch.Disposition != DispatchDispositionOutcomeUnknown {
+		t.Fatalf("guidance dispatch = %#v, want outcome unknown", dispatch)
 	}
 	if elapsed := time.Since(startedAt); elapsed > time.Second {
 		t.Fatalf("steered Exec elapsed = %s, want bounded turn/steer", elapsed)

--- a/packages/agent/daemon/runtime/controller_exec.go
+++ b/packages/agent/daemon/runtime/controller_exec.go
@@ -350,8 +350,22 @@ func (c *Controller) guideActiveTurn(
 	if !ok {
 		return ExecResult{}, ErrActiveTurnGuidanceUnsupported
 	}
+	expectedTurnID = strings.TrimSpace(expectedTurnID)
 	turnID, ok := c.activeTurnID(session.RoomID, session.AgentSessionID)
 	if !ok {
+		if expectedTurnID != "" {
+			return ExecResult{
+					AgentSessionID: session.AgentSessionID,
+					Status:         ExecStatusStarted,
+					TurnID:         expectedTurnID,
+					ProviderDispatch: &ProviderDispatchResult{
+						Disposition: DispatchDispositionNotDispatched,
+					},
+				}, errors.Join(
+					fmt.Errorf("%w: expected %q, current turn is inactive", ErrActiveTurnTargetMismatch, expectedTurnID),
+					ErrSessionNoActiveTurn,
+				)
+		}
 		return ExecResult{}, ErrSessionNoActiveTurn
 	}
 	// The lifecycle lock held by Exec makes this comparison and the provider
@@ -360,7 +374,7 @@ func (c *Controller) guideActiveTurn(
 	// Host consumers must provide the target and are checked before reaching
 	// this method. When a target is present, never retarget to whichever turn is
 	// current when the request happens to arrive.
-	if expectedTurnID = strings.TrimSpace(expectedTurnID); expectedTurnID != "" && expectedTurnID != turnID {
+	if expectedTurnID != "" && expectedTurnID != turnID {
 		return ExecResult{
 			AgentSessionID: session.AgentSessionID,
 			Status:         ExecStatusStarted,
@@ -392,12 +406,56 @@ func (c *Controller) guideActiveTurn(
 	emitCommands := func(snapshot AgentSessionCommandSnapshot) {
 		c.applyCommandSnapshotByAgentSessionID(snapshot)
 	}
-	events, err := guidanceAdapter.GuideActiveTurn(runCtx, session, content, displayPrompt, turnID, emit, emitCommands)
+	var providerDispatch *ProviderDispatchResult
+	var providerDispatchOnce sync.Once
+	reportProviderDispatch := func(result ProviderDispatchResult) {
+		providerDispatchOnce.Do(func() {
+			copy := result
+			providerDispatch = &copy
+		})
+	}
+	var events []activityshared.Event
+	var err error
+	if dispatchAdapter, ok := adapter.(ActiveTurnGuidanceProviderDispatchAdapter); ok {
+		events, err = dispatchAdapter.GuideActiveTurnWithProviderDispatch(
+			runCtx,
+			session,
+			content,
+			displayPrompt,
+			turnID,
+			emit,
+			emitCommands,
+			reportProviderDispatch,
+		)
+	} else {
+		events, err = guidanceAdapter.GuideActiveTurn(
+			runCtx,
+			session,
+			content,
+			displayPrompt,
+			turnID,
+			emit,
+			emitCommands,
+		)
+	}
 	if err != nil {
 		logAgentSubmitTrace("runtime.exec.guidance_failed", session, turnID, metadata, map[string]any{
 			"error": err.Error(),
 		})
-		return ExecResult{}, err
+		// Untyped adapters retain the conservative legacy boundary. Typed
+		// adapters can prove a local preflight rejection, while any error after
+		// provider I/O remains outcome-unknown.
+		if providerDispatch == nil {
+			providerDispatch = &ProviderDispatchResult{
+				Disposition: DispatchDispositionOutcomeUnknown,
+			}
+		}
+		return ExecResult{
+			AgentSessionID:   session.AgentSessionID,
+			Status:           ExecStatusStarted,
+			TurnID:           turnID,
+			ProviderDispatch: providerDispatch,
+		}, err
 	}
 	emittedMu.Lock()
 	remaining := unemittedActivityEvents(events, emitted)
@@ -416,11 +474,12 @@ func (c *Controller) guideActiveTurn(
 		"activity_event_count": len(events),
 	})
 	result := ExecResult{
-		AgentSessionID: session.AgentSessionID,
-		Status:         ExecStatusStarted,
-		TurnID:         turnID,
-		Accepted:       true,
-		SessionStatus:  session.Status,
+		AgentSessionID:   session.AgentSessionID,
+		Status:           ExecStatusStarted,
+		TurnID:           turnID,
+		Accepted:         true,
+		SessionStatus:    session.Status,
+		ProviderDispatch: providerDispatch,
 	}
 	if session.TurnLifecycle != nil {
 		result.TurnLifecycle = *session.TurnLifecycle

--- a/packages/agent/daemon/runtime/controller_exec_test.go
+++ b/packages/agent/daemon/runtime/controller_exec_test.go
@@ -611,6 +611,106 @@ func TestControllerExecGuidanceRejectsChangedExactTargetBeforeProviderCall(t *te
 	waitForSessionStatus(t, controller, "room-1", started.Session.AgentSessionID, SessionStatusReady)
 }
 
+func TestControllerExecGuidanceProviderErrorHasUnknownDeliveryOutcome(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("provider guidance acknowledgement lost")
+	adapter := &guidanceBlockingAdapter{
+		blockingExecAdapter: newBlockingExecAdapter(),
+		guidanceErr:         wantErr,
+	}
+	controller := NewController([]Adapter{adapter}, nil)
+	started, err := controller.Start(t.Context(), StartInput{
+		RoomID:         "room-1",
+		AgentSessionID: "agent-session-1",
+		Provider:       ProviderCodex,
+		Title:          "Codex",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	first, err := controller.Exec(t.Context(), ExecInput{
+		RoomID:         started.Session.RoomID,
+		AgentSessionID: started.Session.AgentSessionID,
+		Content:        textPrompt("first prompt"),
+	})
+	if err != nil {
+		t.Fatalf("first Exec: %v", err)
+	}
+	adapter.waitForPrompt(t, "first prompt")
+
+	result, err := controller.Exec(t.Context(), ExecInput{
+		RoomID:         started.Session.RoomID,
+		AgentSessionID: started.Session.AgentSessionID,
+		TurnID:         first.TurnID,
+		Content:        textPrompt("guide current turn"),
+		Guidance:       true,
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("guidance error = %v, want %v", err, wantErr)
+	}
+	if result.ProviderDispatch == nil ||
+		result.ProviderDispatch.Disposition != DispatchDispositionOutcomeUnknown {
+		t.Fatalf("guidance result = %#v, want outcome unknown", result)
+	}
+	if got := adapter.guidanceCalls.Load(); got != 1 {
+		t.Fatalf("provider guidance calls = %d, want 1", got)
+	}
+
+	adapter.releaseNext()
+	waitForSessionStatus(t, controller, "room-1", started.Session.AgentSessionID, SessionStatusReady)
+}
+
+func TestControllerExecGuidanceAdapterPreflightFailureIsNotDispatched(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("provider session disconnected before guidance dispatch")
+	adapter := &guidanceDispatchAdapter{
+		guidanceBlockingAdapter: &guidanceBlockingAdapter{
+			blockingExecAdapter: newBlockingExecAdapter(),
+			guidanceErr:         wantErr,
+		},
+		disposition: DispatchDispositionNotDispatched,
+	}
+	controller := NewController([]Adapter{adapter}, nil)
+	started, err := controller.Start(t.Context(), StartInput{
+		RoomID:         "room-1",
+		AgentSessionID: "agent-session-1",
+		Provider:       ProviderCodex,
+		Title:          "Codex",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	first, err := controller.Exec(t.Context(), ExecInput{
+		RoomID:         started.Session.RoomID,
+		AgentSessionID: started.Session.AgentSessionID,
+		Content:        textPrompt("first prompt"),
+	})
+	if err != nil {
+		t.Fatalf("first Exec: %v", err)
+	}
+	adapter.waitForPrompt(t, "first prompt")
+
+	result, err := controller.Exec(t.Context(), ExecInput{
+		RoomID:         started.Session.RoomID,
+		AgentSessionID: started.Session.AgentSessionID,
+		TurnID:         first.TurnID,
+		Content:        textPrompt("guide current turn"),
+		Guidance:       true,
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("guidance error = %v, want %v", err, wantErr)
+	}
+	if result.ProviderDispatch == nil ||
+		result.ProviderDispatch.Disposition != DispatchDispositionNotDispatched {
+		t.Fatalf("guidance result = %#v, want not dispatched", result)
+	}
+
+	adapter.releaseNext()
+	waitForSessionStatus(t, controller, "room-1", started.Session.AgentSessionID, SessionStatusReady)
+}
+
 func TestControllerExecGuidanceRequiresActiveTurn(t *testing.T) {
 	t.Parallel()
 
@@ -625,13 +725,58 @@ func TestControllerExecGuidanceRequiresActiveTurn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-	if _, err := controller.Exec(context.Background(), ExecInput{
+	result, err := controller.Exec(context.Background(), ExecInput{
 		RoomID:         started.Session.RoomID,
 		AgentSessionID: started.Session.AgentSessionID,
 		Content:        textPrompt("guide without active turn"),
 		Guidance:       true,
-	}); !errors.Is(err, ErrSessionNoActiveTurn) {
+	})
+	if !errors.Is(err, ErrSessionNoActiveTurn) {
 		t.Fatalf("guidance without active turn error = %v, want %v", err, ErrSessionNoActiveTurn)
+	}
+	if result.ProviderDispatch == nil ||
+		result.ProviderDispatch.Disposition != DispatchDispositionNotDispatched {
+		t.Fatalf("guidance result = %#v, want not dispatched", result)
+	}
+	if got := adapter.guidanceCalls.Load(); got != 0 {
+		t.Fatalf("provider guidance calls = %d, want 0", got)
+	}
+}
+
+func TestControllerExecExactGuidanceTreatsSettledTargetAsNotDispatched(t *testing.T) {
+	t.Parallel()
+
+	adapter := &guidanceBlockingAdapter{blockingExecAdapter: newBlockingExecAdapter()}
+	controller := NewController([]Adapter{adapter}, nil)
+	started, err := controller.Start(t.Context(), StartInput{
+		RoomID:         "room-1",
+		AgentSessionID: "agent-session-1",
+		Provider:       ProviderCodex,
+		Title:          "Codex",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	result, err := controller.Exec(t.Context(), ExecInput{
+		RoomID:         started.Session.RoomID,
+		AgentSessionID: started.Session.AgentSessionID,
+		TurnID:         "turn-settled-after-precheck",
+		Content:        textPrompt("guide settled turn"),
+		Guidance:       true,
+	})
+	if !errors.Is(err, ErrActiveTurnTargetMismatch) || !errors.Is(err, ErrSessionNoActiveTurn) {
+		t.Fatalf("guidance error = %v, want target mismatch joined with no active turn", err)
+	}
+	if result.ProviderDispatch == nil ||
+		result.ProviderDispatch.Disposition != DispatchDispositionNotDispatched {
+		t.Fatalf("guidance result = %#v, want not dispatched", result)
+	}
+	if result.TurnID != "turn-settled-after-precheck" {
+		t.Fatalf("guidance result turn = %q, want exact settled target", result.TurnID)
+	}
+	if got := adapter.guidanceCalls.Load(); got != 0 {
+		t.Fatalf("provider guidance calls = %d, want 0", got)
 	}
 }
 
@@ -728,10 +873,35 @@ func (returnOnlyFinalAdapter) Cancel(context.Context, Session, string) ([]activi
 type guidanceBlockingAdapter struct {
 	*blockingExecAdapter
 	guidanceCalls atomic.Int64
+	guidanceErr   error
+}
+
+type guidanceDispatchAdapter struct {
+	*guidanceBlockingAdapter
+	disposition DispatchDisposition
+}
+
+func (a *guidanceDispatchAdapter) GuideActiveTurnWithProviderDispatch(
+	ctx context.Context,
+	session Session,
+	content []PromptContentBlock,
+	displayPrompt string,
+	turnID string,
+	emit EventSink,
+	emitCommands CommandSnapshotSink,
+	reportDispatch ProviderDispatchSink,
+) ([]activityshared.Event, error) {
+	if reportDispatch != nil {
+		reportDispatch(ProviderDispatchResult{Disposition: a.disposition})
+	}
+	return a.GuideActiveTurn(ctx, session, content, displayPrompt, turnID, emit, emitCommands)
 }
 
 func (a *guidanceBlockingAdapter) GuideActiveTurn(ctx context.Context, session Session, content []PromptContentBlock, _ string, turnID string, emit EventSink, _ CommandSnapshotSink) ([]activityshared.Event, error) {
 	a.guidanceCalls.Add(1)
+	if a.guidanceErr != nil {
+		return nil, a.guidanceErr
+	}
 	events := []activityshared.Event{
 		newTurnActivityEvent(session, EventMessage, turnID, "", RoleUser, promptDisplayText(content), userPromptActivityPayload(content, "", userPromptActivityPayloadExtraFromExecMetadata(ctx, map[string]any{
 			"guidance": true,

--- a/packages/agent/host/edit_retry_saga_test.go
+++ b/packages/agent/host/edit_retry_saga_test.go
@@ -431,6 +431,9 @@ type hostEditRetryRuntime struct {
 	execOutcomeUnknownAccepted  bool
 	execNotDispatchedBeforeTurn bool
 	guidanceMismatch            bool
+	guidanceTargetInactive      bool
+	guidancePreflightFailure    bool
+	guidanceProviderCalls       int
 	guidanceTransportFailure    bool
 	reconcileAcceptanceCalls    int
 	reconcileAcceptanceInput    agenthost.RuntimeProviderTurnAcceptanceInput
@@ -463,10 +466,39 @@ func (r *hostEditRetryRuntime) Exec(ctx context.Context, input agenthost.Runtime
 	outcomeUnknownAccepted := r.execOutcomeUnknownAccepted
 	notDispatchedBeforeTurn := r.execNotDispatchedBeforeTurn
 	guidanceMismatch := r.guidanceMismatch
+	guidanceTargetInactive := r.guidanceTargetInactive
+	guidancePreflightFailure := r.guidancePreflightFailure
 	guidanceTransportFailure := r.guidanceTransportFailure
 	r.execOutcomeUnknown = false
 	r.execOutcomeUnknownAccepted = false
 	r.execNotDispatchedBeforeTurn = false
+	r.guidanceMismatch = false
+	r.guidanceTargetInactive = false
+	r.guidancePreflightFailure = false
+	if input.Guidance && (guidanceMismatch || guidanceTargetInactive) {
+		r.mu.Unlock()
+		// The runtime adapter proves the exact target is inactive before entering
+		// the provider. Model both a changed active turn and the settle race where
+		// no active turn remains with the same Host sentinel/disposition contract.
+		return agenthost.RuntimeExecResult{
+			TurnID: input.TurnID,
+			ProviderDispatch: agenthost.RuntimeProviderDispatchResult{
+				Disposition: agenthost.RuntimeDispatchDispositionNotDispatched,
+			},
+		}, fmt.Errorf("%w: exact guidance target is inactive before provider admission", agenthost.ErrActiveTurnTargetMismatch)
+	}
+	if input.Guidance && guidancePreflightFailure {
+		r.mu.Unlock()
+		return agenthost.RuntimeExecResult{
+			TurnID: input.TurnID,
+			ProviderDispatch: agenthost.RuntimeProviderDispatchResult{
+				Disposition: agenthost.RuntimeDispatchDispositionNotDispatched,
+			},
+		}, errors.New("guidance adapter preflight failed before provider dispatch")
+	}
+	if input.Guidance {
+		r.guidanceProviderCalls++
+	}
 	if !outcomeUnknown || outcomeUnknownAccepted {
 		if !notDispatchedBeforeTurn {
 			r.providerTurns = append(r.providerTurns, agenthost.RuntimeHistoryTurn{
@@ -475,23 +507,13 @@ func (r *hostEditRetryRuntime) Exec(ctx context.Context, input agenthost.Runtime
 		}
 	}
 	r.mu.Unlock()
-	if input.Guidance && guidanceMismatch {
-		// The runtime adapter maps its own target verdict onto the Host
-		// sentinel, so the fixture reports the same shape production sees.
-		return agenthost.RuntimeExecResult{
-			TurnID: input.TurnID,
-			ProviderDispatch: agenthost.RuntimeProviderDispatchResult{
-				Disposition: agenthost.RuntimeDispatchDispositionNotDispatched,
-			},
-		}, fmt.Errorf("%w: guidance target changed before provider admission", agenthost.ErrActiveTurnTargetMismatch)
-	}
 	if input.Guidance && guidanceTransportFailure {
 		return agenthost.RuntimeExecResult{
 			TurnID: input.TurnID,
 			ProviderDispatch: agenthost.RuntimeProviderDispatchResult{
-				Disposition: agenthost.RuntimeDispatchDispositionNotDispatched,
+				Disposition: agenthost.RuntimeDispatchDispositionOutcomeUnknown,
 			},
-		}, errors.New("guidance transport failed before provider admission")
+		}, errors.New("guidance transport failed after provider admission")
 	}
 	if notDispatchedBeforeTurn {
 		return agenthost.RuntimeExecResult{

--- a/packages/agent/host/guidance_target_test.go
+++ b/packages/agent/host/guidance_target_test.go
@@ -2,6 +2,7 @@ package agenthost_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
@@ -102,6 +103,97 @@ func TestHostGuidanceTargetMismatchCleansPreparedClaim(t *testing.T) {
 	}
 }
 
+func TestHostGuidanceSettledAfterCallerPrecheckIsDefinitivelyNotDispatched(t *testing.T) {
+	_, store, runtime := newHostEditRetryFixture(t)
+	host := agenthost.New(agenthost.Config{
+		CanonicalStore:    sqliteCanonicalStore{Store: store},
+		TurnSubmissions:   store,
+		EffectiveHistory:  store,
+		RuntimeOperations: store,
+		Runtime:           runtime,
+		HistoryRuntime:    runtime,
+		GoalRuntime:       runtime,
+		OperationOwner:    "worker-1",
+	})
+	runtime.mu.Lock()
+	runtime.guidanceTargetInactive = true
+	runtime.mu.Unlock()
+
+	_, err := host.SendInput(t.Context(), agenthost.SessionRef{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1",
+	}, agenthost.SendInput{
+		Content:        []agenthost.PromptContentBlock{{Type: "text", Text: "guidance after settle"}},
+		Guidance:       true,
+		TurnID:         "turn-original",
+		ClientSubmitID: "guidance-settle-race",
+	})
+	if !errors.Is(err, agenthost.ErrActiveTurnTargetMismatch) {
+		t.Fatalf("SendInput() error = %v, want ErrActiveTurnTargetMismatch", err)
+	}
+	if _, found, claimErr := store.GetSubmitClaim(t.Context(), "workspace-1", "session-1", "guidance-settle-race"); claimErr != nil || found {
+		t.Fatalf("prepared claim found=%v error=%v, want cleanup", found, claimErr)
+	}
+	claim, created, claimErr := store.PrepareSubmitClaim(t.Context(), storesqlite.SubmitClaimPrepare{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1", ClientSubmitID: "guidance-settle-race",
+		CanonicalTurnID: "turn-retry", NowUnixMS: 2,
+	})
+	if claimErr != nil || !created || claim.CanonicalTurnID != "turn-retry" {
+		t.Fatalf("retry claim=%#v created=%v error=%v, want a fresh claim", claim, created, claimErr)
+	}
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	if runtime.execCalls != 1 {
+		t.Fatalf("runtime exec calls = %d, want 1", runtime.execCalls)
+	}
+	if runtime.guidanceProviderCalls != 0 {
+		t.Fatalf("provider guidance calls = %d, want 0", runtime.guidanceProviderCalls)
+	}
+}
+
+func TestHostGuidanceAdapterPreflightFailureCleansClaimAndCanRetry(t *testing.T) {
+	_, store, runtime := newHostEditRetryFixture(t)
+	host := agenthost.New(agenthost.Config{
+		CanonicalStore:    sqliteCanonicalStore{Store: store},
+		TurnSubmissions:   store,
+		EffectiveHistory:  store,
+		RuntimeOperations: store,
+		Runtime:           runtime,
+		HistoryRuntime:    runtime,
+		GoalRuntime:       runtime,
+		OperationOwner:    "worker-1",
+	})
+	runtime.mu.Lock()
+	runtime.guidancePreflightFailure = true
+	runtime.mu.Unlock()
+	input := agenthost.SendInput{
+		Content:        []agenthost.PromptContentBlock{{Type: "text", Text: "retryable guidance"}},
+		Guidance:       true,
+		TurnID:         "turn-original",
+		ClientSubmitID: "guidance-preflight",
+	}
+
+	_, err := host.SendInput(t.Context(), agenthost.SessionRef{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1",
+	}, input)
+	if err == nil || errors.Is(err, agenthost.ErrSubmitDeliveryUnknown) {
+		t.Fatalf("first SendInput() error = %v, want known preflight failure", err)
+	}
+	if _, found, claimErr := store.GetSubmitClaim(t.Context(), "workspace-1", "session-1", "guidance-preflight"); claimErr != nil || found {
+		t.Fatalf("prepared claim found=%v error=%v, want cleanup", found, claimErr)
+	}
+
+	if _, err := host.SendInput(t.Context(), agenthost.SessionRef{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1",
+	}, input); err != nil {
+		t.Fatalf("retry SendInput(): %v", err)
+	}
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	if runtime.execCalls != 2 || runtime.guidanceProviderCalls != 1 {
+		t.Fatalf("exec calls=%d provider calls=%d, want 2/1", runtime.execCalls, runtime.guidanceProviderCalls)
+	}
+}
+
 func TestHostGuidanceTransportFailureReportsMessageSendFailure(t *testing.T) {
 	observer := &recordingGuidanceTerminalFailureObserver{}
 	_, store, runtime := newHostEditRetryFixture(t)
@@ -125,6 +217,12 @@ func TestHostGuidanceTransportFailureReportsMessageSendFailure(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("SendInput() error = nil, want transport failure")
+	}
+	if !errors.Is(err, agenthost.ErrSubmitDeliveryUnknown) {
+		t.Fatalf("SendInput() error = %v, want ErrSubmitDeliveryUnknown", err)
+	}
+	if _, found, claimErr := store.GetSubmitClaim(t.Context(), "workspace-1", "session-1", "guidance-transport"); claimErr != nil || !found {
+		t.Fatalf("prepared claim found=%v error=%v, want retained delivery fence", found, claimErr)
 	}
 	if len(observer.failures) != 1 {
 		t.Fatalf("terminal failures = %#v, want 1", observer.failures)


### PR DESCRIPTION
## Summary

- classify an exact guidance target that becomes inactive before provider dispatch as definitively not dispatched
- classify untyped failures after the provider adapter starts as outcome unknown
- let Activity Core recognize both no-active-turn error codes and re-drain the queued prompt as ordinary work

This is the narrow upstream safety fix for the Shared Agent steer race. It does not add an adaptive command, schema, or new public fallback API.

## Verification

- `pnpm check:changed` (18 push-ready lanes)
- focused daemon and Host settle-race regressions
- local TSH integration against the packed `@tutti-os/agent-activity-core` package: 134 renderer tests

## Fallback Three Questions

Not applicable. This change corrects delivery classification at the provider-dispatch boundary and adds no timer, retry, or cache.

## Checklist

- [x] Host lifecycle behavior uses the existing Host delivery-unknown fence; regressions cover the Host settle race.
- [x] I kept the change focused on one concern.
- [x] Documentation is not required because no public API or contributor workflow changes.
- [x] No translated README/CONTRIBUTING source changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] The commit is signed off with DCO.
