### PR TITLE
feat(connectors): gate installs and auto-update releases

### DIFF
--- a/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
+++ b/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
@@ -9,7 +9,10 @@ import {
 } from "@renderer/features/analytics";
 import { startPredefinePageviewAnalytics } from "@renderer/features/analytics/predefinePageviewAnalytics.ts";
 import { registerAppUpdateServices } from "@renderer/features/app-update/services/registerAppUpdateServices";
-import { registerConnectorMarketModule } from "@renderer/features/connector-market";
+import {
+  registerConnectorMarketModule,
+  requestDesktopConnectorInstallAdmission
+} from "@renderer/features/connector-market";
 import { registerDesktopPreferencesServices } from "@renderer/features/desktop-preferences/services/registerDesktopPreferencesServices.ts";
 import { registerRichTextAtServices } from "@renderer/features/rich-text-at/services/registerRichTextAtServices";
 import { createDesktopAgentSessionStatusViewResolver } from "@renderer/features/rich-text-at/providers/desktopAgentSessionStatusView.ts";
@@ -227,7 +230,13 @@ export async function createWorkspaceWindowContainer(): Promise<WorkspaceWindowC
           source: "workspace-renderer"
         })
         .catch(() => undefined);
-    }
+    },
+    requestInstallAdmission: () =>
+      requestDesktopConnectorInstallAdmission(
+        accountService,
+        notificationService,
+        translate("workspace.accountMenu.signInFailed")
+      )
   });
   const workspaceAgentServices = registerWorkspaceAgentServices(registry, {
     accountLogin: accountService,

--- a/apps/desktop/src/renderer/src/features/connector-market/index.ts
+++ b/apps/desktop/src/renderer/src/features/connector-market/index.ts
@@ -1,1 +1,2 @@
 export { registerConnectorMarketModule } from "./services/registerConnectorMarketModule.ts";
+export { requestDesktopConnectorInstallAdmission } from "./services/requestDesktopConnectorInstallAdmission.ts";

--- a/apps/desktop/src/renderer/src/features/connector-market/services/registerConnectorMarketModule.ts
+++ b/apps/desktop/src/renderer/src/features/connector-market/services/registerConnectorMarketModule.ts
@@ -13,11 +13,13 @@ import { createDesktopConnectorMarketBackend } from "./internal/desktopConnector
 import { createDesktopConnectorMarketEvents } from "./internal/desktopConnectorMarketEvents.ts";
 
 export interface ConnectorMarketModuleRegistrationInput {
+  autoUpdateInstalledConnectors?: boolean;
   canRequest?: () => boolean;
   client: ConnectorMarketClient;
   eventStreamClient: TuttidEventStreamClient;
   openAuthorizationUrl?: (url: string) => Promise<void>;
   reportDiagnostic?: (error: unknown) => void;
+  requestInstallAdmission?: () => void | Promise<void>;
 }
 
 export function registerConnectorMarketModule(
@@ -26,11 +28,14 @@ export function registerConnectorMarketModule(
 ): ConnectorMarketModuleService {
   const module = new ConnectorMarketModule({
     market: {
+      autoUpdateInstalledConnectors:
+        input.autoUpdateInstalledConnectors ?? true,
       backend: createDesktopConnectorMarketBackend(input.client),
       canRequest: input.canRequest,
       events: createDesktopConnectorMarketEvents(input.eventStreamClient),
       openAuthorizationUrl: input.openAuthorizationUrl,
-      reportDiagnostic: input.reportDiagnostic
+      reportDiagnostic: input.reportDiagnostic,
+      requestInstallAdmission: input.requestInstallAdmission
     },
     scope: {}
   });

--- a/apps/desktop/src/renderer/src/features/connector-market/services/requestDesktopConnectorInstallAdmission.test.ts
+++ b/apps/desktop/src/renderer/src/features/connector-market/services/requestDesktopConnectorInstallAdmission.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { requestDesktopConnectorInstallAdmission } from "./requestDesktopConnectorInstallAdmission.ts";
+
+test("connector install admission starts account login without reporting a successful launch", async () => {
+  let loginCalls = 0;
+  let notificationCalls = 0;
+
+  await requestDesktopConnectorInstallAdmission(
+    {
+      async startLogin() {
+        loginCalls += 1;
+        return { error: null };
+      }
+    },
+    {
+      error() {
+        notificationCalls += 1;
+        return "notification-1";
+      }
+    },
+    "Unable to start sign-in"
+  );
+
+  assert.equal(loginCalls, 1);
+  assert.equal(notificationCalls, 0);
+});
+
+test("connector install admission reports an account login launch failure", async () => {
+  const messages: Array<{ description?: string; title: string }> = [];
+
+  await requestDesktopConnectorInstallAdmission(
+    {
+      async startLogin() {
+        return { error: "Failed to fetch" };
+      }
+    },
+    {
+      error(message) {
+        messages.push(message);
+        return "notification-1";
+      }
+    },
+    "Unable to start sign-in"
+  );
+
+  assert.deepEqual(messages, [
+    {
+      description: "Failed to fetch",
+      title: "Unable to start sign-in"
+    }
+  ]);
+});

--- a/apps/desktop/src/renderer/src/features/connector-market/services/requestDesktopConnectorInstallAdmission.ts
+++ b/apps/desktop/src/renderer/src/features/connector-market/services/requestDesktopConnectorInstallAdmission.ts
@@ -1,0 +1,20 @@
+import type { NotificationService } from "@tutti-os/ui-notifications";
+
+export interface DesktopConnectorAccountLogin {
+  startLogin(): Promise<{ error: string | null }>;
+}
+
+export async function requestDesktopConnectorInstallAdmission(
+  accountLogin: DesktopConnectorAccountLogin,
+  notifications: Pick<NotificationService, "error">,
+  failureTitle: string
+): Promise<void> {
+  const result = await accountLogin.startLogin();
+  const error = result.error?.trim();
+  if (error) {
+    notifications.error({
+      description: error,
+      title: failureTitle
+    });
+  }
+}

--- a/docs/architecture/connector-market.md
+++ b/docs/architecture/connector-market.md
@@ -499,6 +499,16 @@ synchronizing -> materializing -> ready`; failure is terminal and disposes
   account authentication, activates the module without network access while
   signed out, reloads after login, and keeps reconnect/resume paths silent
   after logout
+- install intent that arrives while Tutti is signed out invokes the host-owned
+  account login flow through `requestInstallAdmission`; the service rechecks
+  admission and returns `not_admitted` without calling the backend or showing
+  installation success when login is still pending
+- Tutti enables renderer-owned automatic updates for installed, compatible
+  Connectors. After an authoritative snapshot, catalog page, or connector event
+  publishes a different active release digest, Market starts the existing
+  install/update command in the background. It never opens login from a
+  background update and attempts one release digest only once per renderer
+  lifetime, leaving explicit update available after failure
 - the shared renderer subscribes at leaf components through a stable context,
   uses `@tutti-os/ui-system`, and owns no transport, startup, disposal, or
   business-state reconciliation

--- a/packages/connector/host/application_runtime_convergence_test.go
+++ b/packages/connector/host/application_runtime_convergence_test.go
@@ -137,3 +137,67 @@ func TestUpdateKeepsCurrentReleaseUntilCandidateRuntimeIsObserved(t *testing.T) 
 		t.Fatalf("update did not promote observed candidate: connector=%#v operation=%#v", completed, operation)
 	}
 }
+
+func TestAuthorizedUpdateInspectsPreparedCandidateBeforePromotion(t *testing.T) {
+	connector := testManagedAuthorizedConnector("lark-cli")
+	connector.Authorization = Authorization{State: AuthorizationStateConnected}
+	oldRelease := connector.Release
+	connector.Release.Version = "2.0.0"
+	connector.Release.ReleaseID = "lark-cli@2.0.0"
+	connector.Release.ReleaseDigest = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	connector.Release.ManifestDigest = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	repository := newMemoryRepository(connector)
+	repository.operations["old-install"] = Operation{
+		OperationID: "old-install", ConnectorKey: connector.Key, Kind: OperationKindInstall,
+		State: OperationStateCompleted, Target: &OperationTarget{
+			ConnectorKey: connector.Key, ReleaseDigest: oldRelease.ReleaseDigest, Release: &oldRelease,
+		},
+	}
+	runtime := &memoryInstallRuntime{}
+	application := newTestApplication(t, repository, &memoryScheduler{}, runtime, CatalogSnapshot{})
+	inspector := &candidateAuthorizationInspector{}
+	application.config.Authorization = inspector
+
+	accepted, err := application.Install(context.Background(), ConnectorMutation{
+		Mutation: Mutation{ClientRequestID: "update-authorized-lark"}, ConnectorKey: connector.Key,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := application.ExecuteOperation(context.Background(), accepted.Operation.OperationID); err != nil {
+		t.Fatal(err)
+	}
+	if len(inspector.requests) != 1 {
+		t.Fatalf("authorization inspections = %d, want 1", len(inspector.requests))
+	}
+	inspected := inspector.requests[0].Connector
+	if inspected.Installation.State != InstallationStateUpdating ||
+		inspected.Installation.CandidateReleaseDigest != connector.Release.ReleaseDigest ||
+		inspected.Release.ReleaseDigest != connector.Release.ReleaseDigest {
+		t.Fatalf("inspected candidate connector = %#v", inspected)
+	}
+	completed, err := repository.Connector(context.Background(), connector.Key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if completed.Installation.State != InstallationStateInstalled ||
+		completed.Installation.InstalledReleaseDigest != connector.Release.ReleaseDigest {
+		t.Fatalf("completed authorized update = %#v", completed.Installation)
+	}
+}
+
+type candidateAuthorizationInspector struct {
+	authorizationProviderStub
+	requests []AuthorizationInspectRequest
+}
+
+func (inspector *candidateAuthorizationInspector) InspectAuthorization(
+	_ context.Context,
+	request AuthorizationInspectRequest,
+) (AuthorizationObservation, error) {
+	inspector.requests = append(inspector.requests, request)
+	return AuthorizationObservation{
+		State: AuthorizationObservationConnected, ConnectorKey: request.Connector.Key,
+		ReleaseDigest: request.Connector.Release.ReleaseDigest, ConnectionID: defaultConnectorConnectionID,
+	}, nil
+}

--- a/packages/connector/host/application_scoped_runtime.go
+++ b/packages/connector/host/application_scoped_runtime.go
@@ -388,7 +388,20 @@ func (application *Application) FenceInstalledRuntimesForScope(ctx context.Conte
 		}
 		installedRelease, evidenceErr := application.installedReleaseEvidence(ctx, connector)
 		if evidenceErr != nil {
-			fenceErrors = append(fenceErrors, evidenceErr)
+			// Legacy stores may have lost the previous release metadata when a
+			// prepared update failed. The implementation host can still fence every
+			// route for the connector by identity, without trusting that metadata.
+			// This keeps the connector fail-closed without holding the global
+			// publication gate closed and blocking a repair install.
+			fallbackErr := application.config.Host.DeactivateRuntime(ctx, RuntimeDeactivationRequest{
+				Scope: scope, ConnectionID: defaultConnectorConnectionID, ConnectorKey: connector.Key,
+				ReleaseDigest: connector.Installation.InstalledReleaseDigest, AllConnections: true,
+				Generation: HostGeneration{BootEpoch: application.config.BootEpoch, Generation: maxGeneration(connector.Revision)},
+				Deadline:   application.config.Now().UTC().Add(5 * time.Second),
+			})
+			if fallbackErr != nil {
+				fenceErrors = append(fenceErrors, errors.Join(evidenceErr, fallbackErr))
+			}
 			continue
 		}
 		connector.Release = installedRelease

--- a/packages/connector/host/application_test.go
+++ b/packages/connector/host/application_test.go
@@ -659,6 +659,31 @@ func TestApplicationStartupReconcileAdvancesPastFence(t *testing.T) {
 	}
 }
 
+func TestApplicationStartupFenceFallsBackToConnectorIdentityWhenReleaseEvidenceIsMissing(t *testing.T) {
+	connector := testConnector("lark-cli")
+	installedRelease := connector.Release
+	connector.Installation = Installation{
+		State: InstallationStateInstalled, InstalledVersion: installedRelease.Version,
+		InstalledReleaseID: installedRelease.ReleaseID, InstalledReleaseDigest: installedRelease.ReleaseDigest,
+	}
+	connector.Release.Version = "2.0.0"
+	connector.Release.ReleaseID = connector.Key + "@2.0.0"
+	connector.Release.ReleaseDigest = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	connector.Release.ManifestDigest = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	repository := newMemoryRepository(connector)
+	host := &memoryInstallRuntime{}
+	application := newTestApplication(t, repository, &memoryScheduler{}, host, CatalogSnapshot{})
+
+	if err := application.FenceInstalledRuntimes(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if host.deactivations != 1 || !host.lastDeactivation.AllConnections ||
+		host.lastDeactivation.ConnectorKey != connector.Key ||
+		host.lastDeactivation.ReleaseDigest != installedRelease.ReleaseDigest {
+		t.Fatalf("fallback deactivation = %#v", host.lastDeactivation)
+	}
+}
+
 func TestApplicationCrossDeviceRemoteReconcileUsesAccountProjectionAuthorization(t *testing.T) {
 	connector := testConnector("tencent-docs")
 	connector.Release.Manifest.AuthorizationKind = "api_key"

--- a/packages/connector/market/README.md
+++ b/packages/connector/market/README.md
@@ -50,8 +50,10 @@ import {
 const connectorMarketModule = new ConnectorMarketModule({
   market: {
     backend: hostConnectorMarketBackend,
+    autoUpdateInstalledConnectors: true,
     canRequest: () => hostAccountState.authenticated,
-    events: hostConnectorMarketEvents
+    events: hostConnectorMarketEvents,
+    requestInstallAdmission: () => hostAccountLogin.open()
   },
   scope: {}
 });
@@ -75,6 +77,17 @@ Hosts whose market requires authentication must provide `canRequest`. A false
 result keeps startup, reconnect, resume, and command paths transport-silent
 while still allowing the module lifecycle to reach `ready`; after the host
 observes an authenticated transition it calls `root.market.reload()`.
+When an install intent arrives while requests are not admitted, the Market
+service invokes the optional `requestInstallAdmission` host hook and rechecks
+admission. A host may use this hook to open its account login flow. The install
+returns `not_admitted` without calling the backend when authentication remains
+unavailable, so UI callers do not report a false installation success.
+Hosts may enable `autoUpdateInstalledConnectors` to install a newly observed
+compatible release in the background. Tutti enables this policy by default.
+Automatic updates never invoke `requestInstallAdmission`, and one running
+renderer attempts each release digest at most once; failed updates remain
+available for explicit retry and may be retried after restart or after a newer
+release appears.
 Starting an event subscription and every observed `connected` state trigger an
 authoritative reconciliation, including the first connection. Snapshot reads
 are coalesced per service generation and a connection/event arriving during

--- a/packages/connector/market/src/services/connectorMarketService.interface.ts
+++ b/packages/connector/market/src/services/connectorMarketService.interface.ts
@@ -45,9 +45,13 @@ export interface ConnectorMarketStoreState {
 }
 
 export interface ConnectorMarketServiceDependencies {
+  /** Automatically installs a newly observed release for an installed Connector. */
+  autoUpdateInstalledConnectors?: boolean;
   backend: ConnectorMarketBackend;
   /** Host-owned admission check for transport requests. */
   canRequest?: () => boolean;
+  /** Host hook invoked by install intent when transport admission is unavailable. */
+  requestInstallAdmission?: () => void | Promise<void>;
   events?: ConnectorMarketEventSource;
   createRequestId?: () => string;
   openAuthorizationUrl?: (url: string) => Promise<void>;
@@ -75,7 +79,7 @@ export interface IConnectorMarketService {
   reload(): Promise<void>;
   refreshCatalog(): Promise<void>;
   loadMore(sectionId: string): Promise<void>;
-  install(connectorKey: string): Promise<void>;
+  install(connectorKey: string): Promise<ConnectorInstallOutcome>;
   uninstall(connectorKey: string): Promise<ConnectorOperation>;
   dismissUninstallNotification(operationId: string): void;
   beginAuthorization(connectorKey: string, secret?: string): Promise<void>;
@@ -84,6 +88,8 @@ export interface IConnectorMarketService {
   /** Releases subscriptions and makes the service terminal. */
   dispose(): void;
 }
+
+export type ConnectorInstallOutcome = "installed" | "not_admitted";
 
 export const IConnectorMarketService = createDecorator<IConnectorMarketService>(
   "connector-market-service"

--- a/packages/connector/market/src/services/connectorMarketService.test.ts
+++ b/packages/connector/market/src/services/connectorMarketService.test.ts
@@ -151,6 +151,123 @@ test("loads server categories and appends cursor pages", async () => {
   service.dispose();
 });
 
+test("automatically updates an installed connector when catalog discovery observes a new release", async () => {
+  const installed = connector("github", 1);
+  installed.release.releaseDigest =
+    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+  installed.installation = {
+    state: "installed",
+    installedReleaseDigest: installed.release.releaseDigest,
+    installedReleaseId: installed.release.releaseId,
+    installedVersion: installed.release.version
+  };
+  const available = structuredClone(installed);
+  available.release.releaseId = "github@1.1.0";
+  available.release.version = "1.1.0";
+  available.release.releaseDigest =
+    "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+  available.revision = 2;
+  const updated = structuredClone(available);
+  updated.installation = {
+    state: "installed",
+    installedReleaseDigest: available.release.releaseDigest,
+    installedReleaseId: available.release.releaseId,
+    installedVersion: available.release.version
+  };
+  updated.revision = 3;
+  const installInputs: Parameters<
+    ConnectorMarketBackend["installConnector"]
+  >[0][] = [];
+  let installAdmissionRequests = 0;
+  const service = new ConnectorMarketService({
+    autoUpdateInstalledConnectors: true,
+    backend: backendWith({
+      getSnapshot: async () => snapshot(1, [installed]),
+      listCategories: async () => [
+        {
+          categoryId: "development",
+          kind: "category",
+          sortOrder: 20,
+          itemCount: 1
+        }
+      ],
+      listCatalogPage: async () => ({
+        sectionId: "development",
+        items: [
+          {
+            categoryId: "development",
+            featured: false,
+            connector: available
+          }
+        ],
+        revision: 2
+      }),
+      installConnector: async (input) => {
+        installInputs.push(input);
+        return {
+          connector: updated,
+          operation: {
+            operationId: "operation-auto-update",
+            clientRequestId: input.clientRequestId,
+            connectorKey: "github",
+            kind: "install",
+            state: "completed",
+            stage: "completed",
+            attempt: 1,
+            createdAt: "2026-08-15T00:00:00Z",
+            updatedAt: "2026-08-15T00:00:01Z"
+          },
+          revision: 3
+        };
+      }
+    }),
+    requestInstallAdmission: () => {
+      installAdmissionRequests += 1;
+    }
+  });
+
+  await service.ensureLoaded();
+  await waitFor(() => installInputs.length === 1);
+
+  assert.equal(installInputs[0]?.connectorKey, "github");
+  assert.equal(installInputs[0]?.expectedConnectorRevision, 2);
+  assert.equal(installAdmissionRequests, 0);
+  assert.equal(
+    service.dataStore.connectorsByKey.github?.installation
+      .installedReleaseDigest,
+    available.release.releaseDigest
+  );
+  service.dispose();
+});
+
+test("attempts automatic update only once for the same failed release", async () => {
+  const installed = connector("github", 1);
+  installed.installation = {
+    state: "installed",
+    installedReleaseDigest:
+      "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+  };
+  let installCalls = 0;
+  const service = new ConnectorMarketService({
+    autoUpdateInstalledConnectors: true,
+    backend: backendWith({
+      getSnapshot: async () => snapshot(1, [installed]),
+      installConnector: async () => {
+        installCalls += 1;
+        throw new Error("update failed");
+      }
+    })
+  });
+
+  await service.ensureLoaded();
+  await waitFor(() => installCalls === 1);
+  await service.reload();
+  await Promise.resolve();
+
+  assert.equal(installCalls, 1);
+  service.dispose();
+});
+
 test("keeps healthy catalog sections available and retries a failed section", async () => {
   let otherFails = true;
   const diagnostics: unknown[] = [];
@@ -351,6 +468,54 @@ test("rejects overlapping mutations for one connector", async () => {
     service.dataStore.operationsByConnectorKey.github?.operationId,
     "operation-1"
   );
+  service.dispose();
+});
+
+test("requests host admission instead of installing when account access is unavailable", async () => {
+  let admitted = false;
+  let admissionRequests = 0;
+  let installCalls = 0;
+  const installed = connector("github", 1);
+  installed.installation = {
+    state: "installed",
+    installedReleaseDigest: installed.release.releaseDigest
+  };
+  const service = new ConnectorMarketService({
+    backend: backendWith({
+      installConnector: async () => {
+        installCalls += 1;
+        return {
+          connector: installed,
+          operation: {
+            operationId: "operation-install-1",
+            clientRequestId: "request-install-1",
+            connectorKey: "github",
+            kind: "install",
+            state: "completed",
+            stage: "completed",
+            attempt: 1,
+            createdAt: "2026-08-03T00:00:00Z",
+            updatedAt: "2026-08-03T00:00:01Z"
+          },
+          revision: 1
+        };
+      }
+    }),
+    canRequest: () => admitted,
+    requestInstallAdmission: () => {
+      admissionRequests += 1;
+    }
+  });
+
+  assert.equal(await service.install("github"), "not_admitted");
+  assert.equal(admissionRequests, 1);
+  assert.equal(installCalls, 0);
+  assert.deepEqual(service.dataStore.pendingInstallationsByConnectorKey, {});
+
+  admitted = true;
+  assert.equal(await service.install("github"), "installed");
+  assert.equal(admissionRequests, 1);
+  assert.equal(installCalls, 1);
   service.dispose();
 });
 

--- a/packages/connector/market/src/services/connectorMarketService.ts
+++ b/packages/connector/market/src/services/connectorMarketService.ts
@@ -9,6 +9,7 @@ import type {
 } from "../contracts/index.ts";
 import type {
   ConnectorMarketServiceDependencies,
+  ConnectorInstallOutcome,
   ConnectorMarketStoreState,
   IConnectorMarketService
 } from "./connectorMarketService.interface.ts";
@@ -118,6 +119,10 @@ export class ConnectorMarketService implements IConnectorMarketService {
   private eventConnectionUnsubscribe: (() => void) | null = null;
   private refreshInFlight: Promise<void> | null = null;
   private readonly sectionLoads = new Map<string, Promise<void>>();
+  private readonly automaticUpdateReleaseByConnectorKey = new Map<
+    string,
+    string
+  >();
   private loadInFlight: {
     generation: number;
     promise: Promise<void>;
@@ -238,7 +243,33 @@ export class ConnectorMarketService implements IConnectorMarketService {
     return promise;
   }
 
-  install(connectorKey: string): Promise<void> {
+  async install(connectorKey: string): Promise<ConnectorInstallOutcome> {
+    if (this.disposed) {
+      return "not_admitted";
+    }
+    if (!this.canRequest()) {
+      await this.dependencies.requestInstallAdmission?.();
+    }
+    if (this.disposed || !this.canRequest()) {
+      return "not_admitted";
+    }
+    const installed = await this.installConnector(connectorKey);
+    return installed ? "installed" : "not_admitted";
+  }
+
+  private installConnector(connectorKey: string): Promise<boolean> {
+    const connector = this.dataStore.connectorsByKey[connectorKey];
+    if (
+      connector?.installation.state === "installed" &&
+      connector.installation.installedReleaseDigest &&
+      connector.installation.installedReleaseDigest !==
+        connector.release.releaseDigest
+    ) {
+      this.automaticUpdateReleaseByConnectorKey.set(
+        connectorKey,
+        connector.release.releaseDigest
+      );
+    }
     return this.runConnectorMutation(
       connectorKey,
       () =>
@@ -466,8 +497,8 @@ export class ConnectorMarketService implements IConnectorMarketService {
     }
   }
 
-  disconnectAuthorization(connectorKey: string): Promise<void> {
-    return this.runConnectorMutation(connectorKey, () =>
+  async disconnectAuthorization(connectorKey: string): Promise<void> {
+    await this.runConnectorMutation(connectorKey, () =>
       this.dependencies.backend.disconnectAuthorization({
         connectorKey,
         clientRequestId: this.createRequestId(),
@@ -498,6 +529,7 @@ export class ConnectorMarketService implements IConnectorMarketService {
     this.operationTracks.clear();
     this.refreshInFlight = null;
     this.sectionLoads.clear();
+    this.automaticUpdateReleaseByConnectorKey.clear();
     this.eventUnsubscribe?.();
     this.eventUnsubscribe = null;
     this.eventConnectionUnsubscribe?.();
@@ -641,6 +673,7 @@ export class ConnectorMarketService implements IConnectorMarketService {
       for (const pageError of pageErrors) {
         this.reportDiagnostic(pageError);
       }
+      this.requestAutomaticUpdates();
     } catch (error) {
       if (!this.isCurrent(generation)) {
         return;
@@ -674,6 +707,7 @@ export class ConnectorMarketService implements IConnectorMarketService {
       });
       if (this.isCurrent(generation)) {
         applyConnectorMarketCatalogPage(this.dataStore, page);
+        this.requestAutomaticUpdates();
       }
     } catch (error) {
       if (this.isCurrent(generation)) {
@@ -765,20 +799,52 @@ export class ConnectorMarketService implements IConnectorMarketService {
     }
     this.dataStore.revision = Math.max(this.dataStore.revision, event.revision);
     this.dataStore.lastError = null;
+    this.requestAutomaticUpdates();
+  }
+
+  private requestAutomaticUpdates(): void {
+    if (
+      !this.dependencies.autoUpdateInstalledConnectors ||
+      !this.canRequest()
+    ) {
+      return;
+    }
+    for (const connector of Object.values(this.dataStore.connectorsByKey)) {
+      const installedReleaseDigest =
+        connector.installation.installedReleaseDigest;
+      const targetReleaseDigest = connector.release.releaseDigest;
+      if (
+        connector.compatibility.state !== "supported" ||
+        connector.release.status !== "available" ||
+        connector.installation.state !== "installed" ||
+        !installedReleaseDigest ||
+        installedReleaseDigest === targetReleaseDigest ||
+        this.connectorMutations.has(connector.key) ||
+        this.automaticUpdateReleaseByConnectorKey.get(connector.key) ===
+          targetReleaseDigest
+      ) {
+        continue;
+      }
+      this.automaticUpdateReleaseByConnectorKey.set(
+        connector.key,
+        targetReleaseDigest
+      );
+      void this.installConnector(connector.key).catch(() => undefined);
+    }
   }
 
   private async runConnectorMutation(
     connectorKey: string,
     operation: () => Promise<ConnectorMutationResult>,
     projectPendingInstallation = false
-  ): Promise<void> {
+  ): Promise<boolean> {
     const result = await this.runConnectorMutationResult(
       connectorKey,
       operation,
       projectPendingInstallation
     );
     if (!result) {
-      return;
+      return false;
     }
     const tracked = this.trackOperation(result.operation);
     if (tracked) {
@@ -794,6 +860,7 @@ export class ConnectorMarketService implements IConnectorMarketService {
         terminal.failureCode
       );
     }
+    return true;
   }
 
   private async runConnectorMutationResult(
@@ -1007,6 +1074,7 @@ export class ConnectorMarketService implements IConnectorMarketService {
         this.dataStore.revision,
         connector.revision
       );
+      this.requestAutomaticUpdates();
       return;
     }
     const snapshot = await this.dependencies.backend.getSnapshot();
@@ -1015,6 +1083,7 @@ export class ConnectorMarketService implements IConnectorMarketService {
       // state depend on another remote categories/icons request.
       applyConnectorMarketSnapshot(this.dataStore, snapshot);
       this.reconcileUninstallNotificationStates(snapshot.operations);
+      this.requestAutomaticUpdates();
     }
   }
 

--- a/packages/connector/market/src/services/index.ts
+++ b/packages/connector/market/src/services/index.ts
@@ -8,6 +8,7 @@ export {
 } from "./openConnectorMarketDialog.ts";
 export {
   IConnectorMarketService,
+  type ConnectorInstallOutcome,
   type ConnectorMarketLoadState,
   type ConnectorMarketServiceDependencies,
   type ConnectorMarketStoreState

--- a/packages/connector/market/src/ui/dialogs/ConnectorMarketDialogs.tsx
+++ b/packages/connector/market/src/ui/dialogs/ConnectorMarketDialogs.tsx
@@ -158,7 +158,10 @@ export function ConnectorMarketDialogs() {
                 setShowSuccessToast(null);
                 void market
                   .install(dialog.connectorKey)
-                  .then(() => {
+                  .then((outcome) => {
+                    if (outcome !== "installed") {
+                      return;
+                    }
                     setShowSuccessToast("install");
                     uiState.closeDialog();
                   })

--- a/packages/connector/runtime/implementationhost/credential_authorization.go
+++ b/packages/connector/runtime/implementationhost/credential_authorization.go
@@ -345,7 +345,7 @@ func (host *Host) authorizationRoute(ctx context.Context, scope market.Operation
 	managed := connector.Release.Manifest.Implementation.ManagedStdio
 	if connector.Release.Manifest.Implementation.Kind != market.ImplementationKindManagedStdio ||
 		connector.Release.Manifest.AuthorizationKind == "none" || managed == nil || managed.CredentialBroker == nil ||
-		connector.Installation.State != market.InstallationStateInstalled {
+		!installationTargetsRelease(connector.Installation, connector.Release.ReleaseDigest) {
 		return nil, errors.New("managed connector authorization is unavailable")
 	}
 	connectionID := "default"
@@ -388,7 +388,7 @@ func (host *Host) buildAuthorizationRoute(ctx context.Context, connectionID stri
 	if err := market.ValidateRuntimeReleaseShape(connector.Release); err != nil {
 		return nil, err
 	}
-	if connector.Installation.InstalledReleaseDigest != connector.Release.ReleaseDigest {
+	if !installationTargetsRelease(connector.Installation, connector.Release.ReleaseDigest) {
 		return nil, errors.New("managed connector authorization release is not installed")
 	}
 	prepared, err := host.artifacts.ResolvePrepared(ctx, connector.Release)

--- a/packages/connector/runtime/implementationhost/credential_authorization_test.go
+++ b/packages/connector/runtime/implementationhost/credential_authorization_test.go
@@ -212,6 +212,62 @@ func TestManagedCredentialAuthorizationInspectReturnsFencedObservation(t *testin
 	}
 }
 
+func TestInstallationTargetsReleaseAcceptsOnlyActiveCurrentOrCandidate(t *testing.T) {
+	tests := []struct {
+		name          string
+		installation  market.Installation
+		releaseDigest string
+		want          bool
+	}{
+		{
+			name: "installed current release",
+			installation: market.Installation{
+				State: market.InstallationStateInstalled, InstalledReleaseDigest: "current",
+			},
+			releaseDigest: "current",
+			want:          true,
+		},
+		{
+			name: "installing candidate release",
+			installation: market.Installation{
+				State: market.InstallationStateInstalling, CandidateReleaseDigest: "candidate",
+			},
+			releaseDigest: "candidate",
+			want:          true,
+		},
+		{
+			name: "updating candidate release",
+			installation: market.Installation{
+				State: market.InstallationStateUpdating, InstalledReleaseDigest: "current", CandidateReleaseDigest: "candidate",
+			},
+			releaseDigest: "candidate",
+			want:          true,
+		},
+		{
+			name: "updating superseded current release",
+			installation: market.Installation{
+				State: market.InstallationStateUpdating, InstalledReleaseDigest: "current", CandidateReleaseDigest: "candidate",
+			},
+			releaseDigest: "current",
+		},
+		{
+			name: "failed candidate release",
+			installation: market.Installation{
+				State: market.InstallationStateFailed, CandidateReleaseDigest: "candidate",
+			},
+			releaseDigest: "candidate",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := installationTargetsRelease(test.installation, test.releaseDigest); got != test.want {
+				t.Fatalf("installationTargetsRelease() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
 func awaitAuthorizationObservations(t *testing.T, host *credentialAuthorizationHostStub, count int) []market.AuthorizationState {
 	t.Helper()
 	deadline := time.Now().Add(time.Second)

--- a/packages/connector/runtime/implementationhost/host.go
+++ b/packages/connector/runtime/implementationhost/host.go
@@ -222,13 +222,7 @@ func (host *Host) Reconcile(ctx context.Context, request ReconcileRequest) (mark
 		return market.RuntimeReceipt{}, err
 	}
 	key := connectorRouteKey(runtimeRequest.ConnectionID, runtimeRequest.Connector.Key)
-	installation := runtimeRequest.Connector.Installation
-	currentRelease := installation.State == market.InstallationStateInstalled &&
-		installation.InstalledReleaseDigest == runtimeRequest.Connector.Release.ReleaseDigest
-	candidateRelease := (installation.State == market.InstallationStateInstalling ||
-		installation.State == market.InstallationStateUpdating) &&
-		installation.CandidateReleaseDigest == runtimeRequest.Connector.Release.ReleaseDigest
-	if !currentRelease && !candidateRelease {
+	if !installationTargetsRelease(runtimeRequest.Connector.Installation, runtimeRequest.Connector.Release.ReleaseDigest) {
 		return market.RuntimeReceipt{}, errors.New("connector installed release is not active")
 	}
 	if err := host.validateAuthorization(runtimeRequest); err != nil {
@@ -306,6 +300,17 @@ func (host *Host) Reconcile(ctx context.Context, request ReconcileRequest) (mark
 	return market.RuntimeReceipt{OperationID: runtimeRequest.OperationID, ConnectionID: runtimeRequest.ConnectionID,
 		ConnectorKey: runtimeRequest.Connector.Key, ReleaseDigest: route.releaseDigest,
 		Generation: runtimeRequest.Generation, Readiness: cloneRuntimeReadiness(route.readiness), Summary: &summary}, nil
+}
+
+func installationTargetsRelease(installation market.Installation, releaseDigest string) bool {
+	switch installation.State {
+	case market.InstallationStateInstalled:
+		return installation.InstalledReleaseDigest == releaseDigest
+	case market.InstallationStateInstalling, market.InstallationStateUpdating:
+		return installation.CandidateReleaseDigest == releaseDigest
+	default:
+		return false
+	}
 }
 
 func (*Host) validateAuthorization(request market.RuntimeReconcileRequest) error {

--- a/packages/connector/store-sqlite/lifecycle.go
+++ b/packages/connector/store-sqlite/lifecycle.go
@@ -127,9 +127,10 @@ func backfillInstalledReleaseEvidence(ctx context.Context, tx *sql.Tx) error {
 		if digest == "" {
 			continue
 		}
-		var storedDigest string
-		err := tx.QueryRowContext(ctx, `SELECT release_digest FROM connector_market_installed_releases WHERE connector_key = ?`, connector.Key).Scan(&storedDigest)
-		if err == nil && storedDigest == digest {
+		var historicalDigest string
+		err := tx.QueryRowContext(ctx, `SELECT release_digest FROM connector_market_release_installations
+WHERE connector_key = ? AND release_digest = ?`, connector.Key, digest).Scan(&historicalDigest)
+		if err == nil {
 			continue
 		}
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
@@ -140,7 +141,12 @@ func backfillInstalledReleaseEvidence(ctx context.Context, tx *sql.Tx) error {
 			return err
 		}
 		if !found {
-			return fmt.Errorf("backfill installed connector release %q for %q: %w", digest, connector.Key, market.ErrNotFound)
+			// Older stores could promote a prepared candidate in the current-release
+			// index before runtime convergence completed. If that update then failed,
+			// the previous release metadata was no longer recoverable from SQLite.
+			// Keep the store available and let runtime recovery fail this connector
+			// closed until a subsequent install repairs its durable evidence.
+			continue
 		}
 		if err := saveInstalledReleaseOn(ctx, tx, release); err != nil {
 			return err
@@ -150,6 +156,19 @@ func backfillInstalledReleaseEvidence(ctx context.Context, tx *sql.Tx) error {
 }
 
 func legacyInstalledReleaseEvidence(ctx context.Context, tx *sql.Tx, connector market.Connector, digest string) (market.Release, bool, error) {
+	var currentPayload string
+	err := tx.QueryRowContext(ctx, `SELECT release_json FROM connector_market_installed_releases
+WHERE connector_key = ? AND release_digest = ?`, connector.Key, digest).Scan(&currentPayload)
+	if err == nil {
+		var release market.Release
+		if err := json.Unmarshal([]byte(currentPayload), &release); err != nil {
+			return market.Release{}, false, fmt.Errorf("decode current installed connector release: %w", err)
+		}
+		return release, true, nil
+	}
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return market.Release{}, false, err
+	}
 	if connector.Release.ReleaseDigest == digest {
 		return connector.Release, true, nil
 	}
@@ -185,7 +204,10 @@ func saveInstalledReleaseEvidenceOn(ctx context.Context, tx *sql.Tx, operation m
 		if operation.Target == nil || operation.Target.Release == nil || operation.Target.ReleaseDigest == "" {
 			return errors.New("prepared connector install is missing release evidence")
 		}
-		return saveInstalledReleaseOn(ctx, tx, *operation.Target.Release)
+		if operation.State == market.OperationStateCompleted {
+			return saveInstalledReleaseOn(ctx, tx, *operation.Target.Release)
+		}
+		return saveReleaseInstallationOn(ctx, tx, *operation.Target.Release)
 	case market.OperationKindUninstall:
 		if operation.State != market.OperationStateCompleted {
 			return nil
@@ -202,15 +224,10 @@ func saveInstalledReleaseEvidenceOn(ctx context.Context, tx *sql.Tx, operation m
 }
 
 func saveInstalledReleaseOn(ctx context.Context, tx *sql.Tx, release market.Release) error {
-	payload, err := json.Marshal(release)
-	if err != nil {
+	if err := saveReleaseInstallationOn(ctx, tx, release); err != nil {
 		return err
 	}
-	_, err = tx.ExecContext(ctx, `
-INSERT INTO connector_market_release_installations (connector_key, release_digest, release_json)
-VALUES (?, ?, ?)
-ON CONFLICT(connector_key, release_digest) DO UPDATE SET
-  release_json = excluded.release_json`, release.ConnectorKey, release.ReleaseDigest, string(payload))
+	payload, err := json.Marshal(release)
 	if err != nil {
 		return err
 	}
@@ -219,6 +236,19 @@ INSERT INTO connector_market_installed_releases (connector_key, release_digest, 
 VALUES (?, ?, ?)
 ON CONFLICT(connector_key) DO UPDATE SET
   release_digest = excluded.release_digest,
+  release_json = excluded.release_json`, release.ConnectorKey, release.ReleaseDigest, string(payload))
+	return err
+}
+
+func saveReleaseInstallationOn(ctx context.Context, tx *sql.Tx, release market.Release) error {
+	payload, err := json.Marshal(release)
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, `
+INSERT INTO connector_market_release_installations (connector_key, release_digest, release_json)
+VALUES (?, ?, ?)
+ON CONFLICT(connector_key, release_digest) DO UPDATE SET
   release_json = excluded.release_json`, release.ConnectorKey, release.ReleaseDigest, string(payload))
 	return err
 }

--- a/packages/connector/store-sqlite/lifecycle_test.go
+++ b/packages/connector/store-sqlite/lifecycle_test.go
@@ -421,12 +421,35 @@ func TestStoreRetainsCurrentAndPreparedCandidateReleaseEvidence(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+	var currentDigest string
+	if err := store.db.QueryRowContext(ctx, `SELECT release_digest FROM connector_market_installed_releases
+WHERE connector_key = ?`, connector.Key).Scan(&currentDigest); err != nil {
+		t.Fatal(err)
+	}
+	if currentDigest != current.ReleaseDigest {
+		t.Fatalf("current release pointer = %q, want %q", currentDigest, current.ReleaseDigest)
+	}
 
 	for name, expected := range map[string]market.Release{"current": current, "candidate": candidate} {
 		got, err := store.InstalledRelease(ctx, connector.Key, expected.ReleaseDigest)
 		if err != nil || got.ReleaseDigest != expected.ReleaseDigest || got.ManifestDigest != expected.ManifestDigest {
 			t.Fatalf("%s release = %#v, error = %v", name, got, err)
 		}
+	}
+
+	candidateOperation.State = market.OperationStateCompleted
+	candidateOperation.Stage = market.OperationStageCompleted
+	if err := store.Transaction(ctx, func(tx market.Transaction) error {
+		return tx.SaveOperation(candidateOperation)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRowContext(ctx, `SELECT release_digest FROM connector_market_installed_releases
+WHERE connector_key = ?`, connector.Key).Scan(&currentDigest); err != nil {
+		t.Fatal(err)
+	}
+	if currentDigest != candidate.ReleaseDigest {
+		t.Fatalf("promoted release pointer = %q, want %q", currentDigest, candidate.ReleaseDigest)
 	}
 }
 
@@ -439,6 +462,11 @@ func TestStoreMigrationBackfillsLifecycleTimestampAndInstalledReleaseEvidence(t 
 	}
 	for _, statement := range []string{
 		`CREATE TABLE connector_market_connectors (connector_key TEXT PRIMARY KEY, connector_json TEXT NOT NULL)`,
+		`CREATE TABLE connector_market_installed_releases (
+  connector_key TEXT PRIMARY KEY,
+  release_digest TEXT NOT NULL,
+  release_json TEXT NOT NULL
+)`,
 		`CREATE TABLE connector_market_operations (
   operation_id TEXT PRIMARY KEY,
   client_request_id TEXT NOT NULL UNIQUE,
@@ -489,6 +517,15 @@ func TestStoreMigrationBackfillsLifecycleTimestampAndInstalledReleaseEvidence(t 
 		connector.Key, string(connectorPayload)); err != nil {
 		t.Fatal(err)
 	}
+	installedReleasePayload, err := json.Marshal(installedRelease)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := legacy.ExecContext(ctx, `INSERT INTO connector_market_installed_releases
+(connector_key, release_digest, release_json) VALUES (?, ?, ?)`, connector.Key, installedRelease.ReleaseDigest,
+		string(installedReleasePayload)); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := legacy.ExecContext(ctx, `INSERT INTO connector_market_operations (
 operation_id, client_request_id, connector_key, kind, state, lease_owner, lease_token, lease_expires_at_unix_ms, operation_json
 ) VALUES (?, ?, ?, ?, ?, '', 0, NULL, ?)`, operation.OperationID, operation.ClientRequestID, operation.ConnectorKey,
@@ -514,6 +551,54 @@ operation_id, client_request_id, connector_key, kind, state, lease_owner, lease_
 	release, err := store.InstalledRelease(ctx, connector.Key, installedRelease.ReleaseDigest)
 	if err != nil || release.ReleaseDigest != installedRelease.ReleaseDigest {
 		t.Fatalf("migrated installed release = %#v, error = %v", release, err)
+	}
+	var historicalCount int
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM connector_market_release_installations
+WHERE connector_key = ? AND release_digest = ?`, connector.Key, installedRelease.ReleaseDigest).Scan(&historicalCount); err != nil {
+		t.Fatal(err)
+	}
+	if historicalCount != 1 {
+		t.Fatalf("migrated release installation evidence count = %d, want 1", historicalCount)
+	}
+}
+
+func TestStoreReopenToleratesMissingLegacyInstalledReleaseEvidence(t *testing.T) {
+	ctx := context.Background()
+	databasePath := filepath.Join(t.TempDir(), "tuttid.db")
+	store, err := Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	connector := testConnector()
+	installedRelease := connector.Release
+	connector.Installation = market.Installation{
+		State: market.InstallationStateInstalled, InstalledVersion: installedRelease.Version,
+		InstalledReleaseID: installedRelease.ReleaseID, InstalledReleaseDigest: installedRelease.ReleaseDigest,
+	}
+	connector.Release.Version = "2.0.0"
+	connector.Release.ReleaseID = connector.Key + "@2.0.0"
+	connector.Release.ReleaseDigest = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	connector.Release.ManifestDigest = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+	if err := store.Transaction(ctx, func(tx market.Transaction) error {
+		connector.Revision = tx.AdvanceRevision()
+		return tx.SaveConnector(connector)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := Open(ctx, databasePath)
+	if err != nil {
+		t.Fatalf("reopen with missing legacy evidence: %v", err)
+	}
+	defer reopened.Close()
+	if _, err := reopened.Connector(ctx, connector.Key); err != nil {
+		t.Fatalf("load connector after compatible reopen: %v", err)
+	}
+	if _, err := reopened.InstalledRelease(ctx, connector.Key, installedRelease.ReleaseDigest); !errors.Is(err, market.ErrNotFound) {
+		t.Fatalf("missing release evidence error = %v, want not found", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- require an authenticated Tutti account before user-initiated Connector installation, opening the existing login flow when signed out
- automatically update compatible installed Connectors when the catalog publishes a new release digest
- allow verified install/update candidates through managed authorization inspection before promotion
- preserve current-release evidence until runtime convergence completes and fail closed per Connector when repairing legacy evidence gaps

## Verification

- pnpm check:changed -- --push-ready (22 lanes passed)
- Connector host, runtime, SQLite store, and daemon Go module tests passed
- live Tutti verification: Lark CLI automatically converged from Connector 0.8.2 failure state to installed Connector 0.8.3 with connected authorization