### PR TITLE
fix(agent-gui): distinguish unavailable images from load failures

### DIFF
--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
@@ -15,6 +15,7 @@ import { enAgentGuiProjectLaunch } from "./en.agentGuiProjectLaunch.ts";
 export const enAgentGui = {
   imageDownloaded: "Image downloaded",
   imageLoadFailed: "Image failed to load",
+  imageTemporarilyUnavailable: "Image temporarily unavailable",
   retryImage: "Retry",
   initialPlaceholder: "Type @ to reference sessions, files, tasks, and apps",
   followupPlaceholder: "Request follow-up changes from {{provider}}",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
@@ -13,6 +13,7 @@ import { zhCNAgentGuiProjectLaunch } from "./zh-CN.agentGuiProjectLaunch.ts";
 export const zhCNAgentGui = {
   imageDownloaded: "图片已下载",
   imageLoadFailed: "图片加载失败",
+  imageTemporarilyUnavailable: "图片暂时无法查看",
   retryImage: "重试",
   codexSaverModeLabel: "Codex 省额度模式",
   codexSaverModeDescription:

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageImages.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageImages.tsx
@@ -19,6 +19,7 @@ import type {
 } from "../contracts/agentMessageRowVM";
 
 type ImageFailureKind = "load" | "read" | "unavailable";
+type ImageFailureUnavailableReason = "source_vm";
 type ImageFailureSource =
   | {
       kind: "resolved";
@@ -30,6 +31,7 @@ type ImageFailureSource =
       kind: "locator";
       path: string;
       readerAvailable: boolean;
+      unavailableReason?: ImageFailureUnavailableReason;
       workspaceId: string;
     };
 type ImageFailureReporter = (
@@ -67,11 +69,10 @@ export function AgentUserImageGrid({
       {images.map((image) => {
         const src = sources.get(image.id) ?? imageSourceUrl(image);
         const failureSource = imageFailureSource(image, src, runtime);
-        const failed = isMatchingImageFailure(
-          failedSources.get(image.id),
-          failureSource
-        );
-        const canRetry = canRetryImageFailure(failureSource);
+        const failedSource = failedSources.get(image.id);
+        const displayedFailureSource = failedSource ?? failureSource;
+        const failed = isMatchingImageFailure(failedSource, failureSource);
+        const canRetry = canRetryImageFailure(displayedFailureSource);
         const attempt = retryCounts.get(image.id) ?? 0;
         return (
           <AgentUserImageTile
@@ -82,7 +83,7 @@ export function AgentUserImageGrid({
             failed={failed}
             sourceLoading={!src && loadingIds.has(image.id)}
             attempt={attempt}
-            failureLabel={t(imageFailureLabelKey(failureSource))}
+            failureLabel={t(imageFailureLabelKey(displayedFailureSource))}
             retryLabel={t("agentHost.agentGui.retryImage")}
             onFailed={() => {
               markFailed(image.id, failureSource);
@@ -300,10 +301,20 @@ function useAgentMessageImageSources(
               return next;
             });
           })
-          .catch(() => {
+          .catch((error: unknown) => {
             if (canceled) return;
-            markFailed(image.id, imageFailureSource(image, null, runtime));
-            reportFailure(image, "read", attempt);
+            const unavailableReason = isSourceVMUnavailableError(error)
+              ? "source_vm"
+              : undefined;
+            markFailed(
+              image.id,
+              imageFailureSource(image, null, runtime, unavailableReason)
+            );
+            reportFailure(
+              image,
+              unavailableReason ? "unavailable" : "read",
+              attempt
+            );
           })
           .finally(() => {
             if (canceled) return;
@@ -458,7 +469,8 @@ function imageSourceUrl(image: AgentMessageImageVM): string | null {
 function imageFailureSource(
   image: AgentMessageImageVM,
   src: string | null,
-  runtime: AgentGUIRuntime | null
+  runtime: AgentGUIRuntime | null,
+  unavailableReason?: ImageFailureUnavailableReason
 ): ImageFailureSource {
   if (src) {
     return { kind: "resolved", src };
@@ -472,12 +484,16 @@ function imageFailureSource(
     path: image.path?.trim() ?? "",
     readerAvailable: Boolean(
       attachmentId ? runtime?.readSessionAttachment : runtime?.readPromptAsset
-    )
+    ),
+    ...(unavailableReason ? { unavailableReason } : {})
   };
 }
 
 function canRetryImageFailure(source: ImageFailureSource): boolean {
-  return source.kind === "resolved" || source.readerAvailable;
+  return (
+    source.kind === "resolved" ||
+    (source.readerAvailable && !source.unavailableReason)
+  );
 }
 
 function imageFailureLabelKey(
@@ -485,9 +501,20 @@ function imageFailureLabelKey(
 ):
   | "agentHost.agentGui.imageLoadFailed"
   | "agentHost.agentGui.imageTemporarilyUnavailable" {
-  return source.kind === "locator" && !source.readerAvailable
+  return source.kind === "locator" &&
+    (source.unavailableReason === "source_vm" || !source.readerAvailable)
     ? "agentHost.agentGui.imageTemporarilyUnavailable"
     : "agentHost.agentGui.imageLoadFailed";
+}
+
+function isSourceVMUnavailableError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code ===
+      "agent_session_attachment_vm_unavailable"
+  );
 }
 
 function isMatchingImageFailure(

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageImages.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageImages.tsx
@@ -71,16 +71,18 @@ export function AgentUserImageGrid({
           failedSources.get(image.id),
           failureSource
         );
+        const canRetry = canRetryImageFailure(failureSource);
         const attempt = retryCounts.get(image.id) ?? 0;
         return (
           <AgentUserImageTile
             key={image.id}
+            canRetry={canRetry}
             image={image}
             src={src}
             failed={failed}
             sourceLoading={!src && loadingIds.has(image.id)}
             attempt={attempt}
-            failureLabel={t("agentHost.agentGui.imageLoadFailed")}
+            failureLabel={t(imageFailureLabelKey(failureSource))}
             retryLabel={t("agentHost.agentGui.retryImage")}
             onFailed={() => {
               markFailed(image.id, failureSource);
@@ -96,6 +98,7 @@ export function AgentUserImageGrid({
 
 function AgentUserImageTile({
   attempt,
+  canRetry,
   failed,
   failureLabel,
   image,
@@ -106,6 +109,7 @@ function AgentUserImageTile({
   src
 }: {
   attempt: number;
+  canRetry: boolean;
   failed: boolean;
   failureLabel: string;
   image: AgentMessageImageVM;
@@ -134,6 +138,7 @@ function AgentUserImageTile({
     >
       {showingFailure ? (
         <ImageLoadFailurePlaceholder
+          canRetry={canRetry}
           label={failureLabel}
           retryLabel={retryLabel}
           icon={AlertCircle}
@@ -353,11 +358,13 @@ function ImageLoadingPlaceholder(): JSX.Element {
 }
 
 function ImageLoadFailurePlaceholder({
+  canRetry,
   icon: Icon,
   label,
   onRetry,
   retryLabel
 }: {
+  canRetry: boolean;
   icon: LucideIcon;
   label: string;
   onRetry: () => void;
@@ -374,10 +381,12 @@ function ImageLoadFailurePlaceholder({
       <span className="max-w-full truncate text-xs" title={label}>
         {label}
       </span>
-      <Button type="button" variant="ghost" size="xs" onClick={onRetry}>
-        <RotateCcw aria-hidden="true" />
-        {retryLabel}
-      </Button>
+      {canRetry ? (
+        <Button type="button" variant="ghost" size="xs" onClick={onRetry}>
+          <RotateCcw aria-hidden="true" />
+          {retryLabel}
+        </Button>
+      ) : null}
     </div>
   );
 }
@@ -465,6 +474,20 @@ function imageFailureSource(
       attachmentId ? runtime?.readSessionAttachment : runtime?.readPromptAsset
     )
   };
+}
+
+function canRetryImageFailure(source: ImageFailureSource): boolean {
+  return source.kind === "resolved" || source.readerAvailable;
+}
+
+function imageFailureLabelKey(
+  source: ImageFailureSource
+):
+  | "agentHost.agentGui.imageLoadFailed"
+  | "agentHost.agentGui.imageTemporarilyUnavailable" {
+  return source.kind === "locator" && !source.readerAvailable
+    ? "agentHost.agentGui.imageTemporarilyUnavailable"
+    : "agentHost.agentGui.imageLoadFailed";
 }
 
 function isMatchingImageFailure(

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
@@ -859,6 +859,9 @@ describe("AgentTranscriptItemView render stability", () => {
       await screen.findByTestId("agent-gui-message-image-failed")
     ).toBeInTheDocument();
     expect(
+      screen.getByText("agentHost.agentGui.imageLoadFailed")
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole("button", { name: "agentHost.agentGui.retryImage" })
     ).toBeInTheDocument();
 
@@ -877,6 +880,46 @@ describe("AgentTranscriptItemView render stability", () => {
 
     expect(screen.queryByTestId("agent-gui-message-image-failed")).toBeNull();
     expect(screen.queryByTestId("agent-gui-message-image-loading")).toBeNull();
+  });
+
+  it("does not offer retry when a prompt image is unavailable in this host", async () => {
+    delete (window as { agentGUIRuntime?: unknown }).agentGUIRuntime;
+
+    render(
+      <AgentMessageBlock
+        workspaceRoot="/workspace/demo"
+        basePath="/workspace/demo"
+        row={userMessageRow({
+          kind: "message-content",
+          id: "user-images-unavailable",
+          turnId: "turn-1",
+          body: "",
+          contentKind: "image-grid",
+          images: [
+            {
+              id: "unavailable-image",
+              workspaceId: "room-1",
+              agentSessionId: "session-1",
+              attachmentId: "attachment-from-another-host",
+              mimeType: "image/png",
+              name: "screen.png"
+            }
+          ],
+          occurredAtUnixMs: 1
+        })}
+        thinkingLabel="Thought process"
+      />
+    );
+
+    expect(
+      await screen.findByTestId("agent-gui-message-image-failed")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("agentHost.agentGui.imageTemporarilyUnavailable")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "agentHost.agentGui.retryImage" })
+    ).toBeNull();
   });
 
   it("starts a fresh load when a failed remote image URL changes", async () => {

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
@@ -654,6 +654,102 @@ describe("AgentTranscriptItemView render stability", () => {
     delete (window as { agentGUIRuntime?: unknown }).agentGUIRuntime;
   });
 
+  it("offers retry for an ordinary prompt image read failure", async () => {
+    const readSessionAttachment = vi.fn(async () => {
+      throw new Error("attachment not found");
+    });
+    Object.defineProperty(window, "agentGUIRuntime", {
+      configurable: true,
+      value: {
+        readSessionAttachment
+      } as Partial<AgentGUIRuntime>
+    });
+
+    render(
+      <AgentMessageBlock
+        workspaceRoot="/workspace/demo"
+        basePath="/workspace/demo"
+        row={userMessageRow({
+          kind: "message-content",
+          id: "user-images-read-failed",
+          turnId: "turn-1",
+          body: "",
+          contentKind: "image-grid",
+          images: [
+            {
+              id: "read-failed-image",
+              workspaceId: "room-1",
+              agentSessionId: "session-1",
+              attachmentId: "attachment-read-failed",
+              mimeType: "image/png",
+              name: "screen.png"
+            }
+          ],
+          occurredAtUnixMs: 1
+        })}
+        thinkingLabel="Thought process"
+      />
+    );
+
+    expect(
+      await screen.findByText("agentHost.agentGui.imageLoadFailed")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "agentHost.agentGui.retryImage" })
+    ).toBeInTheDocument();
+
+    delete (window as { agentGUIRuntime?: unknown }).agentGUIRuntime;
+  });
+
+  it("does not offer retry when the prompt image belongs to another VM", async () => {
+    const readSessionAttachment = vi.fn(async () => {
+      throw Object.assign(new Error("attachment is on another VM"), {
+        code: "agent_session_attachment_vm_unavailable"
+      });
+    });
+    Object.defineProperty(window, "agentGUIRuntime", {
+      configurable: true,
+      value: {
+        readSessionAttachment
+      } as Partial<AgentGUIRuntime>
+    });
+
+    render(
+      <AgentMessageBlock
+        workspaceRoot="/workspace/demo"
+        basePath="/workspace/demo"
+        row={userMessageRow({
+          kind: "message-content",
+          id: "user-images-vm-unavailable",
+          turnId: "turn-1",
+          body: "",
+          contentKind: "image-grid",
+          images: [
+            {
+              id: "vm-unavailable-image",
+              workspaceId: "room-1",
+              agentSessionId: "session-1",
+              attachmentId: "attachment-from-another-vm",
+              mimeType: "image/png",
+              name: "screen.png"
+            }
+          ],
+          occurredAtUnixMs: 1
+        })}
+        thinkingLabel="Thought process"
+      />
+    );
+
+    expect(
+      await screen.findByText("agentHost.agentGui.imageTemporarilyUnavailable")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "agentHost.agentGui.retryImage" })
+    ).toBeNull();
+
+    delete (window as { agentGUIRuntime?: unknown }).agentGUIRuntime;
+  });
+
   it("keeps a loaded optimistic image mounted when its durable attachment arrives", async () => {
     const readPromptAsset = vi.fn(async () => ({
       attachmentId: "prompt-asset-1",


### PR DESCRIPTION
## Summary

- Keep `图片加载失败` for actual image loading or reading failures.
- Show `图片暂时无法查看` when TSH/desktopd explicitly reports `agent_session_attachment_vm_unavailable`.
- Hide Retry for source-VM-unavailable images while preserving Retry for ordinary read and remote-image failures.
- Add regression coverage for source-VM and ordinary read failures.

## Why
The AgentGUI renderer must consume a semantic source-VM error from desktopd; it must not infer that every HTTP 404 is a VM failure.

## Validation

- `pnpm --dir packages/agent/gui typecheck` passed.
- AgentGUI test suite passed: 324 files / 2923 tests.
- Tutti checked push gate passed 13 lanes.

## Notes
- The desktopd protocol and source-device classification are in [TSH PR #2785](https://github.com/tutti-lab/tsh/pull/2785).
- No E2E tests were run.