### PR TITLE
fix(agent): return session mention links

### DIFF
--- a/docs/conventions/tutti-cli-contract.md
+++ b/docs/conventions/tutti-cli-contract.md
@@ -81,9 +81,11 @@ compatibility alias. It resolves the currently active Turn, emits a
 
 ## Agent Session References
 
-Session objects returned by the builtin `agent sessions`, `agent get`,
-`agent start`, `agent send`, `agent open`, and `agent wait` JSON commands carry
-the raw `agentSessionId` plus `workspaceId` and a canonical `mentionUri`:
+Each item returned by `agent sessions` carries the raw `agentSessionId` plus
+`workspaceId` and a canonical `mentionUri`. Singleton `agent get`, `agent
+start`, `agent send`, `agent open`, and `agent wait` JSON results expose the
+same three fields at the top level so consumers do not need command-specific
+nested lookup:
 
 ```json
 {
@@ -96,7 +98,8 @@ the raw `agentSessionId` plus `workspaceId` and a canonical `mentionUri`:
 Agents should use `mentionUri` as the destination of a descriptive Markdown
 link when returning a session reference. Consumers must treat it as internal
 data for Tutti mention routing, not as a web URL, filesystem path, or command.
-The raw ids remain available for CLI continuation and automation.
+Nested session objects retain the same reference fields for compatibility, and
+raw ids remain available for CLI continuation and automation.
 
 ## Boundaries
 

--- a/docs/conventions/tutti-cli-contract.md
+++ b/docs/conventions/tutti-cli-contract.md
@@ -79,6 +79,25 @@ The old `agent cancel --session-id <id>` path remains an integration-only
 compatibility alias. It resolves the currently active Turn, emits a
 `deprecated_agent_cancel` warning, and must not be used by new integrations.
 
+## Agent Session References
+
+Session objects returned by the builtin `agent sessions`, `agent get`,
+`agent start`, `agent send`, `agent open`, and `agent wait` JSON commands carry
+the raw `agentSessionId` plus `workspaceId` and a canonical `mentionUri`:
+
+```json
+{
+  "agentSessionId": "session-1",
+  "workspaceId": "workspace-1",
+  "mentionUri": "mention://agent-session/session-1?workspaceId=workspace-1"
+}
+```
+
+Agents should use `mentionUri` as the destination of a descriptive Markdown
+link when returning a session reference. Consumers must treat it as internal
+data for Tutti mention routing, not as a web URL, filesystem path, or command.
+The raw ids remain available for CLI continuation and automation.
+
 ## Boundaries
 
 The daemon has two CLI command surfaces:

--- a/packages/agent/runtimeprep/capability_test.go
+++ b/packages/agent/runtimeprep/capability_test.go
@@ -59,6 +59,8 @@ func TestHostAppContextUsesNativeGeneratedImageArtifactsOnlyForSupportedProvider
 	}
 	if !strings.Contains(codexPolicy, "rendered directly from `imageGeneration` tool output") ||
 		!strings.Contains(codexPolicy, "do not repeat generated images as Markdown image tags") ||
+		!strings.Contains(codexPolicy, "[title](mentionUri)") ||
+		!strings.Contains(codexPolicy, "never return only `agentSessionId`") ||
 		strings.Contains(codexPolicy, "final response must include Markdown image tag") {
 		t.Fatalf("codex host policy = %q, want native generated-image artifact contract", codexPolicy)
 	}

--- a/packages/agent/runtimeprep/policy_templates/host-app-context.md
+++ b/packages/agent/runtimeprep/policy_templates/host-app-context.md
@@ -4,9 +4,7 @@ You are running inside the Tutti desktop app host, which can render local and we
 
 ## Media
 
-- Images/videos: use Markdown, e.g. `![alt](/absolute/path.png)`.
-- Local media/file links: absolute filesystem paths only.
-- Public direct image URL: render as image, e.g. `![alt](https://example.com/image.png)`.
+- Images/videos: use Markdown with absolute paths for local files or direct public URLs.
 
 {{GENERATED_IMAGE_OUTPUT_POLICY}}
 
@@ -24,3 +22,4 @@ You are running inside the Tutti desktop app host, which can render local and we
 - Code/workspace files: use `[filename](/abs/path)` Markdown links; target must be absolute. For spaces: `[filename](</abs/path with spaces>)`.
 - No relative paths, line suffixes, `file://`, `vscode://`, or link backticks.
 - Web URLs: Markdown links, e.g. `[label](https://example.com)`.
+- Agent sessions: render returned `mentionUri` as `[title](mentionUri)`; never return only `agentSessionId`.

--- a/packages/agent/runtimeprep/preparer_test.go
+++ b/packages/agent/runtimeprep/preparer_test.go
@@ -279,7 +279,9 @@ func TestDefaultPreparerCodexWritesInstructionsSkillManifestAndEnv(t *testing.T)
 	if !strings.Contains(string(skill), "`tutti <scope> --help`") ||
 		!strings.Contains(string(skill), "this skill's `command-guide.md`") ||
 		!strings.Contains(string(skill), "mention://agent-target") ||
-		!strings.Contains(string(skill), "handed off, not absorbed") {
+		!strings.Contains(string(skill), "handed off, not absorbed") ||
+		!strings.Contains(string(skill), "render the session as a descriptive Markdown link") ||
+		!strings.Contains(string(skill), "keep the raw `agentSessionId` only as secondary data") {
 		t.Fatalf("skill content = %q", string(skill))
 	}
 	commandGuideReference, err := os.ReadFile(filepath.Join(codexHome, "skills", "tutti-cli", commandGuideReferencePath))

--- a/packages/agent/runtimeprep/skill_templates/tutti-cli.md
+++ b/packages/agent/runtimeprep/skill_templates/tutti-cli.md
@@ -105,6 +105,7 @@ Output rules:
 
 - Follow each capability's advertised default output mode and JSON support.
 - Save ids returned by create/start/run-create commands and reuse them.
+- When an Agent command returns `mentionUri`, render the session as a descriptive Markdown link using that exact value; keep the raw `agentSessionId` only as secondary data.
   {{if .OutputModes}}- Advertised default modes in this snapshot: {{range .OutputModes}}`{{.}}` {{end}}
   {{end}}
 

--- a/services/tuttid/service/cli/providers/agentcontext/compact_output.go
+++ b/services/tuttid/service/cli/providers/agentcontext/compact_output.go
@@ -2,6 +2,7 @@ package agentcontext
 
 import (
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"strings"
 
@@ -11,7 +12,27 @@ import (
 
 type imageLocalPathResolver func(agentSessionID string, attachmentID string, mimeType string) (string, bool)
 
-func sessionSummaryValue(session agentservice.Session) map[string]any {
+func agentSessionMentionURI(workspaceID string, sessionID string) string {
+	workspaceID = strings.TrimSpace(workspaceID)
+	sessionID = strings.TrimSpace(sessionID)
+	if workspaceID == "" || sessionID == "" {
+		return ""
+	}
+	query := url.Values{"workspaceId": []string{workspaceID}}
+	return "mention://agent-session/" + url.PathEscape(sessionID) + "?" + query.Encode()
+}
+
+func addAgentSessionReference(value map[string]any, workspaceID string, sessionID string) {
+	workspaceID = strings.TrimSpace(workspaceID)
+	mentionURI := agentSessionMentionURI(workspaceID, sessionID)
+	if mentionURI == "" {
+		return
+	}
+	value["workspaceId"] = workspaceID
+	value["mentionUri"] = mentionURI
+}
+
+func sessionSummaryValue(workspaceID string, session agentservice.Session) map[string]any {
 	value := map[string]any{
 		"agentSessionId":  strings.TrimSpace(session.ID),
 		"agentTargetId":   strings.TrimSpace(session.AgentTargetID),
@@ -22,6 +43,7 @@ func sessionSummaryValue(session agentservice.Session) map[string]any {
 		"createdAtUnixMs": session.CreatedAt.UnixMilli(),
 		"activeTurnId":    nil,
 	}
+	addAgentSessionReference(value, workspaceID, session.ID)
 	if session.UpdatedAt != nil {
 		value["updatedAtUnixMs"] = session.UpdatedAt.UnixMilli()
 	}
@@ -47,21 +69,22 @@ func sessionSummaryValue(session agentservice.Session) map[string]any {
 	return value
 }
 
-func sessionInspectValue(session agentservice.Session) map[string]any {
-	value := sessionSummaryValue(session)
+func sessionInspectValue(workspaceID string, session agentservice.Session) map[string]any {
+	value := sessionSummaryValue(workspaceID, session)
 	if session.Settings != nil {
 		value["settings"] = agentservice.ComposerSettingsToMap(*session.Settings)
 	}
 	return value
 }
 
-func sessionActionValue(session agentservice.Session) map[string]any {
+func sessionActionValue(workspaceID string, session agentservice.Session) map[string]any {
 	value := map[string]any{
 		"agentSessionId": strings.TrimSpace(session.ID),
 		"agentTargetId":  strings.TrimSpace(session.AgentTargetID),
 		"provider":       strings.TrimSpace(session.Provider),
 		"activeTurnId":   strings.TrimSpace(session.ActiveTurnID),
 	}
+	addAgentSessionReference(value, workspaceID, session.ID)
 	if session.Title != nil {
 		title := strings.TrimSpace(*session.Title)
 		if title != "" {
@@ -85,10 +108,10 @@ func isolationCompactValue(isolation agentservice.SessionIsolation) map[string]a
 	return value
 }
 
-func sessionSummaryValues(sessions []agentservice.Session) []any {
+func sessionSummaryValues(workspaceID string, sessions []agentservice.Session) []any {
 	values := make([]any, 0, len(sessions))
 	for _, session := range sessions {
-		values = append(values, sessionSummaryValue(session))
+		values = append(values, sessionSummaryValue(workspaceID, session))
 	}
 	return values
 }

--- a/services/tuttid/service/cli/providers/agentcontext/compact_output.go
+++ b/services/tuttid/service/cli/providers/agentcontext/compact_output.go
@@ -24,10 +24,12 @@ func agentSessionMentionURI(workspaceID string, sessionID string) string {
 
 func addAgentSessionReference(value map[string]any, workspaceID string, sessionID string) {
 	workspaceID = strings.TrimSpace(workspaceID)
+	sessionID = strings.TrimSpace(sessionID)
 	mentionURI := agentSessionMentionURI(workspaceID, sessionID)
 	if mentionURI == "" {
 		return
 	}
+	value["agentSessionId"] = sessionID
 	value["workspaceId"] = workspaceID
 	value["mentionUri"] = mentionURI
 }

--- a/services/tuttid/service/cli/providers/agentcontext/compact_output_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/compact_output_test.go
@@ -141,12 +141,15 @@ func TestMessageCompactImageLocalPathPrefersResolverOverPayloadPath(t *testing.T
 }
 
 func TestSessionSummaryValueOmitsRuntimeContext(t *testing.T) {
-	value := sessionSummaryValue(agentserviceSessionWithRuntime())
+	value := sessionSummaryValue("WORKSPACE-1", agentserviceSessionWithRuntime())
 	if value["agentSessionId"] != "SESSION-1" {
 		t.Fatalf("value = %#v", value)
 	}
 	if value["agentTargetId"] != "local:codex" {
 		t.Fatalf("agentTargetId = %#v", value["agentTargetId"])
+	}
+	if value["workspaceId"] != "WORKSPACE-1" || value["mentionUri"] != "mention://agent-session/SESSION-1?workspaceId=WORKSPACE-1" {
+		t.Fatalf("session reference = %#v", value)
 	}
 	if _, ok := value["id"]; ok {
 		t.Fatalf("session JSON should use typed id key: %#v", value)
@@ -166,7 +169,7 @@ func TestSessionSummaryValueOmitsRuntimeContext(t *testing.T) {
 }
 
 func TestSessionSummaryValueIncludesTurnEntitiesAndInteractions(t *testing.T) {
-	value := sessionSummaryValue(agentserviceSessionWithLifecycle())
+	value := sessionSummaryValue("WORKSPACE-1", agentserviceSessionWithLifecycle())
 
 	turn, ok := value["latestTurn"].(map[string]any)
 	if !ok {
@@ -184,14 +187,14 @@ func TestSessionSummaryValueIncludesTurnEntitiesAndInteractions(t *testing.T) {
 }
 
 func TestSessionInspectValueIncludesTurnEntities(t *testing.T) {
-	value := sessionInspectValue(agentserviceSessionWithLifecycle())
+	value := sessionInspectValue("WORKSPACE-1", agentserviceSessionWithLifecycle())
 	if _, ok := value["latestTurn"].(map[string]any); !ok {
 		t.Fatalf("latestTurn = %#v", value["latestTurn"])
 	}
 }
 
 func TestSessionActionValueIncludesExactAgentTarget(t *testing.T) {
-	value := sessionActionValue(agentserviceSessionWithRuntime())
+	value := sessionActionValue("WORKSPACE-1", agentserviceSessionWithRuntime())
 	if value["agentTargetId"] != "local:codex" {
 		t.Fatalf("agentTargetId = %#v", value["agentTargetId"])
 	}
@@ -204,8 +207,8 @@ func TestSessionValuesIncludeWorktreeIsolation(t *testing.T) {
 		Branch: "tutti/SESSION-1", BaseCommit: "abc123",
 	}
 	for name, value := range map[string]map[string]any{
-		"summary": sessionSummaryValue(session),
-		"action":  sessionActionValue(session),
+		"summary": sessionSummaryValue("WORKSPACE-1", session),
+		"action":  sessionActionValue("WORKSPACE-1", session),
 	} {
 		isolation, ok := value["isolation"].(map[string]any)
 		if !ok || isolation["mode"] != "worktree" || isolation["worktreeId"] != "worktree-1" ||
@@ -217,7 +220,7 @@ func TestSessionValuesIncludeWorktreeIsolation(t *testing.T) {
 }
 
 func TestSessionSummaryValueOmitsOptionalEmptyRuntimeProtocolFields(t *testing.T) {
-	value := sessionSummaryValue(agentservice.Session{
+	value := sessionSummaryValue("WORKSPACE-1", agentservice.Session{
 		ID:           "SESSION-1",
 		Provider:     "codex",
 		ActiveTurnID: "",
@@ -227,6 +230,17 @@ func TestSessionSummaryValueOmitsOptionalEmptyRuntimeProtocolFields(t *testing.T
 	}
 	if interactions, ok := value["pendingInteractions"].([]any); !ok || len(interactions) != 0 {
 		t.Fatalf("pendingInteractions = %#v", value["pendingInteractions"])
+	}
+}
+
+func TestAgentSessionMentionURIEscapesIdentifiers(t *testing.T) {
+	got := agentSessionMentionURI(" workspace one/blue ", " session/one? ")
+	want := "mention://agent-session/session%2Fone%3F?workspaceId=workspace+one%2Fblue"
+	if got != want {
+		t.Fatalf("agentSessionMentionURI() = %q, want %q", got, want)
+	}
+	if got := agentSessionMentionURI("", "SESSION-1"); got != "" {
+		t.Fatalf("agentSessionMentionURI() without workspace = %q", got)
 	}
 }
 

--- a/services/tuttid/service/cli/providers/agentcontext/provider_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider_test.go
@@ -553,6 +553,7 @@ func TestSessionSummaryCommandUsesLimitAndAfterVersion(t *testing.T) {
 	if !ok || session["agentSessionId"] != "SESSION-1" {
 		t.Fatalf("output = %#v", output.Value)
 	}
+	requireAgentSessionReference(t, output.Value, "workspace-1", "SESSION-1")
 	requireAgentSessionReference(t, session, "workspace-1", "SESSION-1")
 	messages := output.Value["messages"].([]any)
 	if len(messages) != 1 {
@@ -808,6 +809,7 @@ func TestWaitCommandReturnsStopPointWithoutMessages(t *testing.T) {
 		t.Fatalf("output = %#v", output.Value)
 	}
 	session := output.Value["session"].(map[string]any)
+	requireAgentSessionReference(t, output.Value, "workspace-1", "SESSION-1")
 	requireAgentSessionReference(t, session, "workspace-1", "SESSION-1")
 	if _, ok := session["settings"]; ok {
 		t.Fatalf("wait session should stay compact: %#v", session)
@@ -1087,6 +1089,7 @@ func TestStartCommandPassesDisplayPrompt(t *testing.T) {
 		t.Fatalf("output turnId = %#v, want turn-new", output.Value["turnId"])
 	}
 	requireAgentSessionReference(t, output.Value["session"].(map[string]any), "workspace-1", "SESSION-NEW")
+	requireAgentSessionReference(t, output.Value, "workspace-1", "SESSION-NEW")
 }
 
 func TestStartCommandRequiresOneSelectorAndPrompt(t *testing.T) {
@@ -2053,6 +2056,7 @@ func TestGetCommandReturnsEmptyConversationWithSession(t *testing.T) {
 	if session["agentSessionId"] != "SESSION-1" || sessions.workspaceID != "workspace-1" {
 		t.Fatalf("output = %#v sessions = %#v", output.Value, sessions)
 	}
+	requireAgentSessionReference(t, output.Value, "workspace-1", "SESSION-1")
 	requireAgentSessionReference(t, session, "workspace-1", "SESSION-1")
 	if output.Value["view"] != getViewConversation || output.Value["hasMoreTurns"] != false {
 		t.Fatalf("output = %#v", output.Value)

--- a/services/tuttid/service/cli/providers/agentcontext/provider_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider_test.go
@@ -505,6 +505,28 @@ func optionalTestString(value *string) string {
 	return *value
 }
 
+func requireAgentSessionReference(t *testing.T, value map[string]any, workspaceID string, sessionID string) {
+	t.Helper()
+	if value["workspaceId"] != workspaceID || value["mentionUri"] != agentSessionMentionURI(workspaceID, sessionID) {
+		t.Fatalf("session reference = %#v", value)
+	}
+}
+
+func TestSessionsCommandReturnsMentionReferences(t *testing.T) {
+	sessions := &fakeAgentSessions{}
+	command := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newSessionsCommand([]string{"agent", "sessions"}, "agent-context.agent.sessions")
+	output, err := command.Handler(context.Background(), cliservice.InvokeRequest{OutputMode: cliservice.OutputModeJSON})
+	if err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
+	items := output.Value["sessions"].([]any)
+	if len(items) != 2 || sessions.workspaceID != "workspace-1" {
+		t.Fatalf("output = %#v sessions = %#v", output.Value, sessions)
+	}
+	requireAgentSessionReference(t, items[0].(map[string]any), "workspace-1", "SESSION-1")
+	requireAgentSessionReference(t, items[1].(map[string]any), "workspace-1", "SESSION-2")
+}
+
 func TestSessionSummaryCommandUsesLimitAndAfterVersion(t *testing.T) {
 	sessions := &fakeAgentSessions{}
 	command := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newSessionSummaryCommand()
@@ -531,6 +553,7 @@ func TestSessionSummaryCommandUsesLimitAndAfterVersion(t *testing.T) {
 	if !ok || session["agentSessionId"] != "SESSION-1" {
 		t.Fatalf("output = %#v", output.Value)
 	}
+	requireAgentSessionReference(t, session, "workspace-1", "SESSION-1")
 	messages := output.Value["messages"].([]any)
 	if len(messages) != 1 {
 		t.Fatalf("messages = %#v", messages)
@@ -785,6 +808,7 @@ func TestWaitCommandReturnsStopPointWithoutMessages(t *testing.T) {
 		t.Fatalf("output = %#v", output.Value)
 	}
 	session := output.Value["session"].(map[string]any)
+	requireAgentSessionReference(t, session, "workspace-1", "SESSION-1")
 	if _, ok := session["settings"]; ok {
 		t.Fatalf("wait session should stay compact: %#v", session)
 	}
@@ -1062,6 +1086,7 @@ func TestStartCommandPassesDisplayPrompt(t *testing.T) {
 	if output.Value["turnId"] != "turn-new" {
 		t.Fatalf("output turnId = %#v, want turn-new", output.Value["turnId"])
 	}
+	requireAgentSessionReference(t, output.Value["session"].(map[string]any), "workspace-1", "SESSION-NEW")
 }
 
 func TestStartCommandRequiresOneSelectorAndPrompt(t *testing.T) {
@@ -2028,6 +2053,7 @@ func TestGetCommandReturnsEmptyConversationWithSession(t *testing.T) {
 	if session["agentSessionId"] != "SESSION-1" || sessions.workspaceID != "workspace-1" {
 		t.Fatalf("output = %#v sessions = %#v", output.Value, sessions)
 	}
+	requireAgentSessionReference(t, session, "workspace-1", "SESSION-1")
 	if output.Value["view"] != getViewConversation || output.Value["hasMoreTurns"] != false {
 		t.Fatalf("output = %#v", output.Value)
 	}

--- a/services/tuttid/service/cli/providers/agentcontext/session_commands.go
+++ b/services/tuttid/service/cli/providers/agentcontext/session_commands.go
@@ -72,6 +72,7 @@ type respondInput struct {
 
 type sessionActionResult struct {
 	Session          agentservice.Session
+	WorkspaceID      string
 	TurnID           string
 	LaunchRequested  bool
 	WaitAfterVersion *uint64
@@ -184,7 +185,7 @@ func (p Provider) runStart(ctx context.Context, invoke framework.InvokeContext, 
 	}
 	return sessionActionResult{
 		Session: session, TurnID: strings.TrimSpace(created.TurnID),
-		LaunchRequested: launchRequested, Warnings: warnings,
+		LaunchRequested: launchRequested, Warnings: warnings, WorkspaceID: invoke.WorkspaceID,
 	}, nil
 }
 
@@ -270,7 +271,7 @@ func (p Provider) runOpen(ctx context.Context, invoke framework.InvokeContext, i
 	if err := p.publishLaunchRequested(ctx, invoke.WorkspaceID, session, "open", invoke.Request.Context.Source); err != nil {
 		return nil, err
 	}
-	return sessionActionResult{Session: session, LaunchRequested: true}, nil
+	return sessionActionResult{Session: session, LaunchRequested: true, WorkspaceID: invoke.WorkspaceID}, nil
 }
 
 func (p Provider) newGetCommand() cliservice.Command {
@@ -351,6 +352,7 @@ func (p Provider) runSend(ctx context.Context, invoke framework.InvokeContext, i
 	session := result.Session
 	return sessionActionResult{
 		Session: session, TurnID: strings.TrimSpace(result.TurnID), WaitAfterVersion: &waitAfterVersion,
+		WorkspaceID: invoke.WorkspaceID,
 	}, nil
 }
 
@@ -575,7 +577,7 @@ func (p Provider) runLegacyCancel(ctx context.Context, invoke framework.InvokeCo
 		}
 	}
 	return sessionActionResult{
-		Session: session,
+		Session: session, WorkspaceID: invoke.WorkspaceID,
 		Warnings: []cliservice.CommandWarning{{
 			Code:    "deprecated_agent_cancel",
 			Message: "agent cancel is deprecated; use agent cancel-turn --session-id <id> --turn-id <id>",
@@ -605,7 +607,7 @@ func sessionActionOutputSpec() framework.OutputSpec {
 				action := result.(sessionActionResult)
 				value := map[string]any{
 					"launchRequested": action.LaunchRequested,
-					"session":         sessionActionValue(action.Session),
+					"session":         sessionActionValue(action.WorkspaceID, action.Session),
 				}
 				if turnID := strings.TrimSpace(action.TurnID); turnID != "" {
 					value["turnId"] = turnID

--- a/services/tuttid/service/cli/providers/agentcontext/session_commands.go
+++ b/services/tuttid/service/cli/providers/agentcontext/session_commands.go
@@ -609,6 +609,7 @@ func sessionActionOutputSpec() framework.OutputSpec {
 					"launchRequested": action.LaunchRequested,
 					"session":         sessionActionValue(action.WorkspaceID, action.Session),
 				}
+				addAgentSessionReference(value, action.WorkspaceID, action.Session.ID)
 				if turnID := strings.TrimSpace(action.TurnID); turnID != "" {
 					value["turnId"] = turnID
 				}

--- a/services/tuttid/service/cli/providers/agentcontext/session_get.go
+++ b/services/tuttid/service/cli/providers/agentcontext/session_get.go
@@ -291,6 +291,7 @@ func sessionGetJSONValue(result any) map[string]any {
 		"view":    got.View,
 		"session": sessionInspectValue(got.WorkspaceID, got.Session),
 	}
+	addAgentSessionReference(value, got.WorkspaceID, got.Session.ID)
 	switch got.View {
 	case getViewTurns:
 		value["turns"] = sessionGetTurnSummaryValues(got.TurnSummaries)

--- a/services/tuttid/service/cli/providers/agentcontext/session_get.go
+++ b/services/tuttid/service/cli/providers/agentcontext/session_get.go
@@ -28,6 +28,7 @@ type sessionGetResult struct {
 	Trace          *sessionGetTraceResult
 	HasMoreTurns   bool
 	ImageLocalPath imageLocalPathResolver
+	WorkspaceID    string
 }
 
 type sessionGetTurnResult struct {
@@ -55,7 +56,7 @@ func (p Provider) getSessionContext(ctx context.Context, workspaceID string, inp
 		if err != nil {
 			return nil, err
 		}
-		return sessionGetResult{View: view, Session: session}, nil
+		return sessionGetResult{View: view, Session: session, WorkspaceID: workspaceID}, nil
 	}
 
 	session, err := p.sessions.Get(ctx, workspaceID, input.SessionID)
@@ -66,6 +67,7 @@ func (p Provider) getSessionContext(ctx context.Context, workspaceID string, inp
 		View:           view,
 		Session:        session,
 		ImageLocalPath: p.imageLocalPathResolver(ctx, workspaceID),
+		WorkspaceID:    workspaceID,
 	}
 	if view == getViewTrace {
 		trace, err := p.getSessionTrace(ctx, workspaceID, input)
@@ -287,7 +289,7 @@ func sessionGetJSONValue(result any) map[string]any {
 	got := result.(sessionGetResult)
 	value := map[string]any{
 		"view":    got.View,
-		"session": sessionInspectValue(got.Session),
+		"session": sessionInspectValue(got.WorkspaceID, got.Session),
 	}
 	switch got.View {
 	case getViewTurns:

--- a/services/tuttid/service/cli/providers/agentcontext/sessions.go
+++ b/services/tuttid/service/cli/providers/agentcontext/sessions.go
@@ -55,10 +55,17 @@ type sessionSummaryResult struct {
 	ImageLocalPath imageLocalPathResolver
 	Page           agentservice.SessionMessagesPage
 	Session        agentservice.Session
+	WorkspaceID    string
 }
 
 type waitCommandResult struct {
-	Result agentservice.WaitResult
+	Result      agentservice.WaitResult
+	WorkspaceID string
+}
+
+type sessionListResult struct {
+	Sessions    []agentservice.Session
+	WorkspaceID string
 }
 
 type turnResourcesResult struct {
@@ -84,12 +91,13 @@ func (p Provider) newSessionsCommand(path []string, id string) cliservice.Comman
 			Table: &framework.TableOutputSpec{
 				Columns: sessionColumns,
 				Rows: func(result any) []map[string]any {
-					return sessionRows(result.([]agentservice.Session))
+					return sessionRows(result.(sessionListResult).Sessions)
 				},
 			},
 			JSONViews: map[framework.OutputView]func(any) map[string]any{
 				framework.ViewSummary: func(result any) map[string]any {
-					return map[string]any{"sessions": sessionSummaryValues(result.([]agentservice.Session))}
+					listed := result.(sessionListResult)
+					return map[string]any{"sessions": sessionSummaryValues(listed.WorkspaceID, listed.Sessions)}
 				},
 			},
 			ListCompact: true,
@@ -102,7 +110,11 @@ func (p Provider) runSessions(ctx context.Context, invoke framework.InvokeContex
 	if err := p.requireSessions(); err != nil {
 		return nil, err
 	}
-	return p.sessions.List(ctx, invoke.WorkspaceID)
+	sessions, err := p.sessions.List(ctx, invoke.WorkspaceID)
+	if err != nil {
+		return nil, err
+	}
+	return sessionListResult{Sessions: sessions, WorkspaceID: invoke.WorkspaceID}, nil
 }
 
 func (p Provider) newSessionSummaryCommand() cliservice.Command {
@@ -199,6 +211,7 @@ func (p Provider) runSessionSummary(ctx context.Context, invoke framework.Invoke
 		ImageLocalPath: p.imageLocalPathResolver(ctx, invoke.WorkspaceID),
 		Page:           page,
 		Session:        session,
+		WorkspaceID:    invoke.WorkspaceID,
 	}, nil
 }
 
@@ -225,7 +238,7 @@ func (p Provider) runWait(ctx context.Context, invoke framework.InvokeContext, i
 	if err != nil {
 		return nil, err
 	}
-	return waitCommandResult{Result: result}, nil
+	return waitCommandResult{Result: result, WorkspaceID: invoke.WorkspaceID}, nil
 }
 
 func (p Provider) runTurnResources(ctx context.Context, invoke framework.InvokeContext, input turnResourcesInput) (any, error) {
@@ -262,7 +275,7 @@ func sessionSummaryJSONValue(result any) map[string]any {
 	summary := result.(sessionSummaryResult)
 	return map[string]any{
 		"agentSessionId": summary.Page.AgentSessionID,
-		"session":        sessionInspectValue(summary.Session),
+		"session":        sessionInspectValue(summary.WorkspaceID, summary.Session),
 		"messages":       messageCompactValues(summary.Page.Messages, summary.ImageLocalPath),
 		"latestVersion":  summary.Page.LatestVersion,
 		"hasMore":        summary.Page.HasMore,
@@ -285,7 +298,7 @@ func waitJSONValue(result any) map[string]any {
 	value := map[string]any{
 		"agentSessionId": waited.Result.Session.ID,
 		"turnId":         nil,
-		"session":        sessionSummaryValue(waited.Result.Session),
+		"session":        sessionSummaryValue(waited.WorkspaceID, waited.Result.Session),
 		"latestVersion":  waited.Result.LatestVersion,
 		"effectiveAfter": waited.Result.EffectiveAfter,
 		"timedOut":       waited.Result.TimedOut,

--- a/services/tuttid/service/cli/providers/agentcontext/sessions.go
+++ b/services/tuttid/service/cli/providers/agentcontext/sessions.go
@@ -273,13 +273,15 @@ func (p Provider) imageLocalPathResolver(ctx context.Context, workspaceID string
 
 func sessionSummaryJSONValue(result any) map[string]any {
 	summary := result.(sessionSummaryResult)
-	return map[string]any{
+	value := map[string]any{
 		"agentSessionId": summary.Page.AgentSessionID,
 		"session":        sessionInspectValue(summary.WorkspaceID, summary.Session),
 		"messages":       messageCompactValues(summary.Page.Messages, summary.ImageLocalPath),
 		"latestVersion":  summary.Page.LatestVersion,
 		"hasMore":        summary.Page.HasMore,
 	}
+	addAgentSessionReference(value, summary.WorkspaceID, summary.Page.AgentSessionID)
+	return value
 }
 
 func turnResourcesJSONValue(result any) map[string]any {
@@ -304,6 +306,7 @@ func waitJSONValue(result any) map[string]any {
 		"timedOut":       waited.Result.TimedOut,
 		"reason":         string(waited.Result.Reason),
 	}
+	addAgentSessionReference(value, waited.WorkspaceID, waited.Result.Session.ID)
 	if turnID := strings.TrimSpace(waited.Result.TurnID); turnID != "" {
 		value["turnId"] = turnID
 	}


### PR DESCRIPTION
## Summary

- add canonical `workspaceId` and `mentionUri` fields to agent session list, get, start, send, open, and wait JSON projections
- teach the desktop host policy and bundled `$tutti-cli` skill to render returned sessions as descriptive Markdown mention links
- document the agent-session reference contract and cover URI escaping plus framework output paths

## Validation

- `go test ./services/tuttid/service/cli/... ./packages/agent/runtimeprep/...`
- `git diff --check origin/main...HEAD`
- independent subagent review: no actionable findings

## Risk

Low. This is an additive JSON contract; raw session ids remain unchanged for automation. Empty identifiers omit the reference fields, while public session commands already require workspace and session identity.