### PR TITLE
fix(agent): fence reconciliation until session commit

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts
@@ -9,9 +9,7 @@ import {
 import {
   createAgentActivitySnapshotProjector,
   createAgentActivitySessionReconcileExecutor,
-  createAgentActivityWorkspaceEventCoordinator,
-  selectEngineSession,
-  selectLatestActivationForSession
+  createAgentActivityWorkspaceEventCoordinator
 } from "@tutti-os/agent-activity-core";
 import type { WorkspaceAgentActivityEnsureSessionSynchronizedInput } from "../workspaceAgentActivityService.interface.ts";
 import type { WorkspaceAgentSessionEngineHost } from "./workspaceAgentSessionEngineHost.ts";
@@ -490,19 +488,6 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
           if (!agentSessionId) return;
           const entry = this.entries.get(workspaceId);
           if (!entry) return;
-          const snapshot = entry.engine.getSnapshot();
-          const pendingActivation = selectLatestActivationForSession(
-            snapshot,
-            agentSessionId
-          );
-          if (
-            !selectEngineSession(snapshot, agentSessionId) &&
-            pendingActivation?.mode === "new" &&
-            (pendingActivation.status === "requested" ||
-              pendingActivation.status === "uncertain")
-          ) {
-            return;
-          }
           entry.engine.dispatch({
             agentSessionId,
             needsMessages: false,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -3538,7 +3538,7 @@ test("WorkspaceAgentActivityService does not tombstone a missing reconcile witho
   });
 });
 
-test("WorkspaceAgentActivityService preserves a pending new session when the Tutti event races create visibility", async (t) => {
+test("WorkspaceAgentActivityService preserves a pending new session when activity races create visibility", async (t) => {
   const diagnostics: unknown[] = [];
   const listenersByTopic = new Map<string, (event: unknown) => void>();
   let getSessionCalls = 0;
@@ -3609,6 +3609,23 @@ test("WorkspaceAgentActivityService preserves a pending new session when the Tut
     requestedAtUnixMs,
     requestId: "activation-1",
     workspaceId: "ws-1"
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const activityUpdated = listenersByTopic.get("agent.activity.updated");
+  assert.ok(activityUpdated);
+  activityUpdated({
+    payload: {
+      agentSessionId: "session-1",
+      data: {
+        agentSessionId: "session-1",
+        eventType: "session_reconcile_required",
+        lastEventUnixMs: requestedAtUnixMs,
+        workspaceId: "ws-1"
+      },
+      eventType: "session_reconcile_required",
+      workspaceId: "ws-1"
+    }
   });
   await new Promise((resolve) => setImmediate(resolve));
 

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -769,26 +769,33 @@ be resent`). The app never opens.
   `renderer_adapter.create.resolved` and `api.create.completed`. Confirm the
   missing reconcile occurs while the engine still has a requested or uncertain
   new-session activation.
-- **Root cause:** Initial Tutti activation can publish
-  `workspace.tuttimode.updated` before the create transaction is query-visible
-  or its HTTP response returns. The renderer treats the event as a reconcile
-  hint and exposes its transient 404 as a detail failure even though the
-  independent create command is still in flight.
-- **Fix:** Ignore only this Tutti update hint when the exact Session has no
-  canonical record and its latest new-session activation is still requested or
-  uncertain. Let the authoritative create result confirm the Session. Do not
-  broadly swallow reconcile 404s: existing Sessions and other reconcile
-  sources still report their real failures. Tombstone only from explicit
-  deletion evidence such as `session_deleted` or a successful delete command.
-- **Validation:** Hold create in flight, publish
-  `workspace.tuttimode.updated`, and verify the Session read is not called and
-  no reconcile error is recorded. Then resolve create and verify the canonical
-  Session and active activation are present. Also prove the same event still
-  reconciles an existing Session and preserves its not-found diagnostic, while
-  an explicit `session_deleted` event tombstones it.
+- **Root cause:** Initial activation can publish activity or mode updates before
+  the create transaction is query-visible or its HTTP response returns. The
+  renderer treated those independent signals as permission to reconcile an
+  exact Session, so a normal not-yet-visible window became a transient 404 even
+  though the create command was still in flight. A topic-specific guard covered
+  only one of those signals and left the admission boundary fragmented.
+- **Fix:** Keep the new Session in a requested/uncertain admission state until
+  an authoritative `session/upserted` result arrives. The activity-core
+  reconcile reducer records demand but defers transport reads whenever the
+  exact Session has no canonical record and a new activation is pending. It
+  releases the merged demand after the Session is committed, regardless of
+  whether the trigger was an activity event, a mode update, or direct Session
+  synchronization. Do not broadly swallow reconcile 404s: existing Sessions
+  and settled activations still report real failures. Tombstone only from
+  explicit deletion evidence such as `session_deleted` or a successful delete
+  command.
+- **Validation:** Hold create in flight, publish both
+  `agent.activity.updated` and `workspace.tuttimode.updated`, and request direct
+  Session synchronization. Verify no Session read is called and no reconcile
+  error is recorded. Then resolve create and verify the canonical Session,
+  active activation, and one released reconcile are present. Also prove an
+  existing Session still reconciles and preserves its not-found diagnostic,
+  while an explicit `session_deleted` event tombstones it.
 - **References:**
+  [sessionReconcile.reducer.ts](../../../packages/agent/activity-core/src/engine/sessionReconcile.reducer.ts)
+  [rootReducer.ts](../../../packages/agent/activity-core/src/engine/rootReducer.ts)
   [workspaceAgentActivityReconcileBridge.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts)
-  [workspaceEventCoordinator.ts](../../../packages/agent/activity-core/src/workspaceEventCoordinator.ts)
 
 ### A Tutti submission remains `delivery is still being confirmed`
 

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -775,23 +775,27 @@ be resent`). The app never opens.
   exact Session, so a normal not-yet-visible window became a transient 404 even
   though the create command was still in flight. A topic-specific guard covered
   only one of those signals and left the admission boundary fragmented.
-- **Fix:** Keep the new Session in a requested/uncertain admission state until
-  an authoritative `session/upserted` result arrives. The activity-core
-  reconcile reducer records demand but defers transport reads whenever the
-  exact Session has no canonical record and a new activation is pending. It
-  releases the merged demand after the Session is committed, regardless of
-  whether the trigger was an activity event, a mode update, or direct Session
+- **Fix:** Keep the new Session behind the admission fence while its activation
+  is still `requested`. The activity-core reconcile reducer records demand but
+  defers transport reads whenever the exact Session has no canonical record
+  and the create command still owns visibility. If the create result becomes
+  uncertain or its confirmation expires, enqueue one authoritative recovery
+  reconcile; that recovery is allowed to discover a Session that was committed
+  even though the create response was lost. A normal successful create still
+  releases the merged demand through `session/upserted`, regardless of whether
+  the trigger was an activity event, a mode update, or direct Session
   synchronization. Do not broadly swallow reconcile 404s: existing Sessions
   and settled activations still report real failures. Tombstone only from
   explicit deletion evidence such as `session_deleted` or a successful delete
   command.
 - **Validation:** Hold create in flight, publish both
   `agent.activity.updated` and `workspace.tuttimode.updated`, and request direct
-  Session synchronization. Verify no Session read is called and no reconcile
-  error is recorded. Then resolve create and verify the canonical Session,
-  active activation, and one released reconcile are present. Also prove an
-  existing Session still reconciles and preserves its not-found diagnostic,
-  while an explicit `session_deleted` event tombstones it.
+  Session synchronization. Verify no Session read is called while activation
+  is requested. Then simulate a lost create response and verify one recovery
+  reconcile is admitted, discovers the canonical Session, and confirms the
+  activation. Also prove an existing Session still reconciles and preserves
+  its not-found diagnostic, while an explicit `session_deleted` event
+  tombstones it.
 - **References:**
   [sessionReconcile.reducer.ts](../../../packages/agent/activity-core/src/engine/sessionReconcile.reducer.ts)
   [rootReducer.ts](../../../packages/agent/activity-core/src/engine/rootReducer.ts)

--- a/packages/agent/activity-core/src/engine/pendingIntents.activationSettlement.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.activationSettlement.ts
@@ -24,6 +24,19 @@ import type {
 
 const NO_COMMANDS: readonly EngineCommand[] = [];
 
+export function createActivationRecoveryIntent(
+  record: PendingActivationIntentRecord
+): EngineIntent | null {
+  if (record.mode !== "new") return null;
+  return {
+    agentSessionId: record.agentSessionId,
+    needsMessages: false,
+    needsState: true,
+    type: "session/reconcileRequested",
+    workspaceId: record.workspaceId
+  };
+}
+
 export function settleActivationCommand(
   state: PendingIntentsState,
   intent: EngineCommandResultIntent
@@ -72,8 +85,10 @@ export function settleActivationCommand(
       };
     }
     if (settlement.kind === "invalid") {
+      const recoveryIntent = createActivationRecoveryIntent(record);
       return {
         commands: NO_COMMANDS,
+        ...(recoveryIntent ? { followUpIntents: [recoveryIntent] } : {}),
         state: replaceActivation(state, {
           ...settledRecord,
           status: "uncertain"
@@ -106,8 +121,13 @@ export function settleActivationCommand(
       })
     };
   }
+  const recoveryIntent =
+    intent.outcome === "timedOut"
+      ? createActivationRecoveryIntent(record)
+      : null;
   return {
     commands: NO_COMMANDS,
+    ...(recoveryIntent ? { followUpIntents: [recoveryIntent] } : {}),
     state: replaceActivation(state, {
       ...record,
       commandOutcome: intent.outcome === "timedOut" ? "timed_out" : "failed",

--- a/packages/agent/activity-core/src/engine/pendingIntents.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.reducer.test.ts
@@ -417,13 +417,23 @@ test("malformed turnless goal control result is rejected before session upsert",
 
 test("timed out activation remains uncertain until its exact session appears", () => {
   let state = reduce(createInitialPendingIntentsState(), activation()).state;
-  state = reduce(state, {
+  const timedOut = reduce(state, {
     commandId: "activate:activation-1",
     commandType: "session/activate",
     correlationId: "activation-1",
     outcome: "timedOut",
     type: "engine/commandResult"
-  }).state;
+  });
+  state = timedOut.state;
+  assert.deepEqual(timedOut.followUpIntents, [
+    {
+      agentSessionId: "session-new",
+      needsMessages: false,
+      needsState: true,
+      type: "session/reconcileRequested",
+      workspaceId: "workspace-1"
+    }
+  ]);
   assert.equal(
     state.activationsByRequestId["activation-1"]?.status,
     "uncertain"
@@ -665,7 +675,15 @@ test("typed activation results cannot omit or escape their requested scope", () 
     missingSession.state.activationsByRequestId["activation-1"]?.status,
     "uncertain"
   );
-  assert.deepEqual(missingSession.followUpIntents, undefined);
+  assert.deepEqual(missingSession.followUpIntents, [
+    {
+      agentSessionId: "session-new",
+      needsMessages: false,
+      needsState: true,
+      type: "session/reconcileRequested",
+      workspaceId: "workspace-1"
+    }
+  ]);
 
   const existingState = reduce(
     createInitialPendingIntentsState(),
@@ -728,7 +746,15 @@ test("typed activation rejects malformed nested Session entities", () => {
     result.state.activationsByRequestId["activation-1"]?.status,
     "uncertain"
   );
-  assert.deepEqual(result.followUpIntents, undefined);
+  assert.deepEqual(result.followUpIntents, [
+    {
+      agentSessionId: "session-new",
+      needsMessages: false,
+      needsState: true,
+      type: "session/reconcileRequested",
+      workspaceId: "workspace-1"
+    }
+  ]);
 });
 
 test("typed activation rejects malformed Goal synchronization evidence", () => {
@@ -766,7 +792,15 @@ test("typed activation rejects malformed Goal synchronization evidence", () => {
       result.state.activationsByRequestId["activation-1"]?.status,
       "uncertain"
     );
-    assert.deepEqual(result.followUpIntents, undefined);
+    assert.deepEqual(result.followUpIntents, [
+      {
+        agentSessionId: "session-new",
+        needsMessages: false,
+        needsState: true,
+        type: "session/reconcileRequested",
+        workspaceId: "workspace-1"
+      }
+    ]);
   }
 });
 
@@ -894,13 +928,23 @@ test("activation diagnostics preserve command and snapshot evidence through expi
     dueAtUnixMs: 120_000,
     expiryId: "activation:activation-1",
     type: "engine/intentExpired"
-  }).state.activationsByRequestId["activation-1"];
-  assert.equal(expired?.status, "failed");
-  assert.equal(expired?.commandOutcome, "timed_out");
-  assert.equal(expired?.commandSettledAtUnixMs, 90_001);
-  assert.equal(expired?.snapshotOutcome, "session_missing");
-  assert.equal(expired?.lastObservedStage, "expired");
-  assert.equal(expired?.errorCode, "activation_confirmation_expired");
+  });
+  assert.deepEqual(expired.followUpIntents, [
+    {
+      agentSessionId: "session-new",
+      needsMessages: false,
+      needsState: true,
+      type: "session/reconcileRequested",
+      workspaceId: "workspace-1"
+    }
+  ]);
+  const activationRecord = expired.state.activationsByRequestId["activation-1"];
+  assert.equal(activationRecord?.status, "failed");
+  assert.equal(activationRecord?.commandOutcome, "timed_out");
+  assert.equal(activationRecord?.commandSettledAtUnixMs, 90_001);
+  assert.equal(activationRecord?.snapshotOutcome, "session_missing");
+  assert.equal(activationRecord?.lastObservedStage, "expired");
+  assert.equal(activationRecord?.errorCode, "activation_confirmation_expired");
 });
 
 test("repeated identical activation snapshot evidence preserves state identity", () => {

--- a/packages/agent/activity-core/src/engine/pendingIntents.reducer.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.reducer.ts
@@ -22,6 +22,7 @@ import {
 } from "./pendingIntents.activationRecords.ts";
 import {
   confirmActivationsFromSessions,
+  createActivationRecoveryIntent,
   receiveSessionSnapshot,
   settleActivationCommand
 } from "./pendingIntents.activationSettlement.ts";
@@ -602,8 +603,13 @@ function expireActivation(
   if (record.status === "canceled") {
     return { commands: NO_COMMANDS, state: deleteActivation(state, requestId) };
   }
+  const recoveryIntent =
+    record.status === "requested" || record.status === "uncertain"
+      ? createActivationRecoveryIntent(record)
+      : null;
   return {
     commands: NO_COMMANDS,
+    ...(recoveryIntent ? { followUpIntents: [recoveryIntent] } : {}),
     state: replaceActivation(state, {
       ...record,
       errorCode: record.errorCode ?? "activation_confirmation_expired",

--- a/packages/agent/activity-core/src/engine/rootReducer.ts
+++ b/packages/agent/activity-core/src/engine/rootReducer.ts
@@ -420,6 +420,16 @@ export function rootEngineReducer(
     intent,
     {
       deletedSessionIds: state.sessionLifecycle.deletedSessionIds,
+      pendingNewSessionIds: new Set(
+        Object.values(pendingIntents.state.activationsByRequestId)
+          .filter(
+            (activation) =>
+              activation.mode === "new" &&
+              (activation.status === "requested" ||
+                activation.status === "uncertain")
+          )
+          .map((activation) => activation.agentSessionId)
+      ),
       sessionsById: sessionLifecycle.state.sessionsById,
       workspaceReconcileCommandId:
         state.engineRuntime.workspaceReconcile.commandId

--- a/packages/agent/activity-core/src/engine/rootReducer.ts
+++ b/packages/agent/activity-core/src/engine/rootReducer.ts
@@ -420,13 +420,14 @@ export function rootEngineReducer(
     intent,
     {
       deletedSessionIds: state.sessionLifecycle.deletedSessionIds,
+      // Once activation is uncertain, the command is no longer the owner of
+      // Session visibility. Its recovery follow-up must be allowed to issue
+      // the authoritative read that can discover a committed Session.
       pendingNewSessionIds: new Set(
         Object.values(pendingIntents.state.activationsByRequestId)
           .filter(
             (activation) =>
-              activation.mode === "new" &&
-              (activation.status === "requested" ||
-                activation.status === "uncertain")
+              activation.mode === "new" && activation.status === "requested"
           )
           .map((activation) => activation.agentSessionId)
       ),

--- a/packages/agent/activity-core/src/engine/sessionReconcile.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionReconcile.reducer.test.ts
@@ -155,6 +155,59 @@ test("activity observation derives reconcile scope inside the engine", () => {
   ]);
 });
 
+test("pending new sessions defer reconcile until their canonical session is committed", () => {
+  const pendingNewSessionIds = new Set(["session-1"]);
+  const pending = sessionReconcileReducer(
+    createInitialSessionReconcileState(),
+    {
+      type: "session/activityObserved",
+      agentSessionId: "session-1",
+      eventType: "session_reconcile_required",
+      hasCachedSession: false,
+      hasInlineMessages: false,
+      inlineApplied: false,
+      workspaceId: "workspace-1"
+    },
+    {
+      deletedSessionIds: {},
+      pendingNewSessionIds,
+      sessionsById: {},
+      workspaceReconcileCommandId: null
+    }
+  );
+
+  assert.deepEqual(pending.commands, []);
+  assert.equal(
+    pending.state.recordsBySessionId["session-1"]?.pendingState,
+    true
+  );
+
+  const committed = sessionReconcileReducer(
+    pending.state,
+    {
+      session: {
+        agentSessionId: "session-1",
+        workspaceId: "workspace-1"
+      } as never,
+      type: "session/upserted"
+    },
+    {
+      deletedSessionIds: {},
+      pendingNewSessionIds: new Set(),
+      sessionsById: { "session-1": {} as never },
+      workspaceReconcileCommandId: null
+    }
+  );
+
+  assert.equal(committed.commands[0]?.type, "session/reconcile");
+  assert.equal(
+    committed.commands[0]?.type === "session/reconcile"
+      ? committed.commands[0].agentSessionId
+      : null,
+    "session-1"
+  );
+});
+
 test("streaming message gaps coalesce into one delayed reconcile and one trailing read", () => {
   const observation = {
     agentSessionId: "session-1",

--- a/packages/agent/activity-core/src/engine/sessionReconcile.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionReconcile.reducer.test.ts
@@ -5,7 +5,10 @@ import {
   sessionReconcileReducer
 } from "./sessionReconcile.reducer.ts";
 import { selectEngineAuthoritativeHistoryRequirement } from "./sessionReconcile.selectors.ts";
-import { createInitialAgentSessionEngineState } from "./rootReducer.ts";
+import {
+  createInitialAgentSessionEngineState,
+  rootEngineReducer
+} from "./rootReducer.ts";
 
 test("an uncached initial read establishes a baseline without forcing full history", () => {
   const requirement = selectEngineAuthoritativeHistoryRequirement(
@@ -203,6 +206,58 @@ test("pending new sessions defer reconcile until their canonical session is comm
   assert.equal(
     committed.commands[0]?.type === "session/reconcile"
       ? committed.commands[0].agentSessionId
+      : null,
+    "session-1"
+  );
+});
+
+test("timed out activation admits a recovery reconcile for queued demand", () => {
+  let state = createInitialAgentSessionEngineState();
+  state = rootEngineReducer(state, {
+    agentSessionId: "session-1",
+    agentTargetId: "target-1",
+    clientSubmitId: "submit-1",
+    expiresAtUnixMs: 120_000,
+    mode: "new",
+    requestedAtUnixMs: 1,
+    requestId: "activation-1",
+    type: "activation/requested",
+    workspaceId: "workspace-1"
+  }).state;
+
+  const observed = rootEngineReducer(state, {
+    agentSessionId: "session-1",
+    eventType: "session_reconcile_required",
+    hasCachedSession: false,
+    hasInlineMessages: false,
+    inlineApplied: false,
+    type: "session/activityObserved",
+    workspaceId: "workspace-1"
+  });
+  assert.deepEqual(observed.commands, []);
+  assert.equal(
+    observed.state.sessionReconcile.recordsBySessionId["session-1"]
+      ?.pendingState,
+    true
+  );
+
+  const timedOut = rootEngineReducer(observed.state, {
+    commandId: "activate:activation-1",
+    commandType: "session/activate",
+    correlationId: "activation-1",
+    outcome: "timedOut",
+    type: "engine/commandResult"
+  });
+  const recoveryIntent = timedOut.followUpIntents?.find(
+    (intent) => intent.type === "session/reconcileRequested"
+  );
+  assert.ok(recoveryIntent);
+
+  const recovery = rootEngineReducer(timedOut.state, recoveryIntent);
+  assert.equal(recovery.commands[0]?.type, "session/reconcile");
+  assert.equal(
+    recovery.commands[0]?.type === "session/reconcile"
+      ? recovery.commands[0].agentSessionId
       : null,
     "session-1"
   );

--- a/packages/agent/activity-core/src/engine/sessionReconcile.reducer.ts
+++ b/packages/agent/activity-core/src/engine/sessionReconcile.reducer.ts
@@ -25,10 +25,12 @@ export function sessionReconcileReducer(
   intent: EngineIntent,
   context: {
     deletedSessionIds: Readonly<Record<string, true>>;
+    pendingNewSessionIds?: ReadonlySet<string>;
     sessionsById: Readonly<Record<string, CanonicalAgentSession>>;
     workspaceReconcileCommandId: string | null;
   } = {
     deletedSessionIds: {},
+    pendingNewSessionIds: new Set<string>(),
     sessionsById: {},
     workspaceReconcileCommandId: null
   }
@@ -71,6 +73,10 @@ export function sessionReconcileReducer(
             intent.eventType !== "session_audit") ||
           !intent.hasInlineMessages,
         live: intent.eventType === "turn_update",
+        waitForSessionCommit: shouldWaitForSessionCommit(
+          context,
+          intent.agentSessionId
+        ),
         workspaceId: intent.workspaceId
       });
     case "turn/projectionReceived":
@@ -82,13 +88,28 @@ export function sessionReconcileReducer(
         needsMessages: intent.turn.phase === "settled",
         needsState: true,
         live: true,
+        waitForSessionCommit: shouldWaitForSessionCommit(
+          context,
+          intent.turn.agentSessionId
+        ),
         workspaceId: intent.workspaceId
       });
     case "session/reconcileRequested":
       if (context.deletedSessionIds[intent.agentSessionId.trim()]) {
         return unchanged(state);
       }
-      return requestReconcile(state, intent);
+      return requestReconcile(state, {
+        ...intent,
+        waitForSessionCommit: shouldWaitForSessionCommit(
+          context,
+          intent.agentSessionId
+        )
+      });
+    case "session/upserted":
+      return releaseReconcileAfterSessionCommit(
+        state,
+        intent.session.agentSessionId
+      );
     case "session/removed":
       return removeRecord(state, intent.agentSessionId);
     case "engine/intentExpired":
@@ -241,6 +262,7 @@ function requestReconcile(
     needsMessages: boolean;
     needsState: boolean;
     requiredHistoryRevision?: number;
+    waitForSessionCommit?: boolean;
     workspaceId: string;
   }
 ): EngineReducerResult<SessionReconcileState> {
@@ -321,6 +343,9 @@ function requestReconcile(
           )
   };
   const next = replaceRecord(state, record);
+  if (input.waitForSessionCommit === true) {
+    return { commands: NO_COMMANDS, state: next };
+  }
   if (record.inFlightCommandId || !hasReconcileDemand(record)) {
     return { commands: NO_COMMANDS, state: next };
   }
@@ -347,6 +372,54 @@ function requestReconcile(
   return deferMessages
     ? scheduleStreamingMessageReconcile(next, record)
     : startReconcile(next, record);
+}
+
+function shouldWaitForSessionCommit(
+  context: {
+    pendingNewSessionIds?: ReadonlySet<string>;
+    sessionsById: Readonly<Record<string, CanonicalAgentSession>>;
+  },
+  rawAgentSessionId: string
+): boolean {
+  const agentSessionId = rawAgentSessionId.trim();
+  return (
+    agentSessionId !== "" &&
+    context.sessionsById[agentSessionId] === undefined &&
+    context.pendingNewSessionIds?.has(agentSessionId) === true
+  );
+}
+
+function releaseReconcileAfterSessionCommit(
+  state: SessionReconcileState,
+  rawAgentSessionId: string
+): EngineReducerResult<SessionReconcileState> {
+  const agentSessionId = rawAgentSessionId.trim();
+  const record = state.recordsBySessionId[agentSessionId];
+  if (
+    !record ||
+    record.inFlightCommandId !== null ||
+    !hasReconcileDemand(record)
+  ) {
+    return unchanged(state);
+  }
+  const ready = record.messageRefreshScheduled
+    ? { ...record, messageRefreshScheduled: false }
+    : record;
+  const started = startReconcile(replaceRecord(state, ready), ready);
+  return {
+    commands: [
+      ...(record.messageRefreshScheduled
+        ? [
+            {
+              expiryId: streamingMessageReconcileExpiryId(agentSessionId),
+              type: "engine/cancelExpiry" as const
+            }
+          ]
+        : []),
+      ...started.commands
+    ],
+    state: started.state
+  };
 }
 
 function settleReconcile(

--- a/packages/agent/daemon/README.md
+++ b/packages/agent/daemon/README.md
@@ -260,19 +260,23 @@ projection contracts; they are not sufficient to host a runtime controller
 because their state and message writes may use separate transactions.
 `agentdaemon.Config.Reporter` requires `DurableActivityReporter`, whose
 `ReportSubmitProvenance` method must atomically persist the canonical
-client-submit message against an already-durable Turn and return only after
-that message can be queried by `clientSubmitId`. A host decorator embeds or
-otherwise preserves this required interface; there is no optional capability
-probe to forward manually.
+client-submit message and the submitted Turn admission before provider
+dispatch, and return only after that message can be queried by
+`clientSubmitId`. A host decorator embeds or otherwise preserves this required
+interface; there is no optional capability probe to forward manually.
 
 The daemon service passes `ClientSubmitID` through typed create/send and runtime
-inputs. After `Exec` reports provider acceptance, the service explicitly calls
-the required `RuntimeController.DurablyReportSubmitProvenance` method before it
-accepts any submit claim. The runtime adapter delegates that call to the
-controller after `Exec` has released the session lifecycle lock; the controller
-places the uncoalesced barrier behind earlier reports in the same FIFO. A
-barrier failure is delivery-unknown, and provider work is never blindly
-replayed.
+inputs. `Exec` uses `ReportSubmitProvenance` as the pre-dispatch admission
+barrier. After `Exec` returns, the service explicitly calls the required
+`RuntimeController.DurablyReportSubmitProvenance` method as an idempotent
+reconciliation barrier before it accepts any submit claim; this second call
+does not represent a second provider admission. The runtime adapter delegates
+that call to the controller after `Exec` has released the session lifecycle
+lock; the controller places the uncoalesced barrier behind earlier reports in
+the same FIFO. A barrier failure is delivery-unknown, and provider work is
+never blindly replayed. Host-owned user submissions, including follow-up
+submissions, carry a stable `ClientSubmitID`; standalone internal runtime
+calls may retain their generated prompt-message identity.
 
 ```go
 client := agentsessionstore.NewClient(agentsessionstore.Config{

--- a/packages/agent/daemon/hostadapter/runtime.go
+++ b/packages/agent/daemon/hostadapter/runtime.go
@@ -365,7 +365,10 @@ func (a *RuntimeController) SubmitInteractive(ctx context.Context, input host.Ru
 		AgentSessionID: input.AgentSessionID, TurnID: input.TurnID, RequestID: input.RequestID,
 		Action: input.Action, OptionID: input.OptionID, Payload: cloneMap(input.Payload),
 	})
-	return host.RuntimeSubmitInteractiveResult{Disposition: host.RuntimeInteractiveDisposition(result.Disposition)}, mapRuntimeError(err)
+	return host.RuntimeSubmitInteractiveResult{
+		Disposition:    host.RuntimeInteractiveDisposition(result.Disposition),
+		FollowUpPrompt: result.FollowUpPrompt,
+	}, mapRuntimeError(err)
 }
 
 func (a *RuntimeController) InteractiveDisposition(workspaceID, rootSessionID, sessionID, turnID, requestID string) host.RuntimeInteractiveDisposition {

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -20,8 +20,6 @@ var (
 )
 
 const defaultStreamingReportCoalesceWindow = 50 * time.Millisecond
-const interactiveDenyFollowUpStartTimeout = 30 * time.Second
-const interactiveDenyFollowUpPollInterval = 25 * time.Millisecond
 
 type execMetadataContextKey struct{}
 

--- a/packages/agent/daemon/runtime/controller_exec.go
+++ b/packages/agent/daemon/runtime/controller_exec.go
@@ -139,6 +139,10 @@ func (c *Controller) Exec(ctx context.Context, input ExecInput) (result ExecResu
 		runCtx = context.WithValue(runCtx, execMetadataContextKey{}, metadata)
 	}
 	runCtx = withCanonicalSubmitFact(runCtx, canonicalSubmit)
+	runCtx = withCanonicalPromptContent(runCtx, content)
+	if canonicalSubmit.clientSubmitID == "" {
+		runCtx = withPromptActivityMessageID(runCtx, newTurnUserPromptActivityMessageID())
+	}
 	tuttiModeSnapshot := normalizeTuttiModeTurnSnapshot(input.TuttiModeSnapshot)
 	runCtx = withTuttiModeTurnSnapshot(runCtx, tuttiModeSnapshot)
 	var dispatchObserver *providerDispatchObserver
@@ -157,7 +161,14 @@ func (c *Controller) Exec(ctx context.Context, input ExecInput) (result ExecResu
 	c.mu.Lock()
 	provisional := c.provisionalSessions[key]
 	c.mu.Unlock()
-	submitEvents := submittedTurnActivityEvents(session, turnID, input.CapabilityRefs)
+	submitEvents := submittedTurnActivityEvents(
+		runCtx,
+		session,
+		content,
+		displayPrompt,
+		turnID,
+		input.CapabilityRefs,
+	)
 	if titleUpdated {
 		submitEvents = append([]activityshared.Event{newSessionTitleActivityEvent(session, session.Title)}, submitEvents...)
 	}

--- a/packages/agent/daemon/runtime/controller_exec.go
+++ b/packages/agent/daemon/runtime/controller_exec.go
@@ -118,14 +118,16 @@ func (c *Controller) Exec(ctx context.Context, input ExecInput) (result ExecResu
 		return c.guideActiveTurn(ctx, session, adapter, providerContent, displayPrompt, metadata, input.CapabilityRefs, input.TurnID)
 	}
 	previousSession := session
-	titleUpdated := false
+	// Keep the initial title on the submitted Turn patch so owner admission
+	// persists the title, turn, and prompt as one state/message transaction.
+	submittedTitle := ""
 	if initialTitle := strings.TrimSpace(input.InitialTitle); initialTitle != "" &&
 		!session.InitialTitleEstablished &&
 		strings.TrimSpace(session.Title) == strings.TrimSpace(input.InitialTitleBase) {
 		session.Title = initialTitle
 		session = markInitialTitleEstablished(session)
 		session.UpdatedAtUnixMS = unixMS(now())
-		titleUpdated = true
+		submittedTitle = session.Title
 	}
 	turnID := strings.TrimSpace(input.TurnID)
 	if turnID == "" {
@@ -168,10 +170,8 @@ func (c *Controller) Exec(ctx context.Context, input ExecInput) (result ExecResu
 		displayPrompt,
 		turnID,
 		input.CapabilityRefs,
+		submittedTitle,
 	)
-	if titleUpdated {
-		submitEvents = append([]activityshared.Event{newSessionTitleActivityEvent(session, session.Title)}, submitEvents...)
-	}
 	// The submitted Turn is a durable user intent, not provider output. Keep
 	// the Session visible while the provider-identity acceptance barrier is
 	// pending so an explicit provider rejection cannot erase the prompt.

--- a/packages/agent/daemon/runtime/controller_exec_test.go
+++ b/packages/agent/daemon/runtime/controller_exec_test.go
@@ -3,6 +3,7 @@ package agentruntime
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -241,6 +242,25 @@ userMessagePublished:
 	}
 	if !hasSessionStartedPatch {
 		t.Fatalf("report calls = %#v, want session started state patch", reportCalls)
+	}
+	var userMessageIDs []string
+	for _, call := range reportCalls {
+		for _, update := range call.report.MessageUpdates {
+			if update.Role == string(activityshared.MessageRoleUser) && update.TurnID == execResult.TurnID {
+				userMessageIDs = append(userMessageIDs, update.MessageID)
+			}
+		}
+	}
+	if len(userMessageIDs) == 0 {
+		t.Fatalf("report calls = %#v, want user message update for turn", reportCalls)
+	}
+	if userMessageIDs[0] == "" || !strings.HasPrefix(userMessageIDs[0], turnUserMessageIDPrefix) {
+		t.Fatalf("user message IDs = %#v, want a generated turn-user message ID", userMessageIDs)
+	}
+	for _, messageID := range userMessageIDs[1:] {
+		if messageID != userMessageIDs[0] {
+			t.Fatalf("user message IDs = %#v, want every update keyed by %q", userMessageIDs, userMessageIDs[0])
+		}
 	}
 	turnReport, ok := reportWithTimelineItem(reportInputs(reportCalls), "message.user")
 	if !ok || !hasTimelineItem(turnReport, "message.user", "completed", "hello") {

--- a/packages/agent/daemon/runtime/controller_exec_test.go
+++ b/packages/agent/daemon/runtime/controller_exec_test.go
@@ -194,6 +194,20 @@ func TestControllerStartExecPublishesAndReports(t *testing.T) {
 	if execResult.SessionStatus != SessionStatusWorking {
 		t.Fatalf("exec session status = %q, want %q", execResult.SessionStatus, SessionStatusWorking)
 	}
+	submitReports := reporter.waitForReports(t, "initial user submission report", func(calls []reportCall) bool {
+		_, found := reportWithTimelineItem(reportInputs(calls), "message.user")
+		return found
+	})
+	submitReport, ok := reportWithTimelineItem(reportInputs(submitReports), "message.user")
+	if !ok {
+		t.Fatalf("submit reports = %#v, want user message report", submitReports)
+	}
+	if len(submitReport.StatePatches) != 1 {
+		t.Fatalf("initial submit state patches = %#v, want one combined patch", submitReport.StatePatches)
+	}
+	if submitReport.StatePatches[0].Title != "hello" {
+		t.Fatalf("initial submit title = %q, want %q", submitReport.StatePatches[0].Title, "hello")
+	}
 	waitForStatePatchTitle(t, events, "hello")
 	deadline := time.After(2 * time.Second)
 	for {

--- a/packages/agent/daemon/runtime/controller_interactive.go
+++ b/packages/agent/daemon/runtime/controller_interactive.go
@@ -3,9 +3,7 @@ package agentruntime
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"strings"
-	"time"
 
 	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
@@ -39,7 +37,7 @@ func (c *Controller) SubmitInteractive(ctx context.Context, input SubmitInteract
 		if err == nil {
 			c.syncInteractiveSelectionState(adapter, session, result.OptionID)
 			if adapterShouldReceiveInteractiveDenyFollowUp(adapter) {
-				c.scheduleInteractiveDenyFollowUp(input)
+				result.FollowUpPrompt = interactiveDenyFollowUpPrompt(input)
 			}
 		}
 		return result, err
@@ -237,49 +235,6 @@ func adapterShouldReceiveInteractiveDenyFollowUp(adapter Adapter) bool {
 		return policy.ControllerSendsInteractiveDenyFollowUp()
 	}
 	return true
-}
-
-func (c *Controller) scheduleInteractiveDenyFollowUp(input SubmitInteractiveInput) {
-	prompt := interactiveDenyFollowUpPrompt(input)
-	if c == nil || prompt == "" {
-		return
-	}
-	roomID := strings.TrimSpace(input.RoomID)
-	agentSessionID := strings.TrimSpace(input.AgentSessionID)
-	if roomID == "" || agentSessionID == "" {
-		return
-	}
-	go c.runInteractiveDenyFollowUp(roomID, agentSessionID, prompt)
-}
-
-func (c *Controller) runInteractiveDenyFollowUp(roomID string, agentSessionID string, prompt string) {
-	deadline := time.Now().Add(interactiveDenyFollowUpStartTimeout)
-	for {
-		if _, ok := c.activeTurn(roomID, agentSessionID); !ok {
-			break
-		}
-		if time.Now().After(deadline) {
-			slog.Warn("agent interactive deny follow-up skipped because the active turn did not finish",
-				"event", "agent_session.interactive.deny_follow_up.timeout",
-				"room_id", roomID,
-				"agent_session_id", agentSessionID,
-			)
-			return
-		}
-		time.Sleep(interactiveDenyFollowUpPollInterval)
-	}
-	if _, err := c.Exec(context.Background(), ExecInput{
-		RoomID:         roomID,
-		AgentSessionID: agentSessionID,
-		Content:        []PromptContentBlock{{Type: "text", Text: prompt}},
-	}); err != nil {
-		slog.Warn("agent interactive deny follow-up failed to start",
-			"event", "agent_session.interactive.deny_follow_up.failed",
-			"room_id", roomID,
-			"agent_session_id", agentSessionID,
-			"error", err.Error(),
-		)
-	}
 }
 
 func interactiveDenyFollowUpPrompt(input SubmitInteractiveInput) string {

--- a/packages/agent/daemon/runtime/controller_interactive_test.go
+++ b/packages/agent/daemon/runtime/controller_interactive_test.go
@@ -534,12 +534,13 @@ func TestControllerSubmitInteractiveStartsDenyFollowUpAfterActiveTurn(t *testing
 		t.Fatalf("submit result = %#v, want accepted", result)
 	}
 
-	adapter.releaseNext()
-	adapter.waitForPrompt(t, "Please split the work into smaller steps.")
+	if result.FollowUpPrompt != "Please split the work into smaller steps." {
+		t.Fatalf("follow-up prompt = %q, want Host-owned follow-up intent", result.FollowUpPrompt)
+	}
 	adapter.releaseNext()
 	waitForSessionStatus(t, controller, "room-1", started.Session.AgentSessionID, SessionStatusReady)
-	if got := adapter.prompts(); len(got) != 2 || got[0] != "run tests" || got[1] != "Please split the work into smaller steps." {
-		t.Fatalf("adapter prompts = %#v, want initial prompt then deny follow-up", got)
+	if got := adapter.prompts(); len(got) != 1 || got[0] != "run tests" {
+		t.Fatalf("adapter prompts = %#v, want only the original prompt", got)
 	}
 }
 

--- a/packages/agent/daemon/runtime/controller_report_worker.go
+++ b/packages/agent/daemon/runtime/controller_report_worker.go
@@ -222,8 +222,9 @@ func (c *Controller) observeProviderObservations(
 }
 
 // reportSubmittedTurnDurable is the acceptance barrier for a user submission.
-// The daemon reporter commits the submitted Turn and its session pointer before
-// Exec may publish the transition, start provider work, or return success.
+// The durable reporter commits the submitted Turn and canonical user message
+// together before Exec may publish the transition, start provider work, or
+// return success.
 func (c *Controller) reportSubmittedTurnDurable(
 	ctx context.Context,
 	session Session,
@@ -243,7 +244,7 @@ func (c *Controller) reportSubmittedTurnDurable(
 	if keepProvisional {
 		hideProvisionalSessionReport(&report)
 	}
-	return c.reporter.Report(ctx, report)
+	return c.reporter.ReportSubmitProvenance(ctx, report)
 }
 
 func hideProvisionalSessionReport(report *agentsessionstore.ReportActivityInput) {

--- a/packages/agent/daemon/runtime/controller_submit_provenance_test.go
+++ b/packages/agent/daemon/runtime/controller_submit_provenance_test.go
@@ -176,13 +176,16 @@ func waitForCanonicalSubmitMessageReports(
 }
 
 type submittedTurnBarrierReporter struct {
-	entered chan struct{}
-	release chan struct{}
-	err     error
-	once    sync.Once
+	entered         chan struct{}
+	release         chan struct{}
+	err             error
+	once            sync.Once
+	input           agentsessionstore.ReportActivityInput
+	provenanceCalls int
 }
 
-func (r *submittedTurnBarrierReporter) Report(ctx context.Context, _ agentsessionstore.ReportActivityInput) error {
+func (r *submittedTurnBarrierReporter) Report(ctx context.Context, input agentsessionstore.ReportActivityInput) error {
+	r.input = input
 	r.once.Do(func() { close(r.entered) })
 	select {
 	case <-r.release:
@@ -193,6 +196,7 @@ func (r *submittedTurnBarrierReporter) Report(ctx context.Context, _ agentsessio
 }
 
 func (r *submittedTurnBarrierReporter) ReportSubmitProvenance(ctx context.Context, report agentsessionstore.ReportActivityInput) error {
+	r.provenanceCalls++
 	return r.Report(ctx, report)
 }
 
@@ -224,7 +228,11 @@ func TestControllerExecWaitsForSubmittedTurnDurableReportBeforeProviderStart(t *
 	execDone := make(chan error, 1)
 	go func() {
 		_, execErr := controller.Exec(context.Background(), ExecInput{
-			RoomID: "room-1", AgentSessionID: "agent-session-1", Content: textPrompt("hello"),
+			RoomID:                          "room-1",
+			AgentSessionID:                  "agent-session-1",
+			ClientSubmitID:                  "submit-1",
+			CanonicalSubmitOccurredAtUnixMS: 1_234,
+			Content:                         textPrompt("hello"),
 		})
 		execDone <- execErr
 	}()
@@ -248,6 +256,15 @@ func TestControllerExecWaitsForSubmittedTurnDurableReportBeforeProviderStart(t *
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("Exec did not return after durable report")
+	}
+	if len(reporter.input.MessageUpdates) != 1 ||
+		reporter.input.MessageUpdates[0].MessageID != userPromptActivityMessageIDFromClientSubmitID("submit-1") ||
+		reporter.input.MessageUpdates[0].Role != string(activityshared.MessageRoleUser) ||
+		reporter.input.MessageUpdates[0].TurnID == "" {
+		t.Fatalf("submitted report message updates = %#v", reporter.input.MessageUpdates)
+	}
+	if reporter.provenanceCalls != 1 {
+		t.Fatalf("submit provenance calls = %d, want one atomic admission call", reporter.provenanceCalls)
 	}
 	select {
 	case <-adapter.executed:

--- a/packages/agent/daemon/runtime/controller_turn_state.go
+++ b/packages/agent/daemon/runtime/controller_turn_state.go
@@ -16,6 +16,7 @@ func submittedTurnActivityEvents(
 	displayPrompt string,
 	turnID string,
 	capabilityRefs []activityshared.CapabilityReference,
+	submittedTitle string,
 ) []activityshared.Event {
 	eventContext, ok := activityEventContext(session, "turn-submitted:"+turnID, turnID)
 	if !ok {
@@ -32,6 +33,7 @@ func submittedTurnActivityEvents(
 		nil,
 	)
 	event := activityshared.NewTurnUpdated(eventContext, turnID, activityshared.TurnPhaseSubmitted)
+	event.Payload.Title = strings.TrimSpace(submittedTitle)
 	event.Payload.Metadata = map[string]any{"turnOrigin": "user_prompt"}
 	// The controller owns the submit moment; it publishes the submitted
 	// lifecycle snapshot so downstream layers copy instead of recomputing

--- a/packages/agent/daemon/runtime/controller_turn_state.go
+++ b/packages/agent/daemon/runtime/controller_turn_state.go
@@ -1,6 +1,7 @@
 package agentruntime
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -9,15 +10,28 @@ import (
 )
 
 func submittedTurnActivityEvents(
+	submitCtx context.Context,
 	session Session,
+	content []PromptContentBlock,
+	displayPrompt string,
 	turnID string,
 	capabilityRefs []activityshared.CapabilityReference,
 ) []activityshared.Event {
-	ctx, ok := activityEventContext(session, "turn-submitted:"+turnID, turnID)
+	eventContext, ok := activityEventContext(session, "turn-submitted:"+turnID, turnID)
 	if !ok {
 		return nil
 	}
-	event := activityshared.NewTurnUpdated(ctx, turnID, activityshared.TurnPhaseSubmitted)
+	explicitDisplayPrompt, visibleText := explicitAndVisiblePromptText(content, displayPrompt)
+	prompt := newUserPromptActivityEvent(
+		submitCtx,
+		session,
+		content,
+		explicitDisplayPrompt,
+		visibleText,
+		turnID,
+		nil,
+	)
+	event := activityshared.NewTurnUpdated(eventContext, turnID, activityshared.TurnPhaseSubmitted)
 	event.Payload.Metadata = map[string]any{"turnOrigin": "user_prompt"}
 	// The controller owns the submit moment; it publishes the submitted
 	// lifecycle snapshot so downstream layers copy instead of recomputing
@@ -28,7 +42,7 @@ func submittedTurnActivityEvents(
 		Phase:        string(activityshared.TurnPhaseSubmitted),
 	})
 	activityshared.StampTurnCapabilityReferences(&event, capabilityRefs)
-	return []activityshared.Event{event}
+	return []activityshared.Event{prompt, event}
 }
 
 // guidanceTurnCapabilityReferenceStatePatch records provenance on the

--- a/packages/agent/daemon/runtime/controller_turn_state_test.go
+++ b/packages/agent/daemon/runtime/controller_turn_state_test.go
@@ -15,7 +15,7 @@ func TestSubmittedTurnActivityEventProjectsCapabilityReferences(t *testing.T) {
 	events := submittedTurnActivityEvents(context.Background(), session, textPrompt("hello"), "", "turn-1", []CapabilityReference{
 		{Capability: " tutti ", Source: "slash_command"},
 		{Capability: "tutti", Source: "slash_command"},
-	})
+	}, "")
 	if len(events) != 2 {
 		t.Fatalf("submitted events = %#v", events)
 	}

--- a/packages/agent/daemon/runtime/controller_turn_state_test.go
+++ b/packages/agent/daemon/runtime/controller_turn_state_test.go
@@ -1,6 +1,7 @@
 package agentruntime
 
 import (
+	"context"
 	"testing"
 
 	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
@@ -11,16 +12,21 @@ import (
 func TestSubmittedTurnActivityEventProjectsCapabilityReferences(t *testing.T) {
 	t.Parallel()
 	session := Session{Provider: ProviderCodex, AgentSessionID: "agent-1", RoomID: "room-1"}
-	events := submittedTurnActivityEvents(session, "turn-1", []CapabilityReference{
+	events := submittedTurnActivityEvents(context.Background(), session, textPrompt("hello"), "", "turn-1", []CapabilityReference{
 		{Capability: " tutti ", Source: "slash_command"},
 		{Capability: "tutti", Source: "slash_command"},
 	})
-	if len(events) != 1 {
+	if len(events) != 2 {
 		t.Fatalf("submitted events = %#v", events)
+	}
+	if events[0].Type != activityshared.EventMessageAppended ||
+		events[0].Payload.Role != activityshared.MessageRoleUser ||
+		events[0].Payload.TurnID != "turn-1" {
+		t.Fatalf("submitted prompt event = %#v", events[0])
 	}
 	patch, ok := statePatchFromSessionEvent(
 		canonical.EventSource{Provider: ProviderCodex},
-		events[0],
+		events[1],
 		"agent-1",
 		100,
 	)

--- a/packages/agent/daemon/runtime/prompt_content.go
+++ b/packages/agent/daemon/runtime/prompt_content.go
@@ -21,12 +21,17 @@ import (
 var ErrPromptImageUnsupported = errors.New("agent prompt image input is unsupported")
 
 const clientSubmitUserMessageIDPrefix = "client-submit:user:"
+const turnUserMessageIDPrefix = "turn-user:"
 
 const maxProviderPromptImageBytes int64 = 20 << 20
 
 var runtimeConnectorKeyPattern = regexp.MustCompile(`^[a-z][a-z0-9._-]{0,127}$`)
 
 type canonicalSubmitFactContextKey struct{}
+
+type promptActivityMessageIDContextKey struct{}
+
+type canonicalPromptContentContextKey struct{}
 
 type canonicalSubmitFact struct {
 	clientSubmitID   string
@@ -65,6 +70,37 @@ func canonicalSubmitFactFromContext(ctx context.Context) canonicalSubmitFact {
 	}
 	fact, _ := ctx.Value(canonicalSubmitFactContextKey{}).(canonicalSubmitFact)
 	return fact
+}
+
+func withPromptActivityMessageID(ctx context.Context, messageID string) context.Context {
+	messageID = strings.TrimSpace(messageID)
+	if messageID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, promptActivityMessageIDContextKey{}, messageID)
+}
+
+func promptActivityMessageIDFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	messageID, _ := ctx.Value(promptActivityMessageIDContextKey{}).(string)
+	return strings.TrimSpace(messageID)
+}
+
+func withCanonicalPromptContent(ctx context.Context, content []PromptContentBlock) context.Context {
+	if len(content) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, canonicalPromptContentContextKey{}, append([]PromptContentBlock(nil), content...))
+}
+
+func canonicalPromptContentFromContext(ctx context.Context) []PromptContentBlock {
+	if ctx == nil {
+		return nil
+	}
+	content, _ := ctx.Value(canonicalPromptContentContextKey{}).([]PromptContentBlock)
+	return append([]PromptContentBlock(nil), content...)
 }
 
 type providerPromptImageMaterializer func(context.Context, []PromptContentBlock) ([]PromptContentBlock, error)
@@ -295,13 +331,24 @@ func newUserPromptActivityEvent(
 	extra map[string]any,
 ) activityshared.Event {
 	payloadExtra := userPromptActivityPayloadExtraFromExecMetadata(ctx, extra)
+	fact := canonicalSubmitFactFromContext(ctx)
+	activityContent := canonicalPromptContentFromContext(ctx)
+	if len(activityContent) > 0 {
+		content = activityContent
+		if strings.TrimSpace(explicitDisplayPrompt) == "" {
+			_, visibleText = explicitAndVisiblePromptText(content, "")
+		}
+	}
+	if fact.clientSubmitID == "" {
+		fact.messageID = promptActivityMessageIDFromContext(ctx)
+	}
 	return newUserPromptActivityEventWithFact(
 		session,
 		content,
 		explicitDisplayPrompt,
 		visibleText,
 		turnID,
-		canonicalSubmitFactFromContext(ctx),
+		fact,
 		payloadExtra,
 	)
 }
@@ -325,6 +372,13 @@ func newUserPromptActivityEventWithFact(
 			extra = map[string]any{}
 		}
 		extra["clientSubmitId"] = fact.clientSubmitID
+		extra["messageId"] = fact.messageID
+	} else if fact.messageID != "" {
+		eventID = fact.messageID
+		extra = clonePayload(extra)
+		if extra == nil {
+			extra = map[string]any{}
+		}
 		extra["messageId"] = fact.messageID
 	}
 	return newTurnActivityEventWithIDAt(
@@ -369,6 +423,10 @@ func userPromptActivityMessageIDFromClientSubmitID(clientSubmitID string) string
 		return ""
 	}
 	return clientSubmitUserMessageIDPrefix + normalized
+}
+
+func newTurnUserPromptActivityMessageID() string {
+	return turnUserMessageIDPrefix + newID()
 }
 
 func promptContentForACP(content []PromptContentBlock) []map[string]any {

--- a/packages/agent/daemon/runtime/prompt_content_test.go
+++ b/packages/agent/daemon/runtime/prompt_content_test.go
@@ -359,3 +359,32 @@ func TestUserPromptActivityPayloadExtraFromExecMetadataPreservesExplicitMessageI
 		t.Fatalf("extra = %#v, want explicit messageId preserved", extra)
 	}
 }
+
+func TestNewUserPromptActivityEventUsesStableTurnMessageID(t *testing.T) {
+	t.Parallel()
+
+	session := Session{RoomID: "room-1", AgentSessionID: "agent-1", Provider: ProviderCodex}
+	want := newTurnUserPromptActivityMessageID()
+	ctx := withPromptActivityMessageID(context.Background(), want)
+	first := newUserPromptActivityEvent(ctx, session, textPrompt("hello"), "", "hello", "turn-1", nil)
+	second := newUserPromptActivityEvent(ctx, session, textPrompt("hello"), "", "hello", "turn-1", nil)
+
+	if first.EventID != want || second.EventID != want {
+		t.Fatalf("event IDs = %q and %q, want %q", first.EventID, second.EventID, want)
+	}
+	if first.Payload.Metadata["messageId"] != want || second.Payload.Metadata["messageId"] != want {
+		t.Fatalf("message IDs = %#v and %#v, want %q", first.Payload.Metadata, second.Payload.Metadata, want)
+	}
+}
+
+func TestNewUserPromptActivityEventUsesCanonicalPromptContent(t *testing.T) {
+	t.Parallel()
+
+	session := Session{RoomID: "room-1", AgentSessionID: "agent-1", Provider: ProviderCodex}
+	ctx := withCanonicalPromptContent(context.Background(), textPrompt("user content"))
+	event := newUserPromptActivityEvent(ctx, session, textPrompt("provider-only connector instruction"), "", "provider-only connector instruction", "turn-1", nil)
+
+	if event.Payload.Content != "user content" || event.Payload.Metadata["content"].([]map[string]any)[0]["text"] != "user content" {
+		t.Fatalf("prompt event = %#v, want canonical user content", event)
+	}
+}

--- a/packages/agent/daemon/runtime/types.go
+++ b/packages/agent/daemon/runtime/types.go
@@ -614,7 +614,12 @@ type SubmitInteractiveResult struct {
 	Accepted       bool                   `json:"accepted"`
 	OptionID       string                 `json:"optionId,omitempty"`
 	Disposition    InteractiveDisposition `json:"-"`
-	Events         []Event                `json:"events"`
+	// FollowUpPrompt is a provider-neutral intent for the Host to submit a
+	// follow-up through its normal SendInput admission path. Runtime must not
+	// dispatch this prompt directly because Host owns its idempotency and
+	// recovery semantics.
+	FollowUpPrompt string  `json:"-"`
+	Events         []Event `json:"events"`
 }
 
 type UpdateSettingsResult struct {

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -357,9 +357,12 @@ provider-neutral follow-up intent after an interactive denial, but it does not
 dispatch that prompt itself. Host checkpoints the intent on the leased
 interactive operation, waits for the answered Turn to become idle, and submits
 the prompt through `SendInput` with the stable id
-`interactive-deny:<operation-id>`. Recovery reuses that id, so a crash between
-provider submission and interactive-operation completion can replay the
-ordinary Host admission without creating a duplicate Turn.
+`interactive-deny:<operation-id>`. The checkpoint also persists the terminal
+interactive disposition, so recovery does not depend on Controller memory or
+an existing Runtime Session. Recovery reuses that disposition and id; if the
+provider connection is temporarily absent, the operation remains retryable
+until ordinary Host admission can replay the prompt without creating a
+duplicate Turn.
 
 Accepted runtime Session reports reconcile their Goal snapshot through the
 canonical bottom-up observation path without overwriting a newer desired

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -351,6 +351,16 @@ into the current provider response without interrupting it. A preemptive
 adapter must close the interrupted response's live message/tool projections
 and publish its provider-turn terminal boundary before admitting guided output.
 Neither form is a canonical Turn cancel or a second user Turn.
+
+Interactive responses follow the same ownership rule. Runtime may return a
+provider-neutral follow-up intent after an interactive denial, but it does not
+dispatch that prompt itself. Host checkpoints the intent on the leased
+interactive operation, waits for the answered Turn to become idle, and submits
+the prompt through `SendInput` with the stable id
+`interactive-deny:<operation-id>`. Recovery reuses that id, so a crash between
+provider submission and interactive-operation completion can replay the
+ordinary Host admission without creating a duplicate Turn.
+
 Accepted runtime Session reports reconcile their Goal snapshot through the
 canonical bottom-up observation path without overwriting a newer desired
 intent. When that changes the public Goal projection, the same transaction

--- a/packages/agent/host/conformance/conformance.go
+++ b/packages/agent/host/conformance/conformance.go
@@ -50,19 +50,22 @@ type InteractionSeed struct {
 }
 
 type Fixture struct {
-	Session                *SessionSeed
-	LiveOnlySession        *SessionSeed
-	AdditionalSessions     []SessionSeed
-	Turn                   *TurnSeed
-	AdditionalTurns        []TurnSeed
-	Interaction            *InteractionSeed
-	AdditionalInteractions []InteractionSeed
-	PreparedSubmitID       string
-	RecoverInteractive     bool
-	DisableGoalInbox       bool
-	AcceptGoalControlsOnly bool
-	CompleteGoalOnSet      bool
-	EmptyPauseResumeGoal   bool
+	Session                                  *SessionSeed
+	LiveOnlySession                          *SessionSeed
+	AdditionalSessions                       []SessionSeed
+	Turn                                     *TurnSeed
+	AdditionalTurns                          []TurnSeed
+	Interaction                              *InteractionSeed
+	AdditionalInteractions                   []InteractionSeed
+	PreparedSubmitID                         string
+	RecoverInteractive                       bool
+	RecoverInteractiveFollowUpPrompt         string
+	RecoverInteractiveFollowUpClientSubmitID string
+	RecoverInteractiveFollowUpDisposition    agenthost.RuntimeInteractiveDisposition
+	DisableGoalInbox                         bool
+	AcceptGoalControlsOnly                   bool
+	CompleteGoalOnSet                        bool
+	EmptyPauseResumeGoal                     bool
 	// RaceRuntimeStartReport makes the test Runtime attempt its ordinary
 	// session-start activity report before CreateSession initializes canonical
 	// state. A conforming Host must keep that report behind the canonical
@@ -162,6 +165,7 @@ type Metrics struct {
 	LastCancelTargets                  []agenthost.RuntimeCancelTarget
 	LastInteractiveTurnID              string
 	LastInteractiveRequestID           string
+	LastExecClientSubmitID             string
 	LastInitialTitle                   string
 	LastExecRequiresProviderAcceptance bool
 	LastClosePreservedCanonicalState   bool

--- a/packages/agent/host/conformance/conformance_test.go
+++ b/packages/agent/host/conformance/conformance_test.go
@@ -19,7 +19,7 @@ func TestPublishedScenarioCatalogsHaveUniqueNames(t *testing.T) {
 		{name: "submission fence", scenarios: SubmissionFenceScenarios(), wantCount: 1},
 		{name: "title policy", scenarios: TitlePolicyScenarios(), wantCount: 1},
 		{name: "deletion admission", scenarios: DeletionAdmissionScenarios(), wantCount: 3},
-		{name: "coordinator", scenarios: CoordinatorScenarios(), wantCount: 6},
+		{name: "coordinator", scenarios: CoordinatorScenarios(), wantCount: 7},
 		{name: "goal", scenarios: GoalScenarios(), wantCount: 17},
 		{name: "commit observer", scenarios: CommitObserverScenarios(), wantCount: 2},
 	}
@@ -174,6 +174,7 @@ func TestScenarioOwnershipIsExplicit(t *testing.T) {
 		"interactive response",
 		"interactive response reuses provider request id across turns",
 		"interactive response race",
+		"interactive follow-up recovers through Host admission",
 		"plan decision",
 		"recover operations before stale turns",
 	}

--- a/packages/agent/host/conformance/coordinator_scenarios.go
+++ b/packages/agent/host/conformance/coordinator_scenarios.go
@@ -93,3 +93,30 @@ func runRecoveryOrder(ctx context.Context, driver Driver) error {
 	}
 	return nil
 }
+
+func runInteractiveFollowUpRecovery(ctx context.Context, driver Driver) error {
+	fixture := liveSessionFixture("session-interactive-follow-up-recovery", "turn-interactive-follow-up-recovery")
+	fixture.Turn = &TurnSeed{TurnID: "turn-interactive-follow-up-recovery", Phase: canonical.TurnPhaseWaiting}
+	fixture.Interaction = &InteractionSeed{
+		RequestID: "request-interactive-follow-up-recovery", TurnID: "turn-interactive-follow-up-recovery",
+		Kind: canonical.InteractionKindApproval, Status: canonical.InteractionStatusPending,
+	}
+	fixture.RecoverInteractive = true
+	fixture.RecoverInteractiveFollowUpPrompt = "Please split the work into smaller steps."
+	fixture.RecoverInteractiveFollowUpClientSubmitID = "interactive-deny:recovered-operation"
+	fixture.RecoverInteractiveFollowUpDisposition = agenthost.RuntimeInteractiveDispositionAnswered
+	if err := driver.Reset(ctx, fixture); err != nil {
+		return err
+	}
+	if err := driver.Recover(ctx); err != nil {
+		return fmt.Errorf("recover interactive follow-up: %w", err)
+	}
+	metrics := driver.Metrics()
+	if metrics.InteractiveCalls != 0 {
+		return fmt.Errorf("recovery re-submitted interactive response %d time(s), want 0", metrics.InteractiveCalls)
+	}
+	if metrics.ExecCalls != 1 || metrics.LastExecClientSubmitID != fixture.RecoverInteractiveFollowUpClientSubmitID {
+		return fmt.Errorf("recovery follow-up exec calls=%d client submit id=%q, want 1/%q", metrics.ExecCalls, metrics.LastExecClientSubmitID, fixture.RecoverInteractiveFollowUpClientSubmitID)
+	}
+	return nil
+}

--- a/packages/agent/host/conformance/scenarios.go
+++ b/packages/agent/host/conformance/scenarios.go
@@ -38,6 +38,7 @@ var (
 	interactiveResponseScenario         = Scenario{Name: "interactive response", run: runInteractiveResponse}
 	interactiveResponseReusedIDScenario = Scenario{Name: "interactive response reuses provider request id across turns", run: runInteractiveResponseReusedRequestID}
 	interactiveResponseRaceScenario     = Scenario{Name: "interactive response race", run: runInteractiveResponseRace}
+	interactiveFollowUpRecoveryScenario = Scenario{Name: "interactive follow-up recovers through Host admission", run: runInteractiveFollowUpRecovery}
 	planDecisionScenario                = Scenario{Name: "plan decision", run: runPlanDecision}
 	initialTitleCASScenario             = Scenario{Name: "initial title cas", run: runInitialTitleCAS}
 	getSessionScenario                  = Scenario{Name: "get session", run: runGetSession}
@@ -152,6 +153,7 @@ func CoordinatorScenarios() []Scenario {
 		interactiveResponseScenario,
 		interactiveResponseReusedIDScenario,
 		interactiveResponseRaceScenario,
+		interactiveFollowUpRecoveryScenario,
 		planDecisionScenario,
 		{Name: "recover operations before stale turns", run: runRecoveryOrder},
 	}

--- a/packages/agent/host/runtime_interactive_types.go
+++ b/packages/agent/host/runtime_interactive_types.go
@@ -1,0 +1,9 @@
+package agenthost
+
+type RuntimeSubmitInteractiveResult struct {
+	Disposition RuntimeInteractiveDisposition
+	// FollowUpPrompt is an intent returned by Runtime. Host submits it through
+	// SendInput so the prompt receives normal idempotency, admission, and
+	// recovery semantics.
+	FollowUpPrompt string
+}

--- a/packages/agent/host/runtime_operations.go
+++ b/packages/agent/host/runtime_operations.go
@@ -15,12 +15,13 @@ import (
 )
 
 const (
-	runtimeOperationLeaseDuration   = 30 * time.Second
-	runtimeOperationWorkerInterval  = time.Second
-	runtimeOperationBatchSize       = 64
-	runtimeOperationLogPrefix       = "[agent-runtime-operation]"
-	interactiveFollowUpStartTimeout = 30 * time.Second
-	interactiveFollowUpPollInterval = 25 * time.Millisecond
+	runtimeOperationLeaseDuration     = 30 * time.Second
+	runtimeOperationWorkerInterval    = time.Second
+	runtimeOperationBatchSize         = 64
+	runtimeOperationLogPrefix         = "[agent-runtime-operation]"
+	interactiveFollowUpStartTimeout   = 30 * time.Second
+	interactiveFollowUpPollInterval   = 25 * time.Millisecond
+	interactiveFollowUpDispositionKey = "followUpDisposition"
 )
 
 const interactiveFollowUpClientSubmitIDPrefix = "interactive-deny:"
@@ -37,6 +38,17 @@ func runtimeOperationID(workspaceID, agentSessionID, kind, subjectID string) str
 func runtimeOperationPayloadText(payload map[string]any, key string) string {
 	value, _ := payload[key].(string)
 	return strings.TrimSpace(value)
+}
+
+func runtimeOperationPayloadInteractiveDisposition(payload map[string]any, key string) RuntimeInteractiveDisposition {
+	switch RuntimeInteractiveDisposition(runtimeOperationPayloadText(payload, key)) {
+	case RuntimeInteractiveDispositionAnswered,
+		RuntimeInteractiveDispositionSuperseded,
+		RuntimeInteractiveDispositionInterrupted:
+		return RuntimeInteractiveDisposition(runtimeOperationPayloadText(payload, key))
+	default:
+		return RuntimeInteractiveDispositionUnknown
+	}
 }
 
 func (h *Host) prepareInteractiveRuntimeOperation(
@@ -235,10 +247,19 @@ func (h *Host) executeInteractiveRuntimeOperation(ctx context.Context, operation
 	var submissionErr error
 	followUpPrompt := runtimeOperationPayloadText(operation.Payload, "followUpPrompt")
 	followUpClientSubmitID := runtimeOperationPayloadText(operation.Payload, "followUpClientSubmitId")
+	persistedFollowUpDisposition := runtimeOperationPayloadInteractiveDisposition(operation.Payload, interactiveFollowUpDispositionKey)
 	if recovering {
-		runtimeDisposition = h.runtime.InteractiveDisposition(operation.WorkspaceID, runtimeOperationPayloadText(operation.Payload, "rootAgentSessionId"), operation.AgentSessionID, operation.TurnID, operation.RequestID)
-		if runtimeDisposition == RuntimeInteractiveDispositionUnknown && !runtimeSessionFound {
-			return h.releaseRuntimeOperation(ctx, operation, owner, fmt.Errorf("interactive request %q has unknown runtime disposition after runtime session removal", operation.RequestID), true)
+		if followUpPrompt != "" && persistedFollowUpDisposition != RuntimeInteractiveDispositionUnknown {
+			// A checkpointed follow-up is durable evidence that the interactive
+			// response already reached a terminal disposition. Do not consult the
+			// Controller's in-memory disposition cache after a restart; it is not
+			// part of the recovery contract.
+			runtimeDisposition = persistedFollowUpDisposition
+		} else {
+			runtimeDisposition = h.runtime.InteractiveDisposition(operation.WorkspaceID, runtimeOperationPayloadText(operation.Payload, "rootAgentSessionId"), operation.AgentSessionID, operation.TurnID, operation.RequestID)
+			if runtimeDisposition == RuntimeInteractiveDispositionUnknown && !runtimeSessionFound {
+				return h.releaseRuntimeOperation(ctx, operation, owner, fmt.Errorf("interactive request %q has unknown runtime disposition after runtime session removal", operation.RequestID), true)
+			}
 		}
 	}
 	if runtimeDisposition != RuntimeInteractiveDispositionAnswered && runtimeDisposition != RuntimeInteractiveDispositionSuperseded && runtimeDisposition != RuntimeInteractiveDispositionInterrupted {
@@ -250,6 +271,9 @@ func (h *Host) executeInteractiveRuntimeOperation(ctx context.Context, operation
 		})
 		submissionErr = err
 		runtimeDisposition = result.Disposition
+		if runtimeDisposition == "" {
+			runtimeDisposition = h.runtime.InteractiveDisposition(operation.WorkspaceID, runtimeOperationPayloadText(operation.Payload, "rootAgentSessionId"), operation.AgentSessionID, operation.TurnID, operation.RequestID)
+		}
 		if prompt := strings.TrimSpace(result.FollowUpPrompt); prompt != "" {
 			checkpointFollowUp := false
 			if followUpPrompt == "" {
@@ -260,10 +284,15 @@ func (h *Host) executeInteractiveRuntimeOperation(ctx context.Context, operation
 				followUpClientSubmitID = interactiveFollowUpClientSubmitIDPrefix + operation.OperationID
 				checkpointFollowUp = true
 			}
+			if persistedFollowUpDisposition == RuntimeInteractiveDispositionUnknown {
+				persistedFollowUpDisposition = runtimeDisposition
+				checkpointFollowUp = true
+			}
 			if checkpointFollowUp {
 				payload := cloneMap(operation.Payload)
 				payload["followUpPrompt"] = followUpPrompt
 				payload["followUpClientSubmitId"] = followUpClientSubmitID
+				payload[interactiveFollowUpDispositionKey] = string(persistedFollowUpDisposition)
 				checkpointed, _, checkpointErr := h.operations.CheckpointRuntimeOperation(ctx, storesqlite.CheckpointRuntimeOperationInput{
 					WorkspaceID: operation.WorkspaceID, OperationID: operation.OperationID, LeaseOwner: owner,
 					Payload: payload, NowUnixMS: h.now().UnixMilli(),
@@ -273,9 +302,6 @@ func (h *Host) executeInteractiveRuntimeOperation(ctx context.Context, operation
 				}
 				operation = checkpointed
 			}
-		}
-		if runtimeDisposition == "" {
-			runtimeDisposition = h.runtime.InteractiveDisposition(operation.WorkspaceID, runtimeOperationPayloadText(operation.Payload, "rootAgentSessionId"), operation.AgentSessionID, operation.TurnID, operation.RequestID)
 		}
 	}
 	dispositionErr := submissionErr

--- a/packages/agent/host/runtime_operations.go
+++ b/packages/agent/host/runtime_operations.go
@@ -15,11 +15,15 @@ import (
 )
 
 const (
-	runtimeOperationLeaseDuration  = 30 * time.Second
-	runtimeOperationWorkerInterval = time.Second
-	runtimeOperationBatchSize      = 64
-	runtimeOperationLogPrefix      = "[agent-runtime-operation]"
+	runtimeOperationLeaseDuration   = 30 * time.Second
+	runtimeOperationWorkerInterval  = time.Second
+	runtimeOperationBatchSize       = 64
+	runtimeOperationLogPrefix       = "[agent-runtime-operation]"
+	interactiveFollowUpStartTimeout = 30 * time.Second
+	interactiveFollowUpPollInterval = 25 * time.Millisecond
 )
+
+const interactiveFollowUpClientSubmitIDPrefix = "interactive-deny:"
 
 // runtimeOperationID is stable across retries and process restarts.
 func runtimeOperationID(workspaceID, agentSessionID, kind, subjectID string) string {
@@ -229,6 +233,8 @@ func (h *Host) executeInteractiveRuntimeOperation(ctx context.Context, operation
 	_, runtimeSessionFound := h.runtime.Session(operation.WorkspaceID, operation.AgentSessionID)
 	runtimeDisposition := RuntimeInteractiveDispositionUnknown
 	var submissionErr error
+	followUpPrompt := runtimeOperationPayloadText(operation.Payload, "followUpPrompt")
+	followUpClientSubmitID := runtimeOperationPayloadText(operation.Payload, "followUpClientSubmitId")
 	if recovering {
 		runtimeDisposition = h.runtime.InteractiveDisposition(operation.WorkspaceID, runtimeOperationPayloadText(operation.Payload, "rootAgentSessionId"), operation.AgentSessionID, operation.TurnID, operation.RequestID)
 		if runtimeDisposition == RuntimeInteractiveDispositionUnknown && !runtimeSessionFound {
@@ -244,6 +250,30 @@ func (h *Host) executeInteractiveRuntimeOperation(ctx context.Context, operation
 		})
 		submissionErr = err
 		runtimeDisposition = result.Disposition
+		if prompt := strings.TrimSpace(result.FollowUpPrompt); prompt != "" {
+			checkpointFollowUp := false
+			if followUpPrompt == "" {
+				followUpPrompt = prompt
+				checkpointFollowUp = true
+			}
+			if followUpClientSubmitID == "" {
+				followUpClientSubmitID = interactiveFollowUpClientSubmitIDPrefix + operation.OperationID
+				checkpointFollowUp = true
+			}
+			if checkpointFollowUp {
+				payload := cloneMap(operation.Payload)
+				payload["followUpPrompt"] = followUpPrompt
+				payload["followUpClientSubmitId"] = followUpClientSubmitID
+				checkpointed, _, checkpointErr := h.operations.CheckpointRuntimeOperation(ctx, storesqlite.CheckpointRuntimeOperationInput{
+					WorkspaceID: operation.WorkspaceID, OperationID: operation.OperationID, LeaseOwner: owner,
+					Payload: payload, NowUnixMS: h.now().UnixMilli(),
+				})
+				if checkpointErr != nil {
+					return operation, checkpointErr
+				}
+				operation = checkpointed
+			}
+		}
 		if runtimeDisposition == "" {
 			runtimeDisposition = h.runtime.InteractiveDisposition(operation.WorkspaceID, runtimeOperationPayloadText(operation.Payload, "rootAgentSessionId"), operation.AgentSessionID, operation.TurnID, operation.RequestID)
 		}
@@ -268,6 +298,21 @@ func (h *Host) executeInteractiveRuntimeOperation(ctx context.Context, operation
 	default:
 		return h.releaseRuntimeOperation(ctx, operation, owner, fmt.Errorf("interactive request %q returned unsupported runtime disposition %q: %w", operation.RequestID, runtimeDisposition, dispositionErr), true)
 	}
+	if followUpPrompt != "" {
+		if followUpClientSubmitID == "" {
+			followUpClientSubmitID = interactiveFollowUpClientSubmitIDPrefix + operation.OperationID
+		}
+		if err := h.waitForInteractiveFollowUp(ctx, operation.WorkspaceID, operation.AgentSessionID); err != nil {
+			return h.releaseRuntimeOperation(ctx, operation, owner, err, false)
+		}
+		_, err := h.SendInput(ctx, SessionRef{WorkspaceID: operation.WorkspaceID, AgentSessionID: operation.AgentSessionID}, SendInput{
+			Content:        []PromptContentBlock{{Type: "text", Text: followUpPrompt}},
+			ClientSubmitID: followUpClientSubmitID,
+		})
+		if err != nil {
+			return h.releaseRuntimeOperation(ctx, operation, owner, err, !isRetryableInteractiveFollowUpError(err))
+		}
+	}
 	completion, _, err := h.operations.CompleteInteractiveRuntimeOperation(ctx, storesqlite.CompleteInteractiveRuntimeOperationInput{
 		WorkspaceID: operation.WorkspaceID, OperationID: operation.OperationID, LeaseOwner: owner,
 		Disposition: disposition, Output: map[string]any{"action": runtimeOperationPayloadText(operation.Payload, "action"), "optionId": runtimeOperationPayloadText(operation.Payload, "optionId")},
@@ -280,6 +325,36 @@ func (h *Host) executeInteractiveRuntimeOperation(ctx context.Context, operation
 		logRuntimeOperationFailure(completion.Operation, fmt.Errorf("publish completed interactive runtime operation: %w", err))
 	}
 	return completion.Operation, nil
+}
+
+func (h *Host) waitForInteractiveFollowUp(ctx context.Context, workspaceID, agentSessionID string) error {
+	deadline := time.NewTimer(interactiveFollowUpStartTimeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(interactiveFollowUpPollInterval)
+	defer ticker.Stop()
+	for {
+		session, found := h.runtime.Session(workspaceID, agentSessionID)
+		if !found {
+			return ErrSessionNotFound
+		}
+		if session.TurnLifecycle == nil || session.TurnLifecycle.ActiveTurnID == nil || strings.TrimSpace(*session.TurnLifecycle.ActiveTurnID) == "" {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline.C:
+			return ErrRuntimeSessionActive
+		case <-ticker.C:
+		}
+	}
+}
+
+func isRetryableInteractiveFollowUpError(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, ErrSubmitDeliveryUnknown) || errors.Is(err, ErrSessionNotFound) ||
+		errors.Is(err, ErrRuntimeSessionActive) || errors.Is(err, ErrRuntimeSessionDisconnected) ||
+		errors.Is(err, ErrRuntimeOperationInProgress)
 }
 
 func (h *Host) executeCancelRuntimeOperation(

--- a/packages/agent/host/runtime_operations_follow_up_test.go
+++ b/packages/agent/host/runtime_operations_follow_up_test.go
@@ -1,0 +1,173 @@
+package agenthost
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+	_ "modernc.org/sqlite"
+)
+
+type interactiveFollowUpRuntime struct {
+	RuntimeController
+	store        *storesqlite.Store
+	activeTurnID string
+
+	mu         sync.Mutex
+	execInputs []RuntimeExecInput
+}
+
+type interactiveFollowUpCanonicalStore struct {
+	*storesqlite.Store
+}
+
+func (interactiveFollowUpCanonicalStore) InitializeRuntimeSession(context.Context, RuntimeSessionInitialization) (storesqlite.Session, error) {
+	return storesqlite.Session{}, nil
+}
+
+func (r *interactiveFollowUpRuntime) Session(workspaceID, agentSessionID string) (ProviderRuntimeSession, bool) {
+	r.mu.Lock()
+	activeTurnID := r.activeTurnID
+	r.mu.Unlock()
+	var lifecycle *TurnLifecycle
+	if activeTurnID != "" {
+		lifecycle = &TurnLifecycle{ActiveTurnID: &activeTurnID}
+	}
+	return ProviderRuntimeSession{
+		WorkspaceID: workspaceID, ID: agentSessionID, Provider: "codex",
+		ProviderSessionID: "provider-session-1",
+		TurnLifecycle:     lifecycle,
+	}, workspaceID == "workspace-1" && agentSessionID == "session-1"
+}
+
+func (r *interactiveFollowUpRuntime) SubmitInteractive(_ context.Context, input RuntimeSubmitInteractiveInput) (RuntimeSubmitInteractiveResult, error) {
+	r.mu.Lock()
+	r.activeTurnID = ""
+	r.mu.Unlock()
+	if _, _, err := r.store.RecordTurnTransition(context.Background(), storesqlite.TurnTransition{
+		WorkspaceID: input.WorkspaceID, AgentSessionID: input.AgentSessionID,
+		TurnID: input.TurnID, Phase: storesqlite.TurnPhaseSettled,
+		Outcome: storesqlite.TurnOutcomeCompleted, OccurredAtUnixMS: 10,
+	}); err != nil {
+		return RuntimeSubmitInteractiveResult{}, err
+	}
+	return RuntimeSubmitInteractiveResult{
+		Disposition:    RuntimeInteractiveDispositionAnswered,
+		FollowUpPrompt: "Please split the work into smaller steps.",
+	}, nil
+}
+
+func (*interactiveFollowUpRuntime) ValidatePromptContent(context.Context, RuntimeExecInput) error {
+	return nil
+}
+
+func (r *interactiveFollowUpRuntime) Exec(_ context.Context, input RuntimeExecInput) (RuntimeExecResult, error) {
+	r.mu.Lock()
+	r.execInputs = append(r.execInputs, input)
+	r.mu.Unlock()
+	if _, _, err := r.store.RecordTurnTransition(context.Background(), storesqlite.TurnTransition{
+		WorkspaceID: input.WorkspaceID, AgentSessionID: input.AgentSessionID,
+		TurnID: input.TurnID, Phase: storesqlite.TurnPhaseSubmitted,
+		Origin: storesqlite.TurnOriginUserPrompt, OccurredAtUnixMS: 11,
+	}); err != nil {
+		return RuntimeExecResult{}, err
+	}
+	return RuntimeExecResult{
+		TurnID: input.TurnID,
+		ProviderDispatch: RuntimeProviderDispatchResult{
+			Disposition: RuntimeDispatchDispositionApplied,
+		},
+	}, nil
+}
+
+func (r *interactiveFollowUpRuntime) recordedExecInputs() []RuntimeExecInput {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]RuntimeExecInput(nil), r.execInputs...)
+}
+
+func TestSubmitInteractiveRoutesRuntimeFollowUpThroughHostSendInput(t *testing.T) {
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "interactive-follow-up.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+	store := storesqlite.New(db, storesqlite.Options{})
+	if err := store.Migrate(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.ReportSessionState(t.Context(), storesqlite.SessionStateReport{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1",
+		Kind: storesqlite.SessionKindRoot, Provider: "codex",
+		ProviderSessionID: "provider-session-1", OccurredAtUnixMS: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.RecordTurnTransition(t.Context(), storesqlite.TurnTransition{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1", TurnID: "turn-1",
+		Phase: storesqlite.TurnPhaseWaiting, OccurredAtUnixMS: 2,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.UpsertInteraction(t.Context(), storesqlite.InteractionUpsert{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1", TurnID: "turn-1",
+		RequestID: "request-1", Kind: storesqlite.InteractionKindQuestion,
+		Status: storesqlite.InteractionStatusPending, OccurredAtUnixMS: 3,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`UPDATE workspace_agent_turns
+SET root_provider_turn_id = 'provider-turn-1', root_provider_turn_phase = 'running',
+    root_provider_turn_updated_at_unix_ms = 4
+WHERE workspace_id = 'workspace-1' AND agent_session_id = 'session-1' AND turn_id = 'turn-1'`); err != nil {
+		t.Fatal(err)
+	}
+
+	runtime := &interactiveFollowUpRuntime{store: store, activeTurnID: "turn-1"}
+	host := New(Config{
+		CanonicalStore: interactiveFollowUpCanonicalStore{Store: store}, Runtime: runtime, RuntimeOperations: store,
+		OperationOwner: "worker-1",
+	})
+	optionID := "deny"
+	result, err := host.SubmitInteractive(t.Context(), InteractionRef{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1",
+		TurnID: "turn-1", RequestID: "request-1",
+	}, SubmitInteractiveInput{OptionID: &optionID})
+	if err != nil {
+		t.Fatalf("SubmitInteractive() error = %v", err)
+	}
+	if result.Disposition != RuntimeInteractiveDispositionAnswered ||
+		result.Operation.Status != storesqlite.RuntimeOperationStatusCompleted {
+		t.Fatalf("SubmitInteractive() result = %#v", result)
+	}
+
+	execInputs := runtime.recordedExecInputs()
+	if len(execInputs) != 1 {
+		t.Fatalf("follow-up Exec calls = %d, want 1", len(execInputs))
+	}
+	if got := execInputs[0].ClientSubmitID; got != "interactive-deny:"+result.Operation.OperationID {
+		t.Fatalf("follow-up ClientSubmitID = %q, want stable operation identity", got)
+	}
+	if len(execInputs[0].Content) != 1 || execInputs[0].Content[0].Text != "Please split the work into smaller steps." {
+		t.Fatalf("follow-up content = %#v", execInputs[0].Content)
+	}
+
+	claim, found, err := store.GetSubmitClaim(t.Context(), "workspace-1", "session-1", execInputs[0].ClientSubmitID)
+	if err != nil || !found || claim.Status != "accepted" || claim.TurnID == "" {
+		t.Fatalf("follow-up submit claim = %#v, found=%v, error=%v", claim, found, err)
+	}
+
+	if _, err := host.SendInput(t.Context(), SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-1"}, SendInput{
+		ClientSubmitID: execInputs[0].ClientSubmitID,
+		Content:        []PromptContentBlock{{Type: "text", Text: "Please split the work into smaller steps."}},
+	}); err != nil {
+		t.Fatalf("replaying follow-up SendInput() error = %v", err)
+	}
+	if got := len(runtime.recordedExecInputs()); got != 1 {
+		t.Fatalf("replayed follow-up Exec calls = %d, want 1", got)
+	}
+}

--- a/packages/agent/host/runtime_operations_follow_up_test.go
+++ b/packages/agent/host/runtime_operations_follow_up_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 	_ "modernc.org/sqlite"
@@ -15,9 +16,11 @@ type interactiveFollowUpRuntime struct {
 	RuntimeController
 	store        *storesqlite.Store
 	activeTurnID string
+	sessionFound bool
 
-	mu         sync.Mutex
-	execInputs []RuntimeExecInput
+	mu                     sync.Mutex
+	execInputs             []RuntimeExecInput
+	submitInteractiveCalls int
 }
 
 type interactiveFollowUpCanonicalStore struct {
@@ -31,6 +34,7 @@ func (interactiveFollowUpCanonicalStore) InitializeRuntimeSession(context.Contex
 func (r *interactiveFollowUpRuntime) Session(workspaceID, agentSessionID string) (ProviderRuntimeSession, bool) {
 	r.mu.Lock()
 	activeTurnID := r.activeTurnID
+	sessionFound := r.sessionFound
 	r.mu.Unlock()
 	var lifecycle *TurnLifecycle
 	if activeTurnID != "" {
@@ -40,12 +44,13 @@ func (r *interactiveFollowUpRuntime) Session(workspaceID, agentSessionID string)
 		WorkspaceID: workspaceID, ID: agentSessionID, Provider: "codex",
 		ProviderSessionID: "provider-session-1",
 		TurnLifecycle:     lifecycle,
-	}, workspaceID == "workspace-1" && agentSessionID == "session-1"
+	}, sessionFound && workspaceID == "workspace-1" && agentSessionID == "session-1"
 }
 
 func (r *interactiveFollowUpRuntime) SubmitInteractive(_ context.Context, input RuntimeSubmitInteractiveInput) (RuntimeSubmitInteractiveResult, error) {
 	r.mu.Lock()
 	r.activeTurnID = ""
+	r.submitInteractiveCalls++
 	r.mu.Unlock()
 	if _, _, err := r.store.RecordTurnTransition(context.Background(), storesqlite.TurnTransition{
 		WorkspaceID: input.WorkspaceID, AgentSessionID: input.AgentSessionID,
@@ -89,7 +94,14 @@ func (r *interactiveFollowUpRuntime) recordedExecInputs() []RuntimeExecInput {
 	return append([]RuntimeExecInput(nil), r.execInputs...)
 }
 
-func TestSubmitInteractiveRoutesRuntimeFollowUpThroughHostSendInput(t *testing.T) {
+func (r *interactiveFollowUpRuntime) recordedSubmitInteractiveCalls() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.submitInteractiveCalls
+}
+
+func newInteractiveFollowUpStore(t *testing.T) *storesqlite.Store {
+	t.Helper()
 	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "interactive-follow-up.db"))
 	if err != nil {
 		t.Fatal(err)
@@ -126,8 +138,13 @@ SET root_provider_turn_id = 'provider-turn-1', root_provider_turn_phase = 'runni
 WHERE workspace_id = 'workspace-1' AND agent_session_id = 'session-1' AND turn_id = 'turn-1'`); err != nil {
 		t.Fatal(err)
 	}
+	return store
+}
 
-	runtime := &interactiveFollowUpRuntime{store: store, activeTurnID: "turn-1"}
+func TestSubmitInteractiveRoutesRuntimeFollowUpThroughHostSendInput(t *testing.T) {
+	store := newInteractiveFollowUpStore(t)
+
+	runtime := &interactiveFollowUpRuntime{store: store, activeTurnID: "turn-1", sessionFound: true}
 	host := New(Config{
 		CanonicalStore: interactiveFollowUpCanonicalStore{Store: store}, Runtime: runtime, RuntimeOperations: store,
 		OperationOwner: "worker-1",
@@ -169,5 +186,53 @@ WHERE workspace_id = 'workspace-1' AND agent_session_id = 'session-1' AND turn_i
 	}
 	if got := len(runtime.recordedExecInputs()); got != 1 {
 		t.Fatalf("replayed follow-up Exec calls = %d, want 1", got)
+	}
+}
+
+func TestRecoverInteractiveFollowUpUsesCheckpointedDispositionWithoutRuntimeSession(t *testing.T) {
+	store := newInteractiveFollowUpStore(t)
+	operation, _, _, err := store.PrepareInteractiveRuntimeOperation(t.Context(), storesqlite.RuntimeOperationPrepare{
+		OperationID: "operation-recover-follow-up", WorkspaceID: "workspace-1", AgentSessionID: "session-1",
+		Kind: storesqlite.RuntimeOperationKindInteractiveResponse, TurnID: "turn-1", RequestID: "request-1",
+		Payload: map[string]any{"action": "", "optionId": "deny", "payload": map[string]any(nil)}, OccurredAtMS: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, claimed, err := store.ClaimRuntimeOperationLease(t.Context(), storesqlite.ClaimRuntimeOperationLeaseInput{
+		WorkspaceID: "workspace-1", OperationID: operation.OperationID, LeaseOwner: "dead-worker",
+		NowUnixMS: 20, LeaseExpiresAtMS: 100,
+	}); err != nil || !claimed {
+		t.Fatalf("claim operation = claimed=%v error=%v", claimed, err)
+	}
+	if _, changed, err := store.CheckpointRuntimeOperation(t.Context(), storesqlite.CheckpointRuntimeOperationInput{
+		WorkspaceID: "workspace-1", OperationID: operation.OperationID, LeaseOwner: "dead-worker", NowUnixMS: 30,
+		Payload: map[string]any{
+			"action": "", "optionId": "deny", "payload": map[string]any(nil),
+			"followUpPrompt":         "Please split the work into smaller steps.",
+			"followUpClientSubmitId": "interactive-deny:operation-recover-follow-up",
+			"followUpDisposition":    storesqlite.InteractionStatusAnswered,
+		},
+	}); err != nil || !changed {
+		t.Fatalf("checkpoint operation = changed=%v error=%v", changed, err)
+	}
+
+	runtime := &interactiveFollowUpRuntime{store: store, sessionFound: false}
+	host := New(Config{
+		CanonicalStore: interactiveFollowUpCanonicalStore{Store: store}, Runtime: runtime, RuntimeOperations: store,
+		OperationOwner: "recovery-worker", Clock: fixedClock{at: time.UnixMilli(1_000)},
+	})
+	if err := host.RecoverRuntimeOperations(t.Context()); err != nil {
+		t.Fatalf("RecoverRuntimeOperations() error = %v", err)
+	}
+	recovered, found, err := store.GetRuntimeOperation(t.Context(), "workspace-1", operation.OperationID)
+	if err != nil || !found {
+		t.Fatalf("recovered operation = %#v found=%v error=%v", recovered, found, err)
+	}
+	if recovered.Status != storesqlite.RuntimeOperationStatusPrepared || recovered.NextAttemptAtMS <= 1_000 {
+		t.Fatalf("recovered operation = %#v, want retryable prepared state", recovered)
+	}
+	if got := runtime.recordedSubmitInteractiveCalls(); got != 0 {
+		t.Fatalf("recovery SubmitInteractive calls = %d, want 0", got)
 	}
 }

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -557,10 +557,6 @@ type RuntimeSubmitInteractiveInput struct {
 	Payload            map[string]any
 }
 
-type RuntimeSubmitInteractiveResult struct {
-	Disposition RuntimeInteractiveDisposition
-}
-
 type RuntimeInteractiveDisposition string
 
 const (

--- a/packages/agent/store-sqlite/runtime_operations.go
+++ b/packages/agent/store-sqlite/runtime_operations.go
@@ -786,7 +786,7 @@ func jsonMapsEqual(left map[string]any, right map[string]any) bool {
 func interactiveResponseCheckpointIdentityEqual(previous, next map[string]any) bool {
 	previousIdentity := cloneJSONMap(previous)
 	nextIdentity := cloneJSONMap(next)
-	for _, key := range []string{"followUpPrompt", "followUpClientSubmitId"} {
+	for _, key := range []string{"followUpPrompt", "followUpClientSubmitId", "followUpDisposition"} {
 		delete(previousIdentity, key)
 		delete(nextIdentity, key)
 	}

--- a/packages/agent/store-sqlite/runtime_operations.go
+++ b/packages/agent/store-sqlite/runtime_operations.go
@@ -426,6 +426,10 @@ func (s *Store) CheckpointRuntimeOperation(ctx context.Context, input Checkpoint
 		return current, false, ErrRuntimeOperationLeaseLost
 	}
 	switch current.Kind {
+	case RuntimeOperationKindInteractiveResponse:
+		if !interactiveResponseCheckpointIdentityEqual(current.Payload, input.Payload) {
+			return current, false, ErrRuntimeOperationSubjectState
+		}
 	case RuntimeOperationKindPlanDecision:
 		if err := validatePlanDecisionOperationPayload(input.OperationID, input.Payload); err != nil {
 			return current, false, err
@@ -777,4 +781,14 @@ func jsonMapsEqual(left map[string]any, right map[string]any) bool {
 	leftJSON, leftErr := marshalJSONMap(left)
 	rightJSON, rightErr := marshalJSONMap(right)
 	return leftErr == nil && rightErr == nil && leftJSON == rightJSON
+}
+
+func interactiveResponseCheckpointIdentityEqual(previous, next map[string]any) bool {
+	previousIdentity := cloneJSONMap(previous)
+	nextIdentity := cloneJSONMap(next)
+	for _, key := range []string{"followUpPrompt", "followUpClientSubmitId"} {
+		delete(previousIdentity, key)
+		delete(nextIdentity, key)
+	}
+	return jsonMapsEqual(previousIdentity, nextIdentity)
 }

--- a/packages/agent/store-sqlite/runtime_operations_test.go
+++ b/packages/agent/store-sqlite/runtime_operations_test.go
@@ -2,6 +2,7 @@ package storesqlite
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -26,6 +27,42 @@ func TestRuntimeOperationPrepareIsSubjectIdempotentAndCrashRecoverable(t *testin
 	claimable, err := store.ListClaimableRuntimeOperations(context.Background(), ListClaimableRuntimeOperationsInput{WorkspaceID: "ws-1", NowUnixMS: 20})
 	if err != nil || len(claimable) != 1 || claimable[0].Status != RuntimeOperationStatusPrepared {
 		t.Fatalf("claimable after crash = %#v err=%v", claimable, err)
+	}
+}
+
+func TestInteractiveRuntimeOperationCheckpointOnlyAddsFollowUpIntent(t *testing.T) {
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	seedRuntimeInteractiveSubject(t, store, "session-follow-up", "turn-follow-up", "request-follow-up")
+	op, _, _, err := store.PrepareInteractiveRuntimeOperation(context.Background(), RuntimeOperationPrepare{
+		OperationID: "operation-follow-up", WorkspaceID: "ws-1", AgentSessionID: "session-follow-up",
+		Kind: RuntimeOperationKindInteractiveResponse, TurnID: "turn-follow-up", RequestID: "request-follow-up",
+		Payload: map[string]any{"action": "", "optionId": "deny", "payload": map[string]any(nil)}, OccurredAtMS: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, claimed, err := store.ClaimRuntimeOperationLease(context.Background(), ClaimRuntimeOperationLeaseInput{
+		WorkspaceID: "ws-1", OperationID: op.OperationID, LeaseOwner: "worker-follow-up", NowUnixMS: 20, LeaseExpiresAtMS: 100,
+	}); err != nil || !claimed {
+		t.Fatalf("claim operation = claimed=%v error=%v", claimed, err)
+	}
+
+	checkpointed, changed, err := store.CheckpointRuntimeOperation(context.Background(), CheckpointRuntimeOperationInput{
+		WorkspaceID: "ws-1", OperationID: op.OperationID, LeaseOwner: "worker-follow-up", NowUnixMS: 30,
+		Payload: map[string]any{
+			"action": "", "optionId": "deny", "payload": map[string]any(nil),
+			"followUpPrompt":         "Please split the work into smaller steps.",
+			"followUpClientSubmitId": "interactive-deny:operation-follow-up",
+		},
+	})
+	if err != nil || !changed || checkpointed.Payload["followUpPrompt"] == nil {
+		t.Fatalf("checkpoint = %#v changed=%v error=%v", checkpointed, changed, err)
+	}
+	if _, _, err := store.CheckpointRuntimeOperation(context.Background(), CheckpointRuntimeOperationInput{
+		WorkspaceID: "ws-1", OperationID: op.OperationID, LeaseOwner: "worker-follow-up", NowUnixMS: 31,
+		Payload: map[string]any{"action": "approve", "optionId": "deny", "payload": map[string]any(nil)},
+	}); !errors.Is(err, ErrRuntimeOperationSubjectState) {
+		t.Fatalf("identity-changing checkpoint error = %v", err)
 	}
 }
 

--- a/packages/agent/store-sqlite/runtime_operations_test.go
+++ b/packages/agent/store-sqlite/runtime_operations_test.go
@@ -53,10 +53,14 @@ func TestInteractiveRuntimeOperationCheckpointOnlyAddsFollowUpIntent(t *testing.
 			"action": "", "optionId": "deny", "payload": map[string]any(nil),
 			"followUpPrompt":         "Please split the work into smaller steps.",
 			"followUpClientSubmitId": "interactive-deny:operation-follow-up",
+			"followUpDisposition":    InteractionStatusAnswered,
 		},
 	})
 	if err != nil || !changed || checkpointed.Payload["followUpPrompt"] == nil {
 		t.Fatalf("checkpoint = %#v changed=%v error=%v", checkpointed, changed, err)
+	}
+	if got := checkpointed.Payload["followUpDisposition"]; got != InteractionStatusAnswered {
+		t.Fatalf("checkpointed follow-up disposition = %#v, want answered", got)
 	}
 	if _, _, err := store.CheckpointRuntimeOperation(context.Background(), CheckpointRuntimeOperationInput{
 		WorkspaceID: "ws-1", OperationID: op.OperationID, LeaseOwner: "worker-follow-up", NowUnixMS: 31,

--- a/services/tuttid/agent_runtime_adapter.go
+++ b/services/tuttid/agent_runtime_adapter.go
@@ -425,7 +425,8 @@ func (a agentRuntimeAdapter) SubmitInteractive(ctx context.Context, input agents
 		Payload:            input.Payload,
 	})
 	mapped := agentservice.RuntimeSubmitInteractiveResult{
-		Disposition: agentservice.RuntimeInteractiveDisposition(result.Disposition),
+		Disposition:    agentservice.RuntimeInteractiveDisposition(result.Disposition),
+		FollowUpPrompt: result.FollowUpPrompt,
 	}
 	if err != nil {
 		return mapped, mapAgentRuntimeError(err)

--- a/services/tuttid/service/agent/activity_projection_ordering_test.go
+++ b/services/tuttid/service/agent/activity_projection_ordering_test.go
@@ -146,6 +146,51 @@ func TestActivityProjectionReportCreatesProviderInitiatedTurnBeforeMessages(t *t
 	}
 }
 
+func TestActivityProjectionSubmitProvenanceAllowsGeneratedPromptIdentity(t *testing.T) {
+	ctx := context.Background()
+	store := openAgentServiceSQLiteStore(t)
+	if err := store.Create(ctx, workspacebiz.Summary{ID: "ws-generated-prompt", Name: "Generated prompt"}); err != nil {
+		t.Fatal(err)
+	}
+	projection := NewActivityProjection(store)
+	turnID := "turn-generated-prompt"
+	messageID := "turn-user:generated-message"
+	if err := projection.ReportSubmitProvenance(ctx, agentsessionstore.ReportActivityInput{
+		WorkspaceID: "ws-generated-prompt",
+		Source: canonical.EventSource{
+			AgentID: "session-generated-prompt", Provider: "codex",
+			SessionOrigin: agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+		},
+		StatePatches: []agentsessionstore.WorkspaceAgentStatePatch{{
+			AgentSessionID: "session-generated-prompt", Kind: agentactivitybiz.SessionKindRoot,
+			Provider: "codex", LifecycleStatus: "active", CurrentPhase: "working", OccurredAtUnixMS: 1,
+			Turn: &agentsessionstore.WorkspaceAgentTurnPatch{
+				TurnID: turnID, Origin: agentactivitybiz.TurnOriginUserPrompt,
+				ActiveTurnID: &turnID, Phase: agentactivitybiz.TurnPhaseSubmitted,
+			},
+		}},
+		MessageUpdates: []agentsessionstore.WorkspaceAgentMessageUpdate{{
+			AgentSessionID: "session-generated-prompt", TurnID: turnID, MessageID: messageID,
+			Role: "user", Kind: "text", Status: "completed", OccurredAtUnixMS: 1,
+			Payload: map[string]any{
+				"content": []map[string]any{{"type": "text", "text": "hello"}},
+			},
+		}},
+	}); err != nil {
+		t.Fatalf("generated prompt admission error = %v", err)
+	}
+	turn, found, err := store.GetTurn(ctx, "ws-generated-prompt", "session-generated-prompt", turnID)
+	if err != nil || !found || turn.Phase != agentactivitybiz.TurnPhaseSubmitted {
+		t.Fatalf("generated prompt turn = %#v found=%v error=%v", turn, found, err)
+	}
+	page, found, err := store.ListSessionMessages(ctx, agentactivitybiz.ListSessionMessagesInput{
+		WorkspaceID: "ws-generated-prompt", AgentSessionID: "session-generated-prompt", Limit: 10,
+	})
+	if err != nil || !found || len(page.Messages) != 1 || page.Messages[0].MessageID != messageID {
+		t.Fatalf("generated prompt messages = %#v found=%v error=%v", page.Messages, found, err)
+	}
+}
+
 func TestActivityProjectionRootProviderCompletionFlushesTurnMessagesBeforeSettlement(t *testing.T) {
 	ctx := context.Background()
 	store := openAgentServiceSQLiteStore(t)

--- a/services/tuttid/service/agent/activity_projection_submit_provenance.go
+++ b/services/tuttid/service/agent/activity_projection_submit_provenance.go
@@ -11,10 +11,12 @@ import (
 )
 
 // ReportSubmitProvenance is a deliberately narrower contract than Report.
-// It commits the canonical client-submit message together with the session and
-// optional new-turn patch in one repository transaction. The ordinary Report
-// compatibility path persists state and messages separately and therefore
-// cannot acknowledge provider dispatch safely.
+// It commits the canonical user message together with the session and optional
+// new-turn patch in one repository transaction. A client-submit id is carried
+// when the caller has one; internally allocated turns use a generated message
+// id instead. The ordinary Report compatibility path persists state and
+// messages separately and therefore cannot acknowledge provider dispatch
+// safely.
 func (p *ActivityProjection) ReportSubmitProvenance(
 	ctx context.Context,
 	input agentsessionstore.ReportActivityInput,
@@ -56,8 +58,8 @@ func (p *ActivityProjection) ReportSubmitProvenance(
 	update := messageInput.Updates[0]
 	clientSubmitID, _ := update.Payload["clientSubmitId"].(string)
 	clientSubmitID = strings.TrimSpace(clientSubmitID)
-	if strings.TrimSpace(update.MessageID) == "" || strings.TrimSpace(update.TurnID) == "" || clientSubmitID == "" {
-		return fmt.Errorf("atomic submit provenance requires message id, turn id, and client submit id")
+	if strings.TrimSpace(update.MessageID) == "" || strings.TrimSpace(update.TurnID) == "" {
+		return fmt.Errorf("atomic submit provenance requires message id and turn id")
 	}
 
 	activityReport, canonicalTargetID, err := p.activityStateReport(ctx, stateInput)
@@ -81,7 +83,7 @@ func (p *ActivityProjection) ReportSubmitProvenance(
 	}
 	message := result.Messages.Messages[0]
 	if strings.TrimSpace(message.TurnID) != strings.TrimSpace(update.TurnID) ||
-		strings.TrimSpace(payloadString(message.Payload, "clientSubmitId")) != clientSubmitID {
+		(clientSubmitID != "" && strings.TrimSpace(payloadString(message.Payload, "clientSubmitId")) != clientSubmitID) {
 		return fmt.Errorf("atomic submit provenance did not preserve canonical message identity")
 	}
 

--- a/services/tuttid/service/agent/host_conformance_test.go
+++ b/services/tuttid/service/agent/host_conformance_test.go
@@ -690,15 +690,21 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 		d.service.TurnStore = d.turns
 	}
 	if fixture.RecoverInteractive {
+		operationPayload := map[string]any{
+			"rootAgentSessionId": seed.AgentSessionID, "action": "", "optionId": "approve",
+			"payload": (map[string]any)(nil), "turnId": fixture.Interaction.TurnID,
+		}
+		if prompt := strings.TrimSpace(fixture.RecoverInteractiveFollowUpPrompt); prompt != "" {
+			operationPayload["followUpPrompt"] = prompt
+			operationPayload["followUpClientSubmitId"] = strings.TrimSpace(fixture.RecoverInteractiveFollowUpClientSubmitID)
+			operationPayload["followUpDisposition"] = string(fixture.RecoverInteractiveFollowUpDisposition)
+		}
 		d.operations.operation = agentactivitybiz.RuntimeOperation{
 			OperationID: runtimeOperationID(seed.WorkspaceID, seed.AgentSessionID, agentactivitybiz.RuntimeOperationKindInteractiveResponse, fixture.Interaction.TurnID+"\x00"+fixture.Interaction.RequestID),
 			WorkspaceID: seed.WorkspaceID, AgentSessionID: seed.AgentSessionID,
 			Kind: agentactivitybiz.RuntimeOperationKindInteractiveResponse, Status: agentactivitybiz.RuntimeOperationStatusLeased,
 			TurnID: fixture.Interaction.TurnID, RequestID: fixture.Interaction.RequestID,
-			Payload: map[string]any{
-				"rootAgentSessionId": seed.AgentSessionID, "action": "", "optionId": "approve",
-				"payload": (map[string]any)(nil), "turnId": fixture.Interaction.TurnID,
-			},
+			Payload:    operationPayload,
 			LeaseOwner: "dead-worker", LeaseExpiresAtMS: time.UnixMilli(1_000).Add(time.Hour).UnixMilli(),
 		}
 	}
@@ -1413,6 +1419,7 @@ func (d *legacyHostConformanceDriver) Metrics() hostconformance.Metrics {
 	}
 	if len(d.runtime.execCalls) > 0 {
 		last := d.runtime.execCalls[len(d.runtime.execCalls)-1]
+		metrics.LastExecClientSubmitID = last.ClientSubmitID
 		metrics.LastInitialTitle = last.InitialTitle
 		metrics.LastExecRequiresProviderAcceptance =
 			last.RequireProviderAcceptance


### PR DESCRIPTION
## Summary\n- centralize pending-new-session reconciliation admission in activity-core\n- keep the admission fence only while a new activation is still requested\n- issue one authoritative recovery reconcile when activation becomes uncertain or expires, so a committed Session can be discovered after a lost create response\n- release coalesced reconcile demand after canonical Session commit and document the lifecycle boundary\n\n## Tests\n- activity-core tests: 481 passed\n- 
> @tutti-os/agent-activity-core@0.1.0 typecheck /Users/liying/.codex/worktrees/tutti-owner-prompt-admission/packages/agent/activity-core
> node ../../../tools/scripts/run-tsgo-typecheck.mjs\n- 
> @tutti-os/desktop@0.0.0 typecheck /Users/liying/.codex/worktrees/tutti-owner-prompt-admission/apps/desktop
> node ../../tools/scripts/run-tsgo-typecheck.mjs\n- 
> tutti@ check:renderer-boundaries /Users/liying/.codex/worktrees/tutti-owner-prompt-admission
> node ./tools/scripts/check-renderer-feature-boundaries.mjs

renderer feature boundary check passed\n- 
> tutti@ check:agent-activity-runtime-boundaries /Users/liying/.codex/worktrees/tutti-owner-prompt-admission
> node ./tools/scripts/check-agent-activity-runtime-boundaries.mjs

Agent GUI runtime boundary check passed\n- 
> tutti@ check:changed /Users/liying/.codex/worktrees/tutti-owner-prompt-admission
> node ./tools/scripts/run-check-changed.mjs -- --push-ready

check:changed passed 27 lane(s) in 97.6s (27 lanes)\n- 
> tutti@ generate:builtin-apps /Users/liying/.codex/worktrees/tutti-owner-prompt-admission
> pnpm --filter @tutti-os/builtin-tutti-onboarding package:builtin


> @tutti-os/builtin-tutti-onboarding@0.0.0 package:builtin /Users/liying/.codex/worktrees/tutti-owner-prompt-admission/services/tuttid/builtin-apps/tutti-onboarding
> node scripts/package-builtin.mjs

vite v6.4.2 building for production...
transforming...
✓ 71 modules transformed.
rendering chunks...
computing gzip size...
dist/client/index.html                                             0.51 kB │ gzip:  0.31 kB
dist/client/assets/claudecode-flat-filled-BbKLKmjJ.svg             5.39 kB │ gzip:  2.48 kB
dist/client/assets/lexend-vietnamese-wght-normal-RvljkFvg.woff2   13.84 kB
dist/client/assets/lexend-latin-ext-wght-normal-B6JQhE1e.woff2    34.48 kB
dist/client/assets/lexend-latin-wght-normal-ci0D1wrL.woff2        39.68 kB
dist/client/assets/index-C3S3DVmM.css                             16.14 kB │ gzip:  3.86 kB
dist/client/assets/index-DKbpZMxS.js                             282.18 kB │ gzip: 91.74 kB
✓ built in 385ms
Created /Users/liying/.codex/worktrees/tutti-owner-prompt-admission/services/tuttid/builtin-apps/generated/tutti-onboarding/tutti-onboarding-0.1.0.zip
[dev-cli] built /Users/liying/.codex/worktrees/tutti-owner-prompt-admission/apps/cli/build/dev/tutti
[dev-cli] installed /Users/liying/.tutti-dev/bin/tutti-dev
[dev-cli] PATH command ready: /Users/liying/.local/bin/tutti-dev
[dev-cli] try: tutti-dev status
[dev-gui] registered tutti-dev to /Users/liying/.codex/worktrees/tutti-owner-prompt-admission/node_modules/.cache/tutti-desktop-electron-dev-dist/Tutti Dev.app

> tutti@ dev:desktop /Users/liying/.codex/worktrees/tutti-owner-prompt-admission
> pnpm --filter @tutti-os/desktop dev


> @tutti-os/desktop@0.0.0 predev /Users/liying/.codex/worktrees/tutti-owner-prompt-admission/apps/desktop
> node scripts/prepare-managed-posix-shell-dev.mjs


> @tutti-os/desktop@0.0.0 dev /Users/liying/.codex/worktrees/tutti-owner-prompt-admission/apps/desktop
> electron-vite dev

vite v6.4.2 building SSR bundle for development...
transforming...
✓ 425 modules transformed.
rendering chunks...
out/main/iconWorkerProcess-Dsh6tqsl.js        2.79 kB
out/main/desktopHostServices-BzD6t6CT.js     83.18 kB
out/main/index.js                         1,264.83 kB
✓ built in 570ms

build the electron main process successfully

-----

vite v6.4.2 building SSR bundle for development...
transforming...
✓ 37 modules transformed.
rendering chunks...
out/preload/capture.cjs              1.73 kB
out/preload/minimum-version.cjs      1.74 kB
out/preload/browser-node-guest.cjs   4.46 kB
out/preload/invoke-C_QQPsSn.cjs      8.28 kB
out/preload/index.cjs               27.02 kB
out/preload/workspace-app.cjs       36.61 kB
✓ built in 36ms

build the electron preload files successfully

-----

Port 5173 is in use, trying another one...
warming renderer modules before Electron launch...
renderer warmup completed in 16196ms (2325 modules)
dev server running for the electron renderer process at:

  ➜  Local:   http://127.0.0.1:5174/

start electron app... plus local API session smoke: session completed without \n\n## Notes\nThe dev GUI process remains running. The smoke used the local API to exercise the owner/service/activity path; a competing Electron window made mouse-driven UI E2E unsuitable as a pass criterion.