### PR TITLE
fix(agent): admit prompts before provider dispatch

### DIFF
--- a/packages/agent/daemon/runtime/controller_exec.go
+++ b/packages/agent/daemon/runtime/controller_exec.go
@@ -139,6 +139,10 @@ func (c *Controller) Exec(ctx context.Context, input ExecInput) (result ExecResu
 		runCtx = context.WithValue(runCtx, execMetadataContextKey{}, metadata)
 	}
 	runCtx = withCanonicalSubmitFact(runCtx, canonicalSubmit)
+	runCtx = withCanonicalPromptContent(runCtx, content)
+	if canonicalSubmit.clientSubmitID == "" {
+		runCtx = withPromptActivityMessageID(runCtx, newTurnUserPromptActivityMessageID())
+	}
 	tuttiModeSnapshot := normalizeTuttiModeTurnSnapshot(input.TuttiModeSnapshot)
 	runCtx = withTuttiModeTurnSnapshot(runCtx, tuttiModeSnapshot)
 	var dispatchObserver *providerDispatchObserver
@@ -157,7 +161,14 @@ func (c *Controller) Exec(ctx context.Context, input ExecInput) (result ExecResu
 	c.mu.Lock()
 	provisional := c.provisionalSessions[key]
 	c.mu.Unlock()
-	submitEvents := submittedTurnActivityEvents(session, turnID, input.CapabilityRefs)
+	submitEvents := submittedTurnActivityEvents(
+		runCtx,
+		session,
+		content,
+		displayPrompt,
+		turnID,
+		input.CapabilityRefs,
+	)
 	if titleUpdated {
 		submitEvents = append([]activityshared.Event{newSessionTitleActivityEvent(session, session.Title)}, submitEvents...)
 	}

--- a/packages/agent/daemon/runtime/controller_exec.go
+++ b/packages/agent/daemon/runtime/controller_exec.go
@@ -118,14 +118,16 @@ func (c *Controller) Exec(ctx context.Context, input ExecInput) (result ExecResu
 		return c.guideActiveTurn(ctx, session, adapter, providerContent, displayPrompt, metadata, input.CapabilityRefs, input.TurnID)
 	}
 	previousSession := session
-	titleUpdated := false
+	// Keep the initial title on the submitted Turn patch so owner admission
+	// persists the title, turn, and prompt as one state/message transaction.
+	submittedTitle := ""
 	if initialTitle := strings.TrimSpace(input.InitialTitle); initialTitle != "" &&
 		!session.InitialTitleEstablished &&
 		strings.TrimSpace(session.Title) == strings.TrimSpace(input.InitialTitleBase) {
 		session.Title = initialTitle
 		session = markInitialTitleEstablished(session)
 		session.UpdatedAtUnixMS = unixMS(now())
-		titleUpdated = true
+		submittedTitle = session.Title
 	}
 	turnID := strings.TrimSpace(input.TurnID)
 	if turnID == "" {
@@ -168,10 +170,8 @@ func (c *Controller) Exec(ctx context.Context, input ExecInput) (result ExecResu
 		displayPrompt,
 		turnID,
 		input.CapabilityRefs,
+		submittedTitle,
 	)
-	if titleUpdated {
-		submitEvents = append([]activityshared.Event{newSessionTitleActivityEvent(session, session.Title)}, submitEvents...)
-	}
 	// The submitted Turn is a durable user intent, not provider output. Keep
 	// the Session visible while the provider-identity acceptance barrier is
 	// pending so an explicit provider rejection cannot erase the prompt.

--- a/packages/agent/daemon/runtime/controller_exec_test.go
+++ b/packages/agent/daemon/runtime/controller_exec_test.go
@@ -3,6 +3,7 @@ package agentruntime
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -241,6 +242,25 @@ userMessagePublished:
 	}
 	if !hasSessionStartedPatch {
 		t.Fatalf("report calls = %#v, want session started state patch", reportCalls)
+	}
+	var userMessageIDs []string
+	for _, call := range reportCalls {
+		for _, update := range call.report.MessageUpdates {
+			if update.Role == string(activityshared.MessageRoleUser) && update.TurnID == execResult.TurnID {
+				userMessageIDs = append(userMessageIDs, update.MessageID)
+			}
+		}
+	}
+	if len(userMessageIDs) == 0 {
+		t.Fatalf("report calls = %#v, want user message update for turn", reportCalls)
+	}
+	if userMessageIDs[0] == "" || !strings.HasPrefix(userMessageIDs[0], turnUserMessageIDPrefix) {
+		t.Fatalf("user message IDs = %#v, want a generated turn-user message ID", userMessageIDs)
+	}
+	for _, messageID := range userMessageIDs[1:] {
+		if messageID != userMessageIDs[0] {
+			t.Fatalf("user message IDs = %#v, want every update keyed by %q", userMessageIDs, userMessageIDs[0])
+		}
 	}
 	turnReport, ok := reportWithTimelineItem(reportInputs(reportCalls), "message.user")
 	if !ok || !hasTimelineItem(turnReport, "message.user", "completed", "hello") {

--- a/packages/agent/daemon/runtime/controller_exec_test.go
+++ b/packages/agent/daemon/runtime/controller_exec_test.go
@@ -194,6 +194,20 @@ func TestControllerStartExecPublishesAndReports(t *testing.T) {
 	if execResult.SessionStatus != SessionStatusWorking {
 		t.Fatalf("exec session status = %q, want %q", execResult.SessionStatus, SessionStatusWorking)
 	}
+	submitReports := reporter.waitForReports(t, "initial user submission report", func(calls []reportCall) bool {
+		_, found := reportWithTimelineItem(reportInputs(calls), "message.user")
+		return found
+	})
+	submitReport, ok := reportWithTimelineItem(reportInputs(submitReports), "message.user")
+	if !ok {
+		t.Fatalf("submit reports = %#v, want user message report", submitReports)
+	}
+	if len(submitReport.StatePatches) != 1 {
+		t.Fatalf("initial submit state patches = %#v, want one combined patch", submitReport.StatePatches)
+	}
+	if submitReport.StatePatches[0].Title != "hello" {
+		t.Fatalf("initial submit title = %q, want %q", submitReport.StatePatches[0].Title, "hello")
+	}
 	waitForStatePatchTitle(t, events, "hello")
 	deadline := time.After(2 * time.Second)
 	for {

--- a/packages/agent/daemon/runtime/controller_report_worker.go
+++ b/packages/agent/daemon/runtime/controller_report_worker.go
@@ -222,8 +222,9 @@ func (c *Controller) observeProviderObservations(
 }
 
 // reportSubmittedTurnDurable is the acceptance barrier for a user submission.
-// The daemon reporter commits the submitted Turn and its session pointer before
-// Exec may publish the transition, start provider work, or return success.
+// The durable reporter commits the submitted Turn and canonical user message
+// together before Exec may publish the transition, start provider work, or
+// return success.
 func (c *Controller) reportSubmittedTurnDurable(
 	ctx context.Context,
 	session Session,
@@ -243,7 +244,7 @@ func (c *Controller) reportSubmittedTurnDurable(
 	if keepProvisional {
 		hideProvisionalSessionReport(&report)
 	}
-	return c.reporter.Report(ctx, report)
+	return c.reporter.ReportSubmitProvenance(ctx, report)
 }
 
 func hideProvisionalSessionReport(report *agentsessionstore.ReportActivityInput) {

--- a/packages/agent/daemon/runtime/controller_submit_provenance_test.go
+++ b/packages/agent/daemon/runtime/controller_submit_provenance_test.go
@@ -176,13 +176,16 @@ func waitForCanonicalSubmitMessageReports(
 }
 
 type submittedTurnBarrierReporter struct {
-	entered chan struct{}
-	release chan struct{}
-	err     error
-	once    sync.Once
+	entered         chan struct{}
+	release         chan struct{}
+	err             error
+	once            sync.Once
+	input           agentsessionstore.ReportActivityInput
+	provenanceCalls int
 }
 
-func (r *submittedTurnBarrierReporter) Report(ctx context.Context, _ agentsessionstore.ReportActivityInput) error {
+func (r *submittedTurnBarrierReporter) Report(ctx context.Context, input agentsessionstore.ReportActivityInput) error {
+	r.input = input
 	r.once.Do(func() { close(r.entered) })
 	select {
 	case <-r.release:
@@ -193,6 +196,7 @@ func (r *submittedTurnBarrierReporter) Report(ctx context.Context, _ agentsessio
 }
 
 func (r *submittedTurnBarrierReporter) ReportSubmitProvenance(ctx context.Context, report agentsessionstore.ReportActivityInput) error {
+	r.provenanceCalls++
 	return r.Report(ctx, report)
 }
 
@@ -224,7 +228,11 @@ func TestControllerExecWaitsForSubmittedTurnDurableReportBeforeProviderStart(t *
 	execDone := make(chan error, 1)
 	go func() {
 		_, execErr := controller.Exec(context.Background(), ExecInput{
-			RoomID: "room-1", AgentSessionID: "agent-session-1", Content: textPrompt("hello"),
+			RoomID:                          "room-1",
+			AgentSessionID:                  "agent-session-1",
+			ClientSubmitID:                  "submit-1",
+			CanonicalSubmitOccurredAtUnixMS: 1_234,
+			Content:                         textPrompt("hello"),
 		})
 		execDone <- execErr
 	}()
@@ -248,6 +256,15 @@ func TestControllerExecWaitsForSubmittedTurnDurableReportBeforeProviderStart(t *
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("Exec did not return after durable report")
+	}
+	if len(reporter.input.MessageUpdates) != 1 ||
+		reporter.input.MessageUpdates[0].MessageID != userPromptActivityMessageIDFromClientSubmitID("submit-1") ||
+		reporter.input.MessageUpdates[0].Role != string(activityshared.MessageRoleUser) ||
+		reporter.input.MessageUpdates[0].TurnID == "" {
+		t.Fatalf("submitted report message updates = %#v", reporter.input.MessageUpdates)
+	}
+	if reporter.provenanceCalls != 1 {
+		t.Fatalf("submit provenance calls = %d, want one atomic admission call", reporter.provenanceCalls)
 	}
 	select {
 	case <-adapter.executed:

--- a/packages/agent/daemon/runtime/controller_turn_state.go
+++ b/packages/agent/daemon/runtime/controller_turn_state.go
@@ -16,6 +16,7 @@ func submittedTurnActivityEvents(
 	displayPrompt string,
 	turnID string,
 	capabilityRefs []activityshared.CapabilityReference,
+	submittedTitle string,
 ) []activityshared.Event {
 	eventContext, ok := activityEventContext(session, "turn-submitted:"+turnID, turnID)
 	if !ok {
@@ -32,6 +33,7 @@ func submittedTurnActivityEvents(
 		nil,
 	)
 	event := activityshared.NewTurnUpdated(eventContext, turnID, activityshared.TurnPhaseSubmitted)
+	event.Payload.Title = strings.TrimSpace(submittedTitle)
 	event.Payload.Metadata = map[string]any{"turnOrigin": "user_prompt"}
 	// The controller owns the submit moment; it publishes the submitted
 	// lifecycle snapshot so downstream layers copy instead of recomputing

--- a/packages/agent/daemon/runtime/controller_turn_state.go
+++ b/packages/agent/daemon/runtime/controller_turn_state.go
@@ -1,6 +1,7 @@
 package agentruntime
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -9,15 +10,28 @@ import (
 )
 
 func submittedTurnActivityEvents(
+	submitCtx context.Context,
 	session Session,
+	content []PromptContentBlock,
+	displayPrompt string,
 	turnID string,
 	capabilityRefs []activityshared.CapabilityReference,
 ) []activityshared.Event {
-	ctx, ok := activityEventContext(session, "turn-submitted:"+turnID, turnID)
+	eventContext, ok := activityEventContext(session, "turn-submitted:"+turnID, turnID)
 	if !ok {
 		return nil
 	}
-	event := activityshared.NewTurnUpdated(ctx, turnID, activityshared.TurnPhaseSubmitted)
+	explicitDisplayPrompt, visibleText := explicitAndVisiblePromptText(content, displayPrompt)
+	prompt := newUserPromptActivityEvent(
+		submitCtx,
+		session,
+		content,
+		explicitDisplayPrompt,
+		visibleText,
+		turnID,
+		nil,
+	)
+	event := activityshared.NewTurnUpdated(eventContext, turnID, activityshared.TurnPhaseSubmitted)
 	event.Payload.Metadata = map[string]any{"turnOrigin": "user_prompt"}
 	// The controller owns the submit moment; it publishes the submitted
 	// lifecycle snapshot so downstream layers copy instead of recomputing
@@ -28,7 +42,7 @@ func submittedTurnActivityEvents(
 		Phase:        string(activityshared.TurnPhaseSubmitted),
 	})
 	activityshared.StampTurnCapabilityReferences(&event, capabilityRefs)
-	return []activityshared.Event{event}
+	return []activityshared.Event{prompt, event}
 }
 
 // guidanceTurnCapabilityReferenceStatePatch records provenance on the

--- a/packages/agent/daemon/runtime/controller_turn_state_test.go
+++ b/packages/agent/daemon/runtime/controller_turn_state_test.go
@@ -15,7 +15,7 @@ func TestSubmittedTurnActivityEventProjectsCapabilityReferences(t *testing.T) {
 	events := submittedTurnActivityEvents(context.Background(), session, textPrompt("hello"), "", "turn-1", []CapabilityReference{
 		{Capability: " tutti ", Source: "slash_command"},
 		{Capability: "tutti", Source: "slash_command"},
-	})
+	}, "")
 	if len(events) != 2 {
 		t.Fatalf("submitted events = %#v", events)
 	}

--- a/packages/agent/daemon/runtime/controller_turn_state_test.go
+++ b/packages/agent/daemon/runtime/controller_turn_state_test.go
@@ -1,6 +1,7 @@
 package agentruntime
 
 import (
+	"context"
 	"testing"
 
 	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
@@ -11,16 +12,21 @@ import (
 func TestSubmittedTurnActivityEventProjectsCapabilityReferences(t *testing.T) {
 	t.Parallel()
 	session := Session{Provider: ProviderCodex, AgentSessionID: "agent-1", RoomID: "room-1"}
-	events := submittedTurnActivityEvents(session, "turn-1", []CapabilityReference{
+	events := submittedTurnActivityEvents(context.Background(), session, textPrompt("hello"), "", "turn-1", []CapabilityReference{
 		{Capability: " tutti ", Source: "slash_command"},
 		{Capability: "tutti", Source: "slash_command"},
 	})
-	if len(events) != 1 {
+	if len(events) != 2 {
 		t.Fatalf("submitted events = %#v", events)
+	}
+	if events[0].Type != activityshared.EventMessageAppended ||
+		events[0].Payload.Role != activityshared.MessageRoleUser ||
+		events[0].Payload.TurnID != "turn-1" {
+		t.Fatalf("submitted prompt event = %#v", events[0])
 	}
 	patch, ok := statePatchFromSessionEvent(
 		canonical.EventSource{Provider: ProviderCodex},
-		events[0],
+		events[1],
 		"agent-1",
 		100,
 	)

--- a/packages/agent/daemon/runtime/prompt_content.go
+++ b/packages/agent/daemon/runtime/prompt_content.go
@@ -21,12 +21,17 @@ import (
 var ErrPromptImageUnsupported = errors.New("agent prompt image input is unsupported")
 
 const clientSubmitUserMessageIDPrefix = "client-submit:user:"
+const turnUserMessageIDPrefix = "turn-user:"
 
 const maxProviderPromptImageBytes int64 = 20 << 20
 
 var runtimeConnectorKeyPattern = regexp.MustCompile(`^[a-z][a-z0-9._-]{0,127}$`)
 
 type canonicalSubmitFactContextKey struct{}
+
+type promptActivityMessageIDContextKey struct{}
+
+type canonicalPromptContentContextKey struct{}
 
 type canonicalSubmitFact struct {
 	clientSubmitID   string
@@ -65,6 +70,37 @@ func canonicalSubmitFactFromContext(ctx context.Context) canonicalSubmitFact {
 	}
 	fact, _ := ctx.Value(canonicalSubmitFactContextKey{}).(canonicalSubmitFact)
 	return fact
+}
+
+func withPromptActivityMessageID(ctx context.Context, messageID string) context.Context {
+	messageID = strings.TrimSpace(messageID)
+	if messageID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, promptActivityMessageIDContextKey{}, messageID)
+}
+
+func promptActivityMessageIDFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	messageID, _ := ctx.Value(promptActivityMessageIDContextKey{}).(string)
+	return strings.TrimSpace(messageID)
+}
+
+func withCanonicalPromptContent(ctx context.Context, content []PromptContentBlock) context.Context {
+	if len(content) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, canonicalPromptContentContextKey{}, append([]PromptContentBlock(nil), content...))
+}
+
+func canonicalPromptContentFromContext(ctx context.Context) []PromptContentBlock {
+	if ctx == nil {
+		return nil
+	}
+	content, _ := ctx.Value(canonicalPromptContentContextKey{}).([]PromptContentBlock)
+	return append([]PromptContentBlock(nil), content...)
 }
 
 type providerPromptImageMaterializer func(context.Context, []PromptContentBlock) ([]PromptContentBlock, error)
@@ -295,13 +331,24 @@ func newUserPromptActivityEvent(
 	extra map[string]any,
 ) activityshared.Event {
 	payloadExtra := userPromptActivityPayloadExtraFromExecMetadata(ctx, extra)
+	fact := canonicalSubmitFactFromContext(ctx)
+	activityContent := canonicalPromptContentFromContext(ctx)
+	if len(activityContent) > 0 {
+		content = activityContent
+		if strings.TrimSpace(explicitDisplayPrompt) == "" {
+			_, visibleText = explicitAndVisiblePromptText(content, "")
+		}
+	}
+	if fact.clientSubmitID == "" {
+		fact.messageID = promptActivityMessageIDFromContext(ctx)
+	}
 	return newUserPromptActivityEventWithFact(
 		session,
 		content,
 		explicitDisplayPrompt,
 		visibleText,
 		turnID,
-		canonicalSubmitFactFromContext(ctx),
+		fact,
 		payloadExtra,
 	)
 }
@@ -325,6 +372,13 @@ func newUserPromptActivityEventWithFact(
 			extra = map[string]any{}
 		}
 		extra["clientSubmitId"] = fact.clientSubmitID
+		extra["messageId"] = fact.messageID
+	} else if fact.messageID != "" {
+		eventID = fact.messageID
+		extra = clonePayload(extra)
+		if extra == nil {
+			extra = map[string]any{}
+		}
 		extra["messageId"] = fact.messageID
 	}
 	return newTurnActivityEventWithIDAt(
@@ -369,6 +423,10 @@ func userPromptActivityMessageIDFromClientSubmitID(clientSubmitID string) string
 		return ""
 	}
 	return clientSubmitUserMessageIDPrefix + normalized
+}
+
+func newTurnUserPromptActivityMessageID() string {
+	return turnUserMessageIDPrefix + newID()
 }
 
 func promptContentForACP(content []PromptContentBlock) []map[string]any {

--- a/packages/agent/daemon/runtime/prompt_content_test.go
+++ b/packages/agent/daemon/runtime/prompt_content_test.go
@@ -359,3 +359,32 @@ func TestUserPromptActivityPayloadExtraFromExecMetadataPreservesExplicitMessageI
 		t.Fatalf("extra = %#v, want explicit messageId preserved", extra)
 	}
 }
+
+func TestNewUserPromptActivityEventUsesStableTurnMessageID(t *testing.T) {
+	t.Parallel()
+
+	session := Session{RoomID: "room-1", AgentSessionID: "agent-1", Provider: ProviderCodex}
+	want := newTurnUserPromptActivityMessageID()
+	ctx := withPromptActivityMessageID(context.Background(), want)
+	first := newUserPromptActivityEvent(ctx, session, textPrompt("hello"), "", "hello", "turn-1", nil)
+	second := newUserPromptActivityEvent(ctx, session, textPrompt("hello"), "", "hello", "turn-1", nil)
+
+	if first.EventID != want || second.EventID != want {
+		t.Fatalf("event IDs = %q and %q, want %q", first.EventID, second.EventID, want)
+	}
+	if first.Payload.Metadata["messageId"] != want || second.Payload.Metadata["messageId"] != want {
+		t.Fatalf("message IDs = %#v and %#v, want %q", first.Payload.Metadata, second.Payload.Metadata, want)
+	}
+}
+
+func TestNewUserPromptActivityEventUsesCanonicalPromptContent(t *testing.T) {
+	t.Parallel()
+
+	session := Session{RoomID: "room-1", AgentSessionID: "agent-1", Provider: ProviderCodex}
+	ctx := withCanonicalPromptContent(context.Background(), textPrompt("user content"))
+	event := newUserPromptActivityEvent(ctx, session, textPrompt("provider-only connector instruction"), "", "provider-only connector instruction", "turn-1", nil)
+
+	if event.Payload.Content != "user content" || event.Payload.Metadata["content"].([]map[string]any)[0]["text"] != "user content" {
+		t.Fatalf("prompt event = %#v, want canonical user content", event)
+	}
+}

--- a/services/tuttid/service/agent/activity_projection_ordering_test.go
+++ b/services/tuttid/service/agent/activity_projection_ordering_test.go
@@ -146,6 +146,51 @@ func TestActivityProjectionReportCreatesProviderInitiatedTurnBeforeMessages(t *t
 	}
 }
 
+func TestActivityProjectionSubmitProvenanceAllowsGeneratedPromptIdentity(t *testing.T) {
+	ctx := context.Background()
+	store := openAgentServiceSQLiteStore(t)
+	if err := store.Create(ctx, workspacebiz.Summary{ID: "ws-generated-prompt", Name: "Generated prompt"}); err != nil {
+		t.Fatal(err)
+	}
+	projection := NewActivityProjection(store)
+	turnID := "turn-generated-prompt"
+	messageID := "turn-user:generated-message"
+	if err := projection.ReportSubmitProvenance(ctx, agentsessionstore.ReportActivityInput{
+		WorkspaceID: "ws-generated-prompt",
+		Source: canonical.EventSource{
+			AgentID: "session-generated-prompt", Provider: "codex",
+			SessionOrigin: agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+		},
+		StatePatches: []agentsessionstore.WorkspaceAgentStatePatch{{
+			AgentSessionID: "session-generated-prompt", Kind: agentactivitybiz.SessionKindRoot,
+			Provider: "codex", LifecycleStatus: "active", CurrentPhase: "working", OccurredAtUnixMS: 1,
+			Turn: &agentsessionstore.WorkspaceAgentTurnPatch{
+				TurnID: turnID, Origin: agentactivitybiz.TurnOriginUserPrompt,
+				ActiveTurnID: &turnID, Phase: agentactivitybiz.TurnPhaseSubmitted,
+			},
+		}},
+		MessageUpdates: []agentsessionstore.WorkspaceAgentMessageUpdate{{
+			AgentSessionID: "session-generated-prompt", TurnID: turnID, MessageID: messageID,
+			Role: "user", Kind: "text", Status: "completed", OccurredAtUnixMS: 1,
+			Payload: map[string]any{
+				"content": []map[string]any{{"type": "text", "text": "hello"}},
+			},
+		}},
+	}); err != nil {
+		t.Fatalf("generated prompt admission error = %v", err)
+	}
+	turn, found, err := store.GetTurn(ctx, "ws-generated-prompt", "session-generated-prompt", turnID)
+	if err != nil || !found || turn.Phase != agentactivitybiz.TurnPhaseSubmitted {
+		t.Fatalf("generated prompt turn = %#v found=%v error=%v", turn, found, err)
+	}
+	page, found, err := store.ListSessionMessages(ctx, agentactivitybiz.ListSessionMessagesInput{
+		WorkspaceID: "ws-generated-prompt", AgentSessionID: "session-generated-prompt", Limit: 10,
+	})
+	if err != nil || !found || len(page.Messages) != 1 || page.Messages[0].MessageID != messageID {
+		t.Fatalf("generated prompt messages = %#v found=%v error=%v", page.Messages, found, err)
+	}
+}
+
 func TestActivityProjectionRootProviderCompletionFlushesTurnMessagesBeforeSettlement(t *testing.T) {
 	ctx := context.Background()
 	store := openAgentServiceSQLiteStore(t)

--- a/services/tuttid/service/agent/activity_projection_submit_provenance.go
+++ b/services/tuttid/service/agent/activity_projection_submit_provenance.go
@@ -11,10 +11,12 @@ import (
 )
 
 // ReportSubmitProvenance is a deliberately narrower contract than Report.
-// It commits the canonical client-submit message together with the session and
-// optional new-turn patch in one repository transaction. The ordinary Report
-// compatibility path persists state and messages separately and therefore
-// cannot acknowledge provider dispatch safely.
+// It commits the canonical user message together with the session and optional
+// new-turn patch in one repository transaction. A client-submit id is carried
+// when the caller has one; internally allocated turns use a generated message
+// id instead. The ordinary Report compatibility path persists state and
+// messages separately and therefore cannot acknowledge provider dispatch
+// safely.
 func (p *ActivityProjection) ReportSubmitProvenance(
 	ctx context.Context,
 	input agentsessionstore.ReportActivityInput,
@@ -56,8 +58,8 @@ func (p *ActivityProjection) ReportSubmitProvenance(
 	update := messageInput.Updates[0]
 	clientSubmitID, _ := update.Payload["clientSubmitId"].(string)
 	clientSubmitID = strings.TrimSpace(clientSubmitID)
-	if strings.TrimSpace(update.MessageID) == "" || strings.TrimSpace(update.TurnID) == "" || clientSubmitID == "" {
-		return fmt.Errorf("atomic submit provenance requires message id, turn id, and client submit id")
+	if strings.TrimSpace(update.MessageID) == "" || strings.TrimSpace(update.TurnID) == "" {
+		return fmt.Errorf("atomic submit provenance requires message id and turn id")
 	}
 
 	activityReport, canonicalTargetID, err := p.activityStateReport(ctx, stateInput)
@@ -81,7 +83,7 @@ func (p *ActivityProjection) ReportSubmitProvenance(
 	}
 	message := result.Messages.Messages[0]
 	if strings.TrimSpace(message.TurnID) != strings.TrimSpace(update.TurnID) ||
-		strings.TrimSpace(payloadString(message.Payload, "clientSubmitId")) != clientSubmitID {
+		(clientSubmitID != "" && strings.TrimSpace(payloadString(message.Payload, "clientSubmitId")) != clientSubmitID) {
 		return fmt.Errorf("atomic submit provenance did not preserve canonical message identity")
 	}
 


### PR DESCRIPTION
## Summary
- Durably admit the canonical user prompt together with the submitted Turn before provider dispatch.
- Preserve canonical user content while connector instructions remain provider-only.
- Use stable per-admission message identity for internal submissions without `clientSubmitId`.

## Tests
- `go test ./packages/agent/daemon/runtime -run ... -count=1`
- `go test ./services/tuttid/service/agent -count=1`
- `go test ./packages/agent/host/conformance -count=1`
- `go test -race ./packages/agent/daemon/runtime -run ... -count=1`
- `pnpm check:changed -- --dry-run`

## Notes
- Full runtime tests reproduce three pre-existing Claude sidecar startup failures (`sidecar runtime error`); targeted owner/runtime tests and the full service/agent package pass.
- This PR changes Tutti owner runtime only; TSH dependency upgrade follows after a Tutti release.