### PR TITLE
fix(agent-gui): clear drafts after queued prompt admission

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -325,6 +325,12 @@ Submission acknowledgment and execution are separate presentation signals:
 This keeps feedback optimistic for responsiveness while keeping claims about
 Agent work grounded in the canonical Turn/runtime projection.
 
+The Composer also hands the exact draft used to build a submission to the
+AgentGUI controller. The controller snapshots that handoff for conditional
+post-submit clearing; it must clear only when the current draft still matches
+the submitted snapshot, so a queue admission or accepted send cannot erase a
+newer edit made while the request is in flight.
+
 ### 2.6 On-demand status
 
 AgentGUI owns one provider-neutral `AgentStatusController` for `/status`, Agent

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
@@ -54,6 +54,8 @@ export interface AgentComposerReferenceProvenanceFilters {
 }
 
 export interface AgentComposerSubmitOptions {
+  /** Exact draft captured by the Composer for conditional post-submit clearing. */
+  submittedDraft?: AgentComposerDraft;
   isolation?: "worktree";
   requiredSettingsPatch?: AgentActivitySubmitSettingsPatch;
   capabilityRefs?: readonly AgentComposerCapabilityReference[];

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerSlashActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerSlashActions.ts
@@ -549,6 +549,7 @@ export function useComposerSlashActions(input: UseComposerSlashActionsInput) {
         draft: nextDraftContent,
         skills: availableSkills
       });
+      const submitOptions = { submittedDraft: nextDraftContent };
       const fileReferences = agentComposerFileMentionReferences(nextPrompt);
       const draftFileIds = new Set(currentDraftFiles.map((file) => file.id));
       reportAgentComposerDiagnostic(agentActivityRuntime, {
@@ -580,15 +581,19 @@ export function useComposerSlashActions(input: UseComposerSlashActionsInput) {
           return;
         }
         if (submission.displayPrompt) {
-          onSubmitGuidance(submission.content, submission.displayPrompt);
+          onSubmitGuidance(
+            submission.content,
+            submission.displayPrompt,
+            submitOptions
+          );
         } else {
-          onSubmitGuidance(submission.content);
+          onSubmitGuidance(submission.content, undefined, submitOptions);
         }
       } else {
         if (submission.displayPrompt) {
-          onSubmit(submission.content, submission.displayPrompt);
+          onSubmit(submission.content, submission.displayPrompt, submitOptions);
         } else {
-          onSubmit(submission.content);
+          onSubmit(submission.content, undefined, submitOptions);
         }
       }
       // The controller owns draft clearing: an in-session send clears the

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIControllerRefs.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIControllerRefs.ts
@@ -104,6 +104,7 @@ export function useAgentGUIControllerRefs(
         immediate?: boolean;
         requiredSettingsPatch?: AgentComposerSubmitOptions["requiredSettingsPatch"];
         sendNow?: boolean;
+        submittedDraft?: AgentComposerSubmitOptions["submittedDraft"];
         sourceScopeKey?: string;
         trackDraft?: boolean;
       }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.ts
@@ -326,7 +326,9 @@ export function useAgentGUINewConversationActivation(
       });
       const sourceScopeKey = resolveAgentComposerDraftScopeKey({});
       const submittedDraft =
-        draftByScopeKeyRef.current[sourceScopeKey] ?? emptyAgentComposerDraft();
+        submitOptions?.submittedDraft ??
+        draftByScopeKeyRef.current[sourceScopeKey] ??
+        emptyAgentComposerDraft();
       submittedDraftSnapshotsRef.current[submitTrace.clientSubmitId] = {
         sourceScopeKey,
         content: snapshotAgentComposerDraft(submittedDraft)

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.spec.ts
@@ -533,6 +533,45 @@ describe("existing-session prompt submission", () => {
     ).toBe("");
   });
 
+  it("clears the draft captured by the Composer when the controller ref is stale", () => {
+    const goalControl = vi.fn(async () => undefined);
+    const { input, draftByScopeKeyRef, sessionEngine, setDraftByScopeKey } =
+      createGoalControlInput(goalControl as never);
+    const submittedDraft = draft("continue");
+    draftByScopeKeyRef.current = {
+      "session:session-1": draft("stale projection")
+    };
+    const submitPrompt = vi
+      .spyOn(sessionEngine, "submitPrompt")
+      .mockReturnValue({ accepted: true, queued: true });
+    const { result } = renderHook(() =>
+      useAgentGUISubmitInteractionActions(input)
+    );
+
+    setDraftByScopeKey.mockImplementationOnce((update) => {
+      const current = { "session:session-1": submittedDraft };
+      const next = typeof update === "function" ? update(current) : update;
+      draftByScopeKeyRef.current = next;
+    });
+
+    act(() =>
+      result.current.submitPrompt(
+        [{ type: "text", text: "continue" }],
+        undefined,
+        { submittedDraft }
+      )
+    );
+
+    expect(submitPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: [{ type: "text", text: "continue" }]
+      })
+    );
+    expect(
+      agentComposerDraftPrompt(draftByScopeKeyRef.current["session:session-1"]!)
+    ).toBe("");
+  });
+
   it("keeps the draft when the Engine does not admit the submission", () => {
     const goalControl = vi.fn(async () => undefined);
     const { input, draftByScopeKeyRef, sessionEngine, setDraftByScopeKey } =

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.ts
@@ -91,6 +91,7 @@ interface UseAgentGUISubmitInteractionActionsInput {
         immediate?: boolean;
         requiredSettingsPatch?: AgentComposerSubmitOptions["requiredSettingsPatch"];
         sendNow?: boolean;
+        submittedDraft?: AgentComposerSubmitOptions["submittedDraft"];
         targetTurnId?: AgentComposerSubmitOptions["targetTurnId"];
         sourceScopeKey?: string;
         trackDraft?: boolean;
@@ -225,6 +226,7 @@ export function useAgentGUISubmitInteractionActions(
         immediate?: boolean;
         requiredSettingsPatch?: AgentComposerSubmitOptions["requiredSettingsPatch"];
         sendNow?: boolean;
+        submittedDraft?: AgentComposerSubmitOptions["submittedDraft"];
         targetTurnId?: AgentComposerSubmitOptions["targetTurnId"];
         sourceScopeKey?: string;
         trackDraft?: boolean;
@@ -254,6 +256,7 @@ export function useAgentGUISubmitInteractionActions(
           options.sourceScopeKey ??
           resolveAgentComposerDraftScopeKey({ agentSessionId });
         const submittedDraft =
+          options?.submittedDraft ??
           draftByScopeKeyRef.current[sourceScopeKey] ??
           emptyAgentComposerDraft();
         submittedDraftSnapshotsRef.current[submitTrace.clientSubmitId] = {
@@ -400,6 +403,7 @@ export function useAgentGUISubmitInteractionActions(
         capabilityRefs?: AgentComposerSubmitOptions["capabilityRefs"];
         requiredSettingsPatch?: AgentComposerSubmitOptions["requiredSettingsPatch"];
         sendNow?: boolean;
+        submittedDraft?: AgentComposerSubmitOptions["submittedDraft"];
         targetTurnId?: AgentComposerSubmitOptions["targetTurnId"];
         sourceScopeKey?: string;
         trackDraft?: boolean;
@@ -431,6 +435,7 @@ export function useAgentGUISubmitInteractionActions(
         requiredSettingsPatch: options?.requiredSettingsPatch,
         targetTurnId: options?.targetTurnId,
         sendNow: options?.sendNow === true,
+        submittedDraft: options?.submittedDraft,
         sourceScopeKey: options?.sourceScopeKey,
         trackDraft: options?.trackDraft === true
       });
@@ -510,6 +515,7 @@ export function useAgentGUISubmitInteractionActions(
               {
                 capabilityRefs: options?.capabilityRefs,
                 requiredSettingsPatch: options?.requiredSettingsPatch,
+                submittedDraft: options?.submittedDraft,
                 sourceScopeKey: resolveAgentComposerDraftScopeKey({}),
                 trackDraft: true
               }
@@ -519,7 +525,9 @@ export function useAgentGUISubmitInteractionActions(
         }
         const homeDraftKey = resolveAgentComposerDraftScopeKey({});
         const submittedHomeDraft = snapshotAgentComposerDraft(
-          draftByScopeKeyRef.current[homeDraftKey] ?? emptyAgentComposerDraft()
+          options?.submittedDraft ??
+            draftByScopeKeyRef.current[homeDraftKey] ??
+            emptyAgentComposerDraft()
         );
         const activationResult = startConversation(
           normalizedContent,
@@ -559,6 +567,7 @@ export function useAgentGUISubmitInteractionActions(
         {
           capabilityRefs: options?.capabilityRefs,
           requiredSettingsPatch: options?.requiredSettingsPatch,
+          submittedDraft: options?.submittedDraft,
           trackDraft: true
         }
       );
@@ -610,6 +619,7 @@ export function useAgentGUISubmitInteractionActions(
         {
           capabilityRefs: options?.capabilityRefs,
           sendNow: true,
+          submittedDraft: options?.submittedDraft,
           targetTurnId: activeTurnId,
           trackDraft: true
         }


### PR DESCRIPTION
## Summary
- Pass the exact Composer draft through the submit handoff.
- Clear accepted or queued prompts only when the current draft still matches that snapshot.
- Add a stale-controller-ref regression test and document the invariant.

## Tests
- `pnpm check:changed -- --push-ready`
- `pnpm --filter @tutti-os/agent-gui test` (323 files, 2880 tests)
- `pnpm --filter @tutti-os/agent-gui typecheck`

## Notes
- TSH source and dependency manifests are unchanged; the fix belongs in the Tutti AgentGUI package.