### PR TITLE
fix(analytics): preserve prerelease app versions

### DIFF
--- a/docs/architecture/analytics-tracking.md
+++ b/docs/architecture/analytics-tracking.md
@@ -64,15 +64,19 @@ Runtime and application metadata that DataFinder defines as preset properties
 is sent in the SDK header as well as retained in the legacy custom common
 params where one already exists. This keeps existing dashboards compatible
 while allowing DataFinder's built-in dimensions to receive `os_name`,
-`os_version`, `app_version`, and `cpu_abi`. Event UUIDs follow the same
-transition: `event_id` remains in event params and is also assigned to the SDK
-event's preset ID field.
+`os_version`, `app_version`, `app_version_minor`, and `cpu_abi`. The reporter
+sends the exact configured application version to both version fields. This
+preserves prerelease suffixes such as `-rc.0` in `app_version_minor` when
+DataFinder normalizes `app_version`. Event UUIDs follow the same transition:
+`event_id` remains in event params and is also assigned to the SDK event's
+preset ID field.
 
 | Param               | Owner    | Notes                                               |
 | ------------------- | -------- | --------------------------------------------------- |
 | `device_id`         | tuttid   | Persisted UUID in state dir; stable across restarts |
 | `session_id`        | tuttid   | UUID generated once at daemon startup               |
 | `app_version`       | tuttid   | Resolved from generated defaults or env override    |
+| `app_version_minor` | tuttid   | Exact version, including prerelease suffixes        |
 | `os`                | tuttid   | Resolved at startup                                 |
 | `os_name`           | tuttid   | Preset SDK header; currently the Go runtime OS key  |
 | `os_version`        | tuttid   | Preset SDK header; best-effort product OS version   |

--- a/packages/analytics/reporter-go/reporter.go
+++ b/packages/analytics/reporter-go/reporter.go
@@ -227,10 +227,11 @@ func currentRuntimeInfo() runtimeInfo {
 
 func (c reporterCommon) teaHeader() teaSDKHeader {
 	return teaSDKHeader{
-		AppVersion: c.appVersion,
-		OSName:     c.osName,
-		OSVersion:  c.osVersion,
-		CPUABI:     c.cpuABI,
+		AppVersion:      c.appVersion,
+		AppVersionMinor: c.appVersion,
+		OSName:          c.osName,
+		OSVersion:       c.osVersion,
+		CPUABI:          c.cpuABI,
 	}
 }
 
@@ -285,7 +286,7 @@ func normalizeEvents(events []Event, common map[string]any, header teaSDKHeader)
 		for key := range common {
 			delete(params, key)
 		}
-		for _, key := range []string{"app_version", "os_name", "os_version", "cpu_abi"} {
+		for _, key := range []string{"app_version", "app_version_minor", "os_name", "os_version", "cpu_abi"} {
 			delete(params, key)
 		}
 		eventID, _ := params["event_id"].(string)

--- a/packages/analytics/reporter-go/reporter_test.go
+++ b/packages/analytics/reporter-go/reporter_test.go
@@ -133,7 +133,7 @@ func TestTeaReporterPersistsIdentityAndSendsSanitizedEvents(t *testing.T) {
 			AppID:         20004092,
 			AppKey:        "app-key",
 			ChannelDomain: "https://example.test",
-			AppVersion:    "0.0.0",
+			AppVersion:    "0.2.31-rc.0",
 		},
 		DebugPublisher: publisher,
 		StateDir:       stateDir,
@@ -179,7 +179,7 @@ func TestTeaReporterPersistsIdentityAndSendsSanitizedEvents(t *testing.T) {
 	if send.events[0].EventID == "" || send.events[0].EventID != send.events[0].Params["event_id"] {
 		t.Fatalf("event ID preset=%q params=%v, want matching compatibility values", send.events[0].EventID, send.events[0].Params["event_id"])
 	}
-	if send.header.AppVersion != "0.0.0" || send.header.OSName == "" || send.header.CPUABI == "" {
+	if send.header.AppVersion != "0.2.31-rc.0" || send.header.AppVersionMinor != "0.2.31-rc.0" || send.header.OSName == "" || send.header.CPUABI == "" {
 		t.Fatalf("preset header = %#v, want app and runtime metadata", send.header)
 	}
 	for _, key := range []string{"device_id", "session_id", "app_version", "os", "product_variant"} {
@@ -219,7 +219,7 @@ func TestTeaReporterPersistsIdentityAndSendsSanitizedEvents(t *testing.T) {
 
 func TestReporterCommonBuildsPresetHeaderFromRuntimeInfo(t *testing.T) {
 	common, err := newReporterCommonWithRuntimeInfo(Config{
-		Analytics: AnalyticsConfig{AppVersion: "1.2.3"},
+		Analytics: AnalyticsConfig{AppVersion: "1.2.3-rc.4"},
 		DeviceID:  "host-device",
 	}, runtimeInfo{
 		osName:    "darwin",
@@ -232,10 +232,11 @@ func TestReporterCommonBuildsPresetHeaderFromRuntimeInfo(t *testing.T) {
 
 	got := common.teaHeader()
 	want := (teaSDKHeader{
-		AppVersion: "1.2.3",
-		OSName:     "darwin",
-		OSVersion:  "15.6",
-		CPUABI:     "arm64",
+		AppVersion:      "1.2.3-rc.4",
+		AppVersionMinor: "1.2.3-rc.4",
+		OSName:          "darwin",
+		OSVersion:       "15.6",
+		CPUABI:          "arm64",
 	})
 	if got != want {
 		t.Fatalf("preset header = %#v, want %#v", got, want)
@@ -245,7 +246,7 @@ func TestReporterCommonBuildsPresetHeaderFromRuntimeInfo(t *testing.T) {
 func TestDebugReporterPublishesPresetHeaderFields(t *testing.T) {
 	publisher := &fakeDebugPublisher{}
 	common, err := newReporterCommonWithRuntimeInfo(Config{
-		Analytics: AnalyticsConfig{AppVersion: "1.2.3"},
+		Analytics: AnalyticsConfig{AppVersion: "1.2.3-rc.4"},
 		DeviceID:  "host-device",
 	}, runtimeInfo{
 		osName:    "darwin",
@@ -270,10 +271,11 @@ func TestDebugReporterPublishesPresetHeaderFields(t *testing.T) {
 		t.Fatalf("debug events = %d, want 1", len(publisher.events))
 	}
 	for key, want := range map[string]string{
-		"app_version": "1.2.3",
-		"os_name":     "darwin",
-		"os_version":  "15.6",
-		"cpu_abi":     "arm64",
+		"app_version":       "1.2.3-rc.4",
+		"app_version_minor": "1.2.3-rc.4",
+		"os_name":           "darwin",
+		"os_version":        "15.6",
+		"cpu_abi":           "arm64",
 	} {
 		if got := publisher.events[0].Params[key]; got != want {
 			t.Fatalf("debug params[%q] = %v, want %q", key, got, want)
@@ -300,16 +302,17 @@ func TestNormalizeEventsAlwaysProtectsPresetHeaderFields(t *testing.T) {
 	events := normalizeEvents([]Event{{
 		Name: "workspace.opened",
 		Params: map[string]any{
-			"app_version": "spoofed",
-			"os_name":     "spoofed",
-			"os_version":  "spoofed",
-			"cpu_abi":     "spoofed",
+			"app_version":       "spoofed",
+			"app_version_minor": "spoofed",
+			"os_name":           "spoofed",
+			"os_version":        "spoofed",
+			"cpu_abi":           "spoofed",
 		},
 	}}, nil, teaSDKHeader{})
 	if len(events) != 1 {
 		t.Fatalf("normalizeEvents() returned %d events, want 1", len(events))
 	}
-	for _, key := range []string{"app_version", "os_name", "os_version", "cpu_abi"} {
+	for _, key := range []string{"app_version", "app_version_minor", "os_name", "os_version", "cpu_abi"} {
 		if _, exists := events[0].Params[key]; exists {
 			t.Fatalf("normalized event contains protected preset key %q", key)
 		}

--- a/packages/analytics/reporter-go/tea_sdk_adapter.go
+++ b/packages/analytics/reporter-go/tea_sdk_adapter.go
@@ -31,19 +31,21 @@ type teaSDKEvent struct {
 }
 
 type teaSDKHeader struct {
-	AppVersion string
-	OSName     string
-	OSVersion  string
-	CPUABI     string
+	AppVersion      string
+	AppVersionMinor string
+	OSName          string
+	OSVersion       string
+	CPUABI          string
 }
 
 func (h teaSDKHeader) presetParams() map[string]any {
 	params := map[string]any{}
 	for key, value := range map[string]string{
-		"app_version": h.AppVersion,
-		"os_name":     h.OSName,
-		"os_version":  h.OSVersion,
-		"cpu_abi":     h.CPUABI,
+		"app_version":       h.AppVersion,
+		"app_version_minor": h.AppVersionMinor,
+		"os_name":           h.OSName,
+		"os_version":        h.OSVersion,
+		"cpu_abi":           h.CPUABI,
 	} {
 		if value = strings.TrimSpace(value); value != "" {
 			params[key] = value
@@ -157,13 +159,14 @@ func (d defaultTeaSDK) Send(
 		sdkEvents = append(sdkEvents, sdkEvent)
 	}
 	sdkHeader := &sdk.Header{
-		Aid:          &appID,
-		Custom:       common,
-		UserUniqueId: &uuid,
-		AppVersion:   optionalTeaString(header.AppVersion),
-		OsName:       optionalTeaString(header.OSName),
-		OsVersion:    optionalTeaString(header.OSVersion),
-		CpuAbi:       optionalTeaString(header.CPUABI),
+		Aid:             &appID,
+		Custom:          common,
+		UserUniqueId:    &uuid,
+		AppVersion:      optionalTeaString(header.AppVersion),
+		AppVersionMinor: optionalTeaString(header.AppVersionMinor),
+		OsName:          optionalTeaString(header.OSName),
+		OsVersion:       optionalTeaString(header.OSVersion),
+		CpuAbi:          optionalTeaString(header.CPUABI),
 	}
 	sendEventsWithHeader := d.sendEventsWithHeader
 	if sendEventsWithHeader == nil {

--- a/packages/analytics/reporter-go/tea_sdk_adapter_test.go
+++ b/packages/analytics/reporter-go/tea_sdk_adapter_test.go
@@ -33,12 +33,13 @@ func TestTeaSDKPayloadUsesPresetHeaderAndEventID(t *testing.T) {
 			EventID:  eventID,
 			Params:   map[string]any{"event_id": eventID},
 		}},
-		map[string]any{"os": "darwin", "app_version": "1.2.3"},
+		map[string]any{"os": "darwin", "app_version": "1.2.3-rc.4"},
 		teaSDKHeader{
-			AppVersion: "1.2.3",
-			OSName:     "darwin",
-			OSVersion:  "15.6",
-			CPUABI:     "arm64",
+			AppVersion:      "1.2.3-rc.4",
+			AppVersionMinor: "1.2.3-rc.4",
+			OSName:          "darwin",
+			OSVersion:       "15.6",
+			CPUABI:          "arm64",
 		},
 	)
 	if err != nil {
@@ -50,10 +51,11 @@ func TestTeaSDKPayloadUsesPresetHeaderAndEventID(t *testing.T) {
 	}
 	decodedHeader := decoded["header"].(map[string]any)
 	for key, want := range map[string]string{
-		"app_version": "1.2.3",
-		"os_name":     "darwin",
-		"os_version":  "15.6",
-		"cpu_abi":     "arm64",
+		"app_version":       "1.2.3-rc.4",
+		"app_version_minor": "1.2.3-rc.4",
+		"os_name":           "darwin",
+		"os_version":        "15.6",
+		"cpu_abi":           "arm64",
 	} {
 		if got := decodedHeader[key]; got != want {
 			t.Fatalf("header[%q] = %v, want %q; payload=%s", key, got, want, payload)


### PR DESCRIPTION
## Summary

- mirror the exact configured app version into DataFinder app_version_minor while retaining app_version
- protect the native version-minor field from event-level overrides and expose it in debug payloads
- document prerelease-version reporting behavior for downstream consumers such as TSH

## Verification

- go test ./... (packages/analytics/reporter-go)
- pnpm check:changed (4 lanes)
- pre-push pnpm check:changed -- --push-ready (5 lanes)
- negative control: temporarily removed the AppVersionMinor SDK mapping; TestTeaSDKPayloadUsesPresetHeaderAndEventID failed because app_version_minor was absent, then passed after restoring the fix

## Test evidence

- Protected contract or prior failure: versions such as 0.2.31-rc.0 must remain available exactly even when DataFinder normalizes app_version.
- Credible faulty implementation / negative control: omitting Header.AppVersionMinor drops the prerelease-preserving field; the payload test failed under that mutation.
- Existing coverage gap: existing tests asserted only app_version and could not detect DataFinder prerelease loss.
- Owning seam and test level: the shared analytics reporter owns SDK header construction; tests observe the serialized DataFinder SDK payload and reporter sanitization behavior.
- Observable outcomes and important non-effects: both version headers contain the exact value, event-level overrides are removed, and existing app_version reporting remains unchanged.
- Blocking lane and native OS: packages/analytics/reporter-go Go lane selected by check:changed; platform-neutral mapping verified on macOS.
- Residual risk: production DataFinder ingestion should be observed after the fixed Tutti release is consumed; there is no OS-specific path, process, filesystem, or native API impact.

## Checklist

- [x] This change does not alter agent lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] I updated documentation for the changed analytics data flow.
- [x] No README or CONTRIBUTING language variants were changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] The commit is signed off with DCO.