### PR TITLE
fix(agent-gui): clear composer after image upload

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -357,7 +357,10 @@ The Composer also hands the exact draft used to build a submission to the
 AgentGUI controller. The controller snapshots that handoff for conditional
 post-submit clearing; it must clear only when the current draft still matches
 the submitted snapshot, so a queue admission or accepted send cannot erase a
-newer edit made while the request is in flight.
+newer edit made while the request is in flight. For image blocks, provider
+locators and preview/upload-progress metadata may settle asynchronously and do
+not count as user edits; upload errors and unknown fields remain part of the
+comparison.
 
 ### 2.6 On-demand status
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.draftMessageHelpers.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.draftMessageHelpers.spec.ts
@@ -122,13 +122,71 @@ describe("submitted composer draft cleanup", () => {
     expect(clearSubmittedDraftIfUnchanged({ drafts, snapshot })).toBe(drafts);
   });
 
-  it("treats attachment upload metadata as part of the atomic content", () => {
+  it("keeps the full draft comparator sensitive to upload metadata", () => {
     const current = snapshotAgentComposerDraft(submittedDraft);
     const image = current.find((block) => block.type === "image");
     if (image) image.uploading = true;
 
     expect(areAgentComposerDraftsEqual(current, submittedDraft)).toBe(false);
+  });
+
+  it("clears after an image upload swaps its provider locator", () => {
+    const submittedDraft = buildAgentComposerDraft({
+      prompt: "Review this",
+      images: [
+        {
+          id: "image-1",
+          name: "screen.png",
+          mimeType: "image/png",
+          data: "base64-image",
+          previewUrl: "blob:image-1",
+          uploading: true
+        }
+      ]
+    });
+    const currentDraft = buildAgentComposerDraft({
+      prompt: "Review this",
+      images: [
+        {
+          id: "image-1",
+          name: "screen.png",
+          mimeType: "image/png",
+          attachmentId: "attachment-1",
+          url: "https://example.test/screen.png",
+          previewUrl: "blob:image-1",
+          uploading: false
+        }
+      ]
+    });
+    const snapshot: SubmittedDraftSnapshot = {
+      sourceScopeKey,
+      content: snapshotAgentComposerDraft(submittedDraft)
+    };
+    const drafts = { [sourceScopeKey]: currentDraft };
+
+    expect(areAgentComposerDraftsEqual(currentDraft, submittedDraft)).toBe(
+      false
+    );
+    const result = clearSubmittedDraftIfUnchanged({ drafts, snapshot });
+
+    expect(result[sourceScopeKey]).toEqual([{ type: "text", text: "" }]);
+  });
+
+  it("retains an image when its upload reports an error", () => {
+    const current = snapshotAgentComposerDraft(submittedDraft);
+    const image = current.find((block) => block.type === "image");
+    if (image) image.uploadError = "upload failed";
     const drafts = { [sourceScopeKey]: current };
+
+    expect(clearSubmittedDraftIfUnchanged({ drafts, snapshot })).toBe(drafts);
+  });
+
+  it("keeps detecting unknown image metadata as a draft change", () => {
+    const current = snapshotAgentComposerDraft(submittedDraft);
+    const image = current.find((block) => block.type === "image");
+    Object.assign(image ?? {}, { futureMetadata: "edited" });
+    const drafts = { [sourceScopeKey]: current };
+
     expect(clearSubmittedDraftIfUnchanged({ drafts, snapshot })).toBe(drafts);
   });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.draftMessageHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.draftMessageHelpers.ts
@@ -254,6 +254,49 @@ function areDraftValuesStructurallyEqual(
   );
 }
 
+// Upload completion replaces the local image bytes with a provider locator and
+// updates presentation state. Those transitions do not mean the user edited
+// the submitted image. Keep uploadError and unknown fields comparable so a
+// failed upload or a future user-owned field still prevents clearing.
+const IMAGE_SUBMISSION_TRANSIENT_FIELDS = new Set([
+  "attachmentId",
+  "data",
+  "path",
+  "previewUrl",
+  "uploading",
+  "url"
+]);
+
+function submissionComparableDraftBlock(
+  block: AgentComposerDraft[number]
+): unknown {
+  if (block.type !== "image") {
+    return block;
+  }
+  return Object.fromEntries(
+    Object.entries(block).filter(
+      ([key]) => !IMAGE_SUBMISSION_TRANSIENT_FIELDS.has(key)
+    )
+  );
+}
+
+function areAgentComposerDraftsEquivalentForSubmission(
+  left: AgentComposerDraft,
+  right: AgentComposerDraft
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((block, index) => {
+      const other = right[index];
+      if (!other || block.type !== other.type) return false;
+      return areDraftValuesStructurallyEqual(
+        submissionComparableDraftBlock(block),
+        submissionComparableDraftBlock(other)
+      );
+    })
+  );
+}
+
 export function deleteSubmittedDraftSnapshotsForScopes(input: {
   snapshots: Record<string, SubmittedDraftSnapshot>;
   scopeKeys: ReadonlySet<string>;
@@ -405,7 +448,10 @@ export function shouldClearSubmittedDraft(input: {
 }): boolean {
   return Boolean(
     input.currentDraft &&
-    areAgentComposerDraftsEqual(input.currentDraft, input.submittedDraft)
+    areAgentComposerDraftsEquivalentForSubmission(
+      input.currentDraft,
+      input.submittedDraft
+    )
   );
 }
 


### PR DESCRIPTION
## Summary
- clear the composer after an accepted image submission when upload completion only swaps provider locator and presentation metadata
- keep upload errors, unknown fields, and user-owned draft changes protected from cleanup
- document the conditional clearing rule and add regression coverage

## Tests
- `pnpm --dir packages/agent/gui test --run agent-gui/agentGuiNode/controller/agentGuiController.draftMessageHelpers.spec.ts agent-gui/agentGuiNode/controller/AgentGUIEngineSettlementController.spec.ts`
- pre-push: `pnpm check:changed -- --push-ready` (12 lanes passed)

## Notes
- no public API shape changes
- this is the Tutti-side fix; TSH consumes it after the next released `@tutti-os/agent-gui` cohort