### PR TITLE
fix(connectors): prioritize authorized connectors

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -262,7 +262,9 @@ reads its authoritative local Connector Market snapshot, then uses
 installation, compatibility, and authorization state into the closed Composer
 capability contract. Host transports only serialize that projection and route
 semantic open intents; they must not duplicate Connector readiness rules or
-derive Composer entries from renderer-local market state. Connector Market
+derive Composer entries from renderer-local market state. The snapshot uses the
+host's current account scope so Composer status and prompt admission include the
+same authorization overlay as Connector Market management. Connector Market
 change events invalidate retained Composer options, while a menu open may still
 force an authoritative reread as a recovery path.
 

--- a/docs/architecture/connector-market.md
+++ b/docs/architecture/connector-market.md
@@ -440,7 +440,9 @@ unrelated Connector update or overwrite a newer entity.
 Account authorization overlays are read in the same SQLite Snapshot as market
 state. A public projection change atomically advances the Connector revision and
 appends its invalidation event; account state can no longer change invisibly
-between market Snapshot reads.
+between market Snapshot reads. Composer capability projection and prompt
+admission use the current account-scoped Snapshot as well, so their connected
+state cannot diverge from Connector Market management surfaces.
 
 Operation-bearing events carry an internal account audience and are delivered
 only while that owner is the host's active account. Every state change also
@@ -537,8 +539,11 @@ options into that projection and retains only placement plus its Tutti Mode
 fallback. Selecting one item emits a semantic connector-open intent. The host
 executes `openConnectorMarketDialog(root, connectorKey)`, which waits for the
 authoritative market view, rejects invalid or unknown keys, and then advances
-the package-owned dialog state machine. Selecting “more” remains host
-navigation because settings/workbench location is product-owned.
+the package-owned dialog state machine. Before applying the bounded quick-list
+limit, the shared menu stably groups connected connectors ahead of connectors
+that still require authorization or setup; each group preserves host catalog
+order. Selecting “more” remains host navigation because settings/workbench
+location is product-owned.
 
 Every renderer window mounts exactly one `ConnectorMarketDialogHost` alongside
 its other window-level panel hosts. Composer entries and catalog cards never

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerConnectorsMenu.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerConnectorsMenu.spec.tsx
@@ -243,4 +243,39 @@ describe("ComposerConnectorsMenu", () => {
       screen.queryByTestId("connector-market-composer-item-connector-10")
     ).not.toBeInTheDocument();
   });
+
+  it("prioritizes connected connectors before applying the quick menu limit", async () => {
+    const setupRequiredConnectors = Array.from({ length: 10 }, (_, index) =>
+      connector(`setup-${index}`, "setupRequired")
+    );
+    render(
+      <ComposerConnectorsMenu
+        connectors={[
+          ...setupRequiredConnectors,
+          connector("connected-after-limit", "available")
+        ]}
+        disabled={false}
+        labels={labels}
+        onOpenConnector={vi.fn()}
+        onOpenConnectors={vi.fn()}
+      />
+    );
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Connectors" }), {
+      button: 0,
+      ctrlKey: false
+    });
+
+    const quickItems = await screen.findAllByTestId(
+      /^connector-market-composer-item-/
+    );
+    expect(quickItems).toHaveLength(10);
+    expect(quickItems[0]).toHaveAttribute(
+      "data-testid",
+      "connector-market-composer-item-connected-after-limit"
+    );
+    expect(
+      screen.queryByTestId("connector-market-composer-item-setup-9")
+    ).not.toBeInTheDocument();
+  });
 });

--- a/packages/connector/market/README.md
+++ b/packages/connector/market/README.md
@@ -140,7 +140,9 @@ shared component does not import AgentGUI or host settings code. Item selection
 must be routed through `openConnectorMarketDialog` from
 `@tutti-os/connector-market/services`, which loads the authoritative View before
 opening the package-owned installation, authorization, management, or blocked
-dialog. “More connectors” is a separate host navigation callback.
+dialog. The bounded quick list places connected connectors first while
+preserving the host order within connected and remaining groups. “More
+connectors” is a separate host navigation callback.
 
 Mount one `ConnectorMarketDialogHost` per renderer window/application
 container, not per composer entry or settings page. Multiple entries share the

--- a/packages/connector/market/src/ui/composer/ConnectorComposerMenu.tsx
+++ b/packages/connector/market/src/ui/composer/ConnectorComposerMenu.tsx
@@ -216,7 +216,8 @@ export function ConnectorComposerMenu({
 export function normalizeConnectorItems(
   items: readonly ConnectorComposerItem[]
 ): ConnectorComposerItem[] {
-  const normalizedItems: ConnectorComposerItem[] = [];
+  const connectedItems: ConnectorComposerItem[] = [];
+  const remainingItems: ConnectorComposerItem[] = [];
   const seenConnectorKeys = new Set<string>();
   for (const item of items) {
     const connectorKey = item.connectorKey.trim();
@@ -224,9 +225,14 @@ export function normalizeConnectorItems(
       continue;
     }
     seenConnectorKeys.add(connectorKey);
-    normalizedItems.push({ ...item, connectorKey });
+    const normalizedItem = { ...item, connectorKey };
+    if (normalizedItem.status === "connected") {
+      connectedItems.push(normalizedItem);
+    } else {
+      remainingItems.push(normalizedItem);
+    }
   }
-  return normalizedItems;
+  return [...connectedItems, ...remainingItems];
 }
 
 function ConnectorComposerIcon({

--- a/packages/connector/market/src/ui/composer/connectorComposerMenuModel.test.ts
+++ b/packages/connector/market/src/ui/composer/connectorComposerMenuModel.test.ts
@@ -6,24 +6,29 @@ import {
   type ConnectorComposerItem
 } from "./ConnectorComposerMenu.tsx";
 
-test("normalizes connector keys while preserving catalog order and first identity", () => {
+test("prioritizes connected connectors while preserving group order and first identity", () => {
   const items: ConnectorComposerItem[] = [
     item(" github "),
-    item("notion"),
+    item("notion", "connected"),
     item("github"),
+    item("lark"),
+    item("figma", "connected"),
     item("   ")
   ];
 
   assert.deepEqual(
     normalizeConnectorItems(items).map((entry) => entry.connectorKey),
-    ["github", "notion"]
+    ["notion", "figma", "github", "lark"]
   );
 });
 
-function item(connectorKey: string): ConnectorComposerItem {
+function item(
+  connectorKey: string,
+  status: ConnectorComposerItem["status"] = "setup_required"
+): ConnectorComposerItem {
   return {
     connectorKey,
     name: connectorKey,
-    status: "setup_required"
+    status
   };
 }

--- a/services/tuttid/service/agent/composer_options.go
+++ b/services/tuttid/service/agent/composer_options.go
@@ -327,7 +327,11 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 		})
 		if s.ConnectorMarketSnapshots != nil {
 			capabilityGroup.Go(func() error {
-				localConnectors, localConnectorsErr = localConnectorCapabilityOptions(capabilityContext, s.ConnectorMarketSnapshots)
+				localConnectors, localConnectorsErr = localConnectorCapabilityOptions(
+					capabilityContext,
+					s.ConnectorMarketSnapshots,
+					s.ConnectorMarketCurrentScope,
+				)
 				return nil
 			})
 		}

--- a/services/tuttid/service/agent/local_connector_capabilities.go
+++ b/services/tuttid/service/agent/local_connector_capabilities.go
@@ -37,7 +37,7 @@ func (s *Service) validatePromptConnectors(ctx context.Context, content []Prompt
 	if s == nil || s.ConnectorMarketSnapshots == nil {
 		return fmt.Errorf("%w: local connector state is unavailable", ErrInvalidArgument)
 	}
-	snapshot, err := s.ConnectorMarketSnapshots.Snapshot(ctx)
+	snapshot, err := connectorMarketSnapshot(ctx, s.ConnectorMarketSnapshots, s.ConnectorMarketCurrentScope)
 	if err != nil {
 		return fmt.Errorf("read local connector state: %w", err)
 	}
@@ -60,8 +60,24 @@ func (s *Service) validatePromptConnectors(ctx context.Context, content []Prompt
 func localConnectorCapabilityOptions(
 	ctx context.Context,
 	source market.SnapshotReader,
+	currentScope func() market.OperationScope,
 ) ([]ComposerCapabilityOption, error) {
-	return composercatalog.ConnectorOptions(ctx, source)
+	snapshot, err := connectorMarketSnapshot(ctx, source, currentScope)
+	if err != nil {
+		return nil, err
+	}
+	return composercatalog.ProjectConnectorOptions(snapshot), nil
+}
+
+func connectorMarketSnapshot(
+	ctx context.Context,
+	source market.SnapshotReader,
+	currentScope func() market.OperationScope,
+) (market.Snapshot, error) {
+	if scoped, ok := source.(market.ScopedSnapshotReader); ok && currentScope != nil {
+		return scoped.SnapshotForScope(ctx, currentScope())
+	}
+	return source.Snapshot(ctx)
 }
 
 func replaceComposerConnectorCapabilities(

--- a/services/tuttid/service/agent/local_connector_capabilities_test.go
+++ b/services/tuttid/service/agent/local_connector_capabilities_test.go
@@ -32,12 +32,54 @@ func TestValidatePromptConnectorsRequiresInstalledAuthorizedConnector(t *testing
 	}
 }
 
+func TestValidatePromptConnectorsUsesCurrentAccountAuthorization(t *testing.T) {
+	snapshots := &scopedConnectorMarketSnapshotStub{
+		snapshot: market.Snapshot{Connectors: []market.Connector{
+			localConnectorFixture("github", market.InstallationStateInstalled, market.AuthorizationStateDisconnected, market.CompatibilityStateSupported),
+		}},
+		scopedSnapshot: market.Snapshot{Connectors: []market.Connector{
+			localConnectorFixture("github", market.InstallationStateInstalled, market.AuthorizationStateConnected, market.CompatibilityStateSupported),
+		}},
+	}
+	service := &Service{
+		ConnectorMarketSnapshots: snapshots,
+		ConnectorMarketCurrentScope: func() market.OperationScope {
+			return market.OperationScope{AccountID: "account-1"}
+		},
+	}
+
+	err := service.validatePromptConnectors(context.Background(), []PromptContentBlock{{
+		Type: "connector", ConnectorKey: "github",
+	}})
+	if err != nil {
+		t.Fatalf("validatePromptConnectors(github) error = %v", err)
+	}
+	if snapshots.requestedScope.AccountID != "account-1" {
+		t.Fatalf("connector snapshot scope = %#v, want current account", snapshots.requestedScope)
+	}
+}
+
 type connectorMarketSnapshotStub struct {
 	snapshot market.Snapshot
 }
 
 func (stub connectorMarketSnapshotStub) Snapshot(context.Context) (market.Snapshot, error) {
 	return stub.snapshot, nil
+}
+
+type scopedConnectorMarketSnapshotStub struct {
+	snapshot       market.Snapshot
+	scopedSnapshot market.Snapshot
+	requestedScope market.OperationScope
+}
+
+func (stub *scopedConnectorMarketSnapshotStub) Snapshot(context.Context) (market.Snapshot, error) {
+	return stub.snapshot, nil
+}
+
+func (stub *scopedConnectorMarketSnapshotStub) SnapshotForScope(_ context.Context, scope market.OperationScope) (market.Snapshot, error) {
+	stub.requestedScope = scope
+	return stub.scopedSnapshot, nil
 }
 
 func TestLocalConnectorCapabilityOptionsProjectsCatalogWithSetupState(t *testing.T) {
@@ -49,7 +91,7 @@ func TestLocalConnectorCapabilityOptionsProjectsCatalogWithSetupState(t *testing
 			localConnectorFixture("slack", market.InstallationStateNotInstalled, market.AuthorizationStateConnected, market.CompatibilityStateSupported),
 			localConnectorFixture("lark-cli", market.InstallationStateFailed, market.AuthorizationStateDisconnected, market.CompatibilityStateSupported),
 		}},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("localConnectorCapabilityOptions() error = %v", err)
 	}

--- a/services/tuttid/service/agent/service_composer_options_test.go
+++ b/services/tuttid/service/agent/service_composer_options_test.go
@@ -434,6 +434,47 @@ func TestServiceGetComposerOptionsUsesLocalInstalledConnectorCatalog(t *testing.
 	}
 }
 
+func TestServiceGetComposerOptionsUsesCurrentAccountConnectorAuthorization(t *testing.T) {
+	runtime := newFakeRuntime()
+	service := newIsolatedAgentService(runtime)
+	service.DesktopPreferencesReader = connectorCatalogPreferencesReader(true)
+	snapshots := &scopedConnectorMarketSnapshotStub{
+		snapshot: market.Snapshot{Connectors: []market.Connector{
+			localConnectorFixture(
+				"github",
+				market.InstallationStateInstalled,
+				market.AuthorizationStateDisconnected,
+				market.CompatibilityStateSupported,
+			),
+		}},
+		scopedSnapshot: market.Snapshot{Connectors: []market.Connector{
+			localConnectorFixture(
+				"github",
+				market.InstallationStateInstalled,
+				market.AuthorizationStateConnected,
+				market.CompatibilityStateSupported,
+			),
+		}},
+	}
+	service.ConnectorMarketSnapshots = snapshots
+	service.ConnectorMarketCurrentScope = func() market.OperationScope {
+		return market.OperationScope{AccountID: "account-1"}
+	}
+
+	options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+		Provider: "codex",
+	})
+	if err != nil {
+		t.Fatalf("GetComposerOptions returned error: %v", err)
+	}
+	if len(options.CapabilityCatalog) != 1 || options.CapabilityCatalog[0].Status != "available" {
+		t.Fatalf("capability catalog = %#v, want current account connector available", options.CapabilityCatalog)
+	}
+	if snapshots.requestedScope.AccountID != "account-1" {
+		t.Fatalf("connector snapshot scope = %#v, want current account", snapshots.requestedScope)
+	}
+}
+
 func TestServiceGetComposerOptionsCachesCapabilityCatalog(t *testing.T) {
 	runtime := newFakeRuntime()
 	lister := &recordingComposerCapabilityLister{}

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -74,6 +74,7 @@ type Service struct {
 	ComputerUseAvailable           func() bool
 	CapabilityLister               ComposerCapabilityLister
 	ConnectorMarketSnapshots       market.SnapshotReader
+	ConnectorMarketCurrentScope    func() market.OperationScope
 	ExtensionComposerProfiles      ExtensionComposerProfileResolver
 	AgentComposerDefaultsReader    AgentComposerDefaultsReader
 	DesktopPreferencesReader       DesktopPreferencesReader

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -415,6 +415,7 @@ func (w *tuttiWiring) buildWorkspaceModule(ctx context.Context) error {
 		}
 		if service, ok := api.AgentSessionService.(*agentservice.Service); ok {
 			service.ConnectorMarketSnapshots = connectorMarketHost.Application
+			service.ConnectorMarketCurrentScope = connectorMarketScope
 		}
 		api.ConnectorMarketService = connectorMarketHost.Application
 		api.ConnectorMarketScope = connectorMarketScope


### PR DESCRIPTION
## Summary

Composer connector options were built from the unscoped Connector Market snapshot, so current-account authorization overlays were omitted and already authorized connectors appeared as requiring authorization.

This change routes Composer options and prompt connector admission through the current account scope, while retaining the unscoped snapshot fallback for compatible sources. The connector quick menu now performs a stable connected-first partition before applying its 10-item limit, preserving catalog order within each status group.

Regression coverage verifies account-scoped authorization projection and the connected-first bounded menu. Connector Market and AgentGUI architecture documentation now describe the account-scope and ordering guarantees.

## Verification

- Added a negative-control-backed AgentGUI regression where the connected connector starts beyond the first 10 catalog entries; it now renders first and displaces the last setup-required item.
- Added service regressions proving Composer options and prompt admission use the current account authorization projection.
- Manually verified in Tutti Dev that Dropbox, GitHub, Gmail, Google Calendar, Google Drive, Google Sheets, Lark CLI, Linear, Notion, and Slack appear first and show `已连接`.

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter. (N/A: connector option projection only.)
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. (N/A: no README/CONTRIBUTING language source changed.)
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
