### PR TITLE
fix(agent-gui): filter Codex skills budget warning variants

### DIFF
--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -1051,7 +1051,9 @@ file or directory`. A failed `codex app-server` probe is diagnostic evidence,
   boundary and replay the answer again in `turn/completed`, sometimes with
   whitespace polish; treating each report as a new segment creates duplicate
   bubbles. The model-metadata warning is runtime diagnostic noise rather than
-  an actionable user error.
+  an actionable user error. Persisted skill-context warnings may omit their
+  optional `source` metadata, and Codex has emitted both percentage and
+  non-percentage variants of that wording.
 - Fix:
   Treat Codex app-server `model/list` as the authoritative catalog regardless
   of `model_provider`. Preserve the full returned list and reasoning metadata;
@@ -1060,7 +1062,10 @@ file or directory`. A failed `codex app-server` probe is diagnostic evidence,
   for whitespace-equivalent item-finalization text and ignore turn-final text
   after an assistant segment has already completed. Filter the metadata
   fallback warning through the same AgentGUI diagnostic-notice projection used
-  for skills-context-budget warnings.
+  for skills-context-budget warnings. Match the optional percentage in the
+  skills warning as diagnostic context rather than as part of its identity;
+  accept a missing source only for that exact warning, preserve explicitly
+  non-runtime notices, and keep the metadata fallback warning runtime-only.
 - Validation:
   Run
   `go test ./packages/agent/daemon/runtime -run 'TestApplyAssistantFinalText|TestApplyAssistantTurnFinalText|TestCodexAppServerAdapterExecStreamsTurn'`,

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
@@ -24,8 +24,10 @@ export interface AgentConversationProjectionOptions {
 }
 
 const RENDER_IRRELEVANT_TRANSCRIPT_ROW_FIELDS = new Set(["occurredAtUnixMs"]);
-const CODEX_SKILLS_CONTEXT_BUDGET_NOTICE_FRAGMENT =
-  "skill descriptions were shortened to fit the 2% skills context budget";
+// Codex has emitted both the older "2%" wording and the current wording
+// without a percentage; the percentage is diagnostic context, not identity.
+const CODEX_SKILLS_CONTEXT_BUDGET_NOTICE_PATTERN =
+  /skill descriptions were shortened to fit the(?:\s+\d+(?:\.\d+)?%)?\s+skills context budget/i;
 const CODEX_MODEL_METADATA_FALLBACK_NOTICE_FRAGMENT =
   "defaulting to fallback metadata";
 const MARKDOWN_IMAGE_PATTERN =
@@ -55,7 +57,7 @@ export function projectAgentConversationVM(
     if (summary) rows.push(summary);
   });
 
-  const normalizedRows = dropCodexRuntimeDiagnosticNotices(
+  const normalizedRows = dropCodexDiagnosticNotices(
     dropRedundantErrorWarningNotices(
       mergeAdjacentAssistantMessageRows(
         dropRedundantCompactFailureEchoRows(
@@ -320,7 +322,7 @@ function mergeAdjacentAssistantMessageRows(
   return merged;
 }
 
-function dropCodexRuntimeDiagnosticNotices(
+function dropCodexDiagnosticNotices(
   rows: readonly AgentTranscriptRowVM[]
 ): AgentTranscriptRowVM[] {
   const filteredRows: AgentTranscriptRowVM[] = [];
@@ -330,7 +332,7 @@ function dropCodexRuntimeDiagnosticNotices(
       continue;
     }
     const messages = row.messages.filter(
-      (message) => !isCodexSkillsContextBudgetNotice(message)
+      (message) => !isCodexDiagnosticNotice(message)
     );
     if (messages.length === 0 && row.thinking.length === 0) {
       continue;
@@ -344,22 +346,22 @@ function dropCodexRuntimeDiagnosticNotices(
   return filteredRows;
 }
 
-function isCodexSkillsContextBudgetNotice(
-  message: AgentMessageContentVM
-): boolean {
+function isCodexDiagnosticNotice(message: AgentMessageContentVM): boolean {
   const notice = message.systemNotice;
   if (!notice || notice.noticeKind !== "warning") {
-    return false;
-  }
-  if (notice.source !== "runtime") {
     return false;
   }
   const text = [notice.title, notice.detail, message.body]
     .filter(Boolean)
     .join("\n")
     .toLowerCase();
+  if (CODEX_SKILLS_CONTEXT_BUDGET_NOTICE_PATTERN.test(text)) {
+    // Persisted skill notices may omit source, but an explicitly non-runtime
+    // notice must remain visible even when its text matches this diagnostic.
+    return !notice.source || notice.source === "runtime";
+  }
   return (
-    text.includes(CODEX_SKILLS_CONTEXT_BUDGET_NOTICE_FRAGMENT) ||
+    notice.source === "runtime" &&
     text.includes(CODEX_MODEL_METADATA_FALLBACK_NOTICE_FRAGMENT)
   );
 }

--- a/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.spec.ts
@@ -1093,7 +1093,7 @@ describe("projectWorkspaceAgentMessagesToConversationVM", () => {
     expect(toolRows[0]?.calls[0]?.toolName).toBe("Agent");
   });
 
-  it("projects Codex warning notices without appending them to assistant text", () => {
+  it("drops source-less skills warnings but preserves explicit non-runtime matches", () => {
     const conversation = projectWorkspaceAgentMessagesToConversationVM({
       activity: activity(),
       session: session(),
@@ -1119,7 +1119,26 @@ describe("projectWorkspaceAgentMessagesToConversationVM", () => {
             severity: "warning",
             title: "Codex warning",
             detail:
-              "Skill descriptions were shortened to fit the 2% skills context budget.",
+              "Skill descriptions were shortened to fit the skills context budget. Codex can still see every skill, but some descriptions are shorter.",
+            text: "Codex warning",
+            content: "Codex warning",
+            contentMode: "snapshot"
+          }
+        }),
+        message({
+          messageId: "notice-2",
+          id: 3,
+          version: 3,
+          role: "assistant",
+          kind: "text",
+          payload: {
+            kind: "agent_system_notice",
+            noticeKind: "warning",
+            severity: "warning",
+            title: "Codex warning",
+            source: "user",
+            detail:
+              "Skill descriptions were shortened to fit the skills context budget.",
             text: "Codex warning",
             content: "Codex warning",
             contentMode: "snapshot"
@@ -1127,8 +1146,8 @@ describe("projectWorkspaceAgentMessagesToConversationVM", () => {
         }),
         message({
           messageId: "assistant-1",
-          id: 3,
-          version: 3,
+          id: 4,
+          version: 4,
           role: "assistant",
           kind: "text",
           payload: {
@@ -1152,14 +1171,59 @@ describe("projectWorkspaceAgentMessagesToConversationVM", () => {
       noticeKind: "warning",
       severity: "warning",
       title: "Codex warning",
+      source: "user",
       detail:
-        "Skill descriptions were shortened to fit the 2% skills context budget.",
+        "Skill descriptions were shortened to fit the skills context budget.",
       retryable: null
     });
-    expect(assistantRows[0]?.messages[0]?.body).toBe("Codex warning");
+    expect(assistantRows[1]?.messages[0]?.systemNotice).toBeNull();
     expect(assistantRows[1]?.messages[0]?.body).toBe(
       "你好。有什么需要我在这个 workspace 里处理?"
     );
+  });
+
+  it("keeps fallback metadata warnings when runtime metadata is absent", () => {
+    const metadataWarning =
+      "Model metadata for `minimax/minimax-m2.5` not found. Defaulting to fallback metadata; this can degrade performance and cause issues.";
+    const conversation = projectWorkspaceAgentMessagesToConversationVM({
+      activity: activity(),
+      session: session(),
+      workspaceRoot: "/workspace/demo",
+      messages: [
+        message({
+          messageId: "notice-1",
+          id: 1,
+          version: 1,
+          role: "assistant",
+          kind: "text",
+          payload: {
+            kind: "agent_system_notice",
+            noticeKind: "warning",
+            severity: "warning",
+            title: metadataWarning,
+            detail: metadataWarning,
+            text: "Codex warning",
+            content: "Codex warning",
+            contentMode: "snapshot"
+          }
+        })
+      ]
+    });
+
+    const warning = conversation.rows.find(
+      (row) => row.kind === "message" && row.speaker === "assistant"
+    );
+    expect(warning).toMatchObject({
+      kind: "message",
+      messages: [
+        {
+          systemNotice: expect.objectContaining({
+            noticeKind: "warning",
+            detail: metadataWarning
+          })
+        }
+      ]
+    });
   });
 
   it("renders an image-only optimistic prompt without synthetic text", () => {


### PR DESCRIPTION
## Summary

- Hide Codex skills-context budget notices across the legacy percentage and current non-percentage wording.
- Accept omitted source metadata only for this exact diagnostic, while preserving explicitly non-runtime notices.
- Keep fallback-metadata filtering runtime-only.
- Add regression coverage for the real workspace projection path and document the troubleshooting rule.

## Validation

- Focused AgentGUI projection suites: 80 tests passed.
- pnpm check:changed: 11 lanes passed.
- Pre-push changed-aware validation: 12 lanes passed.
- Pre-commit formatting, lint, and boundary checks passed.

## Review

A focused subagent review was run after the initial implementation. Its scope concern was addressed with explicit non-runtime and source-less fallback-metadata regression cases.