### PR TITLE
fix(connector): preserve the initiating Tutti environment

### DIFF
--- a/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
+++ b/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
@@ -221,7 +221,10 @@ export async function createWorkspaceWindowContainer(): Promise<WorkspaceWindowC
     eventStreamClient: tuttidEventStreamClient,
     openAuthorizationUrl: (url) =>
       desktopApi.host.files.openExternal(
-        addTuttiDesktopClientToConnectorAuthorizationUrl(url)
+        addTuttiDesktopClientToConnectorAuthorizationUrl(
+          url,
+          import.meta.env.DEV
+        )
       ),
     reportDiagnostic: (error) => {
       void desktopApi.runtime

--- a/apps/desktop/src/renderer/src/features/connector-market/services/connectorAuthorizationClientUrl.test.ts
+++ b/apps/desktop/src/renderer/src/features/connector-market/services/connectorAuthorizationClientUrl.test.ts
@@ -6,21 +6,30 @@ describe("addTuttiDesktopClientToConnectorAuthorizationUrl", () => {
   it("marks the server-owned authorization bridge URL", () => {
     assert.equal(
       addTuttiDesktopClientToConnectorAuthorizationUrl(
-        "https://tutti.sh/connector-authorization/start/nonce?existing=value#step"
+        "https://tutti.sh/connector-authorization/start/nonce?existing=value#step",
+        true
       ),
-      "https://tutti.sh/connector-authorization/start/nonce?existing=value&desktop_client=tutti#step"
+      "https://tutti.sh/connector-authorization/start/nonce?existing=value&desktop_client=tutti&openAppUrl=tutti-dev%3A%2F%2Fopen#step"
+    );
+    assert.equal(
+      addTuttiDesktopClientToConnectorAuthorizationUrl(
+        "https://tutti.sh/connector-authorization/start/nonce",
+        false
+      ),
+      "https://tutti.sh/connector-authorization/start/nonce?desktop_client=tutti&openAppUrl=tutti%3A%2F%2Fopen"
     );
   });
 
   it("does not modify provider or invalid URLs", () => {
     assert.equal(
       addTuttiDesktopClientToConnectorAuthorizationUrl(
-        "https://accounts.google.com/o/oauth2/auth"
+        "https://accounts.google.com/o/oauth2/auth",
+        true
       ),
       "https://accounts.google.com/o/oauth2/auth"
     );
     assert.equal(
-      addTuttiDesktopClientToConnectorAuthorizationUrl("not-a-url"),
+      addTuttiDesktopClientToConnectorAuthorizationUrl("not-a-url", true),
       "not-a-url"
     );
   });

--- a/apps/desktop/src/renderer/src/features/connector-market/services/connectorAuthorizationClientUrl.ts
+++ b/apps/desktop/src/renderer/src/features/connector-market/services/connectorAuthorizationClientUrl.ts
@@ -1,8 +1,10 @@
 const connectorAuthorizationStartPathPrefix = "/connector-authorization/start/";
 const desktopClientQuery = "desktop_client";
+const openAppUrlQuery = "openAppUrl";
 
 export function addTuttiDesktopClientToConnectorAuthorizationUrl(
-  rawUrl: string
+  rawUrl: string,
+  isDevelopment: boolean
 ): string {
   try {
     const url = new URL(rawUrl);
@@ -13,6 +15,10 @@ export function addTuttiDesktopClientToConnectorAuthorizationUrl(
       return rawUrl;
     }
     url.searchParams.set(desktopClientQuery, "tutti");
+    url.searchParams.set(
+      openAppUrlQuery,
+      isDevelopment ? "tutti-dev://open" : "tutti://open"
+    );
     return url.toString();
   } catch {
     return rawUrl;

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -140,6 +140,7 @@ App Center, workspace-app lifecycle, App Factory, file references, and File Mana
 Connector catalog, installation, account authorization, and runtime convergence.
 
 - [OAuth opens once, then the desktop stays disconnected or a second attempt supersedes the first](./connector-market.md#oauth-opens-once-then-the-desktop-stays-disconnected-or-a-second-attempt-supersedes-the-first)
+- [OAuth finishes in the browser but does not return to the initiating desktop build](./connector-market.md#oauth-finishes-in-the-browser-but-does-not-return-to-the-initiating-desktop-build)
 
 ## [Toolchain, Browser, And Terminal](./toolchain-browser-terminal.md)
 

--- a/docs/conventions/troubleshooting/connector-market.md
+++ b/docs/conventions/troubleshooting/connector-market.md
@@ -29,3 +29,19 @@ current session's `pending` state only in the Start command result so shared
 clients continue that idempotent session. Do not persist a synthetic connected
 projection, infer success from the Start operation's terminal state, or create a
 second external session to refresh the UI.
+
+### OAuth finishes in the browser but does not return to the initiating desktop build
+
+**Symptoms**
+
+- the authorization result page renders and its return link uses a valid desktop scheme
+- a development build started the flow, but the link targets the production scheme
+- the result page host is `tutti.sh`, so deriving the desktop environment from the web host selects the wrong application
+
+**Check**
+
+Inspect the server-owned authorization bridge URL before it leaves the renderer. It must carry both the client identity and an exact `openAppUrl` for the initiating build, such as `tutti-dev://open`. Confirm the web transition page stores that value before navigating to the provider and that the result page uses the same sanitized value for both automatic navigation and the manual link.
+
+**Rule**
+
+The initiating desktop build owns the callback environment. Do not infer a production or development desktop scheme from the authorization website hostname. Web code must accept only the exact supported `open` routes and keep the legacy client marker solely as compatibility for already released clients.


### PR DESCRIPTION
## Summary

A development Tutti build can authorize through the production website. Inferring the callback scheme from that website host targets `tutti://open` instead of the initiating `tutti-dev://open`, so authorization finishes in the browser without reopening the correct app.

This change adds an exact, environment-aware `openAppUrl` to the server-owned authorization start URL, keeps the existing `desktop_client=tutti` marker for compatibility, covers both packaged and development builds, and documents the ownership rule for future debugging.

## Verification

- The focused URL helper test verifies `tutti-dev://open` for development builds, `tutti://open` for packaged builds, and no mutation of provider or invalid URLs.
- `pnpm check:changed` passed all 10 selected lanes.

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter. (Not applicable.)
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. (Not applicable.)
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
