### PR TITLE
fix(connector-authorization): replace active attempts safely

### DIFF
--- a/.changeset/connector-authorization-replace-active.md
+++ b/.changeset/connector-authorization-replace-active.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/connector-market": patch
+---
+
+Replace an active Connector authorization attempt through one Host-owned command, wait for managed credential-broker termination before starting the replacement, propagate replacement and cancellation to the account control plane, start managed authorization only after an explicit user action, and keep dialog dismissal separate from explicit cancellation.

--- a/docs/architecture/connector-market.md
+++ b/docs/architecture/connector-market.md
@@ -364,12 +364,19 @@ preserves the projection. Runtime reconcile then performs interface readiness
 checks before any route is published.
 
 Authorization operations follow the same recovery rule. Authorization creation
-is serialized per account and Connector, and an unresolved durable session
-receipt rejects a different request identity, so renderer reload cannot create
-a second external session. Managed runtimes are inspected during convergence;
-restart no longer fabricates a permanently pending observation. Disconnect is
-completed only after the disconnected projection and exact disabled Runtime
-Observed state are durable.
+is serialized per account and Connector. A repeated `clientRequestId` resumes
+the same external session. A different request retains the compatibility
+conflict unless it explicitly sends `replacementPolicy=replace_active`. Replace
+is Host-owned: it interrupts an in-progress initial Begin, moves an existing
+receipt through durable `canceling`, asks the provider to terminate the exact
+attempt, waits until that attempt can no longer publish credentials or events,
+then resolves it as `superseded` before accepting the new operation. A provider
+without confirmed attempt cancellation rejects replacement rather than running
+two sessions against shared credential state. Managed runtimes are inspected
+during convergence; restart finishes `canceling` receipts and no longer
+fabricates a permanently pending observation. Disconnect is completed only
+after the disconnected projection and exact disabled Runtime Observed state are
+durable.
 
 For account-scoped runtimes, `AccountRuntimeBindingResolver` maps `none`
 authorization to an always-active device connection. OAuth/API-key connectors
@@ -425,6 +432,10 @@ authentication only through a host-supplied request authorizer. Neither an API
 key submitted by the user nor the product account session is copied into the
 runtime VM. Remote MCP execution follows the product host's authenticated
 relay, while the VM receives only the non-credential runtime route identity.
+Remote authorization replacement propagates the explicit replacement policy to
+Start and uses the session-scoped control-plane Cancel endpoint when a receipt
+already exists. This covers both a returned session and an interrupted initial
+Begin without relying on a device-local process handle.
 
 ## Event Consistency
 
@@ -512,6 +523,10 @@ synchronizing -> materializing -> ready`; failure is terminal and disposes
   host keeps the mutation request open until runtime work completes; the local
   projection is cleared on both success and failure and never replaces daemon
   installation truth
+- every new user authorization action creates a new `clientRequestId` and sends
+  `replacementPolicy=replace_active`; continuation polling within that action
+  reuses the same identity, while a superseded renderer Promise cannot retain
+  the Connector mutation token
 - event refreshes are coalesced, daemon reconnect performs a full reload, and
   accepted commands are followed through the operation endpoint or events
 - hosts gate connector-market transport through `canRequest`; Tutti binds it to
@@ -558,6 +573,11 @@ authorized connector opens the management dialog. Blocked releases open the
 blocked-state dialog. Only one dialog host is mounted at a time, so
 the catalog keeps the full settings content width and never leaves an empty
 right column.
+
+Closing an authorization dialog only dismisses presentation. The explicit
+Cancel action calls the Host cancellation command. Reopening an unconnected
+Connector starts a new replace-active attempt, so a hidden or stuck renderer
+request cannot lock later authorization actions.
 
 ## Local OpenAPI Reuse
 

--- a/docs/conventions/troubleshooting/connector-market.md
+++ b/docs/conventions/troubleshooting/connector-market.md
@@ -1,34 +1,43 @@
 # Connector Market Troubleshooting
 
-### OAuth opens once, then the desktop stays disconnected or a second attempt supersedes the first
+### Authorization stays loading and reopening cannot start a new attempt
 
 **Symptoms**
 
-- the browser receives a valid OAuth redirect on the first authorization click
+- the authorization button may remain on its initial loading state before a URL
+  is returned
 - the local Start operation is already `completed` while its private session
   receipt is still unresolved
 - the account authorization projection remains `disconnected` until the OAuth
   callback is observed
-- the renderer stops waiting, and a later click creates a new session that may
-  supersede the first one
+- closing and reopening the dialog appears to reuse the old request or reports
+  that another Connector operation is in progress
 
 **Check**
 
-Trace the three states separately: the durable Start operation, its private
-authorization-session receipt, and the account authorization projection. A
+Trace four states separately: the renderer request identity, the durable Start
+operation, its private authorization-session receipt, and the provider process.
+A
 completed Start operation means the external session was created; it does not
 mean the provider authorization is terminal. Confirm that a redirect session
 returns `pending` to the caller even when the durable projection has not changed
-yet, then confirm the same client request identity is reused until the projection
-becomes connected or failed.
+yet. Within one action, confirm that continuation uses one `clientRequestId`.
+For a new user action, confirm that the request carries
+`replacementPolicy=replace_active`, the prior receipt moves through `canceling`
+to `superseded`, and the old Broker/DWS process exits before the replacement is
+launched. If no initial event is returned, verify that the new request cancels
+the active Host-owned Begin instead of waiting behind its authorization lane.
 
 **Rule**
 
 Keep the account projection as durable authorization truth. Preserve the
 current session's `pending` state only in the Start command result so shared
-clients continue that idempotent session. Do not persist a synthetic connected
-projection, infer success from the Start operation's terminal state, or create a
-second external session to refresh the UI.
+clients continue that idempotent session. A new user action is different from a
+continuation: it must use Host-owned replace-active semantics. Fence late
+observations by the durable receipt, require provider cancellation and process
+exit confirmation, then create the replacement. Do not persist a synthetic
+connected projection, infer success from the Start operation's terminal state,
+or let the renderer race separate cancel and start calls.
 
 ### OAuth finishes in the browser but does not return to the initiating desktop build
 

--- a/packages/clients/connector-controlplane/README.md
+++ b/packages/clients/connector-controlplane/README.md
@@ -5,7 +5,8 @@ authorization wire client used by Tutti and TSH.
 
 It owns:
 
-- authorization session start, observation, secret completion, and disconnect;
+- authorization session start, replacement, session cancellation, observation,
+  secret completion, and disconnect;
 - authoritative account authorization snapshots;
 - the `connector.authorization.changed` realtime event protocol;
 - bounded HTTP responses, safe redirect validation, and clearing mutable secret
@@ -34,10 +35,11 @@ client, err := connectorcontrolplane.NewAuthorizationClient(
 ```
 
 The client implements the Connector Host `AuthorizationProvider`,
-`AuthorizationObserver`, and `AuthorizationSnapshotSource` ports. Products
-compose it with `host.NewImplementationAuthorizationRouter`: remote HTTP
-Connectors use this client while managed stdio Connectors keep their
-implementation-owned credential broker.
+`AuthorizationAttemptCanceler`, `AuthorizationObserver`, and
+`AuthorizationSnapshotSource` ports. Products compose it with
+`host.NewImplementationAuthorizationRouter`: remote HTTP Connectors use this
+client while managed stdio Connectors keep their implementation-owned
+credential broker.
 
 ## Validation and releases
 

--- a/packages/clients/connector-controlplane/authorization_client.go
+++ b/packages/clients/connector-controlplane/authorization_client.go
@@ -106,11 +106,19 @@ func (client *AuthorizationClient) Begin(ctx context.Context, request market.Aut
 	defer clear(request.Secret)
 	connectorID := strings.TrimSpace(request.Connector.Key)
 	connectorVersion := strings.TrimSpace(request.Release.Version)
-	var response connectorAuthorizationSessionReply
-	err := client.doJSONForAccount(ctx, request.Scope.AccountID, http.MethodPost, "/connectors/"+url.PathEscape(connectorID)+"/authorization-sessions", nil, map[string]any{
+	body := map[string]any{
 		"clientRequestId":  strings.TrimSpace(request.ClientRequestID),
 		"connectorVersion": connectorVersion,
-	}, &response)
+	}
+	switch request.ReplacementPolicy {
+	case "":
+	case market.AuthorizationReplacementPolicyReplaceActive:
+		body["replacementPolicy"] = "CONNECTOR_AUTHORIZATION_REPLACEMENT_POLICY_REPLACE_ACTIVE"
+	default:
+		return market.AuthorizationSession{}, errors.New("connector authorization replacement policy is invalid")
+	}
+	var response connectorAuthorizationSessionReply
+	err := client.doJSONForAccount(ctx, request.Scope.AccountID, http.MethodPost, "/connectors/"+url.PathEscape(connectorID)+"/authorization-sessions", nil, body, &response)
 	if err != nil {
 		return market.AuthorizationSession{}, err
 	}
@@ -177,6 +185,24 @@ func (client *AuthorizationClient) Begin(ctx context.Context, request market.Aut
 	return session, nil
 }
 
+func (client *AuthorizationClient) Cancel(ctx context.Context, request market.AuthorizationCancelRequest) error {
+	sessionID := strings.TrimSpace(request.Session.SessionID)
+	if sessionID == "" {
+		return errors.New("connector authorization cancellation requires a session id")
+	}
+	var response connectorAuthorizationSessionReply
+	if err := client.doJSONForAccount(ctx, request.Scope.AccountID, http.MethodDelete,
+		"/connector-authorization-sessions/"+url.PathEscape(sessionID), nil, nil, &response); err != nil {
+		return err
+	}
+	if strings.TrimSpace(response.Session.SessionID) != sessionID ||
+		(!authorizationSessionCanceled(response.Session.Status) && !authorizationSessionFailed(response.Session.Status)) {
+		return errors.New("connector authorization cancellation returned a non-terminal session")
+	}
+	client.notifyChanged()
+	return nil
+}
+
 func (client *AuthorizationClient) Disconnect(ctx context.Context, request market.AuthorizationDisconnectRequest) error {
 	connectorID := strings.TrimSpace(request.Connector.Key)
 	if err := client.doJSONForAccount(ctx, request.Scope.AccountID, http.MethodDelete,
@@ -215,6 +241,8 @@ func (client *AuthorizationClient) Observe(ctx context.Context, request market.A
 		return market.AuthorizationObservation{State: market.AuthorizationObservationConnected, ConnectionID: connectionID}, nil
 	case strings.HasSuffix(status, "_FAILED") || status == "FAILED":
 		return market.AuthorizationObservation{State: market.AuthorizationObservationFailed, FailureCode: strings.TrimSpace(response.Session.ErrorCode)}, nil
+	case strings.HasSuffix(status, "_CANCELED") || status == "CANCELED":
+		return market.AuthorizationObservation{State: market.AuthorizationObservationFailed, FailureCode: "authorization_canceled"}, nil
 	case strings.HasSuffix(status, "_CREATED"), strings.HasSuffix(status, "_AWAITING_USER"), strings.HasSuffix(status, "_PROCESSING"),
 		status == "CREATED", status == "AWAITING_USER", status == "PROCESSING":
 		return market.AuthorizationObservation{State: market.AuthorizationObservationPending}, nil
@@ -323,11 +351,22 @@ func authorizationSessionSucceeded(status string) bool {
 	return status == "SUCCEEDED" || strings.HasSuffix(status, "_SUCCEEDED")
 }
 
+func authorizationSessionFailed(status string) bool {
+	status = strings.ToUpper(strings.TrimSpace(status))
+	return status == "FAILED" || strings.HasSuffix(status, "_FAILED")
+}
+
+func authorizationSessionCanceled(status string) bool {
+	status = strings.ToUpper(strings.TrimSpace(status))
+	return status == "CANCELED" || strings.HasSuffix(status, "_CANCELED")
+}
+
 func isLoopbackConnectorAuthorizationHost(host string) bool {
 	host = strings.ToLower(strings.TrimSpace(host))
 	return host == "localhost" || host == "127.0.0.1" || host == "::1"
 }
 
 var _ market.AuthorizationProvider = (*AuthorizationClient)(nil)
+var _ market.AuthorizationAttemptCanceler = (*AuthorizationClient)(nil)
 var _ market.AuthorizationObserver = (*AuthorizationClient)(nil)
 var _ market.AuthorizationSnapshotSource = (*AuthorizationClient)(nil)

--- a/packages/clients/connector-controlplane/authorization_client_test.go
+++ b/packages/clients/connector-controlplane/authorization_client_test.go
@@ -127,6 +127,56 @@ func TestAuthorizationClientAcceptsImmediateSuccessWithoutNextAction(t *testing.
 	}
 }
 
+func TestAuthorizationClientReplacesAndCancelsRemoteSession(t *testing.T) {
+	requests := make([]string, 0, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requests = append(requests, request.Method+" "+request.URL.Path)
+		switch request.URL.Path {
+		case "/v1/connectors/notion/authorization-sessions":
+			var body map[string]any
+			if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			if body["replacementPolicy"] != "CONNECTOR_AUTHORIZATION_REPLACEMENT_POLICY_REPLACE_ACTIVE" {
+				t.Fatalf("replacementPolicy = %#v", body["replacementPolicy"])
+			}
+			_, _ = response.Write([]byte(`{"session":{"sessionId":"auth-replacement","connectorRevision":"1.0.0","status":"CONNECTOR_AUTHORIZATION_SESSION_STATUS_AWAITING_USER","nextAction":{"type":"redirect","url":"https://auth.example/connect"}}}`))
+		case "/v1/connector-authorization-sessions/auth-replacement":
+			if request.Method != http.MethodDelete {
+				t.Fatalf("cancel method = %s", request.Method)
+			}
+			_, _ = response.Write([]byte(`{"session":{"sessionId":"auth-replacement","status":"CONNECTOR_AUTHORIZATION_SESSION_STATUS_CANCELED","errorCode":"authorization_canceled"}}`))
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	defer server.Close()
+	client, err := NewAuthorizationClient(AuthorizationClientConfig{
+		BaseURL: server.URL, APIPrefix: "/v1", HTTPClient: server.Client(),
+		AuthorizeAccountRequest: func(*http.Request, string) error { return nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := client.Begin(context.Background(), market.AuthorizationStartRequest{
+		OperationID: "operation-replacement", ClientRequestID: "request-replacement",
+		ReplacementPolicy: market.AuthorizationReplacementPolicyReplaceActive,
+		Scope:             market.OperationScope{AccountID: "account-1"}, Connector: market.Connector{Key: "notion"},
+		Release: market.Release{Version: "1.0.0", Manifest: market.Manifest{AuthorizationKind: "oauth2"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Cancel(context.Background(), market.AuthorizationCancelRequest{
+		OperationID: "operation-replacement", Scope: market.OperationScope{AccountID: "account-1"}, Session: session,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(requests) != 2 || requests[0] != "POST /v1/connectors/notion/authorization-sessions" || requests[1] != "DELETE /v1/connector-authorization-sessions/auth-replacement" {
+		t.Fatalf("requests = %#v", requests)
+	}
+}
+
 func TestAuthorizationClientSubmitsNativeSecretWithoutPersistingItInSession(t *testing.T) {
 	const token = "user-provided-token"
 	notifications := 0

--- a/packages/clients/tuttid-ts/src/generated/index.ts
+++ b/packages/clients/tuttid-ts/src/generated/index.ts
@@ -548,6 +548,7 @@ export type {
   ConnectorMarketAgentRouting,
   ConnectorMarketArtifact,
   ConnectorMarketAuthorization,
+  ConnectorMarketAuthorizationReplacementPolicy,
   ConnectorMarketAuthorizationRequest,
   ConnectorMarketAuthorizationRequestWritable,
   ConnectorMarketAuthorizationResponse,

--- a/packages/clients/tuttid-ts/src/generated/sdk.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/sdk.gen.ts
@@ -5575,7 +5575,7 @@ export const uninstallConnectorMarketConnector = <
   });
 
 /**
- * Start connector authorization
+ * Start or replace connector authorization
  */
 export const startConnectorMarketAuthorization = <
   ThrowOnError extends boolean = false

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -4953,7 +4953,13 @@ export type ConnectorMarketAuthorizationRequest = {
   clientRequestId: string;
   expectedRevision: number;
   expectedConnectorRevision?: number;
+  replacementPolicy?: ConnectorMarketAuthorizationReplacementPolicy;
 };
+
+/**
+ * When set to replace_active, the Host fences and terminates a different unresolved authorization attempt before starting this request. Omission preserves the legacy resume-or-conflict behavior.
+ */
+export type ConnectorMarketAuthorizationReplacementPolicy = "replace_active";
 
 export type ConnectorMarketMutationResponse = {
   connector?: ConnectorMarketConnector;
@@ -5114,6 +5120,7 @@ export type ConnectorMarketAuthorizationRequestWritable = {
   clientRequestId: string;
   expectedRevision: number;
   expectedConnectorRevision?: number;
+  replacementPolicy?: ConnectorMarketAuthorizationReplacementPolicy;
   secret?: string;
 };
 

--- a/packages/connector/host/application.go
+++ b/packages/connector/host/application.go
@@ -46,11 +46,20 @@ type Application struct {
 	catalogAppliedSequence uint64
 	authorizationMu        sync.Mutex
 	authorizationLanes     map[string]*sync.Mutex
+	authorizationRequests  map[string]*authorizationRequestExecution
 }
 
 type operationExecution struct {
 	done chan struct{}
 	err  error
+}
+
+type authorizationRequestExecution struct {
+	clientRequestID string
+	context         context.Context
+	cancel          context.CancelFunc
+	references      int
+	replacedLive    bool
 }
 
 var _ Service = (*Application)(nil)
@@ -104,7 +113,8 @@ func NewApplication(config ApplicationConfig) (*Application, error) {
 		config.LeaseDuration = 30 * time.Second
 	}
 	return &Application{config: config, inFlight: make(map[string]*operationExecution),
-		authorizationLanes: make(map[string]*sync.Mutex)}, nil
+		authorizationLanes:    make(map[string]*sync.Mutex),
+		authorizationRequests: make(map[string]*authorizationRequestExecution)}, nil
 }
 
 func (application *Application) Snapshot(ctx context.Context) (Snapshot, error) {
@@ -492,12 +502,17 @@ func (application *Application) BeginAuthorization(
 	secret []byte,
 ) (AuthorizationResult, error) {
 	defer clear(secret)
-	if err := validateConnectorMutation(mutation); err != nil {
+	if err := validateAuthorizationMutation(mutation); err != nil {
 		return AuthorizationResult{}, err
 	}
+	requestExecution := application.acquireAuthorizationRequest(ctx, mutation)
+	defer application.releaseAuthorizationRequest(mutation.AccountID, mutation.ConnectorKey, requestExecution)
 	unlock := application.lockAuthorization(mutation.AccountID, mutation.ConnectorKey)
 	defer unlock()
-	current, err := application.config.Repository.Connector(ctx, mutation.ConnectorKey)
+	if err := requestExecution.context.Err(); err != nil {
+		return AuthorizationResult{}, err
+	}
+	current, err := application.config.Repository.Connector(requestExecution.context, mutation.ConnectorKey)
 	if err != nil {
 		return AuthorizationResult{}, err
 	}
@@ -508,7 +523,7 @@ func (application *Application) BeginAuthorization(
 		return AuthorizationResult{}, invalidRequest("accountId is required for remote connector authorization")
 	}
 	idempotentReplay, err := application.isIdempotentConnectorOperation(
-		ctx,
+		requestExecution.context,
 		mutation,
 		OperationKindStartAuthorization,
 	)
@@ -516,22 +531,50 @@ func (application *Application) BeginAuthorization(
 		return AuthorizationResult{}, err
 	}
 	if !idempotentReplay {
+		if mutation.ReplacementPolicy == AuthorizationReplacementPolicyReplaceActive && !requestExecution.replacedLive {
+			if err := application.verifyConnectorMutationRevision(requestExecution.context, mutation); err != nil {
+				return AuthorizationResult{}, err
+			}
+		}
 		unresolved, unresolvedErr := application.config.Repository.UnresolvedAuthorizationSessionOperations(
-			ctx, OperationScope{AccountID: accountID},
+			requestExecution.context, OperationScope{AccountID: accountID},
 		)
 		if unresolvedErr != nil {
 			return AuthorizationResult{}, unresolvedErr
 		}
 		for _, receipt := range unresolved {
 			if receipt.ConnectorKey == mutation.ConnectorKey {
+				if mutation.ReplacementPolicy == AuthorizationReplacementPolicyReplaceActive {
+					if replaceErr := application.cancelAuthorizationAttempt(
+						requestExecution.context, current, receipt, true,
+					); replaceErr != nil {
+						return AuthorizationResult{}, replaceErr
+					}
+					continue
+				}
 				return AuthorizationResult{}, NewDomainError(
 					ErrorCodeOperationInProgress, "connector authorization is already pending", true, nil,
 				)
 			}
 		}
+		if mutation.ReplacementPolicy == AuthorizationReplacementPolicyReplaceActive {
+			if err := application.resetPendingAuthorizationState(
+				requestExecution.context,
+				OperationScope{AccountID: accountID},
+				mutation.ConnectorKey,
+			); err != nil {
+				return AuthorizationResult{}, err
+			}
+			current, err = application.config.Repository.Connector(requestExecution.context, mutation.ConnectorKey)
+			if err != nil {
+				return AuthorizationResult{}, err
+			}
+			currentRevision := current.Revision
+			mutation.ExpectedConnectorRevision = &currentRevision
+		}
 	}
 	if accountScoped && !idempotentReplay {
-		projection, projectionErr := application.GetAuthorizationProjection(ctx, accountID, mutation.ConnectorKey)
+		projection, projectionErr := application.GetAuthorizationProjection(requestExecution.context, accountID, mutation.ConnectorKey)
 		if projectionErr != nil && !errors.Is(projectionErr, ErrNotFound) {
 			return AuthorizationResult{}, projectionErr
 		}
@@ -543,7 +586,7 @@ func (application *Application) BeginAuthorization(
 		}
 	}
 	accepted, err := application.acceptConnectorOperation(
-		ctx,
+		requestExecution.context,
 		mutation,
 		OperationKindStartAuthorization,
 		func(connector Connector) (Connector, error) {
@@ -579,26 +622,30 @@ func (application *Application) BeginAuthorization(
 		)
 	}
 
-	session, err := application.beginAuthorizationSession(ctx, accepted.Operation, secret)
+	session, err := application.beginAuthorizationSession(
+		requestExecution.context, accepted.Operation, secret, mutation.ReplacementPolicy,
+	)
 	if err != nil {
 		// Starting authorization has no durable provider receipt yet. Keep retry
 		// under explicit user control instead of leaving a running operation for
 		// the recovery worker to replay continuously.
 		if accepted.Operation.State != OperationStateCompleted {
-			_ = application.failOperation(ctx, accepted.Operation.OperationID, ErrorCodeAuthorizationFailed)
+			terminalContext, cancelTerminal := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+			_ = application.failOperation(terminalContext, accepted.Operation.OperationID, ErrorCodeAuthorizationFailed)
+			cancelTerminal()
 		}
 		return AuthorizationResult{}, err
 	}
-	operation, err := application.config.Repository.Operation(ctx, accepted.Operation.OperationID)
+	operation, err := application.config.Repository.Operation(requestExecution.context, accepted.Operation.OperationID)
 	if err != nil {
 		return AuthorizationResult{}, err
 	}
-	connector, err := application.config.Repository.Connector(ctx, mutation.ConnectorKey)
+	connector, err := application.config.Repository.Connector(requestExecution.context, mutation.ConnectorKey)
 	if err != nil {
 		return AuthorizationResult{}, err
 	}
 	if accountScoped {
-		projection, projectionErr := application.GetAuthorizationProjection(ctx, accountID, mutation.ConnectorKey)
+		projection, projectionErr := application.GetAuthorizationProjection(requestExecution.context, accountID, mutation.ConnectorKey)
 		if errors.Is(projectionErr, ErrNotFound) {
 			connector.Authorization = Authorization{State: AuthorizationStateDisconnected}
 		} else if projectionErr != nil {
@@ -637,6 +684,7 @@ func (application *Application) CancelAuthorization(
 	if connectorKey == "" {
 		return invalidRequest("connectorKey is required")
 	}
+	application.interruptAuthorizationRequest(scope.AccountID, connectorKey)
 	unlock := application.lockAuthorization(scope.AccountID, connectorKey)
 	defer unlock()
 	connector, err := application.config.Repository.Connector(ctx, connectorKey)
@@ -651,52 +699,15 @@ func (application *Application) CancelAuthorization(
 		if operation.ConnectorKey != connectorKey {
 			continue
 		}
-		if err := application.config.Repository.ResolveAuthorizationSession(
-			ctx,
-			operation.OperationID,
-			AuthorizationSessionResolutionSuperseded,
-		); err != nil {
+		if err := application.cancelAuthorizationAttempt(ctx, connector, operation, false); err != nil {
 			return err
 		}
 	}
-	if connector.Authorization.State == AuthorizationStatePending {
-		if err := application.config.Repository.Transaction(ctx, func(tx Transaction) error {
-			stored, txErr := tx.Connector(connectorKey)
-			if txErr != nil || stored.Authorization.State != AuthorizationStatePending {
-				return txErr
-			}
-			revision := tx.AdvanceRevision()
-			stored.Authorization = Authorization{State: AuthorizationStateDisconnected}
-			stored.Revision = revision
-			if txErr := tx.SaveConnector(stored); txErr != nil {
-				return txErr
-			}
-			return tx.EnqueueConnectorMarketChanged(ChangedEvent{ConnectorKey: connectorKey, Revision: revision})
-		}); err != nil {
-			return err
-		}
-	}
-	if scope.AccountID != "" && application.config.AuthorizationProjections != nil {
-		projection, projectionErr := application.GetAuthorizationProjection(ctx, scope.AccountID, connectorKey)
-		if projectionErr == nil && projection.State == AuthorizationStatePending {
-			projection.State = AuthorizationStateDisconnected
-			projection.ConnectionID = ""
-			projection.FailureCode = ""
-			projection.UpdatedAt = application.config.Now().UTC()
-			if err := application.saveAuthorizationProjection(ctx, ConnectorMutation{
-				ConnectorKey: connectorKey, AccountID: scope.AccountID,
-			}, projection); err != nil {
-				return err
-			}
-		} else if projectionErr != nil && !errors.Is(projectionErr, ErrNotFound) {
-			return projectionErr
-		}
-	}
-	return nil
+	return application.resetPendingAuthorizationState(ctx, scope, connectorKey)
 }
 
 func (application *Application) lockAuthorization(accountID, connectorKey string) func() {
-	key := strings.TrimSpace(accountID) + "\x00" + strings.TrimSpace(connectorKey)
+	key := authorizationLaneKey(accountID, connectorKey)
 	application.authorizationMu.Lock()
 	lane := application.authorizationLanes[key]
 	if lane == nil {
@@ -708,15 +719,175 @@ func (application *Application) lockAuthorization(accountID, connectorKey string
 	return lane.Unlock
 }
 
+func authorizationLaneKey(accountID, connectorKey string) string {
+	return strings.TrimSpace(accountID) + "\x00" + strings.TrimSpace(connectorKey)
+}
+
+func (application *Application) acquireAuthorizationRequest(
+	ctx context.Context,
+	mutation ConnectorMutation,
+) *authorizationRequestExecution {
+	key := authorizationLaneKey(mutation.AccountID, mutation.ConnectorKey)
+	clientRequestID := strings.TrimSpace(mutation.ClientRequestID)
+	application.authorizationMu.Lock()
+	defer application.authorizationMu.Unlock()
+	if current := application.authorizationRequests[key]; current != nil {
+		if current.clientRequestID == clientRequestID {
+			current.references++
+			return current
+		}
+		if mutation.ReplacementPolicy != AuthorizationReplacementPolicyReplaceActive {
+			requestContext, cancel := context.WithCancel(context.WithoutCancel(ctx))
+			return &authorizationRequestExecution{
+				clientRequestID: clientRequestID, context: requestContext, cancel: cancel, references: 1,
+			}
+		}
+		current.cancel()
+		requestContext, cancel := context.WithCancel(context.WithoutCancel(ctx))
+		execution := &authorizationRequestExecution{
+			clientRequestID: clientRequestID, context: requestContext, cancel: cancel, references: 1, replacedLive: true,
+		}
+		application.authorizationRequests[key] = execution
+		return execution
+	}
+	requestContext, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	execution := &authorizationRequestExecution{
+		clientRequestID: clientRequestID, context: requestContext, cancel: cancel, references: 1,
+	}
+	application.authorizationRequests[key] = execution
+	return execution
+}
+
+func (application *Application) releaseAuthorizationRequest(
+	accountID, connectorKey string,
+	execution *authorizationRequestExecution,
+) {
+	if execution == nil {
+		return
+	}
+	key := authorizationLaneKey(accountID, connectorKey)
+	application.authorizationMu.Lock()
+	if application.authorizationRequests[key] == execution {
+		execution.references--
+		if execution.references == 0 {
+			delete(application.authorizationRequests, key)
+			execution.cancel()
+		}
+	} else {
+		execution.cancel()
+	}
+	application.authorizationMu.Unlock()
+}
+
+func (application *Application) interruptAuthorizationRequest(accountID, connectorKey string) {
+	key := authorizationLaneKey(accountID, connectorKey)
+	application.authorizationMu.Lock()
+	if execution := application.authorizationRequests[key]; execution != nil {
+		execution.cancel()
+	}
+	application.authorizationMu.Unlock()
+}
+
+func (application *Application) cancelAuthorizationAttempt(
+	ctx context.Context,
+	connector Connector,
+	operation Operation,
+	requireProviderTermination bool,
+) error {
+	session := operation.Execution.AuthorizationSession
+	if session == nil || session.IsResolved() {
+		return nil
+	}
+	canceler, ok := application.config.Authorization.(AuthorizationAttemptCanceler)
+	if !ok {
+		if requireProviderTermination {
+			return NewDomainError(
+				ErrorCodeUnavailable,
+				"connector authorization provider cannot safely replace an active attempt",
+				false,
+				nil,
+			)
+		}
+		return application.config.Repository.ResolveAuthorizationSession(
+			ctx, operation.OperationID, AuthorizationSessionResolutionSuperseded,
+		)
+	}
+	if session.Resolution != AuthorizationSessionResolutionCanceling {
+		if err := application.config.Repository.ResolveAuthorizationSession(
+			ctx, operation.OperationID, AuthorizationSessionResolutionCanceling,
+		); err != nil {
+			return err
+		}
+	}
+	release, err := frozenRelease(operation)
+	if err != nil {
+		return err
+	}
+	connector.Release = release
+	if err := canceler.Cancel(ctx, AuthorizationCancelRequest{
+		OperationID: operation.OperationID,
+		Scope:       operation.Scope,
+		Connector:   connector,
+		Release:     release,
+		Session:     *session,
+	}); err != nil {
+		return NewDomainError(
+			ErrorCodeUnavailable,
+			"connector authorization attempt could not be terminated",
+			true,
+			err,
+		)
+	}
+	return application.config.Repository.ResolveAuthorizationSession(
+		ctx, operation.OperationID, AuthorizationSessionResolutionSuperseded,
+	)
+}
+
+func (application *Application) resetPendingAuthorizationState(
+	ctx context.Context,
+	scope OperationScope,
+	connectorKey string,
+) error {
+	if err := application.config.Repository.Transaction(ctx, func(tx Transaction) error {
+		stored, err := tx.Connector(connectorKey)
+		if err != nil || stored.Authorization.State != AuthorizationStatePending {
+			return err
+		}
+		revision := tx.AdvanceRevision()
+		stored.Authorization = Authorization{State: AuthorizationStateDisconnected}
+		stored.Revision = revision
+		if err := tx.SaveConnector(stored); err != nil {
+			return err
+		}
+		return tx.EnqueueConnectorMarketChanged(ChangedEvent{ConnectorKey: connectorKey, Revision: revision})
+	}); err != nil {
+		return err
+	}
+	if scope.AccountID == "" || application.config.AuthorizationProjections == nil {
+		return nil
+	}
+	projection, err := application.GetAuthorizationProjection(ctx, scope.AccountID, connectorKey)
+	if errors.Is(err, ErrNotFound) || err == nil && projection.State != AuthorizationStatePending {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	projection.State = AuthorizationStateDisconnected
+	projection.ConnectionID = ""
+	projection.FailureCode = ""
+	projection.UpdatedAt = application.config.Now().UTC()
+	return application.saveAuthorizationProjection(ctx, ConnectorMutation{
+		ConnectorKey: connectorKey, AccountID: scope.AccountID,
+	}, projection)
+}
+
 // ReconcileAuthorizations observes unresolved private start receipts for one
 // explicit account. Remote Connector truth comes from the account projection;
 // the device-scoped Connector authorization field is only used by local
 // Connectors. It is safe to call repeatedly and after a daemon restart.
 func (application *Application) ReconcileAuthorizations(ctx context.Context, scope OperationScope) ([]AuthorizationReconcileIntent, error) {
-	observer, ok := application.config.Authorization.(AuthorizationObserver)
-	if !ok {
-		return nil, nil
-	}
+	observer, canObserve := application.config.Authorization.(AuthorizationObserver)
 	operations, err := application.config.Repository.UnresolvedAuthorizationSessionOperations(ctx, scope)
 	if err != nil {
 		return nil, err
@@ -737,6 +908,16 @@ func (application *Application) ReconcileAuthorizations(ctx context.Context, sco
 			reconcileErr = errors.Join(reconcileErr, releaseErr)
 			continue
 		}
+		session := *operation.Execution.AuthorizationSession
+		if session.Resolution == AuthorizationSessionResolutionCanceling {
+			if cancelErr := application.cancelAuthorizationAttempt(ctx, connector, operation, true); cancelErr != nil {
+				reconcileErr = errors.Join(reconcileErr, cancelErr)
+			}
+			continue
+		}
+		if !canObserve {
+			continue
+		}
 		remote := release.Manifest.Implementation.RemoteStreamableHTTP != nil
 		if remote {
 			projection, projectionErr := application.GetAuthorizationProjection(ctx, scope.AccountID, connector.Key)
@@ -752,7 +933,6 @@ func (application *Application) ReconcileAuthorizations(ctx context.Context, sco
 		} else if connector.Authorization.State != AuthorizationStatePending {
 			continue
 		}
-		session := *operation.Execution.AuthorizationSession
 		observation := AuthorizationObservation{}
 		expiresAt := session.ExpiresAt
 		if expiresAt.IsZero() {
@@ -784,6 +964,16 @@ func (application *Application) ReconcileAuthorizations(ctx context.Context, sco
 		}
 		if observation.State != AuthorizationObservationConnected && observation.State != AuthorizationObservationFailed {
 			reconcileErr = errors.Join(reconcileErr, errors.New("authorization observer returned an invalid state"))
+			continue
+		}
+		currentOperation, currentErr := application.config.Repository.Operation(ctx, operation.OperationID)
+		if currentErr != nil {
+			reconcileErr = errors.Join(reconcileErr, currentErr)
+			continue
+		}
+		currentSession := currentOperation.Execution.AuthorizationSession
+		if currentSession == nil || currentSession.SessionID != session.SessionID ||
+			currentSession.Resolution == AuthorizationSessionResolutionCanceling || currentSession.IsResolved() {
 			continue
 		}
 		resolution := authorizationSessionResolutionForObservation(observation)
@@ -944,7 +1134,7 @@ func (application *Application) executeOperation(ctx context.Context, operationI
 	case OperationKindDisconnectAuthorization:
 		executeErr = application.executeDisconnectAuthorization(executionContext, operation)
 	case OperationKindStartAuthorization:
-		_, executeErr = application.beginAuthorizationSession(executionContext, operation, nil)
+		_, executeErr = application.beginAuthorizationSession(executionContext, operation, nil, "")
 	default:
 		executeErr = invalidRequest(fmt.Sprintf("operation kind %q is not executable", operation.Kind))
 	}
@@ -1292,6 +1482,41 @@ func validateConnectorMutation(mutation ConnectorMutation) error {
 		return invalidRequest("connectorKey is required")
 	}
 	return nil
+}
+
+func validateAuthorizationMutation(mutation ConnectorMutation) error {
+	if err := validateConnectorMutation(mutation); err != nil {
+		return err
+	}
+	if mutation.ReplacementPolicy != "" &&
+		mutation.ReplacementPolicy != AuthorizationReplacementPolicyReplaceActive {
+		return invalidRequest("authorization replacementPolicy is invalid")
+	}
+	return nil
+}
+
+func (application *Application) verifyConnectorMutationRevision(
+	ctx context.Context,
+	mutation ConnectorMutation,
+) error {
+	return application.config.Repository.Transaction(ctx, func(tx Transaction) error {
+		connector, err := tx.Connector(mutation.ConnectorKey)
+		if err != nil {
+			return err
+		}
+		if mutation.ExpectedConnectorRevision != nil {
+			if connector.Revision != *mutation.ExpectedConnectorRevision {
+				return NewDomainError(
+					ErrorCodeRevisionConflict,
+					fmt.Sprintf("expected connector revision %d but current connector revision is %d", *mutation.ExpectedConnectorRevision, connector.Revision),
+					true,
+					nil,
+				)
+			}
+			return nil
+		}
+		return verifyRevision(tx, mutation.ExpectedRevision)
+	})
 }
 
 func verifyRevision(tx Transaction, expected uint64) error {

--- a/packages/connector/host/application_execution.go
+++ b/packages/connector/host/application_execution.go
@@ -325,6 +325,7 @@ func (application *Application) beginAuthorizationSession(
 	ctx context.Context,
 	operation Operation,
 	secret []byte,
+	replacementPolicy AuthorizationReplacementPolicy,
 ) (AuthorizationSession, error) {
 	release, err := frozenRelease(operation)
 	if err != nil {
@@ -359,12 +360,13 @@ func (application *Application) beginAuthorizationSession(
 		}
 	}
 	session, err := application.config.Authorization.Begin(ctx, AuthorizationStartRequest{
-		OperationID:     operation.OperationID,
-		ClientRequestID: operation.ClientRequestID,
-		Scope:           operation.Scope,
-		Connector:       connector,
-		Release:         release,
-		Secret:          secret,
+		OperationID:       operation.OperationID,
+		ClientRequestID:   operation.ClientRequestID,
+		ReplacementPolicy: replacementPolicy,
+		Scope:             operation.Scope,
+		Connector:         connector,
+		Release:           release,
+		Secret:            secret,
 	})
 	if err != nil {
 		return AuthorizationSession{}, NewDomainError(

--- a/packages/connector/host/application_test.go
+++ b/packages/connector/host/application_test.go
@@ -959,6 +959,98 @@ func TestApplicationSerializesConcurrentAuthorizationReceiptCreation(t *testing.
 	}
 }
 
+func TestApplicationReplaceAuthorizationInterruptsStuckInitialBegin(t *testing.T) {
+	connector := testManagedAuthorizedConnector("dingtalk-cli")
+	connector.Authorization = Authorization{State: AuthorizationStateDisconnected}
+	repository := newMemoryRepository(connector)
+	application := newTestApplication(t, repository, &memoryScheduler{}, &memoryInstallRuntime{}, CatalogSnapshot{})
+	provider := &interruptibleAuthorizationProvider{
+		started: make(chan struct{}), canceled: make(chan struct{}),
+	}
+	application.config.Authorization = provider
+	application.config.AuthorizationProjections = &authorizationProjectionStoreStub{projection: AuthorizationProjection{
+		AccountID: "account-1", ConnectorKey: connector.Key, State: AuthorizationStateDisconnected,
+	}}
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := application.BeginAuthorization(context.Background(), ConnectorMutation{
+			Mutation: Mutation{ClientRequestID: "authorization-a"}, ConnectorKey: connector.Key, AccountID: "account-1",
+		}, nil)
+		firstDone <- err
+	}()
+	<-provider.started
+
+	second, err := application.BeginAuthorization(context.Background(), ConnectorMutation{
+		Mutation: Mutation{ClientRequestID: "authorization-b"}, ConnectorKey: connector.Key, AccountID: "account-1",
+		ReplacementPolicy: AuthorizationReplacementPolicyReplaceActive,
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstErr := <-firstDone; !errors.Is(firstErr, context.Canceled) {
+		t.Fatalf("first authorization error = %v, want canceled", firstErr)
+	}
+	select {
+	case <-provider.canceled:
+	default:
+		t.Fatal("stuck initial authorization was not interrupted")
+	}
+	if provider.begins.Load() != 2 || second.Operation.ClientRequestID != "authorization-b" ||
+		second.Connector.Authorization.State != AuthorizationStatePending {
+		t.Fatalf("replacement result=%#v begins=%d", second, provider.begins.Load())
+	}
+	var firstOperation Operation
+	for _, operation := range repository.operations {
+		if operation.ClientRequestID == "authorization-a" {
+			firstOperation = operation
+			break
+		}
+	}
+	if firstOperation.State != OperationStateFailed {
+		t.Fatalf("first operation = %#v, want failed", firstOperation)
+	}
+}
+
+func TestApplicationReplaceAuthorizationCancelsReceiptBeforeStartingNewAttempt(t *testing.T) {
+	connector := testManagedAuthorizedConnector("dingtalk-cli")
+	connector.Authorization = Authorization{State: AuthorizationStateDisconnected}
+	repository := newMemoryRepository(connector)
+	application := newTestApplication(t, repository, &memoryScheduler{}, &memoryInstallRuntime{}, CatalogSnapshot{})
+	provider := &cancelingAuthorizationProvider{}
+	application.config.Authorization = provider
+	application.config.AuthorizationProjections = &authorizationProjectionStoreStub{projection: AuthorizationProjection{
+		AccountID: "account-1", ConnectorKey: connector.Key, State: AuthorizationStateDisconnected,
+	}}
+
+	first, err := application.BeginAuthorization(context.Background(), ConnectorMutation{
+		Mutation: Mutation{ClientRequestID: "authorization-a"}, ConnectorKey: connector.Key, AccountID: "account-1",
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := application.BeginAuthorization(context.Background(), ConnectorMutation{
+		Mutation:     Mutation{ClientRequestID: "authorization-b", ExpectedRevision: repository.revision},
+		ConnectorKey: connector.Key, AccountID: "account-1",
+		ReplacementPolicy: AuthorizationReplacementPolicyReplaceActive,
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstReceipt := repository.operations[first.Operation.OperationID].Execution.AuthorizationSession
+	if firstReceipt == nil || firstReceipt.Resolution != AuthorizationSessionResolutionSuperseded {
+		t.Fatalf("first receipt = %#v, want superseded", firstReceipt)
+	}
+	if len(provider.canceled) != 1 || provider.canceled[0] != first.Operation.OperationID {
+		t.Fatalf("provider cancellations = %#v", provider.canceled)
+	}
+	if provider.begins.Load() != 2 || second.Operation.OperationID == first.Operation.OperationID ||
+		second.Operation.ClientRequestID != "authorization-b" ||
+		provider.lastReplacementPolicy != AuthorizationReplacementPolicyReplaceActive {
+		t.Fatalf("first=%#v second=%#v begins=%d", first.Operation, second.Operation, provider.begins.Load())
+	}
+}
+
 func TestApplicationDisconnectAuthorizationCompletesOnlyAfterRuntimeIsDisabled(t *testing.T) {
 	connector := testManagedAuthorizedConnector("lark-cli")
 	connector.Authorization = Authorization{State: AuthorizationStateConnected}
@@ -1838,6 +1930,39 @@ func TestApplicationReconcilesCompletedAuthorizationSession(t *testing.T) {
 	}
 }
 
+func TestApplicationRecoveryFinishesCancelingAuthorizationReceipt(t *testing.T) {
+	connector := testManagedAuthorizedConnector("dingtalk-cli")
+	connector.Authorization = Authorization{State: AuthorizationStatePending}
+	repository := newMemoryRepository(connector)
+	operation := Operation{
+		OperationID: "authorization-a", ConnectorKey: connector.Key,
+		Kind: OperationKindStartAuthorization, Scope: OperationScope{AccountID: "account-1"},
+		State: OperationStateCompleted, Stage: OperationStageCompleted,
+		Target: operationTarget(OperationKindStartAuthorization, connector),
+		Execution: OperationExecution{AuthorizationSession: &AuthorizationSession{
+			OperationID: "authorization-a", ConnectorKey: connector.Key,
+			SessionID: "session-a", State: AuthorizationStatePending,
+			Resolution: AuthorizationSessionResolutionCanceling,
+		}},
+	}
+	repository.operations[operation.OperationID] = operation
+	provider := &cancelingAuthorizationProvider{}
+	application := newTestApplication(t, repository, &memoryScheduler{}, &memoryInstallRuntime{}, CatalogSnapshot{})
+	application.config.Authorization = provider
+
+	intents, err := application.ReconcileAuthorizations(context.Background(), operation.Scope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(intents) != 0 || len(provider.canceled) != 1 || provider.canceled[0] != operation.OperationID {
+		t.Fatalf("intents=%#v cancellations=%#v", intents, provider.canceled)
+	}
+	receipt := repository.operations[operation.OperationID].Execution.AuthorizationSession
+	if receipt == nil || receipt.Resolution != AuthorizationSessionResolutionSuperseded {
+		t.Fatalf("recovered receipt = %#v, want superseded", receipt)
+	}
+}
+
 func TestApplicationAuthorizationObservationExpiresAfterTenMinutes(t *testing.T) {
 	connector := testConnector("gmail-timeout")
 	connector.Authorization = Authorization{State: AuthorizationStatePending}
@@ -2348,6 +2473,61 @@ type blockingAuthorizationProvider struct {
 	started chan struct{}
 	release chan struct{}
 	begins  atomic.Int32
+}
+
+type interruptibleAuthorizationProvider struct {
+	authorizationProviderStub
+	started  chan struct{}
+	canceled chan struct{}
+	begins   atomic.Int32
+	cancels  atomic.Int32
+}
+
+func (provider *interruptibleAuthorizationProvider) Begin(
+	ctx context.Context,
+	request AuthorizationStartRequest,
+) (AuthorizationSession, error) {
+	if provider.begins.Add(1) == 1 {
+		close(provider.started)
+		<-ctx.Done()
+		close(provider.canceled)
+		return AuthorizationSession{}, ctx.Err()
+	}
+	return provider.authorizationProviderStub.Begin(ctx, request)
+}
+
+func (provider *interruptibleAuthorizationProvider) Cancel(
+	context.Context,
+	AuthorizationCancelRequest,
+) error {
+	provider.cancels.Add(1)
+	return nil
+}
+
+type cancelingAuthorizationProvider struct {
+	authorizationProviderStub
+	begins                atomic.Int32
+	canceled              []string
+	lastReplacementPolicy AuthorizationReplacementPolicy
+}
+
+func (provider *cancelingAuthorizationProvider) Begin(
+	ctx context.Context,
+	request AuthorizationStartRequest,
+) (AuthorizationSession, error) {
+	provider.begins.Add(1)
+	provider.lastReplacementPolicy = request.ReplacementPolicy
+	session, err := provider.authorizationProviderStub.Begin(ctx, request)
+	session.SessionID = request.OperationID + "/session"
+	return session, err
+}
+
+func (provider *cancelingAuthorizationProvider) Cancel(
+	_ context.Context,
+	request AuthorizationCancelRequest,
+) error {
+	provider.canceled = append(provider.canceled, request.OperationID)
+	return nil
 }
 
 func (provider *blockingAuthorizationProvider) Begin(

--- a/packages/connector/host/authorization_router.go
+++ b/packages/connector/host/authorization_router.go
@@ -62,6 +62,21 @@ func (router *ImplementationAuthorizationRouter) Disconnect(
 	return provider.Disconnect(ctx, request)
 }
 
+func (router *ImplementationAuthorizationRouter) Cancel(
+	ctx context.Context,
+	request AuthorizationCancelRequest,
+) error {
+	provider, err := router.provider(request.Release)
+	if err != nil {
+		return err
+	}
+	canceler, ok := provider.(AuthorizationAttemptCanceler)
+	if !ok {
+		return errors.New("connector authorization provider does not support attempt cancellation")
+	}
+	return canceler.Cancel(ctx, request)
+}
+
 func (router *ImplementationAuthorizationRouter) Observe(
 	ctx context.Context,
 	request AuthorizationObserveRequest,
@@ -121,5 +136,6 @@ func (router *ImplementationAuthorizationRouter) InspectAuthorization(
 }
 
 var _ AuthorizationProvider = (*ImplementationAuthorizationRouter)(nil)
+var _ AuthorizationAttemptCanceler = (*ImplementationAuthorizationRouter)(nil)
 var _ AuthorizationObserver = (*ImplementationAuthorizationRouter)(nil)
 var _ AuthorizationInspector = (*ImplementationAuthorizationRouter)(nil)

--- a/packages/connector/host/ports.go
+++ b/packages/connector/host/ports.go
@@ -351,6 +351,13 @@ type AuthorizationProvider interface {
 	Disconnect(ctx context.Context, request AuthorizationDisconnectRequest) error
 }
 
+// AuthorizationAttemptCanceler terminates one provider authorization attempt
+// and returns only after it can no longer publish credentials or events. A
+// provider that cannot make that guarantee must not implement this interface.
+type AuthorizationAttemptCanceler interface {
+	Cancel(ctx context.Context, request AuthorizationCancelRequest) error
+}
+
 // AuthorizationObserver is an optional asynchronous extension implemented by
 // providers whose user interaction completes outside the daemon process.
 type AuthorizationObserver interface {
@@ -377,12 +384,21 @@ type AuthorizationInspectRequest struct {
 }
 
 type AuthorizationStartRequest struct {
-	OperationID     string
-	ClientRequestID string
-	Scope           OperationScope
-	Connector       Connector
-	Release         Release
-	Secret          []byte
+	OperationID       string
+	ClientRequestID   string
+	ReplacementPolicy AuthorizationReplacementPolicy
+	Scope             OperationScope
+	Connector         Connector
+	Release           Release
+	Secret            []byte
+}
+
+type AuthorizationCancelRequest struct {
+	OperationID string
+	Scope       OperationScope
+	Connector   Connector
+	Release     Release
+	Session     AuthorizationSession
 }
 
 type AuthorizationDisconnectRequest struct {

--- a/packages/connector/host/types.go
+++ b/packages/connector/host/types.go
@@ -527,6 +527,7 @@ type AuthorizationSessionResolution string
 
 const (
 	AuthorizationSessionResolutionUnresolved            AuthorizationSessionResolution = "unresolved"
+	AuthorizationSessionResolutionCanceling             AuthorizationSessionResolution = "canceling"
 	AuthorizationSessionResolutionProviderConnected     AuthorizationSessionResolution = "provider_connected"
 	AuthorizationSessionResolutionProviderFailed        AuthorizationSessionResolution = "provider_failed"
 	AuthorizationSessionResolutionAccountStateConverged AuthorizationSessionResolution = "account_state_converged"
@@ -543,7 +544,12 @@ type AuthorizationReconcileIntent struct {
 }
 
 func (session AuthorizationSession) IsResolved() bool {
-	return session.Resolution != "" && session.Resolution != AuthorizationSessionResolutionUnresolved
+	switch session.Resolution {
+	case "", AuthorizationSessionResolutionUnresolved, AuthorizationSessionResolutionCanceling:
+		return false
+	default:
+		return true
+	}
 }
 
 type AuthorizationObservationState string
@@ -592,10 +598,17 @@ type Mutation struct {
 
 type ConnectorMutation struct {
 	Mutation
-	ConnectorKey              string  `json:"connectorKey"`
-	AccountID                 string  `json:"accountId,omitempty"`
-	ExpectedConnectorRevision *uint64 `json:"expectedConnectorRevision,omitempty"`
+	ConnectorKey              string                         `json:"connectorKey"`
+	AccountID                 string                         `json:"accountId,omitempty"`
+	ExpectedConnectorRevision *uint64                        `json:"expectedConnectorRevision,omitempty"`
+	ReplacementPolicy         AuthorizationReplacementPolicy `json:"replacementPolicy,omitempty"`
 }
+
+type AuthorizationReplacementPolicy string
+
+const (
+	AuthorizationReplacementPolicyReplaceActive AuthorizationReplacementPolicy = "replace_active"
+)
 
 // EnsureRuntimeReconcileResult reports whether a level-triggered repair
 // created work from the caller's current desired state or joined older work

--- a/packages/connector/market/openapi/connector-market.v1.yaml
+++ b/packages/connector/market/openapi/connector-market.v1.yaml
@@ -183,7 +183,7 @@ paths:
     post:
       operationId: startConnectorMarketAuthorization
       tags: [connector-market]
-      summary: Start connector authorization
+      summary: Start or replace connector authorization
       requestBody:
         required: true
         content:
@@ -731,11 +731,20 @@ components:
           type: integer
           format: int64
           minimum: 0
+        replacementPolicy:
+          $ref: "#/components/schemas/ConnectorMarketAuthorizationReplacementPolicy"
         secret:
           type: string
           minLength: 1
           maxLength: 16384
           writeOnly: true
+    ConnectorMarketAuthorizationReplacementPolicy:
+      type: string
+      description: >-
+        When set to replace_active, the Host fences and terminates a different
+        unresolved authorization attempt before starting this request. Omission
+        preserves the legacy resume-or-conflict behavior.
+      enum: [replace_active]
     ConnectorMarketMutationResponse:
       type: object
       additionalProperties: false

--- a/packages/connector/market/src/contracts/domain.ts
+++ b/packages/connector/market/src/contracts/domain.ts
@@ -245,6 +245,7 @@ export interface ConnectorMutationInput extends ConnectorMarketMutationInput {
 }
 
 export interface ConnectorAuthorizationInput extends ConnectorMutationInput {
+  replacementPolicy?: "replace_active";
   secret?: string;
 }
 

--- a/packages/connector/market/src/services/connectorMarketArchitectureGuard.test.ts
+++ b/packages/connector/market/src/services/connectorMarketArchitectureGuard.test.ts
@@ -37,6 +37,20 @@ test("connector market UI does not construct services or import host transports"
   );
 });
 
+test("connector authorization starts only from the explicit dialog action", () => {
+  const dialogsSource = readFileSync(
+    join(sourceDirectory, "ui", "dialogs", "ConnectorMarketDialogs.tsx"),
+    "utf8"
+  );
+
+  assert.doesNotMatch(dialogsSource, /autoStartedAuthorization/);
+  assert.doesNotMatch(dialogsSource, /brokeredAuthorizationConnectorKey/);
+  assert.match(
+    dialogsSource,
+    /onAuthorize=\{\(secret\)\s*=>\s*authorizeConnector\(dialog\.connectorKey, secret\)/
+  );
+});
+
 function sourceFiles(directory: string): string[] {
   const files: string[] = [];
   for (const entry of readdirSync(directory)) {

--- a/packages/connector/market/src/services/connectorMarketService.test.ts
+++ b/packages/connector/market/src/services/connectorMarketService.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import type {
   Connector,
+  ConnectorAuthorizationInput,
   ConnectorAuthorizationResult,
   ConnectorMarketBackend,
   ConnectorMarketChangedEvent,
@@ -1107,21 +1108,29 @@ test("forwards a user-provided secret only to the authorization mutation", async
   service.dispose();
 });
 
-test("shares one authorization command across concurrent callers", async () => {
-  const authorization =
+test("a new authorization command supersedes the previous caller", async () => {
+  const firstAuthorization =
+    deferred<
+      Awaited<ReturnType<ConnectorMarketBackend["beginAuthorization"]>>
+    >();
+  const secondAuthorization =
     deferred<
       Awaited<ReturnType<ConnectorMarketBackend["beginAuthorization"]>>
     >();
   let authorizationAttempts = 0;
   let requestIds = 0;
+  const requests: ConnectorAuthorizationInput[] = [];
   const initial = connector("notion", 1);
   initial.authorization = { state: "disconnected" };
   const service = new ConnectorMarketService({
     backend: backendWith({
       getSnapshot: async () => snapshot(1, [initial]),
-      beginAuthorization: async () => {
+      beginAuthorization: async (request) => {
+        requests.push(request);
         authorizationAttempts += 1;
-        return authorization.promise;
+        return authorizationAttempts === 1
+          ? firstAuthorization.promise
+          : secondAuthorization.promise;
       }
     }),
     createRequestId: () => `authorization-${++requestIds}`
@@ -1132,7 +1141,7 @@ test("shares one authorization command across concurrent callers", async () => {
   const second = service.beginAuthorization("notion");
   const connected = connector("notion", 2);
   connected.authorization = { state: "connected" };
-  authorization.resolve({
+  secondAuthorization.resolve({
     connector: connected,
     operation: {
       ...operation("start_authorization", 2),
@@ -1141,10 +1150,43 @@ test("shares one authorization command across concurrent callers", async () => {
     },
     revision: 2
   });
-  await Promise.all([first, second]);
+  await second;
+  firstAuthorization.resolve({
+    connector: connected,
+    operation: {
+      ...operation("start_authorization", 2),
+      connectorKey: "notion",
+      state: "completed"
+    },
+    revision: 2
+  });
+  await assert.rejects(first, (error: unknown) =>
+    Boolean(
+      error &&
+      typeof error === "object" &&
+      "code" in error &&
+      error.code === "connector_authorization_canceled"
+    )
+  );
 
-  assert.equal(authorizationAttempts, 1);
-  assert.equal(requestIds, 1);
+  assert.equal(authorizationAttempts, 2);
+  assert.equal(requestIds, 2);
+  assert.deepEqual(
+    requests.map(({ clientRequestId, replacementPolicy }) => ({
+      clientRequestId,
+      replacementPolicy
+    })),
+    [
+      {
+        clientRequestId: "authorization-1",
+        replacementPolicy: "replace_active"
+      },
+      {
+        clientRequestId: "authorization-2",
+        replacementPolicy: "replace_active"
+      }
+    ]
+  );
   assert.deepEqual(service.dataStore.authorizingConnectorKeys, {});
   service.dispose();
 });
@@ -1205,12 +1247,14 @@ test("converges a busy authorization continuation from a connected snapshot", as
     {
       connectorKey: "notion",
       clientRequestId: "one-notion-authorization",
+      replacementPolicy: "replace_active",
       expectedRevision: 1,
       expectedConnectorRevision: 1
     },
     {
       connectorKey: "notion",
       clientRequestId: "one-notion-authorization",
+      replacementPolicy: "replace_active",
       expectedRevision: 1,
       expectedConnectorRevision: 2
     }
@@ -1280,6 +1324,7 @@ test("recovers one stale authorization revision without dropping the secret", as
     {
       connectorKey: "token-mail",
       clientRequestId: "one-secret-request",
+      replacementPolicy: "replace_active",
       expectedRevision: 1,
       expectedConnectorRevision: 1,
       secret: "secret-value"
@@ -1287,6 +1332,7 @@ test("recovers one stale authorization revision without dropping the secret", as
     {
       connectorKey: "token-mail",
       clientRequestId: "one-secret-request",
+      replacementPolicy: "replace_active",
       expectedRevision: 4,
       expectedConnectorRevision: 4,
       secret: "secret-value"
@@ -1381,18 +1427,21 @@ test("continues one authorization session, opens each URL once, and clears loadi
     {
       connectorKey: "lark-cli",
       clientRequestId: "one-authorization-request",
+      replacementPolicy: "replace_active",
       expectedRevision: 1,
       expectedConnectorRevision: 1
     },
     {
       connectorKey: "lark-cli",
       clientRequestId: "one-authorization-request",
+      replacementPolicy: "replace_active",
       expectedRevision: 1,
       expectedConnectorRevision: 2
     },
     {
       connectorKey: "lark-cli",
       clientRequestId: "one-authorization-request",
+      replacementPolicy: "replace_active",
       expectedRevision: 1,
       expectedConnectorRevision: 3
     }

--- a/packages/connector/market/src/services/connectorMarketService.ts
+++ b/packages/connector/market/src/services/connectorMarketService.ts
@@ -394,9 +394,9 @@ export class ConnectorMarketService implements IConnectorMarketService {
     if (this.disposed || !this.canRequest()) {
       return Promise.resolve();
     }
-    const existing = this.authorizationInFlight.get(connectorKey);
-    if (existing) {
-      return existing;
+    const previousAttempt = this.authorizationAttempts.get(connectorKey);
+    if (previousAttempt) {
+      previousAttempt.canceled = true;
     }
     let authorization!: Promise<void>;
     authorization = this.runAuthorization(connectorKey, secret).finally(() => {
@@ -410,6 +410,7 @@ export class ConnectorMarketService implements IConnectorMarketService {
 
   async cancelAuthorization(connectorKey: string): Promise<void> {
     const attempt = this.authorizationAttempts.get(connectorKey);
+    const mutationToken = this.connectorMutations.get(connectorKey);
     if (attempt) {
       attempt.canceled = true;
     }
@@ -420,6 +421,13 @@ export class ConnectorMarketService implements IConnectorMarketService {
     } finally {
       if (this.authorizationAttempts.get(connectorKey) === attempt) {
         this.authorizationAttempts.delete(connectorKey);
+      }
+      if (
+        mutationToken &&
+        this.connectorMutations.get(connectorKey) === mutationToken
+      ) {
+        this.connectorMutations.delete(connectorKey);
+        delete this.dataStore.authorizingConnectorKeys[connectorKey];
       }
     }
   }
@@ -432,7 +440,9 @@ export class ConnectorMarketService implements IConnectorMarketService {
     connectorKey: string,
     secret?: string
   ): Promise<void> {
-    const token = this.acquireConnectorMutation(connectorKey);
+    const token = this.authorizationAttempts.has(connectorKey)
+      ? this.replaceConnectorMutation(connectorKey)
+      : this.acquireConnectorMutation(connectorKey);
     this.dataStore.authorizingConnectorKeys[connectorKey] = true;
     delete this.dataStore.pendingAuthorizationsByConnectorKey[connectorKey];
     delete this.dataStore.authorizationViewsByConnectorKey[connectorKey];
@@ -446,6 +456,7 @@ export class ConnectorMarketService implements IConnectorMarketService {
     const request = {
       connectorKey,
       clientRequestId: attempt.requestId,
+      replacementPolicy: "replace_active" as const,
       ...(secret ? { secret } : {})
     };
     let expectedRevision = this.dataStore.revision;
@@ -485,6 +496,9 @@ export class ConnectorMarketService implements IConnectorMarketService {
             recoveredRevisionConflict || canRecoverRevision;
           const next = await this.dependencies.backend.getSnapshot();
           if (!this.isCurrentMutation(connectorKey, token, generation)) {
+            if (attempt.canceled) {
+              throw new ConnectorAuthorizationCanceledError(connectorKey);
+            }
             return;
           }
           applyConnectorMarketSnapshot(this.dataStore, next);
@@ -500,6 +514,9 @@ export class ConnectorMarketService implements IConnectorMarketService {
           continue;
         }
         if (!this.isCurrentMutation(connectorKey, token, generation)) {
+          if (attempt.canceled) {
+            throw new ConnectorAuthorizationCanceledError(connectorKey);
+          }
           return;
         }
         if (attempt.canceled) {
@@ -551,6 +568,9 @@ export class ConnectorMarketService implements IConnectorMarketService {
           );
           return;
         }
+      }
+      if (attempt.canceled) {
+        throw new ConnectorAuthorizationCanceledError(connectorKey);
       }
     } catch (error) {
       if (this.isCurrentMutation(connectorKey, token, generation)) {
@@ -1232,12 +1252,21 @@ export class ConnectorMarketService implements IConnectorMarketService {
       }
       await this.waitForAuthorizationContinuation();
     }
+    if (attempt.canceled) {
+      throw new ConnectorAuthorizationCanceledError(connectorKey);
+    }
   }
 
   private acquireConnectorMutation(connectorKey: string): symbol {
     if (this.connectorMutations.has(connectorKey)) {
       throw new ConnectorMarketBusyError(connectorKey);
     }
+    const token = Symbol(connectorKey);
+    this.connectorMutations.set(connectorKey, token);
+    return token;
+  }
+
+  private replaceConnectorMutation(connectorKey: string): symbol {
     const token = Symbol(connectorKey);
     this.connectorMutations.set(connectorKey, token);
     return token;

--- a/packages/connector/market/src/services/view/connectorMarketViewBuilder.test.ts
+++ b/packages/connector/market/src/services/view/connectorMarketViewBuilder.test.ts
@@ -212,7 +212,7 @@ test("preserves the connector authorization interaction for the dialog", () => {
   );
 });
 
-test("marks managed credential brokers for automatic authorization start", () => {
+test("marks managed credential brokers for managed authorization handling", () => {
   const market = createConnectorMarketStoreState();
   const connector = connectorFixture();
   connector.installation = {

--- a/packages/connector/market/src/ui/dialogs/ConnectorMarketDialogs.tsx
+++ b/packages/connector/market/src/ui/dialogs/ConnectorMarketDialogs.tsx
@@ -6,7 +6,7 @@ import {
   ToastTitle,
   ToastViewport
 } from "@tutti-os/ui-system/components";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useSnapshot } from "valtio";
 import type { AuthorizationViewEnvelopeV1 } from "@tutti-os/connector-authorization-protocol/v1";
 
@@ -41,8 +41,6 @@ export function ConnectorMarketDialogs() {
   const [uninstallSubmitting, setUninstallSubmitting] = useState(false);
   const [uninstallSuccess, setUninstallSuccess] =
     useState<UninstallSuccessToast | null>(null);
-  const autoStartedAuthorizationRef = useRef<string | null>(null);
-
   const authorizeConnector = useCallback(
     (connectorKey: string, secret?: string) => {
       setShowSuccessToast(null);
@@ -75,25 +73,6 @@ export function ConnectorMarketDialogs() {
     },
     [i18n, market, onError, uiState]
   );
-
-  const brokeredAuthorizationConnectorKey =
-    dialog?.kind === "authorization" && dialog.brokeredAuthorization
-      ? dialog.connectorKey
-      : null;
-
-  useEffect(() => {
-    if (!brokeredAuthorizationConnectorKey) {
-      autoStartedAuthorizationRef.current = null;
-      return;
-    }
-    if (
-      autoStartedAuthorizationRef.current === brokeredAuthorizationConnectorKey
-    ) {
-      return;
-    }
-    autoStartedAuthorizationRef.current = brokeredAuthorizationConnectorKey;
-    void authorizeConnector(brokeredAuthorizationConnectorKey);
-  }, [authorizeConnector, brokeredAuthorizationConnectorKey]);
 
   useEffect(() => {
     for (const tracked of Object.values(
@@ -137,6 +116,10 @@ export function ConnectorMarketDialogs() {
 
   const cancelAuthorizationDialog = () => {
     if (dialog?.kind !== "authorization") {
+      uiState.closeDialog();
+      return;
+    }
+    if (!dialog.authorizing && !dialog.pending) {
       uiState.closeDialog();
       return;
     }
@@ -191,10 +174,6 @@ export function ConnectorMarketDialogs() {
           open
           onOpenChange={(open) => {
             if (open || (dialog.kind === "installation" && dialog.installing)) {
-              return;
-            }
-            if (dialog.kind === "authorization") {
-              cancelAuthorizationDialog();
               return;
             }
             uiState.closeDialog();

--- a/packages/connector/runtime/README.md
+++ b/packages/connector/runtime/README.md
@@ -100,6 +100,13 @@ credentials remain user-global in the real user home, while the CLI itself is
 installed only in Tutti's private managed directory and is never added to the
 system `PATH`.
 
+Credential-broker sessions are owned by the durable authorization operation,
+not only by the Connector route. Repeating that operation may resume its
+session; a different operation must first cancel the previous session and wait
+for its process to exit. This exit confirmation is required before another
+broker can use the same Connector state directory, including on Windows where
+process-tree termination remains inside the injected process transport.
+
 Connector installation, MCP, CLI, and credential-broker processes intentionally
 do not use an OS process sandbox. `NewConnectorProcessTransport()` preserves
 the security boundary through pinned packages, verified artifact receipts,

--- a/packages/connector/runtime/implementationhost/credential_authorization.go
+++ b/packages/connector/runtime/implementationhost/credential_authorization.go
@@ -57,9 +57,10 @@ type managedCredentialAuthorizationHost interface {
 // connector-provided credential broker. Provider-specific commands, response
 // parsing, and secret handoffs stay inside the verified connector adapter.
 type managedCredentialAuthorizationProvider struct {
-	host     managedCredentialAuthorizationHost
-	mu       sync.Mutex
-	sessions map[string]*credentialBrokerSession
+	host          managedCredentialAuthorizationHost
+	mu            sync.Mutex
+	sessions      map[string]*credentialBrokerSession
+	activeByRoute map[string]string
 }
 
 type credentialBrokerRequest struct {
@@ -75,7 +76,10 @@ type credentialBrokerEvent struct {
 }
 
 type credentialBrokerSession struct {
-	cancel context.CancelFunc
+	operationID string
+	route       *connectorRoute
+	cancel      context.CancelFunc
+	done        chan struct{}
 
 	mu      sync.Mutex
 	state   market.AuthorizationState
@@ -86,7 +90,9 @@ type credentialBrokerSession struct {
 }
 
 func newManagedCredentialAuthorizationProvider(host managedCredentialAuthorizationHost) *managedCredentialAuthorizationProvider {
-	return &managedCredentialAuthorizationProvider{host: host, sessions: make(map[string]*credentialBrokerSession)}
+	return &managedCredentialAuthorizationProvider{
+		host: host, sessions: make(map[string]*credentialBrokerSession), activeByRoute: make(map[string]string),
+	}
 }
 
 func (host *Host) BeginAuthorization(ctx context.Context, request market.AuthorizationStartRequest) (market.AuthorizationSession, error) {
@@ -101,6 +107,13 @@ func (host *Host) DisconnectAuthorization(ctx context.Context, request market.Au
 		return errors.New("connector authorization provider is unavailable")
 	}
 	return host.authorizationProvider.Disconnect(ctx, request)
+}
+
+func (host *Host) CancelAuthorization(ctx context.Context, request market.AuthorizationCancelRequest) error {
+	if host == nil || host.authorizationProvider == nil {
+		return errors.New("connector authorization provider is unavailable")
+	}
+	return host.authorizationProvider.Cancel(ctx, request)
 }
 
 func (host *Host) InspectAuthorization(ctx context.Context, request market.AuthorizationInspectRequest) (market.AuthorizationObservation, error) {
@@ -120,18 +133,20 @@ func (provider *managedCredentialAuthorizationProvider) Begin(
 	if err != nil {
 		return market.AuthorizationSession{}, err
 	}
-	session, err := provider.authorizationSessionOrStart(route)
+	session, err := provider.authorizationSessionOrStart(route, request.OperationID)
 	if err != nil {
 		return market.AuthorizationSession{}, err
 	}
 	if err := session.awaitInitialEvent(ctx); err != nil {
-		provider.clearAuthorizationSession(route.id, session)
-		session.cancel()
-		return market.AuthorizationSession{}, err
+		cleanupContext, cancelCleanup := context.WithTimeout(context.Background(), 5*time.Second)
+		cleanupErr := provider.cancelAuthorizationSession(cleanupContext, session)
+		cancelCleanup()
+		return market.AuthorizationSession{}, errors.Join(err, cleanupErr)
 	}
 	state, authorizationURL, sessionErr := session.snapshot()
 	if sessionErr != nil {
-		provider.clearAuthorizationSession(route.id, session)
+		provider.clearAuthorizationSession(request.OperationID, session)
+		provider.host.releaseAuthorizationRoute(route)
 		return market.AuthorizationSession{}, sessionErr
 	}
 	result := market.AuthorizationSession{
@@ -143,10 +158,23 @@ func (provider *managedCredentialAuthorizationProvider) Begin(
 		State:            state,
 	}
 	if state == market.AuthorizationStateConnected {
-		provider.clearAuthorizationSession(route.id, session)
+		provider.clearAuthorizationSession(request.OperationID, session)
 		provider.host.releaseAuthorizationRoute(route)
 	}
 	return result, nil
+}
+
+func (provider *managedCredentialAuthorizationProvider) Cancel(
+	ctx context.Context,
+	request market.AuthorizationCancelRequest,
+) error {
+	provider.mu.Lock()
+	session := provider.sessions[strings.TrimSpace(request.OperationID)]
+	provider.mu.Unlock()
+	if session == nil {
+		return nil
+	}
+	return provider.cancelAuthorizationSession(ctx, session)
 }
 
 func (provider *managedCredentialAuthorizationProvider) Disconnect(
@@ -157,8 +185,13 @@ func (provider *managedCredentialAuthorizationProvider) Disconnect(
 	if err != nil {
 		return err
 	}
-	if session := provider.takeAuthorizationSession(route.id); session != nil {
+	if session := provider.takeAuthorizationSessionByRoute(route.id); session != nil {
 		session.cancel()
+		select {
+		case <-session.done:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 	operationContext, cancel := context.WithTimeout(ctx, route.credentialBrokerLaunch.timeout)
 	defer cancel()
@@ -226,9 +259,13 @@ func (provider *managedCredentialAuthorizationProvider) Inspect(
 	}, nil
 }
 
-func (provider *managedCredentialAuthorizationProvider) authorizationSessionOrStart(route *connectorRoute) (*credentialBrokerSession, error) {
+func (provider *managedCredentialAuthorizationProvider) authorizationSessionOrStart(
+	route *connectorRoute,
+	operationID string,
+) (*credentialBrokerSession, error) {
+	operationID = strings.TrimSpace(operationID)
 	provider.mu.Lock()
-	if session := provider.sessions[route.id]; session != nil {
+	if session := provider.sessions[operationID]; session != nil {
 		_, _, sessionErr := session.snapshot()
 		if sessionErr == nil {
 			provider.mu.Unlock()
@@ -237,7 +274,31 @@ func (provider *managedCredentialAuthorizationProvider) authorizationSessionOrSt
 		// A broker can fail after emitting its first authorization URL. Do not
 		// make the next user action consume that terminal error merely to clear
 		// the cache; replace it with a fresh broker in this same request.
-		delete(provider.sessions, route.id)
+		delete(provider.sessions, operationID)
+		if provider.activeByRoute[route.id] == operationID {
+			delete(provider.activeByRoute, route.id)
+		}
+	}
+	if activeOperationID := provider.activeByRoute[route.id]; activeOperationID != "" {
+		active := provider.sessions[activeOperationID]
+		if active != nil {
+			_, _, activeErr := active.snapshot()
+			if activeErr != nil {
+				select {
+				case <-active.done:
+					delete(provider.sessions, activeOperationID)
+					delete(provider.activeByRoute, route.id)
+				default:
+					provider.mu.Unlock()
+					return nil, errors.New("connector credential broker termination is still pending")
+				}
+			} else {
+				provider.mu.Unlock()
+				return nil, errors.New("connector credential broker has an active authorization attempt")
+			}
+		} else {
+			delete(provider.activeByRoute, route.id)
+		}
 	}
 	processContext, cancel := context.WithTimeout(context.Background(), route.credentialBrokerLaunch.timeout)
 	connection, processID, err := provider.host.startCredentialBroker(processContext, route, credentialBrokerRequest{
@@ -248,8 +309,11 @@ func (provider *managedCredentialAuthorizationProvider) authorizationSessionOrSt
 		provider.mu.Unlock()
 		return nil, fmt.Errorf("start connector credential broker: %w", err)
 	}
-	session := &credentialBrokerSession{cancel: cancel, changed: make(chan struct{})}
-	provider.sessions[route.id] = session
+	session := &credentialBrokerSession{
+		operationID: operationID, route: route, cancel: cancel, done: make(chan struct{}), changed: make(chan struct{}),
+	}
+	provider.sessions[operationID] = session
+	provider.activeByRoute[route.id] = operationID
 	provider.mu.Unlock()
 	go consumeAuthorizationEvents(provider.host, route, connection, processID, session)
 	return session, nil
@@ -263,6 +327,7 @@ func consumeAuthorizationEvents(
 	session *credentialBrokerSession,
 ) {
 	defer session.cancel()
+	defer close(session.done)
 	defer func() { _ = route.releaseProcess(processID, connection) }()
 	var stdout, stderr strings.Builder
 	for {
@@ -691,27 +756,50 @@ func (session *credentialBrokerSession) terminal() bool {
 	return session.state == market.AuthorizationStateConnected || session.err != nil
 }
 
-func (provider *managedCredentialAuthorizationProvider) takeAuthorizationSession(routeID string) *credentialBrokerSession {
+func (provider *managedCredentialAuthorizationProvider) takeAuthorizationSessionByRoute(routeID string) *credentialBrokerSession {
 	provider.mu.Lock()
 	defer provider.mu.Unlock()
-	session := provider.sessions[routeID]
-	delete(provider.sessions, routeID)
+	operationID := provider.activeByRoute[routeID]
+	session := provider.sessions[operationID]
+	delete(provider.activeByRoute, routeID)
+	delete(provider.sessions, operationID)
 	return session
 }
 
-func (provider *managedCredentialAuthorizationProvider) cancelAuthorizationSession(routeID string) {
+func (provider *managedCredentialAuthorizationProvider) cancelAuthorizationSession(
+	ctx context.Context,
+	session *credentialBrokerSession,
+) error {
+	if provider == nil || session == nil {
+		return nil
+	}
+	session.cancel()
+	select {
+	case <-session.done:
+		provider.clearAuthorizationSession(session.operationID, session)
+		provider.host.releaseAuthorizationRoute(session.route)
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("wait for connector credential broker termination: %w", ctx.Err())
+	}
+}
+
+func (provider *managedCredentialAuthorizationProvider) cancelAuthorizationSessionByRoute(routeID string) {
 	if provider == nil {
 		return
 	}
-	if session := provider.takeAuthorizationSession(routeID); session != nil {
+	if session := provider.takeAuthorizationSessionByRoute(routeID); session != nil {
 		session.cancel()
 	}
 }
 
-func (provider *managedCredentialAuthorizationProvider) clearAuthorizationSession(routeID string, session *credentialBrokerSession) {
+func (provider *managedCredentialAuthorizationProvider) clearAuthorizationSession(operationID string, session *credentialBrokerSession) {
 	provider.mu.Lock()
-	if provider.sessions[routeID] == session {
-		delete(provider.sessions, routeID)
+	if provider.sessions[operationID] == session {
+		delete(provider.sessions, operationID)
+	}
+	if session != nil && provider.activeByRoute[session.route.id] == operationID {
+		delete(provider.activeByRoute, session.route.id)
 	}
 	provider.mu.Unlock()
 }

--- a/packages/connector/runtime/implementationhost/credential_authorization_test.go
+++ b/packages/connector/runtime/implementationhost/credential_authorization_test.go
@@ -344,7 +344,7 @@ func TestManagedCredentialAuthorizationRestartsFailedBrokerOnFirstRetry(t *testi
 	}
 	exitCode := 1
 	failedConnection.frames <- agentruntime.ProcessFrame{Stderr: []byte("broker failed"), ExitCode: &exitCode}
-	awaitCachedAuthorizationFailure(t, provider, route.id)
+	awaitCachedAuthorizationFailure(t, provider, firstRequest.OperationID)
 
 	retryConnection.frames <- agentruntime.ProcessFrame{Stdout: []byte(`{"type":"authorization_url","url":"https://accounts.example.com/retry"}` + "\n")}
 	retry, err := provider.Begin(context.Background(), market.AuthorizationStartRequest{
@@ -361,12 +361,60 @@ func TestManagedCredentialAuthorizationRestartsFailedBrokerOnFirstRetry(t *testi
 	}
 }
 
-func awaitCachedAuthorizationFailure(t *testing.T, provider *managedCredentialAuthorizationProvider, routeID string) {
+func TestManagedCredentialAuthorizationCancelWaitsForBrokerExit(t *testing.T) {
+	connection := newCredentialBrokerConnection()
+	route := &connectorRoute{id: "default\x00dingtalk-cli", credentialBrokerLaunch: &managedCredentialBrokerLaunch{
+		timeout: 5 * time.Minute, allowedHosts: map[string]struct{}{"login.dingtalk.com": {}},
+	}}
+	host := &credentialAuthorizationHostStub{route: route, connections: []agentruntime.ProcessConnection{connection}}
+	provider := newManagedCredentialAuthorizationProvider(host)
+	request := market.AuthorizationStartRequest{OperationID: "authorize-a", Connector: market.Connector{Key: "dingtalk-cli"}}
+	beginDone := make(chan error, 1)
+	go func() {
+		_, err := provider.Begin(context.Background(), request)
+		beginDone <- err
+	}()
+	connection.frames <- agentruntime.ProcessFrame{Stdout: []byte(`{"type":"authorization_url","url":"https://login.dingtalk.com/oauth"}` + "\n")}
+	if err := <-beginDone; err != nil {
+		t.Fatal(err)
+	}
+
+	provider.mu.Lock()
+	session := provider.sessions[request.OperationID]
+	originalCancel := session.cancel
+	cancelRequested := make(chan struct{})
+	session.cancel = func() {
+		close(cancelRequested)
+		originalCancel()
+	}
+	provider.mu.Unlock()
+	cancelDone := make(chan error, 1)
+	go func() {
+		cancelDone <- provider.Cancel(context.Background(), market.AuthorizationCancelRequest{OperationID: request.OperationID})
+	}()
+	<-cancelRequested
+	select {
+	case err := <-cancelDone:
+		t.Fatalf("cancel returned before broker exit: %v", err)
+	default:
+	}
+	close(connection.frames)
+	if err := <-cancelDone; err != nil {
+		t.Fatal(err)
+	}
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	if provider.sessions[request.OperationID] != nil || provider.activeByRoute[route.id] != "" {
+		t.Fatalf("canceled session remained active: sessions=%#v routes=%#v", provider.sessions, provider.activeByRoute)
+	}
+}
+
+func awaitCachedAuthorizationFailure(t *testing.T, provider *managedCredentialAuthorizationProvider, operationID string) {
 	t.Helper()
 	deadline := time.Now().Add(time.Second)
 	for {
 		provider.mu.Lock()
-		session := provider.sessions[routeID]
+		session := provider.sessions[operationID]
 		provider.mu.Unlock()
 		if session != nil {
 			_, _, err := session.snapshot()

--- a/packages/connector/runtime/implementationhost/uninstall.go
+++ b/packages/connector/runtime/implementationhost/uninstall.go
@@ -31,7 +31,7 @@ func (host *Host) deactivateConnector(request market.RuntimeDeactivationRequest)
 	host.authorizationMu.Unlock()
 	var authorizationErrs []error
 	for _, route := range authorizationRoutes {
-		host.authorizationProvider.cancelAuthorizationSession(route.id)
+		host.authorizationProvider.cancelAuthorizationSessionByRoute(route.id)
 		route.Fence()
 		if err := route.Close(request.Deadline); err != nil {
 			// Keep a fenced route reachable so an idempotent uninstall retry can

--- a/packages/connector/runtime/implementationhost/uninstall_lifecycle_test.go
+++ b/packages/connector/runtime/implementationhost/uninstall_lifecycle_test.go
@@ -148,9 +148,12 @@ func TestDeactivateRuntimeAllConnectionsCancelsPendingAuthorizationRoute(t *test
 	route := testUninstallRoute("account-pending", "github", "superseded-release", market.HostGeneration{BootEpoch: "authorization", Generation: 2})
 	host.authorizationRoutes[route.id] = route
 	canceled := make(chan struct{})
-	host.authorizationProvider.sessions[route.id] = &credentialBrokerSession{
+	const operationID = "authorization-pending"
+	host.authorizationProvider.sessions[operationID] = &credentialBrokerSession{
+		operationID: operationID, route: route,
 		cancel: func() { close(canceled) }, changed: make(chan struct{}), state: market.AuthorizationStatePending,
 	}
+	host.authorizationProvider.activeByRoute[route.id] = operationID
 
 	if err := host.DeactivateRuntime(context.Background(), market.RuntimeDeactivationRequest{
 		ConnectionID: "current-connection", ConnectorKey: "github", ReleaseDigest: "release-1",
@@ -163,7 +166,7 @@ func TestDeactivateRuntimeAllConnectionsCancelsPendingAuthorizationRoute(t *test
 	default:
 		t.Fatal("pending credential broker session was not canceled")
 	}
-	if host.authorizationRoutes[route.id] != nil || host.authorizationProvider.sessions[route.id] != nil || !route.processes.IsFenced() {
+	if host.authorizationRoutes[route.id] != nil || host.authorizationProvider.sessions[operationID] != nil || !route.processes.IsFenced() {
 		t.Fatal("pending authorization route survived uninstall")
 	}
 }

--- a/packages/connector/store-sqlite/store.go
+++ b/packages/connector/store-sqlite/store.go
@@ -425,8 +425,8 @@ func (store *Store) ResolveAuthorizationSession(
 	operationID string,
 	resolution market.AuthorizationSessionResolution,
 ) error {
-	if !terminalAuthorizationSessionResolution(resolution) {
-		return errors.New("terminal authorization session resolution is required")
+	if !validAuthorizationSessionResolutionTransition(resolution) {
+		return errors.New("valid authorization session resolution is required")
 	}
 	tx, err := store.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -448,9 +448,10 @@ func (store *Store) ResolveAuthorizationSession(
 	return tx.Commit()
 }
 
-func terminalAuthorizationSessionResolution(resolution market.AuthorizationSessionResolution) bool {
+func validAuthorizationSessionResolutionTransition(resolution market.AuthorizationSessionResolution) bool {
 	switch resolution {
-	case market.AuthorizationSessionResolutionProviderConnected,
+	case market.AuthorizationSessionResolutionCanceling,
+		market.AuthorizationSessionResolutionProviderConnected,
 		market.AuthorizationSessionResolutionProviderFailed,
 		market.AuthorizationSessionResolutionAccountStateConverged,
 		market.AuthorizationSessionResolutionSuperseded:

--- a/packages/connector/store-sqlite/store_test.go
+++ b/packages/connector/store-sqlite/store_test.go
@@ -193,7 +193,6 @@ func TestStorePersistsRevisionOperationBindingAndOutboxAtomically(t *testing.T) 
 	}); err != nil {
 		t.Fatal(err)
 	}
-
 	snapshot, err := store.SnapshotForScope(ctx, operation.Scope)
 	if err != nil {
 		t.Fatal(err)
@@ -371,6 +370,11 @@ func TestStoreKeepsAuthorizationSessionPrivateAndAvailableAfterReopen(t *testing
 	}); err != nil {
 		t.Fatal(err)
 	}
+	if err := store.ResolveAuthorizationSession(
+		ctx, operation.OperationID, market.AuthorizationSessionResolutionCanceling,
+	); err != nil {
+		t.Fatal(err)
+	}
 	if err := store.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -392,7 +396,8 @@ func TestStoreKeepsAuthorizationSessionPrivateAndAvailableAfterReopen(t *testing
 		t.Fatal(err)
 	}
 	if len(operations) != 1 || operations[0].Execution.AuthorizationSession == nil ||
-		operations[0].Execution.AuthorizationSession.SessionID != "session-1" {
+		operations[0].Execution.AuthorizationSession.SessionID != "session-1" ||
+		operations[0].Execution.AuthorizationSession.Resolution != market.AuthorizationSessionResolutionCanceling {
 		t.Fatalf("authorization operations = %#v", operations)
 	}
 }

--- a/services/tuttid/api/daemon_connector_market.go
+++ b/services/tuttid/api/daemon_connector_market.go
@@ -399,6 +399,9 @@ func connectorMarketAuthorizationMutation(
 		Mutation:     market.Mutation{ClientRequestID: body.ClientRequestId, ExpectedRevision: uint64(body.ExpectedRevision)},
 		ConnectorKey: connectorKey,
 	}
+	if body.ReplacementPolicy != nil {
+		result.ReplacementPolicy = market.AuthorizationReplacementPolicy(*body.ReplacementPolicy)
+	}
 	if body.ExpectedConnectorRevision != nil {
 		revision := uint64(*body.ExpectedConnectorRevision)
 		result.ExpectedConnectorRevision = &revision

--- a/services/tuttid/api/daemon_connector_market_test.go
+++ b/services/tuttid/api/daemon_connector_market_test.go
@@ -20,7 +20,16 @@ type stubConnectorMarketService struct {
 	refreshFn    func(context.Context, market.Mutation) (market.MutationResult, error)
 	operationFn  func(context.Context, market.OperationScope, string) (market.Operation, error)
 	cancelFn     func(context.Context, market.OperationScope, string) error
+	beginFn      func(context.Context, market.ConnectorMutation, []byte) (market.AuthorizationResult, error)
 	projectionFn func(context.Context, string, string) (market.AuthorizationProjection, error)
+}
+
+func (service stubConnectorMarketService) BeginAuthorization(
+	ctx context.Context,
+	mutation market.ConnectorMutation,
+	secret []byte,
+) (market.AuthorizationResult, error) {
+	return service.beginFn(ctx, mutation, secret)
 }
 
 func (service stubConnectorMarketService) CancelAuthorization(ctx context.Context, scope market.OperationScope, connectorKey string) error {
@@ -157,6 +166,48 @@ func TestDaemonAPICancelsConnectorAuthorizationForActiveAccount(t *testing.T) {
 	}
 	if gotScope.AccountID != "account-1" || gotConnectorKey != "supabase" {
 		t.Fatalf("cancel scope=%#v connector=%q", gotScope, gotConnectorKey)
+	}
+}
+
+func TestDaemonAPIForwardsReplaceActiveAuthorizationPolicy(t *testing.T) {
+	var received market.ConnectorMutation
+	service := stubConnectorMarketService{beginFn: func(
+		_ context.Context,
+		mutation market.ConnectorMutation,
+		_ []byte,
+	) (market.AuthorizationResult, error) {
+		received = mutation
+		connector := connectorMarketTestConnector()
+		connector.Authorization = market.Authorization{State: market.AuthorizationStatePending}
+		return market.AuthorizationResult{
+			Connector: connector,
+			Operation: market.Operation{
+				OperationID: "operation-b", ClientRequestID: mutation.ClientRequestID,
+				ConnectorKey: connector.Key, Kind: market.OperationKindStartAuthorization,
+				State: market.OperationStateCompleted, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+			},
+			AuthorizationURL:       "https://accounts.example.com/oauth",
+			AuthorizationExpiresAt: time.Now().Add(time.Minute),
+			Revision:               2,
+		}, nil
+	}}
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, NewRoutes(DaemonAPI{
+		ConnectorMarketService: service,
+		ConnectorMarketScope:   func() market.OperationScope { return market.OperationScope{AccountID: "account-1"} },
+	}))
+
+	recorder := performGeneratedRouteRequest(t, mux, http.MethodPost,
+		"/v1/connector-market/connectors/notion/authorization:start", map[string]any{
+			"clientRequestId": "authorization-b", "expectedRevision": 1,
+			"replacementPolicy": "replace_active",
+		})
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if received.AccountID != "account-1" || received.ClientRequestID != "authorization-b" ||
+		received.ReplacementPolicy != market.AuthorizationReplacementPolicyReplaceActive {
+		t.Fatalf("authorization mutation = %#v", received)
 	}
 }
 

--- a/services/tuttid/api/generated/server.gen.go
+++ b/services/tuttid/api/generated/server.gen.go
@@ -116,7 +116,7 @@ type ServerInterface interface {
 	// Disconnect connector authorization
 	// (POST /v1/connector-market/connectors/{connectorKey}/authorization:disconnect)
 	DisconnectConnectorMarketAuthorization(w http.ResponseWriter, r *http.Request, connectorKey ConnectorMarketConnectorKey)
-	// Start connector authorization
+	// Start or replace connector authorization
 	// (POST /v1/connector-market/connectors/{connectorKey}/authorization:start)
 	StartConnectorMarketAuthorization(w http.ResponseWriter, r *http.Request, connectorKey ConnectorMarketConnectorKey)
 	// Install or update one connector
@@ -39616,7 +39616,7 @@ type StrictServerInterface interface {
 	// Disconnect connector authorization
 	// (POST /v1/connector-market/connectors/{connectorKey}/authorization:disconnect)
 	DisconnectConnectorMarketAuthorization(ctx context.Context, request DisconnectConnectorMarketAuthorizationRequestObject) (DisconnectConnectorMarketAuthorizationResponseObject, error)
-	// Start connector authorization
+	// Start or replace connector authorization
 	// (POST /v1/connector-market/connectors/{connectorKey}/authorization:start)
 	StartConnectorMarketAuthorization(ctx context.Context, request StartConnectorMarketAuthorizationRequestObject) (StartConnectorMarketAuthorizationResponseObject, error)
 	// Install or update one connector

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -1348,6 +1348,21 @@ func (e CollaborationRunTriggerSource) Valid() bool {
 	}
 }
 
+// Defines values for ConnectorMarketAuthorizationReplacementPolicy.
+const (
+	ReplaceActive ConnectorMarketAuthorizationReplacementPolicy = "replace_active"
+)
+
+// Valid indicates whether the value is a known member of the ConnectorMarketAuthorizationReplacementPolicy enum.
+func (e ConnectorMarketAuthorizationReplacementPolicy) Valid() bool {
+	switch e {
+	case ReplaceActive:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ConnectorMarketAuthorizationState.
 const (
 	ConnectorMarketAuthorizationStateConnected    ConnectorMarketAuthorizationState = "connected"
@@ -6226,12 +6241,18 @@ type ConnectorMarketAuthorization struct {
 	State       ConnectorMarketAuthorizationState `json:"state"`
 }
 
+// ConnectorMarketAuthorizationReplacementPolicy When set to replace_active, the Host fences and terminates a different unresolved authorization attempt before starting this request. Omission preserves the legacy resume-or-conflict behavior.
+type ConnectorMarketAuthorizationReplacementPolicy string
+
 // ConnectorMarketAuthorizationRequest defines model for ConnectorMarketAuthorizationRequest.
 type ConnectorMarketAuthorizationRequest struct {
-	ClientRequestId           string  `json:"clientRequestId"`
-	ExpectedConnectorRevision *int64  `json:"expectedConnectorRevision,omitempty"`
-	ExpectedRevision          int64   `json:"expectedRevision"`
-	Secret                    *string `json:"secret,omitempty"`
+	ClientRequestId           string `json:"clientRequestId"`
+	ExpectedConnectorRevision *int64 `json:"expectedConnectorRevision,omitempty"`
+	ExpectedRevision          int64  `json:"expectedRevision"`
+
+	// ReplacementPolicy When set to replace_active, the Host fences and terminates a different unresolved authorization attempt before starting this request. Omission preserves the legacy resume-or-conflict behavior.
+	ReplacementPolicy *ConnectorMarketAuthorizationReplacementPolicy `json:"replacementPolicy,omitempty"`
+	Secret            *string                                        `json:"secret,omitempty"`
 }
 
 // ConnectorMarketAuthorizationResponse defines model for ConnectorMarketAuthorizationResponse.

--- a/services/tuttid/service/connectormarket/implementation_host.go
+++ b/services/tuttid/service/connectormarket/implementation_host.go
@@ -102,6 +102,13 @@ func (host *ImplementationHost) Disconnect(ctx context.Context, request market.A
 	return host.runtime.DisconnectAuthorization(ctx, request)
 }
 
+func (host *ImplementationHost) Cancel(ctx context.Context, request market.AuthorizationCancelRequest) error {
+	if host == nil || host.runtime == nil {
+		return errors.New("connector authorization provider is unavailable")
+	}
+	return host.runtime.CancelAuthorization(ctx, request)
+}
+
 func (host *ImplementationHost) InspectAuthorization(ctx context.Context, request market.AuthorizationInspectRequest) (market.AuthorizationObservation, error) {
 	if host == nil || host.runtime == nil {
 		return market.AuthorizationObservation{}, errors.New("connector authorization inspector is unavailable")


### PR DESCRIPTION
## Summary

Connector authorization could become permanently blocked when an earlier provider Begin call, browser flow, or credential-broker process remained unresolved. A later user action reused or conflicted with that attempt, so closing and reopening the dialog could not reliably start a clean authorization flow.

This change gives a new user action explicit `replace_active` semantics while preserving idempotent continuation for the same `clientRequestId`:

- the Connector Host interrupts a live initial Begin, persists an existing receipt as `canceling`, requires provider termination, and only then resolves it as `superseded`
- managed credential brokers are keyed by operation, fenced per route, and cancellation waits for the process to exit before shared credential state can be reused
- remote authorization propagates replacement to the control plane and uses the session-scoped Cancel endpoint introduced by tutti-lab/tsh-server#841
- late observations re-read the durable receipt before publishing state, preventing a superseded attempt from contaminating its replacement
- the renderer creates a fresh request identity for each new authorization action, replaces its mutation token, and keeps dialog dismissal separate from explicit cancellation
- generated daemon clients, OpenAPI, package documentation, architecture guidance, troubleshooting guidance, and the connector-market changeset are updated together

The UI continues to use existing `@tutti-os/ui-system` dialog and toast components; this change adds no bespoke visual primitives or raw styling.

Windows impact: broker termination remains behind the existing injected process transport and `releaseProcess` boundary. The shared Host waits for that capability to report process exit and introduces no OS checks, shell commands, path assumptions, or platform-specific signals. Windows CI remains the native process-tree gate.

## Verification

- `pnpm check:changed` — passed all 22 selected lanes after formatting and commit
- pre-push `pnpm check:changed -- --push-ready` — passed all 24 selected lanes
- targeted behavior is covered by tests for interrupting a stuck initial Begin, cancel-before-replace ordering, restart recovery from durable `canceling`, waiting for broker exit, remote replacement/cancellation wire fields, daemon request mapping, and renderer supersession

## Fallback Three Questions

- Source: external authorization providers can block before returning a receipt, browser flows can outlive their renderer, and credential-broker processes can remain unresolved across dismissal or daemon restart.
- Why can it not be fixed at that source? The Host does not control external browser/provider completion and must serialize access to shared Connector credential state across local and remote provider implementations.
- Removal condition: the defensive recovery path can be removed only if every provider exposes an atomic replace operation with attempt-scoped event fencing and a durable guarantee that the old attempt can no longer publish credentials before the replacement starts.

## Checklist

- [x] This does not change Agent session/turn/goal/runtime-operation lifecycle semantics; it changes the Connector Host authorization lifecycle.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source (not applicable; no repository-level translated README or CONTRIBUTING file changed).
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
