### PR TITLE
fix(connector-market): restore composer pointer actions

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerConnectorsMenu.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerConnectorsMenu.spec.tsx
@@ -60,6 +60,7 @@ describe("ComposerConnectorsMenu", () => {
   it("shows connected versus connect actions and opens the catalog footer", async () => {
     const onOpenConnector = vi.fn();
     const onOpenConnectors = vi.fn();
+    const onOpenChange = vi.fn();
     render(
       <ComposerConnectorsMenu
         connectors={[
@@ -69,6 +70,7 @@ describe("ComposerConnectorsMenu", () => {
         ]}
         disabled={false}
         labels={labels}
+        onOpenChange={onOpenChange}
         onOpenConnector={onOpenConnector}
         onOpenConnectors={onOpenConnectors}
       />
@@ -86,30 +88,38 @@ describe("ComposerConnectorsMenu", () => {
     expect(
       screen.getByTestId("connector-market-composer-status-github")
     ).toHaveClass("ml-auto");
+    expect(connected).toHaveAttribute("data-disabled");
     expect(
       screen.getByTestId("connector-market-composer-item-notion")
     ).toHaveTextContent("Authorize");
     const connectAction = screen.getByTestId(
       "connector-market-composer-item-lark"
     );
-    fireEvent.click(connectAction);
+    fireEvent.pointerDown(connectAction, {
+      button: 0,
+      ctrlKey: false,
+      pointerType: "mouse"
+    });
     expect(onOpenConnector).toHaveBeenCalledWith("lark");
     expect(onOpenConnector).toHaveBeenCalledOnce();
     expect(
       screen.queryByTestId("connector-market-composer-item-lark")
     ).not.toBeInTheDocument();
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
 
     fireEvent.pointerDown(screen.getByRole("button", { name: "Connectors" }), {
       button: 0,
       ctrlKey: false
     });
-    fireEvent.click(
-      await screen.findByTestId("connector-market-composer-more")
+    fireEvent.pointerDown(
+      await screen.findByTestId("connector-market-composer-more"),
+      { button: 0, ctrlKey: false, pointerType: "mouse" }
     );
     expect(onOpenConnectors).toHaveBeenCalledOnce();
     expect(
       screen.queryByTestId("connector-market-composer-more")
     ).not.toBeInTheDocument();
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
   });
 
   it("replaces connected state with authorize when connector status refreshes", async () => {

--- a/packages/connector/market/src/ui/composer/ConnectorComposerMenu.tsx
+++ b/packages/connector/market/src/ui/composer/ConnectorComposerMenu.tsx
@@ -68,6 +68,7 @@ export function ConnectorComposerMenu({
   const additionalConnectorCount = connectedItems.length - previewItems.length;
   const closeAndRun = (action: () => void): void => {
     setOpen(false);
+    onOpenChange?.(false);
     action();
   };
 
@@ -136,14 +137,19 @@ export function ConnectorComposerMenu({
             return (
               <DropdownMenuItem
                 key={item.connectorKey}
-                aria-disabled={connected}
                 className="min-h-9 gap-2.5 px-2.5"
                 data-testid={`connector-market-composer-item-${item.connectorKey}`}
+                disabled={connected}
+                onPointerDown={(event) => {
+                  if (event.button !== 0 || event.ctrlKey) {
+                    return;
+                  }
+                  event.preventDefault();
+                  closeAndRun(() => onOpenConnector(item.connectorKey));
+                }}
                 onSelect={(event) => {
                   event.preventDefault();
-                  if (!connected) {
-                    closeAndRun(() => onOpenConnector(item.connectorKey));
-                  }
+                  closeAndRun(() => onOpenConnector(item.connectorKey));
                 }}
               >
                 <ConnectorComposerIcon
@@ -177,6 +183,13 @@ export function ConnectorComposerMenu({
         <DropdownMenuItem
           className="min-h-9 gap-2.5 px-2.5"
           data-testid="connector-market-composer-more"
+          onPointerDown={(event) => {
+            if (event.button !== 0 || event.ctrlKey) {
+              return;
+            }
+            event.preventDefault();
+            closeAndRun(onOpenMarket);
+          }}
           onSelect={(event) => {
             event.preventDefault();
             closeAndRun(onOpenMarket);


### PR DESCRIPTION
## Summary
- restore Electron-compatible pointer activation for connector rows and the catalog footer
- keep keyboard selection through the existing Radix `onSelect` path
- make connected rows truly disabled and cover both menu actions with regression tests

## Root cause
The shared Connector Composer migration kept Radix `onSelect` but dropped the former local menu's `pointerdown` compatibility path. In Electron, pointer activation could focus the row without dispatching either the connector callback or the market navigation callback.

## Verification
- `pnpm --filter @tutti-os/agent-gui test` (323 files, 2899 tests)
- `pnpm --filter @tutti-os/connector-market test` (69 tests)
- agent-gui and connector-market typechecks
- targeted oxlint and oxfmt checks
- live TSH Electron validation: Dropbox opens Install dialog; View more connectors opens Settings > Agent connector catalog