### PR TITLE
fix(connector-market): isolate operations and harden MCP protocol

### DIFF
--- a/docs/architecture/connector-market.md
+++ b/docs/architecture/connector-market.md
@@ -305,6 +305,16 @@ which stage to resume. Install and uninstall return verifiable results to the
 application; artifact helpers do not write the business repository or publish
 events directly.
 
+Every operation row also stores canonical `owner_account_id` and visibility.
+User commands are `account` visible and public reads always use
+`GetOperationForScope`; an ownership mismatch is indistinguishable from a
+missing row. Runtime reconcile and operations whose legacy owner cannot be
+proven are `system_private`: workers may still recover them, but snapshots and
+operation endpoints never publish them. Legacy rows derive ownership from
+`operation_json.scope.accountId`. The idempotency key is
+`(owner_account_id, client_request_id)`, while the active physical lifecycle
+constraint remains device-global per Connector.
+
 `accepted` and `running` rows have no age-based expiry. The SQLite repository
 protects them with one-active-operation constraints plus renewable,
 token-fenced leases, and daemon startup reschedules every recoverable row. The
@@ -431,6 +441,13 @@ Account authorization overlays are read in the same SQLite Snapshot as market
 state. A public projection change atomically advances the Connector revision and
 appends its invalidation event; account state can no longer change invisibly
 between market Snapshot reads.
+
+Operation-bearing events carry an internal account audience and are delivered
+only while that owner is the host's active account. Every state change also
+produces a machine-level Connector invalidation without an operation id, so a
+different account still observes device installation truth without learning
+another account's command identity. Legacy or private events are fail-closed by
+stripping operation and owner identifiers before publication.
 
 Concurrent catalog requests use a process-local monotonically increasing fetch
 fence: an older page or refresh response that returns after a newer response is

--- a/packages/connector/host/application.go
+++ b/packages/connector/host/application.go
@@ -109,17 +109,17 @@ func NewApplication(config ApplicationConfig) (*Application, error) {
 
 func (application *Application) Snapshot(ctx context.Context) (Snapshot, error) {
 	snapshot, err := application.config.Repository.Snapshot(ctx)
-	return publicSnapshot(snapshot), err
+	return publicSnapshot(snapshot, OperationScope{}), err
 }
 
 func (application *Application) SnapshotForScope(ctx context.Context, scope OperationScope) (Snapshot, error) {
 	if repository, ok := application.config.Repository.(ScopedSnapshotReader); ok {
 		snapshot, err := repository.SnapshotForScope(ctx, scope)
-		return publicSnapshot(snapshot), err
+		return publicSnapshot(snapshot, scope), err
 	}
-	snapshot, err := application.Snapshot(ctx)
+	snapshot, err := application.config.Repository.Snapshot(ctx)
 	if err != nil || strings.TrimSpace(scope.AccountID) == "" || application.config.AuthorizationProjections == nil {
-		return snapshot, err
+		return publicSnapshot(snapshot, scope), err
 	}
 	for index := range snapshot.Connectors {
 		projection, projectionErr := application.config.AuthorizationProjections.AuthorizationProjection(
@@ -135,13 +135,13 @@ func (application *Application) SnapshotForScope(ctx context.Context, scope Oper
 			State: projection.State, FailureCode: projection.FailureCode,
 		}
 	}
-	return snapshot, nil
+	return publicSnapshot(snapshot, scope), nil
 }
 
-func publicSnapshot(snapshot Snapshot) Snapshot {
+func publicSnapshot(snapshot Snapshot, scope OperationScope) Snapshot {
 	operations := snapshot.Operations[:0]
 	for _, operation := range snapshot.Operations {
-		if operation.Kind != OperationKindReconcileRuntime {
+		if OperationVisibleToScope(operation, scope) {
 			operations = append(operations, operation)
 		}
 	}
@@ -305,6 +305,24 @@ func (application *Application) GetOperation(ctx context.Context, operationID st
 		return Operation{}, err
 	}
 	if operation.Kind == OperationKindReconcileRuntime {
+		return Operation{}, ErrNotFound
+	}
+	return operation, nil
+}
+
+func (application *Application) GetOperationForScope(
+	ctx context.Context,
+	scope OperationScope,
+	operationID string,
+) (Operation, error) {
+	if strings.TrimSpace(operationID) == "" {
+		return Operation{}, invalidRequest("operationID is required")
+	}
+	operation, err := application.config.Repository.OperationForScope(ctx, scope, operationID)
+	if err != nil {
+		return Operation{}, err
+	}
+	if !OperationVisibleToScope(operation, scope) {
 		return Operation{}, ErrNotFound
 	}
 	return operation, nil
@@ -994,7 +1012,7 @@ func (application *Application) acceptConnectorOperation(
 	}
 	var result MutationResult
 	err := application.config.Repository.Transaction(ctx, func(tx Transaction) error {
-		existing, err := tx.OperationByClientRequestID(mutation.ClientRequestID)
+		existing, err := tx.OperationByClientRequestID(mutation.AccountID, mutation.ClientRequestID)
 		if err != nil {
 			return err
 		}
@@ -1042,6 +1060,8 @@ func (application *Application) acceptConnectorOperation(
 		operation := Operation{
 			OperationID:     operationID,
 			ClientRequestID: mutation.ClientRequestID,
+			OwnerAccountID:  strings.TrimSpace(mutation.AccountID),
+			Visibility:      OperationVisibilityAccount,
 			ConnectorKey:    mutation.ConnectorKey,
 			Kind:            kind,
 			Scope:           OperationScope{AccountID: strings.TrimSpace(mutation.AccountID)},
@@ -1095,7 +1115,7 @@ func (application *Application) isIdempotentConnectorOperation(
 ) (bool, error) {
 	var replay bool
 	err := application.config.Repository.Transaction(ctx, func(tx Transaction) error {
-		existing, err := tx.OperationByClientRequestID(mutation.ClientRequestID)
+		existing, err := tx.OperationByClientRequestID(mutation.AccountID, mutation.ClientRequestID)
 		if err != nil {
 			return err
 		}
@@ -1122,12 +1142,13 @@ func (application *Application) acceptOperation(
 	}
 	var result MutationResult
 	err := application.config.Repository.Transaction(ctx, func(tx Transaction) error {
-		existing, err := tx.OperationByClientRequestID(mutation.ClientRequestID)
+		ownerAccountID := strings.TrimSpace(mutation.Scope.AccountID)
+		existing, err := tx.OperationByClientRequestID(ownerAccountID, mutation.ClientRequestID)
 		if err != nil {
 			return err
 		}
 		if existing != nil {
-			if err := verifyIdempotentOperation(*existing, kind, connectorKey, ""); err != nil {
+			if err := verifyIdempotentOperation(*existing, kind, connectorKey, ownerAccountID); err != nil {
 				return err
 			}
 			result = MutationResult{Operation: *existing, Revision: tx.Revision()}
@@ -1148,8 +1169,11 @@ func (application *Application) acceptOperation(
 		operation := Operation{
 			OperationID:     operationID,
 			ClientRequestID: mutation.ClientRequestID,
+			OwnerAccountID:  ownerAccountID,
+			Visibility:      OperationVisibilityAccount,
 			ConnectorKey:    connectorKey,
 			Kind:            kind,
+			Scope:           OperationScope{AccountID: ownerAccountID},
 			State:           OperationStateAccepted,
 			Stage:           OperationStageAccepted,
 			CreatedAt:       now,

--- a/packages/connector/host/application_test.go
+++ b/packages/connector/host/application_test.go
@@ -1036,6 +1036,79 @@ func TestApplicationManagedAuthorizationStartRepairsMissingAccountProjection(t *
 	}
 }
 
+func TestApplicationScopesPublicOperationReadsToOwnerAccount(t *testing.T) {
+	repository := newMemoryRepository()
+	now := time.Unix(1, 0).UTC()
+	repository.operations["operation-a"] = Operation{
+		OperationID: "operation-a", ClientRequestID: "request-a", ConnectorKey: "github",
+		Kind: OperationKindInstall, Scope: OperationScope{AccountID: "account-a"},
+		State: OperationStateFailed, CreatedAt: now, UpdatedAt: now,
+	}
+	repository.operations["operation-private"] = Operation{
+		OperationID: "operation-private", ClientRequestID: "request-private", ConnectorKey: "github",
+		Kind: OperationKindReconcileRuntime, Scope: OperationScope{AccountID: "account-a"},
+		State: OperationStateFailed, CreatedAt: now, UpdatedAt: now,
+	}
+	application := newTestApplication(t, repository, &memoryScheduler{}, &memoryInstallRuntime{}, CatalogSnapshot{})
+
+	operation, err := application.GetOperationForScope(context.Background(), OperationScope{AccountID: "account-a"}, "operation-a")
+	if err != nil || operation.OperationID != "operation-a" {
+		t.Fatalf("owner operation = %#v, error = %v", operation, err)
+	}
+	for _, test := range []struct {
+		name, accountID, operationID string
+	}{
+		{name: "different account", accountID: "account-b", operationID: "operation-a"},
+		{name: "private operation", accountID: "account-a", operationID: "operation-private"},
+		{name: "missing account", operationID: "operation-a"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := application.GetOperationForScope(context.Background(), OperationScope{AccountID: test.accountID}, test.operationID)
+			if !errors.Is(err, ErrNotFound) {
+				t.Fatalf("GetOperationForScope error = %v, want ErrNotFound", err)
+			}
+		})
+	}
+}
+
+func TestApplicationScopesIdempotencyByAccountButKeepsConnectorLifecycleGlobal(t *testing.T) {
+	connector := testConnector("github")
+	repository := newMemoryRepository(connector)
+	application := newTestApplication(t, repository, &memoryScheduler{}, &memoryInstallRuntime{}, CatalogSnapshot{})
+
+	first, err := application.Install(context.Background(), ConnectorMutation{
+		Mutation: Mutation{ClientRequestID: "shared-request"}, ConnectorKey: connector.Key, AccountID: "account-a",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = application.Install(context.Background(), ConnectorMutation{
+		Mutation:     Mutation{ClientRequestID: "different-request", ExpectedRevision: repository.revision},
+		ConnectorKey: connector.Key, AccountID: "account-b",
+	})
+	var domainError *DomainError
+	if !errors.As(err, &domainError) || domainError.Code != ErrorCodeOperationInProgress {
+		t.Fatalf("cross-account active operation error = %v", err)
+	}
+
+	finished := repository.operations[first.Operation.OperationID]
+	finished.State = OperationStateFailed
+	repository.operations[finished.OperationID] = finished
+	connector = repository.connectors[connector.Key]
+	connector.Installation = Installation{State: InstallationStateNotInstalled}
+	repository.connectors[connector.Key] = connector
+	second, err := application.Install(context.Background(), ConnectorMutation{
+		Mutation:     Mutation{ClientRequestID: "shared-request", ExpectedRevision: repository.revision},
+		ConnectorKey: connector.Key, AccountID: "account-b",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Operation.OperationID == first.Operation.OperationID || second.Operation.OwnerAccountID != "account-b" {
+		t.Fatalf("cross-account request reuse joined wrong operation: first=%#v second=%#v", first.Operation, second.Operation)
+	}
+}
+
 func TestApplicationManagedAuthorizationStartCanChallengeAnotherAccount(t *testing.T) {
 	connector := testManagedAuthorizedConnector("lark-cli")
 	connector.Authorization = Authorization{State: AuthorizationStateConnected}
@@ -2453,6 +2526,18 @@ func (repository *memoryRepository) Operation(_ context.Context, operationID str
 	return operation, nil
 }
 
+func (repository *memoryRepository) OperationForScope(
+	_ context.Context,
+	scope OperationScope,
+	operationID string,
+) (Operation, error) {
+	operation, ok := repository.operations[operationID]
+	if !ok || !OperationVisibleToScope(operation, scope) {
+		return Operation{}, ErrNotFound
+	}
+	return operation, nil
+}
+
 func (repository *memoryRepository) ClaimOperation(
 	_ context.Context,
 	operationID string,
@@ -2770,9 +2855,10 @@ func (transaction *memoryTransaction) Operation(operationID string) (Operation, 
 	return operation, nil
 }
 
-func (transaction *memoryTransaction) OperationByClientRequestID(clientRequestID string) (*Operation, error) {
+func (transaction *memoryTransaction) OperationByClientRequestID(ownerAccountID, clientRequestID string) (*Operation, error) {
 	for _, operation := range transaction.operations {
-		if operation.ClientRequestID == clientRequestID {
+		operation = NormalizeOperationOwnership(operation)
+		if operation.OwnerAccountID == ownerAccountID && operation.ClientRequestID == clientRequestID {
 			copy := operation
 			return &copy, nil
 		}
@@ -2812,6 +2898,7 @@ func (transaction *memoryTransaction) DeleteConnector(connectorKey string) error
 }
 
 func (transaction *memoryTransaction) SaveOperation(operation Operation) error {
+	operation = NormalizeOperationOwnership(operation)
 	transaction.operations[operation.OperationID] = operation
 	return nil
 }

--- a/packages/connector/host/operation_visibility.go
+++ b/packages/connector/host/operation_visibility.go
@@ -1,0 +1,41 @@
+package host
+
+import "strings"
+
+// NormalizeOperationOwnership upgrades legacy operation payloads into the
+// canonical ownership model. Operations without a provable owner remain
+// recoverable internally but are never public.
+func NormalizeOperationOwnership(operation Operation) Operation {
+	operation.Scope.AccountID = strings.TrimSpace(operation.Scope.AccountID)
+	operation.OwnerAccountID = strings.TrimSpace(operation.OwnerAccountID)
+	if operation.OwnerAccountID == "" {
+		operation.OwnerAccountID = operation.Scope.AccountID
+	}
+	if operation.Scope.AccountID == "" && operation.OwnerAccountID != "" {
+		operation.Scope.AccountID = operation.OwnerAccountID
+	}
+
+	switch {
+	case operation.Kind == OperationKindReconcileRuntime:
+		operation.Visibility = OperationVisibilitySystemPrivate
+	case operation.Visibility == OperationVisibilityAccount && operation.OwnerAccountID != "":
+		// Preserve an explicit public account operation.
+	case operation.Visibility == OperationVisibilitySystemPrivate:
+		// Preserve an explicit private operation.
+	case operation.OwnerAccountID != "":
+		operation.Visibility = OperationVisibilityAccount
+	default:
+		operation.Visibility = OperationVisibilitySystemPrivate
+	}
+	return operation
+}
+
+// OperationVisibleToScope is the single public projection rule for durable
+// operations. Callers receive not-found rather than an ownership oracle.
+func OperationVisibleToScope(operation Operation, scope OperationScope) bool {
+	operation = NormalizeOperationOwnership(operation)
+	accountID := strings.TrimSpace(scope.AccountID)
+	return accountID != "" &&
+		operation.Visibility == OperationVisibilityAccount &&
+		operation.OwnerAccountID == accountID
+}

--- a/packages/connector/host/ports.go
+++ b/packages/connector/host/ports.go
@@ -70,6 +70,7 @@ type Repository interface {
 	Snapshot(ctx context.Context) (Snapshot, error)
 	Connector(ctx context.Context, connectorKey string) (Connector, error)
 	Operation(ctx context.Context, operationID string) (Operation, error)
+	OperationForScope(ctx context.Context, scope OperationScope, operationID string) (Operation, error)
 	// UnresolvedAuthorizationSessionOperations exposes private durable receipts
 	// only for the explicitly active account. Snapshot remains safe for public
 	// presentation and must not contain Operation.Execution.
@@ -96,7 +97,7 @@ type Transaction interface {
 	Connectors() ([]Connector, error)
 	Connector(connectorKey string) (Connector, error)
 	Operation(operationID string) (Operation, error)
-	OperationByClientRequestID(clientRequestID string) (*Operation, error)
+	OperationByClientRequestID(ownerAccountID, clientRequestID string) (*Operation, error)
 	ActiveOperation(connectorKey string) (*Operation, error)
 	SaveCatalogRevision(sourceRevision string) error
 	SetCatalogState(state CatalogState) error
@@ -400,10 +401,12 @@ type OperationScheduler interface {
 }
 
 type ChangedEvent struct {
-	ConnectorKey string `json:"connectorKey,omitempty"`
-	OperationID  string `json:"operationId,omitempty"`
-	Revision     uint64 `json:"revision"`
-	Cursor       int64  `json:"cursor,omitempty"`
+	ConnectorKey   string              `json:"connectorKey,omitempty"`
+	OperationID    string              `json:"operationId,omitempty"`
+	OwnerAccountID string              `json:"ownerAccountId,omitempty"`
+	Visibility     OperationVisibility `json:"visibility,omitempty"`
+	Revision       uint64              `json:"revision"`
+	Cursor         int64               `json:"cursor,omitempty"`
 }
 
 type ChangedEventRecord struct {

--- a/packages/connector/host/service.go
+++ b/packages/connector/host/service.go
@@ -12,6 +12,10 @@ type ScopedSnapshotReader interface {
 	SnapshotForScope(ctx context.Context, scope OperationScope) (Snapshot, error)
 }
 
+type ScopedOperationReader interface {
+	GetOperationForScope(ctx context.Context, scope OperationScope, operationID string) (Operation, error)
+}
+
 // Service is the host-neutral connector-market application boundary. Host
 // daemons provide ports for persistence, artifacts, authorization, scheduling,
 // and events; transports adapt their generated OpenAPI DTOs to this interface.
@@ -20,7 +24,7 @@ type Service interface {
 	ListCatalogCategories(ctx context.Context) ([]CatalogCategory, error)
 	ListCatalogPage(ctx context.Context, query CatalogPageQuery) (CatalogPage, error)
 	GetConnector(ctx context.Context, connectorKey string) (Connector, error)
-	GetOperation(ctx context.Context, operationID string) (Operation, error)
+	GetOperationForScope(ctx context.Context, scope OperationScope, operationID string) (Operation, error)
 	RefreshCatalog(ctx context.Context, mutation Mutation) (MutationResult, error)
 	Install(ctx context.Context, mutation ConnectorMutation) (MutationResult, error)
 	Uninstall(ctx context.Context, mutation ConnectorMutation) (MutationResult, error)

--- a/packages/connector/host/types.go
+++ b/packages/connector/host/types.go
@@ -276,23 +276,25 @@ type Connector struct {
 }
 
 type Operation struct {
-	OperationID     string             `json:"operationId"`
-	ClientRequestID string             `json:"clientRequestId"`
-	ConnectorKey    string             `json:"connectorKey,omitempty"`
-	Kind            OperationKind      `json:"kind"`
-	Scope           OperationScope     `json:"scope,omitempty"`
-	State           OperationState     `json:"state"`
-	Stage           OperationStage     `json:"stage,omitempty"`
-	Target          *OperationTarget   `json:"target,omitempty"`
-	HostGeneration  HostGeneration     `json:"hostGeneration,omitempty"`
-	Execution       OperationExecution `json:"execution,omitempty"`
-	Attempt         uint32             `json:"attempt"`
-	LeaseOwner      string             `json:"leaseOwner,omitempty"`
-	LeaseToken      uint64             `json:"leaseToken,omitempty"`
-	LeaseExpiresAt  *time.Time         `json:"leaseExpiresAt,omitempty"`
-	FailureCode     string             `json:"failureCode,omitempty"`
-	CreatedAt       time.Time          `json:"createdAt"`
-	UpdatedAt       time.Time          `json:"updatedAt"`
+	OperationID     string              `json:"operationId"`
+	ClientRequestID string              `json:"clientRequestId"`
+	OwnerAccountID  string              `json:"ownerAccountId,omitempty"`
+	Visibility      OperationVisibility `json:"visibility"`
+	ConnectorKey    string              `json:"connectorKey,omitempty"`
+	Kind            OperationKind       `json:"kind"`
+	Scope           OperationScope      `json:"scope,omitempty"`
+	State           OperationState      `json:"state"`
+	Stage           OperationStage      `json:"stage,omitempty"`
+	Target          *OperationTarget    `json:"target,omitempty"`
+	HostGeneration  HostGeneration      `json:"hostGeneration,omitempty"`
+	Execution       OperationExecution  `json:"execution,omitempty"`
+	Attempt         uint32              `json:"attempt"`
+	LeaseOwner      string              `json:"leaseOwner,omitempty"`
+	LeaseToken      uint64              `json:"leaseToken,omitempty"`
+	LeaseExpiresAt  *time.Time          `json:"leaseExpiresAt,omitempty"`
+	FailureCode     string              `json:"failureCode,omitempty"`
+	CreatedAt       time.Time           `json:"createdAt"`
+	UpdatedAt       time.Time           `json:"updatedAt"`
 }
 
 // OperationScope freezes the external authority under which a durable
@@ -302,6 +304,13 @@ type Operation struct {
 type OperationScope struct {
 	AccountID string `json:"accountId,omitempty"`
 }
+
+type OperationVisibility string
+
+const (
+	OperationVisibilityAccount       OperationVisibility = "account"
+	OperationVisibilitySystemPrivate OperationVisibility = "system_private"
+)
 
 // OperationTarget freezes the exact release identity at command acceptance so
 // a concurrent catalog refresh cannot change what an operation installs.
@@ -574,8 +583,9 @@ type Snapshot struct {
 }
 
 type Mutation struct {
-	ClientRequestID  string `json:"clientRequestId"`
-	ExpectedRevision uint64 `json:"expectedRevision"`
+	ClientRequestID  string         `json:"clientRequestId"`
+	ExpectedRevision uint64         `json:"expectedRevision"`
+	Scope            OperationScope `json:"scope,omitempty"`
 }
 
 type ConnectorMutation struct {

--- a/packages/connector/runtime/implementationhost/mcp_routes.go
+++ b/packages/connector/runtime/implementationhost/mcp_routes.go
@@ -126,7 +126,8 @@ func listMCPToolsWithProtocol(ctx context.Context, client mcpCaller, requireComp
 			Tools      []mcpTool `json:"tools"`
 			NextCursor *string   `json:"nextCursor"`
 		}
-		if err := json.Unmarshal(raw, &listing); err != nil || (requireComplete && listing.ResultType != "complete") {
+		if err := json.Unmarshal(raw, &listing); err != nil ||
+			(requireComplete && listing.ResultType != "" && listing.ResultType != "complete") {
 			return nil, errors.New("connector MCP tools/list response is invalid")
 		}
 		result = append(result, listing.Tools...)

--- a/packages/connector/runtime/implementationhost/mcp_routes_test.go
+++ b/packages/connector/runtime/implementationhost/mcp_routes_test.go
@@ -1,0 +1,36 @@
+package implementationhost
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+type fixedMCPCaller struct {
+	result json.RawMessage
+}
+
+func (caller fixedMCPCaller) Call(context.Context, string, any) (json.RawMessage, error) {
+	return caller.result, nil
+}
+
+func TestListModernMCPToolsAcceptsStandardResponseWithoutResultTypeExtension(t *testing.T) {
+	tools, err := listModernMCPTools(context.Background(), fixedMCPCaller{result: json.RawMessage(
+		`{"tools":[{"name":"search","description":"Search","inputSchema":{"type":"object"}}]}`,
+	)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 1 || tools[0].Name != "search" {
+		t.Fatalf("tools = %#v", tools)
+	}
+}
+
+func TestListModernMCPToolsRejectsExplicitIncompleteResponse(t *testing.T) {
+	_, err := listModernMCPTools(context.Background(), fixedMCPCaller{result: json.RawMessage(
+		`{"resultType":"partial","tools":[{"name":"search","inputSchema":{"type":"object"}}]}`,
+	)})
+	if err == nil {
+		t.Fatal("explicit incomplete tools/list response was accepted")
+	}
+}

--- a/packages/connector/runtime/mcp/modern_streamable_http_client.go
+++ b/packages/connector/runtime/mcp/modern_streamable_http_client.go
@@ -66,11 +66,14 @@ type modernToolHeader struct {
 type ModernHTTPError struct {
 	StatusCode int
 	Body       []byte
+	Cause      error
 }
 
 func (err *ModernHTTPError) Error() string {
 	return fmt.Sprintf("MCP Streamable HTTP request failed: status %d", err.StatusCode)
 }
+
+func (err *ModernHTTPError) Unwrap() error { return err.Cause }
 
 func NewModernStreamableHTTPClient(config ModernStreamableHTTPClientConfig) (*ModernStreamableHTTPClient, error) {
 	endpoint, err := url.Parse(strings.TrimSpace(config.Endpoint))
@@ -240,20 +243,42 @@ func (client *ModernStreamableHTTPClient) Call(ctx context.Context, method strin
 		return nil, fmt.Errorf("modern MCP Streamable HTTP redirect is forbidden: status %d", response.StatusCode)
 	}
 	contentType, _, _ := mime.ParseMediaType(response.Header.Get("Content-Type"))
-	message, raw, err := readModernResponse(response.Body, contentType, id, client.maxResponse)
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		raw, readErr := readModernRawResponse(response.Body, client.maxResponse)
+		httpErr := &ModernHTTPError{StatusCode: response.StatusCode, Body: raw, Cause: readErr}
+		if readErr == nil && (contentType == "application/json" || contentType == "" || contentType == "text/event-stream") {
+			message, _, decodeErr := readModernResponse(bytes.NewReader(raw), contentType, id, int64(len(raw)))
+			switch {
+			case decodeErr != nil:
+				httpErr.Cause = decodeErr
+			case message != nil && message.Error != nil:
+				httpErr.Cause = message.Error
+			}
+		}
+		return nil, httpErr
+	}
+	message, _, err := readModernResponse(response.Body, contentType, id, client.maxResponse)
 	if err != nil {
 		return nil, err
 	}
 	if message != nil && message.Error != nil {
 		return nil, message.Error
 	}
-	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		return nil, &ModernHTTPError{StatusCode: response.StatusCode, Body: raw}
-	}
 	if message == nil {
 		return nil, errors.New("modern MCP Streamable HTTP response did not contain the matching request id")
 	}
 	return message.Result, nil
+}
+
+func readModernRawResponse(body io.Reader, limit int64) ([]byte, error) {
+	raw, err := io.ReadAll(io.LimitReader(body, limit+1))
+	if err != nil {
+		return raw, err
+	}
+	if int64(len(raw)) > limit {
+		return raw[:limit], fmt.Errorf("modern MCP Streamable HTTP response exceeds limit %d", limit)
+	}
+	return raw, nil
 }
 
 func (client *ModernStreamableHTTPClient) Close(context.Context) error {

--- a/packages/connector/runtime/mcp/modern_streamable_http_client_test.go
+++ b/packages/connector/runtime/mcp/modern_streamable_http_client_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -95,8 +96,26 @@ func TestModernStreamableHTTPClientPreservesJSONRPCErrorOnHTTPFailure(t *testing
 	defer server.Close()
 	client := newModernTestClient(t, server, "1.0.0")
 	_, err := client.Call(context.Background(), "tools/list", map[string]any{})
-	rpcErr, ok := err.(*RPCError)
-	if !ok || rpcErr.Code != -33001 {
+	var httpErr *ModernHTTPError
+	var rpcErr *RPCError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusPreconditionRequired ||
+		!errors.As(err, &rpcErr) || rpcErr.Code != -33001 {
+		t.Fatalf("error = %#v", err)
+	}
+}
+
+func TestModernStreamableHTTPClientPreservesHTTPFailureBeforeContentTypeValidation(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		response.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		response.WriteHeader(http.StatusConflict)
+		_, _ = io.WriteString(response, "Connector is not installed for this release\n")
+	}))
+	defer server.Close()
+	client := newModernTestClient(t, server, "1.0.0")
+	_, err := client.Call(context.Background(), "tools/list", map[string]any{})
+	var httpErr *ModernHTTPError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusConflict ||
+		string(httpErr.Body) != "Connector is not installed for this release\n" {
 		t.Fatalf("error = %#v", err)
 	}
 }

--- a/packages/connector/store-sqlite/lifecycle_test.go
+++ b/packages/connector/store-sqlite/lifecycle_test.go
@@ -247,7 +247,7 @@ func TestStoreCleanupPreservesRecoverableWorkAcrossReopen(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(pending) != 1 || pending[0].Event.OperationID != operation.OperationID {
+	if len(pending) != 1 || pending[0].Event.OperationID != "" || pending[0].Event.ConnectorKey != operation.ConnectorKey {
 		t.Fatalf("pending events = %#v", pending)
 	}
 }

--- a/packages/connector/store-sqlite/operation_ownership.go
+++ b/packages/connector/store-sqlite/operation_ownership.go
@@ -1,0 +1,151 @@
+package storesqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	market "github.com/tutti-os/tutti/packages/connector/host"
+)
+
+func (store *Store) OperationForScope(
+	ctx context.Context,
+	scope market.OperationScope,
+	operationID string,
+) (market.Operation, error) {
+	var payload string
+	if err := store.db.QueryRowContext(ctx, `
+SELECT operation_json FROM connector_market_operations
+WHERE operation_id = ? AND owner_account_id = ? AND visibility = ?`,
+		strings.TrimSpace(operationID), strings.TrimSpace(scope.AccountID), market.OperationVisibilityAccount,
+	).Scan(&payload); err != nil {
+		return market.Operation{}, mapNotFound(err)
+	}
+	operation, err := decodeOperation(payload)
+	if err != nil {
+		return market.Operation{}, err
+	}
+	return publicOperation(operation), nil
+}
+
+func (store *Store) migrateOperationOwnership(ctx context.Context) error {
+	columns, err := store.operationColumns(ctx)
+	if err != nil {
+		return err
+	}
+	if !columns["owner_account_id"] || !columns["visibility"] {
+		if err := store.rebuildOperationsWithOwnership(ctx); err != nil {
+			return err
+		}
+	}
+	for _, statement := range []string{
+		`CREATE UNIQUE INDEX IF NOT EXISTS connector_market_operation_owner_request
+ON connector_market_operations(owner_account_id, client_request_id)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS connector_market_one_active_operation
+ON connector_market_operations(connector_key)
+WHERE state IN ('accepted', 'running')`,
+		`CREATE INDEX IF NOT EXISTS connector_market_operations_terminal_cleanup
+ON connector_market_operations(updated_at_unix_ms, operation_id)
+WHERE state IN ('completed', 'failed')`,
+	} {
+		if _, err := store.db.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf("migrate connector market operation ownership index: %w", err)
+		}
+	}
+	return nil
+}
+
+func (store *Store) operationColumns(ctx context.Context) (map[string]bool, error) {
+	rows, err := store.db.QueryContext(ctx, `PRAGMA table_info(connector_market_operations)`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	columns := make(map[string]bool)
+	for rows.Next() {
+		var cid, notNull, primaryKey int
+		var name, columnType string
+		var defaultValue sql.NullString
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+			return nil, err
+		}
+		columns[strings.ToLower(name)] = true
+	}
+	return columns, rows.Err()
+}
+
+func (store *Store) rebuildOperationsWithOwnership(ctx context.Context) error {
+	tx, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	rows, err := tx.QueryContext(ctx, `SELECT operation_json FROM connector_market_operations ORDER BY operation_id`)
+	if err != nil {
+		return err
+	}
+	var operations []market.Operation
+	for rows.Next() {
+		var payload string
+		if err := rows.Scan(&payload); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		operation, err := decodeOperation(payload)
+		if err != nil {
+			_ = rows.Close()
+			return err
+		}
+		operations = append(operations, market.NormalizeOperationOwnership(operation))
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `CREATE TABLE connector_market_operations_ownership_v2 (
+  operation_id TEXT PRIMARY KEY,
+  client_request_id TEXT NOT NULL,
+  owner_account_id TEXT NOT NULL,
+  visibility TEXT NOT NULL CHECK (visibility IN ('account', 'system_private')),
+  connector_key TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  state TEXT NOT NULL,
+  lease_owner TEXT NOT NULL,
+  lease_token INTEGER NOT NULL DEFAULT 0,
+  lease_expires_at_unix_ms INTEGER,
+  updated_at_unix_ms INTEGER NOT NULL DEFAULT 0,
+  operation_json TEXT NOT NULL
+)`); err != nil {
+		return fmt.Errorf("create connector market operation ownership table: %w", err)
+	}
+	for _, operation := range operations {
+		payload, err := json.Marshal(operation)
+		if err != nil {
+			return err
+		}
+		var leaseExpiresAt any
+		if operation.LeaseExpiresAt != nil {
+			leaseExpiresAt = operation.LeaseExpiresAt.UTC().UnixMilli()
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO connector_market_operations_ownership_v2 (
+  operation_id, client_request_id, owner_account_id, visibility, connector_key, kind, state,
+  lease_owner, lease_token, lease_expires_at_unix_ms, updated_at_unix_ms, operation_json
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			operation.OperationID, operation.ClientRequestID, operation.OwnerAccountID, operation.Visibility,
+			operation.ConnectorKey, operation.Kind, operation.State, operation.LeaseOwner, operation.LeaseToken,
+			leaseExpiresAt, operation.UpdatedAt.UTC().UnixMilli(), string(payload)); err != nil {
+			return fmt.Errorf("backfill connector market operation ownership: %w", err)
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `DROP TABLE connector_market_operations`); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `ALTER TABLE connector_market_operations_ownership_v2 RENAME TO connector_market_operations`); err != nil {
+		return err
+	}
+	return tx.Commit()
+}

--- a/packages/connector/store-sqlite/store.go
+++ b/packages/connector/store-sqlite/store.go
@@ -112,7 +112,9 @@ VALUES (1, 0, 'stale', '') ON CONFLICT(id) DO NOTHING`,
 )`,
 		`CREATE TABLE IF NOT EXISTS connector_market_operations (
   operation_id TEXT PRIMARY KEY,
-  client_request_id TEXT NOT NULL UNIQUE,
+  client_request_id TEXT NOT NULL,
+  owner_account_id TEXT NOT NULL,
+  visibility TEXT NOT NULL CHECK (visibility IN ('account', 'system_private')),
   connector_key TEXT NOT NULL,
   kind TEXT NOT NULL,
   state TEXT NOT NULL,
@@ -144,6 +146,9 @@ ON connector_market_outbox(published_at_unix_ms, sequence)`,
 		return fmt.Errorf("migrate connector market operation lease token: %w", err)
 	}
 	if err := store.migrateLifecycle(ctx); err != nil {
+		return err
+	}
+	if err := store.migrateOperationOwnership(ctx); err != nil {
 		return err
 	}
 	return store.migrateRuntimeConvergence(ctx)
@@ -183,7 +188,7 @@ FROM connector_market_metadata WHERE id = ?`, metadataID).
 			return market.Snapshot{}, err
 		}
 	}
-	operations, err := listOperationsOn(ctx, tx)
+	operations, err := listOperationsOn(ctx, tx, accountID)
 	if err != nil {
 		return market.Snapshot{}, err
 	}
@@ -566,10 +571,12 @@ func (transaction *transaction) Operation(operationID string) (market.Operation,
 	return operationOn(transaction.ctx, transaction.tx, operationID)
 }
 
-func (transaction *transaction) OperationByClientRequestID(clientRequestID string) (*market.Operation, error) {
+func (transaction *transaction) OperationByClientRequestID(ownerAccountID, clientRequestID string) (*market.Operation, error) {
 	var payload string
 	if err := transaction.tx.QueryRowContext(transaction.ctx, `
-SELECT operation_json FROM connector_market_operations WHERE client_request_id = ?`, clientRequestID).Scan(&payload); err != nil {
+SELECT operation_json FROM connector_market_operations
+WHERE owner_account_id = ? AND client_request_id = ?`,
+		strings.TrimSpace(ownerAccountID), clientRequestID).Scan(&payload); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}
@@ -653,6 +660,30 @@ WHERE account_id = ? AND connector_key = ?`, strings.TrimSpace(scope.AccountID),
 }
 
 func (transaction *transaction) EnqueueConnectorMarketChanged(event market.ChangedEvent) error {
+	if strings.TrimSpace(event.OperationID) != "" {
+		operation, err := transaction.Operation(event.OperationID)
+		if err != nil && !errors.Is(err, market.ErrNotFound) {
+			return err
+		}
+		if err == nil {
+			operation = market.NormalizeOperationOwnership(operation)
+			if operation.Visibility == market.OperationVisibilityAccount {
+				accountEvent := event
+				accountEvent.OwnerAccountID = operation.OwnerAccountID
+				accountEvent.Visibility = market.OperationVisibilityAccount
+				if err := transaction.appendChangedEvent(accountEvent); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	event.OperationID = ""
+	event.OwnerAccountID = ""
+	event.Visibility = market.OperationVisibilitySystemPrivate
+	return transaction.appendChangedEvent(event)
+}
+
+func (transaction *transaction) appendChangedEvent(event market.ChangedEvent) error {
 	payload, err := json.Marshal(event)
 	if err != nil {
 		return err
@@ -696,9 +727,15 @@ SELECT connector_json FROM connector_market_connectors ORDER BY connector_key`)
 	return connectors, nil
 }
 
-func listOperationsOn(ctx context.Context, database queryer) ([]market.Operation, error) {
+func listOperationsOn(ctx context.Context, database queryer, accountID string) ([]market.Operation, error) {
+	accountID = strings.TrimSpace(accountID)
+	if accountID == "" {
+		return []market.Operation{}, nil
+	}
 	rows, err := database.QueryContext(ctx, `
-SELECT operation_json FROM connector_market_operations ORDER BY operation_id`)
+SELECT operation_json FROM connector_market_operations
+WHERE owner_account_id = ? AND visibility = ? ORDER BY operation_id`,
+		accountID, market.OperationVisibilityAccount)
 	if err != nil {
 		return nil, err
 	}
@@ -712,9 +749,6 @@ SELECT operation_json FROM connector_market_operations ORDER BY operation_id`)
 		operation, err := decodeOperation(payload)
 		if err != nil {
 			return nil, err
-		}
-		if operation.Kind == market.OperationKindReconcileRuntime {
-			continue
 		}
 		operations = append(operations, publicOperation(operation))
 	}
@@ -731,6 +765,7 @@ SELECT operation_json FROM connector_market_operations WHERE operation_id = ?`, 
 }
 
 func saveOperationOn(ctx context.Context, tx *sql.Tx, operation market.Operation) error {
+	operation = market.NormalizeOperationOwnership(operation)
 	payload, err := json.Marshal(operation)
 	if err != nil {
 		return err
@@ -741,10 +776,12 @@ func saveOperationOn(ctx context.Context, tx *sql.Tx, operation market.Operation
 	}
 	result, err := tx.ExecContext(ctx, `
 INSERT INTO connector_market_operations (
-  operation_id, client_request_id, connector_key, kind, state,
+  operation_id, client_request_id, owner_account_id, visibility, connector_key, kind, state,
   lease_owner, lease_token, lease_expires_at_unix_ms, updated_at_unix_ms, operation_json
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(operation_id) DO UPDATE SET
+	owner_account_id = excluded.owner_account_id,
+	visibility = excluded.visibility,
   state = excluded.state,
   lease_owner = excluded.lease_owner,
 	lease_token = excluded.lease_token,
@@ -755,7 +792,7 @@ WHERE excluded.lease_token = 0 OR (
   connector_market_operations.lease_owner = excluded.lease_owner AND
   connector_market_operations.lease_token = excluded.lease_token
 )`,
-		operation.OperationID, operation.ClientRequestID, operation.ConnectorKey,
+		operation.OperationID, operation.ClientRequestID, operation.OwnerAccountID, operation.Visibility, operation.ConnectorKey,
 		operation.Kind, operation.State, operation.LeaseOwner, operation.LeaseToken, leaseExpiresAt,
 		operation.UpdatedAt.UTC().UnixMilli(), string(payload))
 	if err != nil {

--- a/packages/connector/store-sqlite/store_test.go
+++ b/packages/connector/store-sqlite/store_test.go
@@ -3,6 +3,7 @@ package storesqlite
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -76,6 +77,93 @@ func TestStoreMigrationDropsLegacyTrustTables(t *testing.T) {
 	}
 }
 
+func TestStoreMigrationBackfillsOwnedOperationsAndKeepsUnknownOwnerPrivate(t *testing.T) {
+	ctx := context.Background()
+	databasePath := filepath.Join(t.TempDir(), "tuttid.db")
+	legacy, err := sql.Open("sqlite", databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := legacy.ExecContext(ctx, `CREATE TABLE connector_market_operations (
+  operation_id TEXT PRIMARY KEY,
+  client_request_id TEXT NOT NULL UNIQUE,
+  connector_key TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  state TEXT NOT NULL,
+  lease_owner TEXT NOT NULL,
+  lease_token INTEGER NOT NULL DEFAULT 0,
+  lease_expires_at_unix_ms INTEGER,
+  updated_at_unix_ms INTEGER NOT NULL DEFAULT 0,
+  operation_json TEXT NOT NULL
+)`); err != nil {
+		_ = legacy.Close()
+		t.Fatal(err)
+	}
+	now := time.Unix(1, 0).UTC()
+	operations := []market.Operation{
+		{OperationID: "owned", ClientRequestID: "request-owned", ConnectorKey: "github", Kind: market.OperationKindInstall,
+			Scope: market.OperationScope{AccountID: "account-a"}, State: market.OperationStateFailed, CreatedAt: now, UpdatedAt: now},
+		{OperationID: "private", ClientRequestID: "request-private", ConnectorKey: "slack", Kind: market.OperationKindReconcileRuntime,
+			Scope: market.OperationScope{AccountID: "account-a"}, State: market.OperationStateFailed, CreatedAt: now, UpdatedAt: now},
+		{OperationID: "unknown-owner", ClientRequestID: "request-unknown", ConnectorKey: "notion", Kind: market.OperationKindInstall,
+			State: market.OperationStateAccepted, CreatedAt: now, UpdatedAt: now},
+	}
+	for _, operation := range operations {
+		payload, err := json.Marshal(operation)
+		if err != nil {
+			_ = legacy.Close()
+			t.Fatal(err)
+		}
+		if _, err := legacy.ExecContext(ctx, `INSERT INTO connector_market_operations (
+  operation_id, client_request_id, connector_key, kind, state, lease_owner, lease_token,
+  lease_expires_at_unix_ms, updated_at_unix_ms, operation_json
+) VALUES (?, ?, ?, ?, ?, '', 0, NULL, ?, ?)`, operation.OperationID, operation.ClientRequestID,
+			operation.ConnectorKey, operation.Kind, operation.State, operation.UpdatedAt.UnixMilli(), string(payload)); err != nil {
+			_ = legacy.Close()
+			t.Fatal(err)
+		}
+	}
+	if err := legacy.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	snapshot, err := store.SnapshotForScope(ctx, market.OperationScope{AccountID: "account-a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.Operations) != 1 || snapshot.Operations[0].OperationID != "owned" {
+		t.Fatalf("migrated public operations = %#v", snapshot.Operations)
+	}
+	if _, err := store.OperationForScope(ctx, market.OperationScope{AccountID: "account-a"}, "private"); !errors.Is(err, market.ErrNotFound) {
+		t.Fatalf("private operation error = %v", err)
+	}
+	if _, err := store.OperationForScope(ctx, market.OperationScope{AccountID: "account-a"}, "unknown-owner"); !errors.Is(err, market.ErrNotFound) {
+		t.Fatalf("unknown-owner operation error = %v", err)
+	}
+	recoverable, err := store.RecoverableOperations(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recoverable) != 1 || recoverable[0].OperationID != "unknown-owner" {
+		t.Fatalf("recoverable migrated operations = %#v", recoverable)
+	}
+	for _, accountID := range []string{"account-a", "account-b"} {
+		operation := market.Operation{
+			OperationID: "reused-" + accountID, ClientRequestID: "reused-after-migration", ConnectorKey: "linear",
+			Kind: market.OperationKindInstall, Scope: market.OperationScope{AccountID: accountID},
+			State: market.OperationStateFailed, CreatedAt: now, UpdatedAt: now,
+		}
+		if err := store.Transaction(ctx, func(tx market.Transaction) error { return tx.SaveOperation(operation) }); err != nil {
+			t.Fatalf("reuse client request after migration for %s: %v", accountID, err)
+		}
+	}
+}
+
 func TestStorePersistsRevisionOperationBindingAndOutboxAtomically(t *testing.T) {
 	ctx := context.Background()
 	store, err := Open(ctx, filepath.Join(t.TempDir(), "tuttid.db"))
@@ -87,6 +175,7 @@ func TestStorePersistsRevisionOperationBindingAndOutboxAtomically(t *testing.T) 
 	operation := market.Operation{
 		OperationID: "operation-1", ClientRequestID: "request-1", ConnectorKey: connector.Key,
 		Kind: market.OperationKindInstall, State: market.OperationStateAccepted,
+		Scope: market.OperationScope{AccountID: "account-1"},
 		Stage: market.OperationStageAccepted, CreatedAt: time.Unix(1, 0).UTC(), UpdatedAt: time.Unix(1, 0).UTC(),
 	}
 	if err := store.Transaction(ctx, func(tx market.Transaction) error {
@@ -105,19 +194,152 @@ func TestStorePersistsRevisionOperationBindingAndOutboxAtomically(t *testing.T) 
 		t.Fatal(err)
 	}
 
-	snapshot, err := store.Snapshot(ctx)
+	snapshot, err := store.SnapshotForScope(ctx, operation.Scope)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if snapshot.Revision != 1 || snapshot.EventCursor != 1 || len(snapshot.Connectors) != 1 || len(snapshot.Operations) != 1 {
+	if snapshot.Revision != 1 || snapshot.EventCursor != 2 || len(snapshot.Connectors) != 1 || len(snapshot.Operations) != 1 {
 		t.Fatalf("snapshot = %#v", snapshot)
 	}
 	entries, err := store.PendingChangedEvents(ctx, 10)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(entries) != 1 || entries[0].Event.Revision != 1 {
+	if len(entries) != 2 || entries[0].Event.OperationID != operation.OperationID ||
+		entries[0].Event.OwnerAccountID != operation.Scope.AccountID || entries[1].Event.OperationID != "" {
 		t.Fatalf("outbox = %#v", entries)
+	}
+}
+
+func TestStoreScopedSnapshotOnlyReturnsOperationsOwnedByAccount(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(ctx, filepath.Join(t.TempDir(), "tuttid.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	now := time.Unix(1, 0).UTC()
+	connector := testConnector()
+	connector.Installation = market.Installation{
+		State: market.InstallationStateInstalled, InstalledVersion: connector.Release.Version,
+		InstalledReleaseID: connector.Release.ReleaseID, InstalledReleaseDigest: connector.Release.ReleaseDigest,
+	}
+	if err := store.Transaction(ctx, func(tx market.Transaction) error { return tx.SaveConnector(connector) }); err != nil {
+		t.Fatal(err)
+	}
+	for _, operation := range []market.Operation{
+		{OperationID: "operation-a", ClientRequestID: "request-a", ConnectorKey: "github", Kind: market.OperationKindInstall,
+			Scope: market.OperationScope{AccountID: "account-a"}, State: market.OperationStateAccepted, CreatedAt: now, UpdatedAt: now},
+		{OperationID: "operation-b", ClientRequestID: "request-b", ConnectorKey: "github", Kind: market.OperationKindUninstall,
+			Scope: market.OperationScope{AccountID: "account-b"}, State: market.OperationStateCompleted, CreatedAt: now, UpdatedAt: now},
+		{OperationID: "operation-private", ClientRequestID: "request-private", ConnectorKey: "github", Kind: market.OperationKindReconcileRuntime,
+			Scope: market.OperationScope{AccountID: "account-b"}, State: market.OperationStateCompleted, CreatedAt: now, UpdatedAt: now},
+		{OperationID: "operation-legacy", ClientRequestID: "request-legacy", ConnectorKey: "github", Kind: market.OperationKindInstall,
+			State: market.OperationStateFailed, CreatedAt: now, UpdatedAt: now},
+	} {
+		operation := operation
+		if err := store.Transaction(ctx, func(tx market.Transaction) error { return tx.SaveOperation(operation) }); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	snapshot, err := store.SnapshotForScope(ctx, market.OperationScope{AccountID: "account-b"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.Operations) != 1 || snapshot.Operations[0].OperationID != "operation-b" {
+		t.Fatalf("account-b operations = %#v, want only operation-b", snapshot.Operations)
+	}
+	if len(snapshot.Connectors) != 1 || snapshot.Connectors[0].Installation.State != market.InstallationStateInstalled {
+		t.Fatalf("account-b machine connector state = %#v", snapshot.Connectors)
+	}
+	if operation, err := store.OperationForScope(ctx, market.OperationScope{AccountID: "account-a"}, "operation-a"); err != nil || operation.OperationID != "operation-a" {
+		t.Fatalf("account-a operation = %#v, error = %v", operation, err)
+	}
+	if _, err := store.OperationForScope(ctx, market.OperationScope{AccountID: "account-b"}, "operation-a"); !errors.Is(err, market.ErrNotFound) {
+		t.Fatalf("account-b operation-a error = %v, want ErrNotFound", err)
+	}
+	recoverable, err := store.RecoverableOperations(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recoverable) != 1 || recoverable[0].OperationID != "operation-a" {
+		t.Fatalf("hidden account-a operation was not recoverable: %#v", recoverable)
+	}
+}
+
+func TestStoreAllowsClientRequestIDReuseAcrossAccounts(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(ctx, filepath.Join(t.TempDir(), "tuttid.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	now := time.Unix(1, 0).UTC()
+	for _, accountID := range []string{"account-a", "account-b"} {
+		operation := market.Operation{
+			OperationID: "operation-" + accountID, ClientRequestID: "shared-request", ConnectorKey: "github",
+			Kind: market.OperationKindInstall, Scope: market.OperationScope{AccountID: accountID},
+			State: market.OperationStateFailed, CreatedAt: now, UpdatedAt: now,
+		}
+		if err := store.Transaction(ctx, func(tx market.Transaction) error { return tx.SaveOperation(operation) }); err != nil {
+			t.Fatalf("save operation for %s: %v", accountID, err)
+		}
+	}
+}
+
+func TestStoreKeepsActiveConnectorLifecycleUniqueAcrossAccounts(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(ctx, filepath.Join(t.TempDir(), "tuttid.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	now := time.Unix(1, 0).UTC()
+	for _, accountID := range []string{"account-a", "account-b"} {
+		operation := market.Operation{
+			OperationID: "operation-" + accountID, ClientRequestID: "request-" + accountID, ConnectorKey: "github",
+			Kind: market.OperationKindInstall, Scope: market.OperationScope{AccountID: accountID},
+			State: market.OperationStateAccepted, CreatedAt: now, UpdatedAt: now,
+		}
+		err := store.Transaction(ctx, func(tx market.Transaction) error { return tx.SaveOperation(operation) })
+		if accountID == "account-a" && err != nil {
+			t.Fatal(err)
+		}
+		if accountID == "account-b" && err == nil {
+			t.Fatal("second account started a concurrent physical lifecycle operation for the same connector")
+		}
+	}
+}
+
+func TestStorePrivateOperationEventDoesNotExposeOperationID(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(ctx, filepath.Join(t.TempDir(), "tuttid.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	operation := market.Operation{
+		OperationID: "reconcile-1", ClientRequestID: "reconcile-request", ConnectorKey: "github",
+		Kind: market.OperationKindReconcileRuntime, Scope: market.OperationScope{AccountID: "account-a"},
+		State: market.OperationStateAccepted, CreatedAt: time.Unix(1, 0).UTC(), UpdatedAt: time.Unix(1, 0).UTC(),
+	}
+	if err := store.Transaction(ctx, func(tx market.Transaction) error {
+		if err := tx.SaveOperation(operation); err != nil {
+			return err
+		}
+		return tx.EnqueueConnectorMarketChanged(market.ChangedEvent{
+			ConnectorKey: operation.ConnectorKey, OperationID: operation.OperationID, Revision: tx.AdvanceRevision(),
+		})
+	}); err != nil {
+		t.Fatal(err)
+	}
+	events, err := store.PendingChangedEvents(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].Event.OperationID != "" {
+		t.Fatalf("private operation event = %#v, want one machine event without operation id", events)
 	}
 }
 
@@ -133,6 +355,7 @@ func TestStoreKeepsAuthorizationSessionPrivateAndAvailableAfterReopen(t *testing
 	operation := market.Operation{
 		OperationID: "authorization-1", ClientRequestID: "request-1", ConnectorKey: connector.Key,
 		Kind: market.OperationKindStartAuthorization, State: market.OperationStateCompleted,
+		Scope: market.OperationScope{AccountID: "account-1"},
 		Stage: market.OperationStageCompleted, CreatedAt: time.Unix(1, 0).UTC(), UpdatedAt: time.Unix(2, 0).UTC(),
 		Execution: market.OperationExecution{AuthorizationSession: &market.AuthorizationSession{
 			OperationID: "authorization-1", ConnectorKey: connector.Key,
@@ -157,14 +380,14 @@ func TestStoreKeepsAuthorizationSessionPrivateAndAvailableAfterReopen(t *testing
 		t.Fatal(err)
 	}
 	defer reopened.Close()
-	snapshot, err := reopened.Snapshot(ctx)
+	snapshot, err := reopened.SnapshotForScope(ctx, operation.Scope)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(snapshot.Operations) != 1 || snapshot.Operations[0].Execution.AuthorizationSession != nil {
 		t.Fatalf("public snapshot exposed authorization session: %#v", snapshot.Operations)
 	}
-	operations, err := reopened.UnresolvedAuthorizationSessionOperations(ctx, market.OperationScope{})
+	operations, err := reopened.UnresolvedAuthorizationSessionOperations(ctx, operation.Scope)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/services/tuttid/api/daemon_connector_market.go
+++ b/services/tuttid/api/daemon_connector_market.go
@@ -145,6 +145,7 @@ func (api DaemonAPI) RefreshConnectorMarket(
 	if err != nil {
 		return tuttigenerated.RefreshConnectorMarket400JSONResponse{ConnectorMarketInvalidRequestErrorJSONResponse: invalidConnectorMarketResponse(connectorMarketErrorPayload(err))}, nil
 	}
+	mutation.Scope = market.OperationScope{AccountID: api.connectorMarketAccountID()}
 	result, err := api.ConnectorMarketService.RefreshCatalog(ctx, mutation)
 	if err != nil {
 		payload, status := connectorMarketError(err)
@@ -325,7 +326,11 @@ func (api DaemonAPI) GetConnectorMarketOperation(
 	if api.ConnectorMarketService == nil {
 		return tuttigenerated.GetConnectorMarketOperation503JSONResponse{ConnectorMarketUnavailableErrorJSONResponse: connectorMarketUnavailableError()}, nil
 	}
-	operation, err := api.ConnectorMarketService.GetOperation(ctx, request.OperationID)
+	operation, err := api.ConnectorMarketService.GetOperationForScope(
+		ctx,
+		market.OperationScope{AccountID: api.connectorMarketAccountID()},
+		request.OperationID,
+	)
 	if err != nil {
 		payload, status := connectorMarketError(err)
 		switch status {

--- a/services/tuttid/api/daemon_connector_market_test.go
+++ b/services/tuttid/api/daemon_connector_market_test.go
@@ -17,6 +17,8 @@ type stubConnectorMarketService struct {
 	pageFn       func(context.Context, market.CatalogPageQuery) (market.CatalogPage, error)
 	installFn    func(context.Context, market.ConnectorMutation) (market.MutationResult, error)
 	uninstallFn  func(context.Context, market.ConnectorMutation) (market.MutationResult, error)
+	refreshFn    func(context.Context, market.Mutation) (market.MutationResult, error)
+	operationFn  func(context.Context, market.OperationScope, string) (market.Operation, error)
 	cancelFn     func(context.Context, market.OperationScope, string) error
 	projectionFn func(context.Context, string, string) (market.AuthorizationProjection, error)
 }
@@ -45,6 +47,18 @@ func (service stubConnectorMarketService) Install(ctx context.Context, mutation 
 
 func (service stubConnectorMarketService) Uninstall(ctx context.Context, mutation market.ConnectorMutation) (market.MutationResult, error) {
 	return service.uninstallFn(ctx, mutation)
+}
+
+func (service stubConnectorMarketService) RefreshCatalog(ctx context.Context, mutation market.Mutation) (market.MutationResult, error) {
+	return service.refreshFn(ctx, mutation)
+}
+
+func (service stubConnectorMarketService) GetOperationForScope(
+	ctx context.Context,
+	scope market.OperationScope,
+	operationID string,
+) (market.Operation, error) {
+	return service.operationFn(ctx, scope, operationID)
 }
 
 func (service stubConnectorMarketService) ListCatalogCategories(ctx context.Context) ([]market.CatalogCategory, error) {
@@ -253,6 +267,47 @@ func TestDaemonAPIConnectorMarketRefreshRejectsNegativeRevision(t *testing.T) {
 	})
 	if recorder.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d; body: %s", recorder.Code, http.StatusBadRequest, recorder.Body.String())
+	}
+}
+
+func TestDaemonAPIConnectorMarketRefreshBindsActiveAccount(t *testing.T) {
+	service := stubConnectorMarketService{refreshFn: func(_ context.Context, mutation market.Mutation) (market.MutationResult, error) {
+		if mutation.Scope.AccountID != "account-a" || mutation.ClientRequestID != "request-refresh" {
+			t.Fatalf("refresh mutation = %#v", mutation)
+		}
+		return market.MutationResult{Operation: market.Operation{
+			OperationID: "refresh-1", ClientRequestID: mutation.ClientRequestID, Kind: market.OperationKindRefreshCatalog,
+			Scope: mutation.Scope, State: market.OperationStateAccepted, CreatedAt: time.Unix(1, 0).UTC(), UpdatedAt: time.Unix(1, 0).UTC(),
+		}}, nil
+	}}
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, NewRoutes(DaemonAPI{
+		ConnectorMarketService: service,
+		ConnectorMarketScope:   func() market.OperationScope { return market.OperationScope{AccountID: "account-a"} },
+	}))
+	recorder := performGeneratedRouteRequest(t, mux, http.MethodPost, "/v1/connector-market:refresh", map[string]any{
+		"clientRequestId": "request-refresh", "expectedRevision": 0,
+	})
+	if recorder.Code != http.StatusAccepted {
+		t.Fatalf("status = %d; body: %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestDaemonAPIConnectorMarketOperationUsesScopedRead(t *testing.T) {
+	service := stubConnectorMarketService{operationFn: func(_ context.Context, scope market.OperationScope, operationID string) (market.Operation, error) {
+		if scope.AccountID != "account-b" || operationID != "operation-a" {
+			t.Fatalf("operation scope=%#v id=%q", scope, operationID)
+		}
+		return market.Operation{}, market.ErrNotFound
+	}}
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, NewRoutes(DaemonAPI{
+		ConnectorMarketService: service,
+		ConnectorMarketScope:   func() market.OperationScope { return market.OperationScope{AccountID: "account-b"} },
+	}))
+	recorder := performGeneratedRouteRequest(t, mux, http.MethodGet, "/v1/connector-market/operations/operation-a", nil)
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body: %s", recorder.Code, recorder.Body.String())
 	}
 }
 

--- a/services/tuttid/service/eventstream/connector_market.go
+++ b/services/tuttid/service/eventstream/connector_market.go
@@ -10,7 +10,8 @@ import (
 )
 
 type ConnectorMarketPublisher struct {
-	Service *Service
+	Service      *Service
+	CurrentScope func() market.OperationScope
 }
 
 func (publisher ConnectorMarketPublisher) PublishConnectorMarketChanged(
@@ -19,6 +20,20 @@ func (publisher ConnectorMarketPublisher) PublishConnectorMarketChanged(
 ) error {
 	if publisher.Service == nil {
 		return errors.New("connector market event service is unavailable")
+	}
+	if event.Visibility == market.OperationVisibilityAccount {
+		if publisher.CurrentScope == nil ||
+			publisher.CurrentScope().AccountID != event.OwnerAccountID {
+			return nil
+		}
+		event.OwnerAccountID = ""
+		event.Visibility = ""
+	} else {
+		// Legacy or machine-level invalidations may be broadcast, but never with
+		// an operation identifier or account owner attached.
+		event.OperationID = ""
+		event.OwnerAccountID = ""
+		event.Visibility = ""
 	}
 	payload, err := json.Marshal(event)
 	if err != nil {

--- a/services/tuttid/service/eventstream/connector_market_test.go
+++ b/services/tuttid/service/eventstream/connector_market_test.go
@@ -16,12 +16,48 @@ func TestConnectorMarketPublisherUsesCatalogTopic(t *testing.T) {
 	}
 	if err := (ConnectorMarketPublisher{Service: service}).PublishConnectorMarketChanged(
 		context.Background(),
-		market.ChangedEvent{ConnectorKey: "github", Revision: 2},
+		market.ChangedEvent{ConnectorKey: "github", OperationID: "legacy-operation", Revision: 2},
 	); err != nil {
 		t.Fatal(err)
 	}
 	event := <-service.Events(session)
 	if event.Topic != TopicConnectorMarketChanged || string(event.Payload) != `{"connectorKey":"github","revision":2}` {
 		t.Fatalf("event = %#v", event)
+	}
+}
+
+func TestConnectorMarketPublisherOnlyDeliversAccountOperationEventToOwner(t *testing.T) {
+	service := NewService(DefaultCatalog(), nil)
+	session := service.OpenSession()
+	defer service.CloseSession(session)
+	if err := service.Subscribe(session, []string{TopicConnectorMarketChanged}, EventScope{}); err != nil {
+		t.Fatal(err)
+	}
+	currentAccountID := "account-b"
+	publisher := ConnectorMarketPublisher{
+		Service: service,
+		CurrentScope: func() market.OperationScope {
+			return market.OperationScope{AccountID: currentAccountID}
+		},
+	}
+	event := market.ChangedEvent{
+		ConnectorKey: "github", OperationID: "operation-a", OwnerAccountID: "account-a",
+		Visibility: market.OperationVisibilityAccount, Revision: 2,
+	}
+	if err := publisher.PublishConnectorMarketChanged(context.Background(), event); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case leaked := <-service.Events(session):
+		t.Fatalf("other account received operation event: %#v", leaked)
+	default:
+	}
+	currentAccountID = "account-a"
+	if err := publisher.PublishConnectorMarketChanged(context.Background(), event); err != nil {
+		t.Fatal(err)
+	}
+	delivered := <-service.Events(session)
+	if string(delivered.Payload) != `{"connectorKey":"github","operationId":"operation-a","revision":2}` {
+		t.Fatalf("owner event = %#v", delivered)
 	}
 }

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -388,6 +388,13 @@ func (w *tuttiWiring) buildWorkspaceModule(ctx context.Context) error {
 			api.CLIRegistry.AppCommands, connectorCommands,
 		}}
 		connectorAuthorizationReadiness := connectormarkethost.NewAuthorizationReadinessGate()
+		connectorMarketScope := func() connectormarkethost.OperationScope {
+			session, sessionErr := accountService.ReadSession()
+			if sessionErr != nil || session == nil {
+				return connectormarkethost.OperationScope{}
+			}
+			return connectormarkethost.OperationScope{AccountID: strings.TrimSpace(session.UserID)}
+		}
 		connectorMarketHost, err := connectormarketdaemon.NewHost(ctx, connectormarketdaemon.HostConfig{
 			Repository: connectorMarketStore, CatalogSource: connectorCatalog,
 			ReleaseInstallations: releaseInstaller, ImplementationHost: connectorRuntime,
@@ -398,7 +405,7 @@ func (w *tuttiWiring) buildWorkspaceModule(ctx context.Context) error {
 			AuthorizationReadiness:   connectorAuthorizationReadiness,
 			RuntimeBindings:          connectormarkethost.AccountRuntimeBindingResolver{Projections: connectorMarketStore, Readiness: connectorAuthorizationReadiness},
 			ImplementationRegistry:   implementations, Outbox: connectorMarketStore, Lifecycle: connectorMarketStore,
-			Publisher: eventstreamservice.ConnectorMarketPublisher{Service: events},
+			Publisher: eventstreamservice.ConnectorMarketPublisher{Service: events, CurrentScope: connectorMarketScope},
 		})
 		if err != nil {
 			_ = connectorMarketStore.Close()
@@ -410,13 +417,6 @@ func (w *tuttiWiring) buildWorkspaceModule(ctx context.Context) error {
 			service.ConnectorMarketSnapshots = connectorMarketHost.Application
 		}
 		api.ConnectorMarketService = connectorMarketHost.Application
-		connectorMarketScope := func() connectormarkethost.OperationScope {
-			session, sessionErr := accountService.ReadSession()
-			if sessionErr != nil || session == nil {
-				return connectormarkethost.OperationScope{}
-			}
-			return connectormarkethost.OperationScope{AccountID: strings.TrimSpace(session.UserID)}
-		}
 		api.ConnectorMarketScope = connectorMarketScope
 		api.ConnectorAuthorizationReady = connectorAuthorizationReadiness.Ready
 		existingAccountLoginCompleted := accountService.OnLoginCompleted


### PR DESCRIPTION
## Summary

Connector Market operations were not consistently scoped to their owning account: scoped snapshots could include operations from other accounts, direct operation lookup ignored the authenticated account, and changed events could expose another account's operation ID. Separately, the runtime treated Tutti's optional `resultType` extension as mandatory and classified plain-text non-2xx relay responses as content-type failures, obscuring the real protocol error.

This change makes operation ownership explicit and keeps the public MCP boundary standards-compatible:

- persist normalized `ownerAccountId` and `visibility` for operations, migrate legacy records conservatively, and scope request idempotency by account
- expose only account-owned public operations through scoped snapshots and lookups; keep internal reconciliation and unresolved legacy operations private
- split account operation events from machine-level connector invalidations so operation IDs are never broadcast across accounts
- preserve HTTP status and bounded response bodies before optional JSON-RPC decoding on non-2xx responses
- accept standard MCP `tools/list` responses without the private `resultType` extension while continuing to reject explicit partial results
- document the ownership and event visibility invariants and add migration, API, event, HTTP, and runtime regression tests

The remote control-plane and `tsh-server` protocols are unchanged.

## Verification

- Before the fix, the scoped operation tests reproduced account B observing account A's operation, and the MCP tests reproduced a plain-text 409 being reported as an unsupported content type and a valid SSE `tools/list` response being rejected.
- `pnpm check:changed -- --push-ready` passed all 13 selected lanes.
- `go test ./packages/connector/runtime/mcp ./packages/connector/runtime/implementationhost ./packages/connector/host ./packages/connector/daemon ./packages/connector/store-sqlite ./services/tuttid/api ./services/tuttid/service/eventstream -count=1` passed.
- Local TSH integration completed GitHub install, active uninstall, and reinstall on the first attempt with the linked Tutti source runtime.

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter. (Not applicable; this changes connector operation visibility and MCP transport behavior.)
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. (No translated variants exist for the changed architecture document.)
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
