### PR TITLE
fix(connector-market): preserve empty catalog arrays

### DIFF
--- a/services/tuttid/api/daemon_connector_market.go
+++ b/services/tuttid/api/daemon_connector_market.go
@@ -462,13 +462,13 @@ func projectConnectorMarket[T any](value any) (T, error) {
 func exposeConnectorMarketAuthorizationInteractionMode(value any) any {
 	switch typed := value.(type) {
 	case market.Snapshot:
-		typed.Connectors = append([]market.Connector(nil), typed.Connectors...)
+		typed.Connectors = append([]market.Connector{}, typed.Connectors...)
 		for index := range typed.Connectors {
 			typed.Connectors[index] = exposeConnectorAuthorizationInteractionMode(typed.Connectors[index])
 		}
 		return typed
 	case market.CatalogPage:
-		typed.Items = append([]market.CatalogListing(nil), typed.Items...)
+		typed.Items = append([]market.CatalogListing{}, typed.Items...)
 		for index := range typed.Items {
 			typed.Items[index].Connector = exposeConnectorAuthorizationInteractionMode(typed.Items[index].Connector)
 		}

--- a/services/tuttid/api/daemon_connector_market_test.go
+++ b/services/tuttid/api/daemon_connector_market_test.go
@@ -375,6 +375,30 @@ func TestDaemonAPIConnectorMarketServesCategoriesAndCursorPage(t *testing.T) {
 	}
 }
 
+func TestDaemonAPIConnectorMarketEmptyCatalogPageUsesEmptyItemsArray(t *testing.T) {
+	service := stubConnectorMarketService{
+		pageFn: func(context.Context, market.CatalogPageQuery) (market.CatalogPage, error) {
+			return market.CatalogPage{SectionID: "featured", Revision: 8}, nil
+		},
+	}
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, NewRoutes(DaemonAPI{ConnectorMarketService: service}))
+
+	page := performGeneratedRouteRequest(t, mux, http.MethodGet, "/v1/connector-market/catalog?sectionId=featured&pageSize=20", nil)
+	if page.Code != http.StatusOK {
+		t.Fatalf("page status = %d; body: %s", page.Code, page.Body.String())
+	}
+	var raw map[string]any
+	decodeGeneratedRouteResponse(t, page, &raw)
+	items, ok := raw["items"].([]any)
+	if !ok || items == nil {
+		t.Fatalf("items = %#v, want an empty JSON array", raw["items"])
+	}
+	if len(items) != 0 {
+		t.Fatalf("items = %#v, want empty", items)
+	}
+}
+
 func connectorMarketTestConnector() market.Connector {
 	digest := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	return market.Connector{


### PR DESCRIPTION
## Summary
- preserve empty connector catalog arrays at the public API boundary
- prevent an empty category from aborting the remaining connector catalog load
- add a regression test for empty catalog pages

## Root cause
The API projection cloned empty Go slices with a nil destination, serializing the required `items` array as `null`. The renderer then failed while iterating `page.items`, so available connectors in later categories were hidden behind the empty-state message.

## Validation
- `go test ./services/tuttid/api`
- `pnpm --filter @tutti-os/connector-market test` (73 passed)
- `pnpm --filter @tutti-os/connector-market typecheck`
- live daemon response verified empty categories return `items: []` and `other` returns `supabase`, `wecom-cli`, and `zoom`.