### PR TITLE
fix(agent-gui): preserve composer target during session creation

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerPresentation.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerPresentation.spec.ts
@@ -114,6 +114,21 @@ describe("composer target presentation", () => {
     ).toBeNull();
   });
 
+  it("keeps the submitted target reference while the canonical session is pending", () => {
+    expect(
+      composerTargetDataForConversation({
+        activeConversationId: "session-new",
+        activeSessionTarget: null,
+        data: selectedTarget.data,
+        optimisticTarget: {
+          agentSessionId: "session-new",
+          target: selectedTarget
+        },
+        selectedTarget
+      })
+    ).toBe(selectedTarget);
+  });
+
   it("uses the active session agent target when node data lacks the target id", () => {
     const staleNodeData: AgentGUINodeData = {
       provider: "acp:hermes",

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerPresentation.ts
@@ -82,7 +82,9 @@ export function composerTargetDataForConversation(input: {
   }
   if (
     input.optimisticTarget?.agentSessionId === input.activeConversationId &&
-    !nodeDataMatchesComposerTarget(input.data, input.optimisticTarget.target)
+    (!input.activeSessionTarget ||
+      input.activeSessionTarget.agentSessionId !== input.activeConversationId ||
+      !nodeDataMatchesComposerTarget(input.data, input.optimisticTarget.target))
   ) {
     return input.optimisticTarget.target;
   }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerCapabilities.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerCapabilities.spec.tsx
@@ -2,6 +2,7 @@ import { renderHook } from "@testing-library/react";
 import {
   AGENT_CAPABILITY_KEYS,
   normalizeAgentActivitySession,
+  selectComposerOptions,
   type AgentActivityComposerOptions,
   type AgentActivitySessionCapabilities,
   type CanonicalAgentSession
@@ -266,5 +267,99 @@ describe("useAgentGUIComposerCapabilities", () => {
     );
 
     expect(result.current.composerSupport.browser).toBe(true);
+  });
+
+  it("reuses the target-scoped Composer Options reference across session creation", () => {
+    const data = {
+      provider: "codex" as const,
+      agentTargetId: "local:codex",
+      lastActiveAgentSessionId: null
+    };
+    const selectedComposerTargetData = {
+      agentTargetId: "local:codex",
+      data,
+      provider: "codex" as const,
+      targetId: "local:codex"
+    };
+    const sessionEngine = createTestAgentSessionEngine("workspace-1");
+    sessionEngine.dispatch({
+      type: "composerOptions/loadRequested",
+      commandId: "composer-options-creation",
+      targetKey: "local:codex",
+      provider: "codex",
+      workspaceId: "workspace-1"
+    });
+    sessionEngine.dispatch({
+      type: "engine/commandResult",
+      commandId: "composer-options-creation",
+      commandType: "composerOptions/load",
+      correlationId: "local:codex",
+      outcome: "succeeded",
+      value: composerOptions({ provider: "codex" })
+    });
+    const cachedOptions = selectComposerOptions(
+      sessionEngine.getSnapshot(),
+      "local:codex"
+    );
+    expect(cachedOptions).not.toBeNull();
+
+    type CreationProps = {
+      activeConversationId: string | null;
+      activeEngineSession: CanonicalAgentSession | null;
+      optimisticComposerTarget: {
+        agentSessionId: string;
+        target: typeof selectedComposerTargetData;
+      } | null;
+    };
+    const initialProps: CreationProps = {
+      activeConversationId: null,
+      activeEngineSession: null,
+      optimisticComposerTarget: null
+    };
+    const { result, rerender } = renderHook(
+      ({
+        activeConversationId,
+        activeEngineSession,
+        optimisticComposerTarget
+      }: CreationProps) =>
+        useAgentGUIComposerCapabilities({
+          activeConversationId,
+          activeEngineSession,
+          activeSessionState: null,
+          data,
+          draftSettingsBySessionId: {},
+          optimisticComposerTarget,
+          selectedComposerTargetData,
+          sessionEngine
+        }),
+      { initialProps }
+    );
+
+    expect(result.current.providerComposerOptions).toBe(cachedOptions);
+
+    rerender({
+      activeConversationId: "session-new",
+      activeEngineSession: null,
+      optimisticComposerTarget: {
+        agentSessionId: "session-new",
+        target: selectedComposerTargetData
+      }
+    });
+
+    expect(result.current.composerTargetData).toBe(selectedComposerTargetData);
+    expect(result.current.providerComposerOptions).toBe(cachedOptions);
+
+    rerender({
+      activeConversationId: "session-new",
+      activeEngineSession: engineSession({
+        agentSessionId: "session-new",
+        agentTargetId: "local:codex",
+        provider: "codex",
+        usage: null
+      }),
+      optimisticComposerTarget: null
+    });
+
+    expect(result.current.providerComposerOptions).toBe(cachedOptions);
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerCapabilities.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerCapabilities.ts
@@ -19,7 +19,8 @@ import { composerSettingsSupportFromOptions } from "../model/composerSettingsSup
 import { normalizeOptionalText } from "./agentGuiController.promptHelpers";
 import {
   composerTargetDataForConversation,
-  type AgentGUIComposerTargetData
+  type AgentGUIComposerTargetData,
+  type OptimisticComposerTarget
 } from "./agentGuiController.composerPresentation";
 import { resolvePromptImageSelectedModel } from "./agentGuiController.draftMessageHelpers";
 import { useEngineSelector } from "../../../shared/engine/useEngineSelector";
@@ -30,6 +31,7 @@ interface UseAgentGUIComposerCapabilitiesInput {
   activeSessionState: AgentSessionState | null;
   data: AgentGUINodeData;
   draftSettingsBySessionId: Record<string, AgentSessionComposerSettings>;
+  optimisticComposerTarget?: OptimisticComposerTarget | null;
   selectedComposerTargetData: AgentGUIComposerTargetData;
   sessionEngine: AgentSessionEngine;
 }
@@ -44,7 +46,7 @@ export function useAgentGUIComposerCapabilities(
     activeConversationId: input.activeConversationId,
     activeSessionTarget: input.activeEngineSession,
     data: input.data,
-    optimisticTarget: null,
+    optimisticTarget: input.optimisticComposerTarget ?? null,
     selectedTarget: input.selectedComposerTargetData
   });
   const composerTargetKey = composerTargetData.agentTargetId?.trim() ?? "";

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerOptionsSync.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerOptionsSync.ts
@@ -11,7 +11,8 @@ import { readNodeDefaultDraftSettings } from "./agentGuiController.composerHelpe
 import {
   composerTargetDataForConversation,
   type AgentGUIActiveSessionTarget,
-  type AgentGUIComposerTargetData
+  type AgentGUIComposerTargetData,
+  type OptimisticComposerTarget
 } from "./agentGuiController.composerPresentation";
 import {
   composerDefaultsPatchFromSettings,
@@ -47,6 +48,7 @@ export function useAgentGUIComposerOptionsSync(input: {
   >;
   loadSessionState(agentSessionId: string): void;
   onComposerDefaultsAuthorityReloadedRef: RefObject<AgentGUIComposerDefaultsAuthorityReconciler>;
+  optimisticComposerTarget?: OptimisticComposerTarget | null;
   providerComposerOptions:
     | { behavior?: { prewarmDraftSession?: boolean } | null }
     | null
@@ -160,7 +162,7 @@ export function useAgentGUIComposerOptionsSync(input: {
           activeConversationId: input.activeConversationIdRef.current,
           activeSessionTarget: input.activeSessionTarget,
           data: input.dataRef.current,
-          optimisticTarget: null,
+          optimisticTarget: input.optimisticComposerTarget ?? null,
           selectedTarget: input.selectedComposerTargetDataRef.current
         }),
         {
@@ -178,6 +180,7 @@ export function useAgentGUIComposerOptionsSync(input: {
       input.activeSessionTarget?.provider,
       input.dataRef,
       input.isComposerHomeRef,
+      input.optimisticComposerTarget,
       input.selectedComposerTargetDataRef,
       loadComposerOptionsForTarget
     ]
@@ -210,7 +213,7 @@ export function useAgentGUIComposerOptionsSync(input: {
           activeConversationId: input.activeConversationIdRef.current,
           activeSessionTarget: input.activeSessionTarget,
           data: input.dataRef.current,
-          optimisticTarget: null,
+          optimisticTarget: input.optimisticComposerTarget ?? null,
           selectedTarget: input.selectedComposerTargetDataRef.current
         }).provider;
         const activeId = input.activeConversationIdRef.current;
@@ -242,7 +245,7 @@ export function useAgentGUIComposerOptionsSync(input: {
         activeConversationId: input.activeConversationIdRef.current,
         activeSessionTarget: input.activeSessionTarget,
         data: input.dataRef.current,
-        optimisticTarget: null,
+        optimisticTarget: input.optimisticComposerTarget ?? null,
         selectedTarget: input.selectedComposerTargetDataRef.current
       });
       if (selectedTarget.agentTargetId !== event.agentTargetId) {
@@ -270,6 +273,7 @@ export function useAgentGUIComposerOptionsSync(input: {
     input.activeSessionTarget?.agentSessionId,
     input.activeSessionTarget?.provider,
     input.onComposerDefaultsAuthorityReloadedRef,
+    input.optimisticComposerTarget,
     loadComposerOptionsForTarget
   ]);
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -66,6 +66,7 @@ export {
   permissionModeOptions
 } from "./agentGuiController.composerHelpers";
 import { trackAgentGUISettingsProjectChange } from "./agentGuiProjectAnalytics";
+import type { OptimisticComposerTarget } from "./agentGuiController.composerPresentation";
 export * from "./agentGuiController.conversationHelpers";
 export {
   agentGUIConversationDiagnosticDetails,
@@ -286,6 +287,27 @@ export function useAgentGUINodeController({
         )
       )
   );
+  const optimisticComposerTarget =
+    useMemo<OptimisticComposerTarget | null>(() => {
+      if (
+        !isCreatingConversation ||
+        activePendingActivation?.mode !== "new" ||
+        activePendingActivation.agentSessionId !== activeConversationId ||
+        activePendingActivation.agentTargetId !==
+          selectedComposerTargetData.agentTargetId
+      ) {
+        return null;
+      }
+      return {
+        agentSessionId: activePendingActivation.agentSessionId,
+        target: selectedComposerTargetData
+      };
+    }, [
+      activeConversationId,
+      activePendingActivation,
+      isCreatingConversation,
+      selectedComposerTargetData
+    ]);
   // Bridges submitInteractivePrompt
   // updateComposerSettings (defined later); assigned right after the
   // callback's definition.
@@ -305,6 +327,7 @@ export function useAgentGUINodeController({
     activeSessionState,
     data,
     draftSettingsBySessionId,
+    optimisticComposerTarget,
     selectedComposerTargetData,
     sessionEngine
   });
@@ -627,6 +650,7 @@ export function useAgentGUINodeController({
       loadDraftComposerOptionsRef,
       loadSessionState,
       onComposerDefaultsAuthorityReloadedRef,
+      optimisticComposerTarget,
       providerComposerOptions,
       selectedComposerTargetDataRef,
       selectedProjectPath,


### PR DESCRIPTION
## Summary

Starting a conversation temporarily replaced the selected composer target with an empty loading target while the canonical session projection was still catching up. That changed the composer target key away from `local:codex`, so the connector selector read an empty cache even though connectors were available before submission.

Keep the pending activation's optimistic composer target connected to the existing selected target object until the canonical session target is ready. Composer capabilities, option loading, invalidation, and default reconciliation now resolve through the same target path, preserving the same engine selector cache across the home, creating, and created states. Once projection catches up, the canonical session target remains authoritative.

The tests cover the complete home → pending activation → canonical session transition and assert that the target and composer options retain object identity while the target is unchanged.

## Verification

- `pnpm --filter @tutti-os/agent-gui exec vitest run agent-gui/agentGuiNode/controller/agentGuiController.composerPresentation.spec.ts agent-gui/agentGuiNode/controller/useAgentGUIComposerCapabilities.spec.tsx` — 23 tests passed, including target and cache reference continuity through session creation.
- `pnpm --filter @tutti-os/agent-gui test -- agentGuiController.composerPresentation.spec.ts useAgentGUIComposerCapabilities.spec.tsx` — 2,916 Agent GUI tests passed.

## Fallback Three Questions

- Source: pending activation exposes the new session ID before the canonical session target and node projection are both available.
- Why can it not be fixed at that source? Session creation and projection synchronization are asynchronous lifecycle boundaries; the composer must preserve its already-selected target while those authoritative states converge.
- Removal condition: this bridge can be removed if conversation activation atomically guarantees both the canonical session target and matching node projection before the active conversation ID changes.

## Checklist

- [x] This PR does not change agent lifecycle semantics; it only preserves renderer composer target presentation during the existing creation lifecycle.
- [x] I kept the change focused on one concern.
- [x] Documentation is not required for this bug fix because setup and contributor workflows are unchanged.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commit is signed off with DCO.
