### PR TITLE
fix(desktop): return connector authorization to app

### DIFF
--- a/apps/desktop/src/main/bootstrap.ts
+++ b/apps/desktop/src/main/bootstrap.ts
@@ -54,7 +54,8 @@ import { prepareDesktopCliTarget } from "./cli/cliInstaller.ts";
 import { ensureSingleInstance } from "./singleInstance";
 import {
   completeDesktopLoginCallbackUrl,
-  findDesktopLoginCallbackUrl
+  findDesktopLoginCallbackUrl,
+  isDesktopAppOpenUrl
 } from "./desktopLoginCallback";
 import { getSystemDesktopLocale } from "./desktopLocale";
 import { openDesktopWorkspaceAppFolder } from "./host/workspaceAppFolderAccess";
@@ -124,11 +125,18 @@ export async function bootstrapDesktopApp(): Promise<void> {
     void completeDesktopLoginCallbackUrl(url).catch(() => undefined);
   };
   app.on("open-url", (event, url) => {
-    if (url.startsWith(loginCallbackUrl)) {
-      event.preventDefault();
-      handleLoginCallbackUrl(url);
-      focusPrimaryDesktopWindow();
+    const isLoginCallback = url.startsWith(loginCallbackUrl);
+    if (
+      !isLoginCallback &&
+      !isDesktopAppOpenUrl(url, protocolClientRegistration.scheme)
+    ) {
+      return;
     }
+    event.preventDefault();
+    if (isLoginCallback) {
+      handleLoginCallbackUrl(url);
+    }
+    focusPrimaryDesktopWindow();
   });
   const appName = app.getName();
   const userDataPath = resolveDesktopUserDataPath({

--- a/apps/desktop/src/main/desktopLoginCallback.test.ts
+++ b/apps/desktop/src/main/desktopLoginCallback.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { isDesktopAppOpenUrl } from "./desktopLoginCallback.ts";
+
+describe("isDesktopAppOpenUrl", () => {
+  it("accepts the exact app-open deep link for the active scheme", () => {
+    assert.equal(isDesktopAppOpenUrl("tutti://open", "tutti"), true);
+    assert.equal(isDesktopAppOpenUrl("tutti-dev://open/", "tutti-dev"), true);
+  });
+
+  it("rejects other schemes and paths", () => {
+    assert.equal(isDesktopAppOpenUrl("other://open", "tutti"), false);
+    assert.equal(isDesktopAppOpenUrl("tutti://open/other", "tutti"), false);
+    assert.equal(isDesktopAppOpenUrl("not-a-url", "tutti"), false);
+  });
+});

--- a/apps/desktop/src/main/desktopLoginCallback.ts
+++ b/apps/desktop/src/main/desktopLoginCallback.ts
@@ -9,6 +9,21 @@ export function findDesktopLoginCallbackUrl(
   return values.find((value) => value.startsWith(loginCallbackUrl)) ?? null;
 }
 
+export function isDesktopAppOpenUrl(rawUrl: string, scheme: string): boolean {
+  try {
+    const url = new URL(rawUrl);
+    return (
+      url.protocol === `${scheme}:` &&
+      url.hostname === "open" &&
+      (url.pathname === "" || url.pathname === "/") &&
+      url.username === "" &&
+      url.password === ""
+    );
+  } catch {
+    return false;
+  }
+}
+
 export async function completeDesktopLoginCallbackUrl(
   rawUrl: string
 ): Promise<boolean> {

--- a/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
+++ b/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
@@ -13,6 +13,7 @@ import {
   registerConnectorMarketModule,
   requestDesktopConnectorInstallAdmission
 } from "@renderer/features/connector-market";
+import { addTuttiDesktopClientToConnectorAuthorizationUrl } from "@renderer/features/connector-market/services/connectorAuthorizationClientUrl.ts";
 import { registerDesktopPreferencesServices } from "@renderer/features/desktop-preferences/services/registerDesktopPreferencesServices.ts";
 import { registerRichTextAtServices } from "@renderer/features/rich-text-at/services/registerRichTextAtServices";
 import { createDesktopAgentSessionStatusViewResolver } from "@renderer/features/rich-text-at/providers/desktopAgentSessionStatusView.ts";
@@ -218,7 +219,10 @@ export async function createWorkspaceWindowContainer(): Promise<WorkspaceWindowC
     canRequest: () => accountService.store.user !== null,
     client: tuttidClient,
     eventStreamClient: tuttidEventStreamClient,
-    openAuthorizationUrl: (url) => desktopApi.host.files.openExternal(url),
+    openAuthorizationUrl: (url) =>
+      desktopApi.host.files.openExternal(
+        addTuttiDesktopClientToConnectorAuthorizationUrl(url)
+      ),
     reportDiagnostic: (error) => {
       void desktopApi.runtime
         .logRendererDiagnostic({

--- a/apps/desktop/src/renderer/src/features/connector-market/services/connectorAuthorizationClientUrl.test.ts
+++ b/apps/desktop/src/renderer/src/features/connector-market/services/connectorAuthorizationClientUrl.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { addTuttiDesktopClientToConnectorAuthorizationUrl } from "./connectorAuthorizationClientUrl.ts";
+
+describe("addTuttiDesktopClientToConnectorAuthorizationUrl", () => {
+  it("marks the server-owned authorization bridge URL", () => {
+    assert.equal(
+      addTuttiDesktopClientToConnectorAuthorizationUrl(
+        "https://tutti.sh/connector-authorization/start/nonce?existing=value#step"
+      ),
+      "https://tutti.sh/connector-authorization/start/nonce?existing=value&desktop_client=tutti#step"
+    );
+  });
+
+  it("does not modify provider or invalid URLs", () => {
+    assert.equal(
+      addTuttiDesktopClientToConnectorAuthorizationUrl(
+        "https://accounts.google.com/o/oauth2/auth"
+      ),
+      "https://accounts.google.com/o/oauth2/auth"
+    );
+    assert.equal(
+      addTuttiDesktopClientToConnectorAuthorizationUrl("not-a-url"),
+      "not-a-url"
+    );
+  });
+});

--- a/apps/desktop/src/renderer/src/features/connector-market/services/connectorAuthorizationClientUrl.ts
+++ b/apps/desktop/src/renderer/src/features/connector-market/services/connectorAuthorizationClientUrl.ts
@@ -1,0 +1,20 @@
+const connectorAuthorizationStartPathPrefix = "/connector-authorization/start/";
+const desktopClientQuery = "desktop_client";
+
+export function addTuttiDesktopClientToConnectorAuthorizationUrl(
+  rawUrl: string
+): string {
+  try {
+    const url = new URL(rawUrl);
+    if (
+      (url.protocol !== "https:" && url.protocol !== "http:") ||
+      !url.pathname.startsWith(connectorAuthorizationStartPathPrefix)
+    ) {
+      return rawUrl;
+    }
+    url.searchParams.set(desktopClientQuery, "tutti");
+    return url.toString();
+  } catch {
+    return rawUrl;
+  }
+}


### PR DESCRIPTION
## Summary

Connector authorization opens in the system browser, but the desktop host did not identify itself on the shared authorization bridge URL. The returned page therefore could not reliably select the Tutti deep link, and a running macOS Tutti instance ignored the generic `tutti://open` URL.

This change:

- adds `desktop_client=tutti` only to server-owned connector authorization bridge URLs while leaving provider and invalid URLs unchanged
- recognizes the exact `tutti://open` / `tutti-dev://open` deep link and focuses the existing desktop window without invoking login callback completion
- adds focused coverage for URL tagging and app-open deep-link validation

## Verification

- `node --import ./test/register-asset-stub.mjs --test --experimental-strip-types ./src/main/desktopLoginCallback.test.ts ./src/renderer/src/features/connector-market/services/connectorAuthorizationClientUrl.test.ts` — 4 tests passed
- `pnpm typecheck` in `apps/desktop` — passed
- `pnpm check:changed -- --failed-only` — all 12 repository lanes passed after the naming-policy fixture was corrected

## Fallback Three Questions

- Source: the Connector Market host adapter accepts general external authorization links, including provider URLs and malformed input, while only the server-owned bridge URL supports the desktop-client marker.
- Why can it not be fixed at that source? The shared external-link contract intentionally remains host-neutral and cannot assume that every authorization URL belongs to the Tutti bridge.
- Removal condition: remove the pass-through fallback when the authorization protocol explicitly models the originating desktop client and distinguishes bridge links from provider links.

## Checklist

- [x] This change does not alter agent lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] I reviewed documentation impact; this internal host-adapter marker does not change contributor setup or a public protocol.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commit is signed off with DCO.
