### PR TITLE
fix(agent-replay): preserve guest path compatibility on Windows

### DIFF
--- a/packages/agent/daemon/runtime/process_transport_cassette_test.go
+++ b/packages/agent/daemon/runtime/process_transport_cassette_test.go
@@ -686,6 +686,41 @@ func TestReplayProcessTransportMatchesJSONRPCRequestSemanticsAndMapsResponseID(t
 	}
 }
 
+func TestReplayProcessTransportAcceptsDefaultCWDAddedByNewerProvider(t *testing.T) {
+	expected := []byte(
+		`{"id":18,"method":"turn/start","params":{"input":[{"text":"hello","type":"text"}],"threadId":"thread-1"}}` + "\n",
+	)
+	actual := []byte(
+		`{"id":9,"method":"turn/start","params":{"threadId":"thread-1","cwd":"/workspace","input":[{"text":"hello","type":"text"}]}}` + "\n",
+	)
+
+	descriptor := codexReplayDescriptorForCassetteTest(t)
+	if _, _, matches := processCassetteJSONMatch(
+		descriptor,
+		expected,
+		actual,
+		"",
+		"/workspace",
+		"",
+		nil,
+	); !matches {
+		t.Fatal("turn/start with the explicit replay default cwd did not match an older recording")
+	}
+
+	changedCWD := bytes.Replace(actual, []byte(`/workspace`), []byte(`/other-workspace`), 1)
+	if _, _, matches := processCassetteJSONMatch(
+		descriptor,
+		expected,
+		changedCWD,
+		"",
+		"/workspace",
+		"",
+		nil,
+	); matches {
+		t.Fatal("turn/start with a non-default cwd matched an older recording")
+	}
+}
+
 func TestReplayProcessTransportIgnoresVolatileInitializeClientInfo(t *testing.T) {
 	expected := []byte(
 		`{"id":1,"method":"initialize","params":{"clientInfo":{"name":"codex-cli","title":"Codex","version":"0.146.0"},"capabilities":{"experimentalApi":true}}}` + "\n",

--- a/packages/agent/daemon/runtime/process_transport_replay_json.go
+++ b/packages/agent/daemon/runtime/process_transport_replay_json.go
@@ -83,6 +83,12 @@ func processCassetteJSONMatch(
 				expectedMessage["id"] = actualID
 			}
 		}
+		alignProcessCassetteDefaultReplayCWD(
+			descriptor,
+			expectedMessage,
+			actualMessage,
+			replayCWD,
+		)
 		if !alignProcessCassetteGeneratedIdentityValues(
 			expectedValues[index],
 			actualValues[index],
@@ -97,6 +103,36 @@ func processCassetteJSONMatch(
 		}
 	}
 	return responseIDs, identityValues, true
+}
+
+func alignProcessCassetteDefaultReplayCWD(
+	descriptor replay.ProviderReplayDescriptor,
+	expected map[string]any,
+	actual map[string]any,
+	replayCWD string,
+) {
+	if replayCWD == "" || expected == nil || actual == nil {
+		return
+	}
+	expectedMethod, expectedMethodOK := expected["method"].(string)
+	actualMethod, actualMethodOK := actual["method"].(string)
+	if !expectedMethodOK || !actualMethodOK || expectedMethod != actualMethod ||
+		!descriptor.UsesDefaultReplayCWD(expectedMethod) {
+		return
+	}
+	expectedParams, expectedParamsOK := expected["params"].(map[string]any)
+	actualParams, actualParamsOK := actual["params"].(map[string]any)
+	if !expectedParamsOK || !actualParamsOK {
+		return
+	}
+	if _, recordedCWDExists := expectedParams["cwd"]; recordedCWDExists {
+		return
+	}
+	actualCWD, actualCWDOK := actualParams["cwd"].(string)
+	if !actualCWDOK || actualCWD != replayCWD {
+		return
+	}
+	expectedParams["cwd"] = actualCWD
 }
 
 func processCassetteMessagesAreRequests(

--- a/packages/agent/session-replay/provider_descriptor.go
+++ b/packages/agent/session-replay/provider_descriptor.go
@@ -58,6 +58,7 @@ type ProviderTapeDescriptor struct {
 	GeneratedRequestFields  []ProviderGeneratedRequestField
 	GeneratedIdentityFields []string
 	MatchOnlyIdentityFields []string
+	DefaultReplayCWDMethods []string
 	ExcludeEnvironment      bool
 }
 
@@ -100,6 +101,7 @@ var providerReplayDescriptors = []ProviderReplayDescriptor{
 			GeneratedIdentityFields: []string{
 				"clientUserMessageId",
 			},
+			DefaultReplayCWDMethods: []string{"turn/start"},
 		},
 		PortableRuntime: ProviderPortableRuntimeDescriptor{
 			HomeEnvVars:          []string{"CODEX_HOME"},
@@ -212,6 +214,12 @@ func (d ProviderReplayDescriptor) IsMatchedIdentityField(name string) bool {
 		containsProviderReplayValue(d.Tape.MatchOnlyIdentityFields, name)
 }
 
+// UsesDefaultReplayCWD reports whether a newer Provider client may add the
+// replay workspace as an explicit cwd when an older recording omitted it.
+func (d ProviderReplayDescriptor) UsesDefaultReplayCWD(method string) bool {
+	return containsProviderReplayValue(d.Tape.DefaultReplayCWDMethods, method)
+}
+
 func containsProviderReplayValue(values []string, value string) bool {
 	want := normalizeProviderReplayIdentity(value)
 	for _, candidate := range values {
@@ -241,6 +249,10 @@ func cloneProviderReplayDescriptor(source ProviderReplayDescriptor) ProviderRepl
 	cloned.Tape.MatchOnlyIdentityFields = append(
 		[]string(nil),
 		source.Tape.MatchOnlyIdentityFields...,
+	)
+	cloned.Tape.DefaultReplayCWDMethods = append(
+		[]string(nil),
+		source.Tape.DefaultReplayCWDMethods...,
 	)
 	cloned.PortableRuntime.HomeEnvVars = append(
 		[]string(nil),

--- a/packages/agent/session-replay/provider_descriptor_test.go
+++ b/packages/agent/session-replay/provider_descriptor_test.go
@@ -20,6 +20,7 @@ func TestCodexProviderReplayDescriptorDeclaresCompleteAdapter(t *testing.T) {
 		!descriptor.MethodCarriesCredentials("account/login/start") ||
 		!descriptor.IsOptionalProbeMethod("thread/read") ||
 		!descriptor.IsGeneratedIdentityField("clientUserMessageId") ||
+		!descriptor.UsesDefaultReplayCWD("turn/start") ||
 		!descriptor.IsHomeEnvVar("codex_home") ||
 		descriptor.PortableRuntime.SessionHomeDirectory != "codex-home" {
 		t.Fatalf("Codex replay descriptor = %#v", descriptor)
@@ -72,10 +73,12 @@ func TestProviderReplayRegistryReturnsClones(t *testing.T) {
 		t.Fatal("Codex replay descriptor is missing")
 	}
 	descriptor.Tape.CredentialMethods[0] = "changed"
+	descriptor.Tape.DefaultReplayCWDMethods[0] = "changed"
 	descriptor.PortableRuntime.HomeEnvVars[0] = "CHANGED_HOME"
 
 	again, ok := FindProviderReplayByProvider("codex")
 	if !ok || !again.MethodCarriesCredentials("account/login/start") ||
+		!again.UsesDefaultReplayCWD("turn/start") ||
 		!again.IsHomeEnvVar("CODEX_HOME") {
 		t.Fatalf("registry descriptor was mutated: %#v", again)
 	}

--- a/packages/agent/session-replay/replay_artifact_cassette.go
+++ b/packages/agent/session-replay/replay_artifact_cassette.go
@@ -217,7 +217,7 @@ func validatePortableReplayPath(value any, label string) error {
 		strings.HasPrefix(path, PortableReplayCWDToken+"/") {
 		return nil
 	}
-	if filepath.IsAbs(path) || strings.HasPrefix(path, "file://") {
+	if isCrossPlatformAbsolutePath(path) || strings.HasPrefix(path, "file://") {
 		return fmt.Errorf("%s contains an absolute recording path", label)
 	}
 	return nil

--- a/packages/agent/session-replay/replay_artifact_store_test.go
+++ b/packages/agent/session-replay/replay_artifact_store_test.go
@@ -1,6 +1,7 @@
 package sessionreplay
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -686,7 +687,11 @@ func TestArtifactStoreProjectsSessionCreatePathsAtRecordingBoundary(t *testing.T
 		!strings.Contains(contents, `"projectPath":"${REPLAY_CWD}/packages/agent"`) {
 		t.Fatalf("session.create paths were not projected: %s", contents)
 	}
-	if !strings.Contains(contents, "keep "+recordedCWD+" in user text") {
+	var stored ActivityEvent
+	if err := json.Unmarshal(bytes.TrimSpace(raw), &stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored.Payload["displayPrompt"] != "keep "+recordedCWD+" in user text" {
 		t.Fatalf("user-authored text was rewritten: %s", contents)
 	}
 }

--- a/packages/agent/session-replay/replay_semantic_checkpoints_test.go
+++ b/packages/agent/session-replay/replay_semantic_checkpoints_test.go
@@ -2,7 +2,6 @@ package sessionreplay
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
@@ -380,10 +379,7 @@ func TestProjectBindingMatchesNormalizesRailSectionKeySymlinks(t *testing.T) {
 }
 
 func TestProjectBindingReadinessResolvesPortableExpectedState(t *testing.T) {
-	replayCWD, err := filepath.EvalSymlinks(t.TempDir())
-	if err != nil {
-		t.Fatal(err)
-	}
+	replayCWD := "/workspace/agent-session-replay"
 	actual := storesqlite.Session{
 		AgentTargetID:   "local:codex",
 		Provider:        "codex",

--- a/packages/agent/session-replay/replay_state.go
+++ b/packages/agent/session-replay/replay_state.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	pathpkg "path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -362,8 +363,11 @@ func ResolvePortableAgentState(
 	agent TuttiReplayAgent,
 	replayCWD string,
 ) (TuttiReplayAgent, error) {
-	replayCWD = filepath.Clean(strings.TrimSpace(replayCWD))
-	if replayCWD == "." || !filepath.IsAbs(replayCWD) {
+	// replayCWD belongs to the VM's logical POSIX namespace even when the
+	// product daemon runs on Windows. Host filepath semantics would reject
+	// /workspace/... there and would materialize portable paths with backslashes.
+	replayCWD = pathpkg.Clean(strings.TrimSpace(replayCWD))
+	if replayCWD == "." || !pathpkg.IsAbs(replayCWD) {
 		return TuttiReplayAgent{}, errors.New("replay cwd must be absolute")
 	}
 	resolved := agent
@@ -504,12 +508,10 @@ func resolvePortableReplayPath(path, replayCWD string) (string, error) {
 	if !strings.HasPrefix(path, prefix) {
 		return path, nil
 	}
-	relative := filepath.FromSlash(strings.TrimPrefix(path, prefix))
-	resolved := filepath.Clean(filepath.Join(replayCWD, relative))
-	within, err := filepath.Rel(replayCWD, resolved)
-	if err != nil || within == ".." ||
-		strings.HasPrefix(within, ".."+string(filepath.Separator)) ||
-		filepath.IsAbs(within) {
+	relative := strings.TrimPrefix(path, prefix)
+	resolved := pathpkg.Clean(pathpkg.Join(replayCWD, relative))
+	if replayCWD != "/" && resolved != replayCWD &&
+		!strings.HasPrefix(resolved, replayCWD+"/") {
 		return "", errors.New("portable replay path escapes replay cwd")
 	}
 	return resolved, nil
@@ -661,7 +663,7 @@ func projectPortableCommandField(input map[string]any, key string) {
 	}
 	command = strings.TrimSpace(command)
 	executable, arguments, hasArguments := strings.Cut(command, " ")
-	if !filepath.IsAbs(executable) {
+	if !isCrossPlatformAbsolutePath(executable) {
 		return
 	}
 	projected := filepath.Base(executable)
@@ -669,6 +671,25 @@ func projectPortableCommandField(input map[string]any, key string) {
 		projected += " " + arguments
 	}
 	input[key] = projected
+}
+
+// Recorded paths belong to the provider guest and can use POSIX semantics even
+// when cassette validation or projection runs on a Windows host. Also retain
+// host-native recognition for imported Windows recordings.
+func isCrossPlatformAbsolutePath(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false
+	}
+	if filepath.IsAbs(value) || pathpkg.IsAbs(strings.ReplaceAll(value, `\`, "/")) {
+		return true
+	}
+	if len(value) >= 3 && ((value[0] >= 'A' && value[0] <= 'Z') ||
+		(value[0] >= 'a' && value[0] <= 'z')) && value[1] == ':' &&
+		(value[2] == '\\' || value[2] == '/') {
+		return true
+	}
+	return strings.HasPrefix(value, `\\`)
 }
 
 func cloneReplayMap(source map[string]any) map[string]any {
@@ -742,7 +763,7 @@ func validateReplayPortableValue(path, key string, value any) error {
 	case string:
 		lowerKey := strings.ToLower(key)
 		if (strings.Contains(lowerKey, "path") || lowerKey == "cwd") &&
-			(filepath.IsAbs(value) || strings.HasPrefix(value, "file://")) {
+			(isCrossPlatformAbsolutePath(value) || strings.HasPrefix(value, "file://")) {
 			return fmt.Errorf("tutti replay state contains absolute path at %s", path)
 		}
 	}

--- a/packages/agent/session-replay/replay_state_domain_test.go
+++ b/packages/agent/session-replay/replay_state_domain_test.go
@@ -3,6 +3,7 @@ package sessionreplay
 import (
 	"errors"
 	"fmt"
+	"path"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -43,20 +44,16 @@ func TestProjectAndResolvePortableAgentSessionBinding(t *testing.T) {
 		t.Fatalf("source binding was mutated: %#v", agent.Sessions[0])
 	}
 
-	replayRoot := filepath.Join(
-		string(filepath.Separator),
-		"runtime",
-		"replay",
-	)
+	replayRoot := "/runtime/replay"
 	resolved, err := ResolvePortableAgentState(portable, replayRoot)
 	if err != nil {
 		t.Fatal(err)
 	}
 	session = resolved.Sessions[0]
 	if session.Cwd != replayRoot ||
-		session.RailProjectPath != filepath.Join(replayRoot, "packages", "agent") ||
+		session.RailProjectPath != path.Join(replayRoot, "packages", "agent") ||
 		session.RailSectionKey !=
-			"project:"+filepath.Join(replayRoot, "packages", "agent") {
+			"project:"+path.Join(replayRoot, "packages", "agent") {
 		t.Fatalf("resolved binding = %#v", session)
 	}
 }
@@ -144,6 +141,19 @@ func TestResolvePortableAgentStateRejectsPathEscape(t *testing.T) {
 	}
 }
 
+func TestResolvePortableAgentStateRequiresLogicalPOSIXRoot(t *testing.T) {
+	agent := TuttiReplayAgent{
+		RootSessionID: "session-1",
+		Sessions: []agenthost.HistoricalSession{{
+			ID:  "session-1",
+			Cwd: PortableReplayCWDToken,
+		}},
+	}
+	if _, err := ResolvePortableAgentState(agent, `C:\workspace\replay`); err == nil {
+		t.Fatal("Windows host path was accepted as the logical replay cwd")
+	}
+}
+
 func TestProjectPortableAgentStateProjectsTurnFileChangePaths(t *testing.T) {
 	recordedRoot := filepath.Join(
 		string(filepath.Separator),
@@ -189,14 +199,14 @@ func TestProjectPortableAgentStateProjectsTurnFileChangePaths(t *testing.T) {
 		t.Fatalf("source fileChanges was mutated: %#v", agent.Sessions[0].Turns[0].FileChanges)
 	}
 
-	replayRoot := filepath.Join(string(filepath.Separator), "runtime", "replay")
+	replayRoot := "/runtime/replay"
 	resolved, err := ResolvePortableAgentState(portable, replayRoot)
 	if err != nil {
 		t.Fatal(err)
 	}
 	resolvedFiles, _ := resolved.Sessions[0].Turns[0].FileChanges["files"].([]any)
 	resolvedFile, _ := resolvedFiles[0].(map[string]any)
-	want := filepath.Join(
+	want := path.Join(
 		replayRoot,
 		".tmp",
 		"agent-session-replay-r09",


### PR DESCRIPTION
## Summary

- keep replay CWD and portable state paths in the provider guest POSIX namespace on Windows hosts
- allow older Codex cassettes to match the newer `turn/start.cwd` field only when it equals the declared default replay CWD
- validate POSIX and Windows absolute paths independently of the host OS while preserving user-authored text

## Why

Native Windows TSH replay runs execute the provider inside a Linux HCS guest. Host `filepath` semantics rejected or rewrote guest paths, while older Cassettes omitted the default Codex `turn/start.cwd` field now emitted by newer providers.

## Risk

The compatibility rule is descriptor-owned and narrow: it applies only to declared methods, only when the recorded field is absent, and only when the live value exactly equals the replay CWD. Non-default CWD mismatches continue to fail closed.

## Verification

- `go test ./...` in `packages/agent/session-replay`
- `go test ./packages/agent/daemon/runtime -run 'TestReplayProcessTransport(AcceptsDefaultCWDAddedByNewerProvider|MapsRecordedCWDInStrictJSONMatch|FailsClosedOnOutboundMismatch)$' -count=1`
- real TSH C01 replay completed 8/8 checkpoints twice with `C01_TURN_3_COMPLETED`
- `git diff --check origin/main...HEAD`

## Windows impact

Covered by cross-platform absolute-path tests, logical POSIX replay-root tests, and the real native HCS/VMP replay runs above.

## Documentation impact

No durable documentation change is required. The existing Session Replay README already defines `${REPLAY_CWD}` as the portable guest-path boundary; this change makes Windows implementation match that contract.