### PR TITLE
feat(agent): track terminal turn outcomes

### DIFF
--- a/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
+++ b/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
@@ -138,9 +138,10 @@ export async function createWorkspaceWindowContainer(): Promise<WorkspaceWindowC
     available: analyticsDebugAvailable,
     eventStreamClient: tuttidEventStreamClient
   });
+  const workspaceUiMode = routeView === "agent" ? "agent" : "os";
   const reporterService = registerReporterServices(registry, {
     tuttidClient,
-    mode: routeView === "agent" ? "agent" : "os"
+    mode: workspaceUiMode
   });
   const reportPredefinePageview = shouldReportPredefinePageview(
     window.location.search
@@ -261,6 +262,7 @@ export async function createWorkspaceWindowContainer(): Promise<WorkspaceWindowC
     terminalCommandRunner: createAgentProviderTerminalCommandRunner(
       desktopApi.runtime
     ),
+    uiMode: workspaceUiMode,
     windowLifecycle,
     workspaceId: activeWorkspaceID,
     workspaceUserProjectService

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -456,7 +456,8 @@ test("desktop agent activity adapter forwards typed submit diagnostics", async (
         };
       }
     }),
-    runtimeApi: createRuntimeApi()
+    runtimeApi: createRuntimeApi(),
+    uiMode: "os"
   });
 
   const result = await adapter.sendInput({
@@ -484,7 +485,8 @@ test("desktop agent activity adapter forwards typed submit diagnostics", async (
         guidance: true,
         submitDiagnostics: {
           submittedAtUnixMs: 1234,
-          source: "agent-gui"
+          source: "agent-gui",
+          uiMode: "os"
         }
       } satisfies SendWorkspaceAgentSessionInputRequest,
       signal: controller.signal,
@@ -1363,7 +1365,8 @@ test("desktop agent activity adapter sends plan mode when creating sessions", as
         });
       }
     }),
-    runtimeApi: createRuntimeApi()
+    runtimeApi: createRuntimeApi(),
+    uiMode: "agent"
   });
 
   const session = await adapter.createSession({
@@ -1400,7 +1403,8 @@ test("desktop agent activity adapter sends plan mode when creating sessions", as
         submitDiagnostics: {
           blockCount: 1,
           submittedAtUnixMs: 12345,
-          source: "agent-gui"
+          source: "agent-gui",
+          uiMode: "agent"
         },
         model: "gpt-5.5-codex-spark",
         noProject: null,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -39,6 +39,7 @@ import {
   TuttidProtocolError
 } from "@tutti-os/client-tuttid-ts";
 import type { DesktopRuntimeApi } from "@preload/types";
+import type { DesktopWorkspaceUiMode } from "@shared/preferences";
 import { getActiveLocale } from "../../../i18n/runtime.ts";
 import { wrapLocalizedTuttidErrorIfSpecific } from "../../../lib/desktopErrors.ts";
 import { agentActivityComposerOptionsFromTuttidResult } from "../../../lib/agentComposerOptionsProjection.ts";
@@ -54,6 +55,21 @@ export interface CreateDesktopAgentActivityAdapterInput {
     workspaceId: string,
     recordingId: string
   ) => void;
+  uiMode?: DesktopWorkspaceUiMode;
+}
+
+function submitDiagnosticsWithUiMode<T extends { submitDiagnostics?: object }>(
+  input: T,
+  uiMode: DesktopWorkspaceUiMode | undefined
+): T {
+  if (!uiMode) return input;
+  return {
+    ...input,
+    submitDiagnostics: {
+      ...input.submitDiagnostics,
+      uiMode
+    }
+  };
 }
 
 // Cold ACP/model discovery is materially slower on Windows (Cursor can take
@@ -126,7 +142,8 @@ export function createDesktopAgentActivityAdapter({
   tuttidClient,
   runtimeApi,
   takePendingSessionRecording,
-  restorePendingSessionRecording
+  restorePendingSessionRecording,
+  uiMode
 }: CreateDesktopAgentActivityAdapterInput): DesktopAgentActivityCommandAdapter {
   return {
     async listSessions(input) {
@@ -286,13 +303,16 @@ export function createDesktopAgentActivityAdapter({
         const agentTargetId = requiredAgentTargetId(input.agentTargetId);
         recordingId = takePendingSessionRecording?.(input.workspaceId) ?? null;
         const request = tuttiCreateWorkspaceAgentSessionRequestFromActivity(
-          {
-            ...input,
-            agentSessionId,
-            agentTargetId,
-            noProject:
-              input.noProject ?? (normalizeText(input.cwd) ? null : true)
-          },
+          submitDiagnosticsWithUiMode(
+            {
+              ...input,
+              agentSessionId,
+              agentTargetId,
+              noProject:
+                input.noProject ?? (normalizeText(input.cwd) ? null : true)
+            },
+            uiMode
+          ),
           { recordingId }
         );
         const session = await tuttidClient.createWorkspaceAgentSession(
@@ -348,8 +368,9 @@ export function createDesktopAgentActivityAdapter({
         submitDiagnostics: input.submitDiagnostics,
         workspaceId: input.workspaceId
       });
-      const request =
-        tuttiSendWorkspaceAgentSessionInputRequestFromActivity(input);
+      const request = tuttiSendWorkspaceAgentSessionInputRequestFromActivity(
+        submitDiagnosticsWithUiMode(input, uiMode)
+      );
       let result: Awaited<
         ReturnType<TuttidClient["sendWorkspaceAgentSessionInput"]>
       >;

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -21,6 +21,7 @@ import type {
   WorkspaceAgentProvider
 } from "@tutti-os/client-tuttid-ts";
 import type { DesktopHostFilesApi, DesktopRuntimeApi } from "@preload/types";
+import type { DesktopWorkspaceUiMode } from "@shared/preferences";
 import type { IReporterService } from "../../../analytics/services/reporterService.interface.ts";
 import {
   normalizeComposerSettings,
@@ -98,6 +99,7 @@ export interface WorkspaceAgentActivityServiceDependencies {
   ) => WorkspaceAgentProvider | null;
   workspaceUserProjectService?: IWorkspaceUserProjectService;
   sessionReplayEnabled?: boolean;
+  uiMode?: DesktopWorkspaceUiMode;
 }
 
 type WorkspaceAgentActivityEntry = WorkspaceAgentSessionEngineHost;
@@ -1074,6 +1076,7 @@ export class WorkspaceAgentActivityService
       reconcileSession: (command, signal) =>
         this.executeSessionReconcileCommand(command, signal),
       runtimeApi: this.dependencies.runtimeApi,
+      uiMode: this.dependencies.uiMode,
       executeEngineSendInput: async (input, options) => {
         try {
           const result = await this.executeSendInputEffect(input, options);

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.ts
@@ -20,6 +20,7 @@ import {
 import type { AgentActivityRuntimeActivateSessionInput } from "@tutti-os/agent-gui";
 import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
 import type { DesktopRuntimeApi } from "@preload/types";
+import type { DesktopWorkspaceUiMode } from "@shared/preferences";
 import type { AgentHostAgentSessionComposerSettings } from "@shared/contracts/dto";
 import {
   createDesktopAgentActivityAdapter,
@@ -68,6 +69,7 @@ interface CreateWorkspaceAgentSessionEngineHostInput {
     signal?: AbortSignal
   ): Promise<unknown>;
   runtimeApi: Pick<DesktopRuntimeApi, "logTerminalDiagnostic">;
+  uiMode?: DesktopWorkspaceUiMode;
   takePendingSessionRecording?(workspaceId: string): string | null;
   restorePendingSessionRecording?(
     workspaceId: string,
@@ -162,6 +164,7 @@ export function createWorkspaceAgentSessionEngineHost(
   const adapter = createDesktopAgentActivityAdapter({
     tuttidClient: input.tuttidClient,
     runtimeApi: input.runtimeApi,
+    uiMode: input.uiMode,
     takePendingSessionRecording: input.takePendingSessionRecording,
     restorePendingSessionRecording: input.restorePendingSessionRecording
   });

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/registerWorkspaceAgentServices.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/registerWorkspaceAgentServices.ts
@@ -10,6 +10,7 @@ import type { IReporterService } from "../../analytics/services/reporterService.
 import type { IWorkspaceUserProjectService } from "../../workspace-user-project/index.ts";
 import type { IDesktopPreferencesService } from "../../desktop-preferences/services/desktopPreferencesService.interface.ts";
 import type { NotificationService } from "@tutti-os/ui-notifications";
+import type { DesktopWorkspaceUiMode } from "@shared/preferences";
 import {
   AGENT_SESSION_RECORDING_FLAG,
   EARLY_ACCESS_AGENT_INTEGRATIONS_FLAG,
@@ -65,6 +66,7 @@ export interface WorkspaceAgentServiceRegistrationInput {
     provider: string;
   }) => string;
   terminalCommandRunner: AgentProviderTerminalCommandRunner;
+  uiMode: DesktopWorkspaceUiMode;
   windowLifecycle: WorkspaceWindowLifecycle;
   workspaceId: string;
   workspaceUserProjectService?: IWorkspaceUserProjectService;

--- a/docs/superpowers/specs/2026-08-17-agent-turn-terminal-analytics-design.md
+++ b/docs/superpowers/specs/2026-08-17-agent-turn-terminal-analytics-design.md
@@ -1,0 +1,195 @@
+# Agent Turn Terminal Analytics Design
+
+## Summary
+
+Add reliable local-desktop analytics for the terminal result of a user-submitted Agent turn. The implementation reuses the VM event family without the VM suffix:
+
+- `agent.turn_completed`
+- `agent.turn_failed`
+- `agent.turn_cancelled`
+
+The canonical Host turn settlement is the only terminal trigger. The desktop UI mode is captured when the user submits the turn, persisted with the turn submission envelope, and reused when the daemon reports the terminal event. Therefore every reported event has `mode=os` or `mode=agent`; the implementation never reports a terminal event with a missing, `null`, inferred, or hard-coded mode.
+
+This event measures a technical terminal result. `completed` means that the canonical Agent turn completed successfully; it does not prove that the answer satisfied the user's goal.
+
+## Motivation and VM Evidence
+
+The VM implementation established the useful three-event model, but its current data has two producers:
+
+- a renderer producer that knows the UI mode but can miss a settlement after its window closes;
+- a daemon producer that observes canonical settlements but does not know the submitting window's mode.
+
+A diagnostic DataFinder query for 2026-08-03 through 2026-08-16 found a `null` mode on 286 of 970 VM completed events, 33 of 103 failed events, and 38 of 61 cancelled events. Copying either VM producer alone would retain one of those defects.
+
+The local implementation must combine the useful properties of both paths: durable submission-time mode and canonical daemon-side settlement.
+
+## Goals
+
+- Report one terminal analytics event for each newly submitted, user-prompt root turn that reaches a canonical terminal outcome.
+- Preserve the exact submitting window mode, even if the window closes, the user changes modes, or the daemon restarts before settlement.
+- Keep completion, failure, and cancellation definitions aligned with canonical Host outcomes.
+- Exclude child Agent turns, automatic Goal turns, provider-initiated turns, imported history, and legacy turns that have no validated submission mode from the product completion metric.
+- Reuse VM-compatible parameter names where the local product has an authoritative value.
+- Keep prompts, responses, paths, raw error messages, and other content out of analytics.
+
+## Non-goals
+
+- Semantic grading of whether the Agent solved the user's problem.
+- User feedback, thumbs-up/down, or answer-quality analytics.
+- Retrofitting terminal events for turns created before this release.
+- Measuring provider-native child/subagent success with the product event family.
+- Changing Host turn lifecycle or settlement semantics.
+- Updating the existing DataFinder dashboard in this pull request.
+
+## Considered Approaches
+
+### 1. Persist submission mode and report canonical settlement (selected)
+
+Capture `os` or `agent` on create/send, persist it with the canonical turn's submission envelope, and report from `CommittedDelta.RootTurnsSettled`.
+
+This remains correct when the renderer disappears and preserves mode across restarts. It adds a narrow request-contract and persistence change, but it is the only approach that satisfies both reliability and mode completeness.
+
+### 2. Port the VM renderer observer
+
+Observe settled turns in the renderer and rely on the renderer reporter's common `mode` parameter. This is smaller, but it misses turns that settle after the window closes and risks duplicate reports across reloads or multiple observers.
+
+### 3. Report directly from the daemon without submission mode
+
+Observe canonical settlements in the daemon without adding submission provenance. This gives reliable outcomes but reproduces the VM `mode=null` bucket and makes OS-versus-Agent rollout analysis incomplete.
+
+## Architecture and Ownership
+
+The change does not define when a turn becomes terminal. `packages/agent/host` remains the sole owner of lifecycle semantics and already exposes exhaustive post-commit settlements through `CommittedDelta.RootTurnsSettled`.
+
+The implementation has three bounded responsibilities:
+
+1. **Desktop submission context**: the workspace window composition passes its already-authoritative route mode (`os` or `agent`) into the desktop Agent activity adapter. The adapter adds that value to typed submit diagnostics for create and send requests.
+2. **Durable submission provenance**: the daemon validates the mode, carries it in Host submission metadata, and persists the metadata JSON in the existing `TurnSubmission` envelope. The Host does not interpret the product mode or change lifecycle behavior.
+3. **Analytics adapter**: `services/tuttid/service/agent` consumes `RootTurnsSettled`, reads the matching submission envelope, applies the product population rules, and emits one terminal event through the existing daemon analytics reporter.
+
+The analytics adapter belongs in `services/tuttid` because event naming, population policy, and DataFinder parameters are product analytics concerns. No second settlement state machine is introduced.
+
+## Data Flow
+
+1. A user submits an initial prompt or follow-up from a workspace window.
+2. The desktop adapter sends `submitDiagnostics.uiMode` with the exact route mode.
+3. The daemon accepts only `os` or `agent` and adds the value to submission metadata.
+4. Host admits the turn and persists the existing turn submission envelope, including the metadata JSON and client submit ID.
+5. The canonical turn reaches `settled` with outcome `completed`, `failed`, `canceled`, or `interrupted`.
+6. Host publishes the committed `RootTurnSettled` fact after the canonical transaction commits.
+7. The tuttid analytics adapter reads the persisted envelope by workspace, session, and turn ID.
+8. If the turn is eligible and has a valid mode, the adapter reports exactly one event. Missing or invalid mode causes the event to be skipped and logged as a content-free diagnostic; it is never replaced with a guessed value.
+
+## Product Population
+
+A terminal event is reported only when all of the following are true:
+
+- the committed entity is a canonical root turn;
+- `is_child_session` is false;
+- `turn.origin` is `user_prompt`;
+- `turn.backfilled` is false;
+- the persisted submission mode is exactly `os` or `agent`.
+
+Goal arm/continuation turns, provider-initiated turns, child sessions, imported turns, and legacy turns without mode are excluded. This keeps the terminal numerator compatible with user-submission analytics and prevents automatic work from inflating completion counts.
+
+## Outcome Mapping
+
+| Canonical outcome | Event | `status` | Notes |
+| --- | --- | --- | --- |
+| `completed` | `agent.turn_completed` | `completed` | Technical completion |
+| `failed` | `agent.turn_failed` | `failed` | Canonical failure |
+| `canceled` | `agent.turn_cancelled` | `cancelled` | User/runtime cancellation |
+| `interrupted` | `agent.turn_cancelled` | `cancelled` | Distinguished by `turn_outcome=interrupted`; startup recovery is identified separately |
+
+The event family is mutually exclusive for a canonical turn. A repeated observation that does not represent a newly accepted canonical settlement must not create another event.
+
+## Event Parameters
+
+All three events include:
+
+| Parameter | Value |
+| --- | --- |
+| `mode` | Required `os` or `agent` captured at submission |
+| `agent_session_id` | Canonical Agent session ID |
+| `turn_id` | Canonical turn ID |
+| `client_submit_id` | Stable submit correlation ID when present |
+| `invocation_id` | Canonical turn ID for VM-compatible correlation |
+| `operation_id` | Canonical turn ID for VM-compatible correlation |
+| `provider` | Canonical provider, normalized to `unknown` only if absent |
+| `duration_ms` | Non-negative `settled_at - started_at` when timestamps are valid |
+| `duration_bucket` | Stable bounded duration category |
+| `turn_outcome` | Exact canonical outcome |
+| `turn_origin` | `user_prompt` |
+| `status` | Event-family status from the mapping above |
+| `event_source` | `canonical_turn_settled` |
+| `interaction_source` | `user` |
+| `surface` | `direct_session` |
+| `agent_kind` | `local-agent` |
+| `is_child_session` | `false` |
+| `startup_reconciled` | Whether Host settled the turn during startup recovery |
+| `viewer_relationship` | `self` |
+| `viewer_role` | `owner` |
+
+`agent.turn_completed` additionally includes `value_enum=completed`.
+
+`agent.turn_failed` additionally includes:
+
+- `failure_stage=settled`;
+- `error_category=runtime` for VM compatibility in the first version;
+- a bounded, content-free `error_code`, falling back to `agent_unknown_error`.
+
+It does not include the canonical raw error message. Provider error messages may contain paths, prompts, command output, or credentials and are not safe analytics dimensions.
+
+`agent.turn_cancelled` additionally includes `source=runtime_event` or `source=startup_reconciliation`.
+
+Workspace IDs, prompt/response content, file paths, command output, and raw errors are not reported.
+
+## Reliability and Failure Handling
+
+- Terminal analytics is triggered only after canonical commit and cannot affect the command result.
+- The existing analytics reporter remains best effort and owns transport buffering/retry behavior.
+- Failure to read a submission envelope or validate its mode skips the event and emits only a local structured diagnostic with correlation IDs. It does not produce a `null`, `unknown`, or fabricated mode.
+- A startup-reconciled interrupted turn is eligible only if its original user submission already persisted a valid mode. It reports as cancelled with `startup_reconciled=true`.
+- Old rows receive an empty metadata value during migration and are intentionally excluded.
+
+## Storage and Compatibility
+
+The existing turn-submission table gains a non-null metadata JSON column with an empty-object default. Record/get conflict checks include the new field so an idempotent replay cannot silently change the submitting mode.
+
+The OpenAPI submit diagnostics schema gains optional `uiMode` with the closed enum `os | agent`; generated Go and TypeScript clients are regenerated from the schema. Older clients remain compatible because the field is optional. New desktop requests always populate it for user submissions.
+
+The storage and transport changes are platform-neutral. They add no paths, process behavior, shell behavior, native dependencies, or OS branches, so Windows and POSIX behavior are identical.
+
+## Testing
+
+Focused tests cover:
+
+- desktop create and send requests include the exact workspace window mode;
+- the OpenAPI adapter accepts `os` and `agent` and rejects/omits invalid values;
+- turn submission metadata persists and is preserved across reads and idempotent replay;
+- completed, failed, canceled, and interrupted canonical settlements map to the expected event and parameters;
+- child, Goal, provider-initiated, backfilled, missing-mode, and invalid-mode turns produce no product terminal event;
+- startup-reconciled interruption reports cancellation with the recovery marker;
+- raw error messages are never present in event parameters;
+- repeated/non-accepted settlement projections do not double-report.
+
+Validation uses the repository's changed-aware check plus focused desktop, store-sqlite, and tuttid Agent package tests. The Agent Host boundary check must pass because the change observes existing lifecycle facts rather than adding adapter-owned lifecycle behavior.
+
+## Rollout and Data Validation
+
+After a build containing this change reaches production, DataFinder validation should use that app version or later and verify:
+
+- `mode` contains only `os` and `agent`; `null` is zero;
+- a `turn_id` appears in at most one event across the three-event family;
+- `turn_origin=user_prompt` and `is_child_session=false` for all rows;
+- completed, failed, and cancelled event totals reconcile with canonical user-turn terminal outcomes;
+- the dashboard excludes `startup_reconciled=true` from ordinary user cancellation-rate interpretation.
+
+Recommended product metrics are:
+
+- technical completion rate = completed terminal turns / all terminal turns;
+- failure rate = failed terminal turns / all terminal turns;
+- cancellation rate = cancelled terminal turns / all terminal turns;
+- terminal coverage = terminal turns / submissions after applying an observation window long enough for active work to settle.
+
+OS-versus-Agent comparisons group these metrics by the required submission-time `mode`. Existing dashboards are unaffected until they explicitly add the new event family.

--- a/packages/agent/activity-core/src/types.ts
+++ b/packages/agent/activity-core/src/types.ts
@@ -440,6 +440,7 @@ export interface AgentActivitySubmitDiagnostics {
   promptLength?: number;
   queued?: boolean;
   source?: string;
+  uiMode?: "os" | "agent";
 }
 
 export type AgentActivitySendInputResult =

--- a/packages/agent/activity-tuttid-adapter/src/requests.ts
+++ b/packages/agent/activity-tuttid-adapter/src/requests.ts
@@ -218,7 +218,8 @@ function tuttiSubmitDiagnosticsFromActivity(
     ...(input.source !== undefined ? { source: input.source } : {}),
     ...(input.submittedAtUnixMs !== undefined
       ? { submittedAtUnixMs: input.submittedAtUnixMs }
-      : {})
+      : {}),
+    ...(input.uiMode !== undefined ? { uiMode: input.uiMode } : {})
   };
 }
 

--- a/packages/agent/host/edit_retry_projection.go
+++ b/packages/agent/host/edit_retry_projection.go
@@ -110,9 +110,15 @@ func editRetryReplacementInput(
 	if err := json.Unmarshal([]byte(envelope.TuttiModeSnapshotJSON), &tuttiModeSnapshot); err != nil {
 		return SendInput{}, err
 	}
+	var metadata map[string]any
+	if strings.TrimSpace(envelope.MetadataJSON) != "" {
+		if err := json.Unmarshal([]byte(envelope.MetadataJSON), &metadata); err != nil {
+			return SendInput{}, err
+		}
+	}
 	return SendInput{
 		Content: normalized, DisplayPrompt: editedText,
-		CapabilityRefs: capabilityRefs, TuttiModeSnapshot: tuttiModeSnapshot,
+		CapabilityRefs: capabilityRefs, Metadata: metadata, TuttiModeSnapshot: tuttiModeSnapshot,
 	}, nil
 }
 

--- a/packages/agent/host/edit_retry_projection_test.go
+++ b/packages/agent/host/edit_retry_projection_test.go
@@ -1,0 +1,22 @@
+package agenthost
+
+import (
+	"testing"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+func TestEditRetryReplacementInputPreservesSubmissionMetadata(t *testing.T) {
+	input, err := editRetryReplacementInput(storesqlite.TurnSubmission{
+		ContentJSON:           `[{"type":"text","text":"before"}]`,
+		CapabilityRefsJSON:    `[]`,
+		TuttiModeSnapshotJSON: `null`,
+		MetadataJSON:          `{"uiMode":"agent"}`,
+	}, "after")
+	if err != nil {
+		t.Fatalf("editRetryReplacementInput() error=%v", err)
+	}
+	if input.Metadata["uiMode"] != "agent" {
+		t.Fatalf("metadata=%#v, want submission uiMode", input.Metadata)
+	}
+}

--- a/packages/agent/host/edit_retry_replacement.go
+++ b/packages/agent/host/edit_retry_replacement.go
@@ -362,7 +362,7 @@ func (h *Host) recordEditRetryReplacementSubmission(
 		ctx,
 		SessionRef{WorkspaceID: operation.WorkspaceID, AgentSessionID: operation.AgentSessionID},
 		payload.ReplacementTurnID, payload.ClientSubmitID, input.Content,
-		input.DisplayPrompt, input.CapabilityRefs, input.TuttiModeSnapshot,
+		input.DisplayPrompt, input.CapabilityRefs, input.Metadata, input.TuttiModeSnapshot,
 	); err != nil {
 		return err
 	}

--- a/packages/agent/host/lifecycle.go
+++ b/packages/agent/host/lifecycle.go
@@ -2,7 +2,6 @@ package agenthost
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -286,7 +285,7 @@ func (h *Host) createSession(ctx context.Context, workspaceID string, input Crea
 				ctx, SessionRef{WorkspaceID: workspaceID, AgentSessionID: session.ID}, execResult,
 				firstNonEmpty(claim.ClientSubmitID, input.ClientSubmitID, legacyClientSubmitID(metadata)),
 				claim.CreatedAtUnixMS, preparedContent, displayPrompt, input.CapabilityRefs,
-				input.TuttiModeSnapshot,
+				metadata, input.TuttiModeSnapshot,
 			); persistErr != nil {
 				claimPending = false
 				return createSessionCreatedErrorResult(input, session, canonicalSession, errors.Join(ErrSubmitDeliveryUnknown, err, persistErr))
@@ -333,7 +332,7 @@ func (h *Host) createSession(ctx context.Context, workspaceID string, input Crea
 	}
 	if err := h.recordTurnSubmission(
 		ctx, ref, turnID, input.ClientSubmitID, preparedContent.Persisted,
-		displayPrompt, input.CapabilityRefs, input.TuttiModeSnapshot,
+		displayPrompt, input.CapabilityRefs, metadata, input.TuttiModeSnapshot,
 	); err != nil {
 		claimPending = false
 		return createSessionCreatedErrorResult(input, session, canonicalSession, errors.Join(ErrSubmitDeliveryUnknown, err))
@@ -650,7 +649,7 @@ func (h *Host) sendInputSerialized(
 				ctx, ref, execResult,
 				firstNonEmpty(claim.ClientSubmitID, input.ClientSubmitID, legacyClientSubmitID(metadata)),
 				claim.CreatedAtUnixMS, preparedContent, displayPrompt, input.CapabilityRefs,
-				input.TuttiModeSnapshot,
+				metadata, input.TuttiModeSnapshot,
 			); persistErr != nil {
 				claimPending = false
 				return SendInputResult{}, errors.Join(ErrSubmitDeliveryUnknown, err, persistErr)
@@ -707,7 +706,7 @@ func (h *Host) sendInputSerialized(
 	if !input.Guidance {
 		if err := h.recordTurnSubmission(
 			ctx, ref, turnID, input.ClientSubmitID, preparedContent.Persisted,
-			displayPrompt, input.CapabilityRefs, input.TuttiModeSnapshot,
+			displayPrompt, input.CapabilityRefs, metadata, input.TuttiModeSnapshot,
 		); err != nil {
 			claimPending = false
 			return SendInputResult{}, errors.Join(ErrSubmitDeliveryUnknown, err)
@@ -767,47 +766,6 @@ func (h *Host) UpdateTitle(ctx context.Context, input UpdateTitleInput) (UpdateT
 	}
 	result.Session = runtimeSession
 	return result, nil
-}
-
-func (h *Host) recordTurnSubmission(
-	ctx context.Context,
-	ref SessionRef,
-	turnID string,
-	clientSubmitID string,
-	content []PromptContentBlock,
-	displayPrompt string,
-	capabilityRefs []CapabilityReference,
-	tuttiModeSnapshot *TuttiModeTurnSnapshot,
-) error {
-	if h == nil || h.turnSubmissions == nil {
-		return nil
-	}
-	contentJSON, err := json.Marshal(content)
-	if err != nil {
-		return fmt.Errorf("encode turn submission content: %w", err)
-	}
-	capabilityRefsJSON, err := json.Marshal(capabilityRefs)
-	if err != nil {
-		return fmt.Errorf("encode turn submission capability refs: %w", err)
-	}
-	tuttiModeSnapshotJSON, err := json.Marshal(tuttiModeSnapshot)
-	if err != nil {
-		return fmt.Errorf("encode turn submission tutti mode snapshot: %w", err)
-	}
-	now := h.now().UnixMilli()
-	_, _, err = h.turnSubmissions.RecordTurnSubmission(ctx, storesqlite.TurnSubmission{
-		WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
-		TurnID: strings.TrimSpace(turnID), ContentJSON: string(contentJSON),
-		DisplayPrompt:         strings.TrimSpace(displayPrompt),
-		CapabilityRefsJSON:    string(capabilityRefsJSON),
-		TuttiModeSnapshotJSON: string(tuttiModeSnapshotJSON),
-		ClientSubmitID:        strings.TrimSpace(clientSubmitID),
-		CreatedAtUnixMS:       now, UpdatedAtUnixMS: now,
-	})
-	if err != nil {
-		return fmt.Errorf("record turn submission envelope: %w", err)
-	}
-	return nil
 }
 
 func (h *Host) requireSendAllowedByEffectiveHistory(ctx context.Context, ref SessionRef) error {

--- a/packages/agent/host/submit_provenance_recovery.go
+++ b/packages/agent/host/submit_provenance_recovery.go
@@ -56,6 +56,7 @@ func (h *Host) persistRuntimeSubmitOutcome(
 	prepared preparedPromptContent,
 	displayPrompt string,
 	capabilityRefs []CapabilityReference,
+	metadata map[string]any,
 	tuttiModeSnapshot *TuttiModeTurnSnapshot,
 ) error {
 	return h.persistSubmitAfterRuntimeOutcome(
@@ -70,6 +71,7 @@ func (h *Host) persistRuntimeSubmitOutcome(
 		displayPrompt,
 		false,
 		capabilityRefs,
+		metadata,
 		tuttiModeSnapshot,
 	)
 }
@@ -90,6 +92,7 @@ func (h *Host) persistSubmitAfterRuntimeOutcome(
 	displayPrompt string,
 	guidance bool,
 	capabilityRefs []CapabilityReference,
+	metadata map[string]any,
 	tuttiModeSnapshot *TuttiModeTurnSnapshot,
 ) error {
 	if h == nil || strings.TrimSpace(turnID) == "" {
@@ -126,6 +129,7 @@ func (h *Host) persistSubmitAfterRuntimeOutcome(
 		persistedContent,
 		displayPrompt,
 		capabilityRefs,
+		metadata,
 		tuttiModeSnapshot,
 	)
 }

--- a/packages/agent/host/turn_submission.go
+++ b/packages/agent/host/turn_submission.go
@@ -1,0 +1,60 @@
+package agenthost
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+func (h *Host) recordTurnSubmission(
+	ctx context.Context,
+	ref SessionRef,
+	turnID string,
+	clientSubmitID string,
+	content []PromptContentBlock,
+	displayPrompt string,
+	capabilityRefs []CapabilityReference,
+	metadata map[string]any,
+	tuttiModeSnapshot *TuttiModeTurnSnapshot,
+) error {
+	if h == nil || h.turnSubmissions == nil {
+		return nil
+	}
+	contentJSON, err := json.Marshal(content)
+	if err != nil {
+		return fmt.Errorf("encode turn submission content: %w", err)
+	}
+	capabilityRefsJSON, err := json.Marshal(capabilityRefs)
+	if err != nil {
+		return fmt.Errorf("encode turn submission capability refs: %w", err)
+	}
+	metadataJSON := []byte("{}")
+	if len(metadata) > 0 {
+		metadataJSON, err = json.Marshal(metadata)
+		if err != nil {
+			return fmt.Errorf("encode turn submission metadata: %w", err)
+		}
+	}
+	tuttiModeSnapshotJSON, err := json.Marshal(tuttiModeSnapshot)
+	if err != nil {
+		return fmt.Errorf("encode turn submission tutti mode snapshot: %w", err)
+	}
+	now := h.now().UnixMilli()
+	_, _, err = h.turnSubmissions.RecordTurnSubmission(ctx, storesqlite.TurnSubmission{
+		WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
+		TurnID: strings.TrimSpace(turnID), ContentJSON: string(contentJSON),
+		DisplayPrompt:         strings.TrimSpace(displayPrompt),
+		CapabilityRefsJSON:    string(capabilityRefsJSON),
+		TuttiModeSnapshotJSON: string(tuttiModeSnapshotJSON),
+		MetadataJSON:          string(metadataJSON),
+		ClientSubmitID:        strings.TrimSpace(clientSubmitID),
+		CreatedAtUnixMS:       now, UpdatedAtUnixMS: now,
+	})
+	if err != nil {
+		return fmt.Errorf("record turn submission envelope: %w", err)
+	}
+	return nil
+}

--- a/packages/agent/store-sqlite/effective_history.go
+++ b/packages/agent/store-sqlite/effective_history.go
@@ -50,9 +50,14 @@ type TurnSubmission struct {
 	DisplayPrompt         string
 	CapabilityRefsJSON    string
 	TuttiModeSnapshotJSON string
+	MetadataJSON          string
 	ClientSubmitID        string
 	CreatedAtUnixMS       int64
 	UpdatedAtUnixMS       int64
+}
+
+type TurnSubmissionReader interface {
+	GetTurnSubmission(context.Context, string, string, string) (TurnSubmission, bool, error)
 }
 
 func (s *Store) GetSessionHistory(ctx context.Context, workspaceID, agentSessionID string) (SessionHistory, bool, error) {
@@ -117,10 +122,16 @@ func (s *Store) RecordTurnSubmission(ctx context.Context, input TurnSubmission) 
 	input.AgentSessionID = strings.TrimSpace(input.AgentSessionID)
 	input.TurnID = strings.TrimSpace(input.TurnID)
 	input.ClientSubmitID = strings.TrimSpace(input.ClientSubmitID)
+	if strings.TrimSpace(input.MetadataJSON) == "" {
+		input.MetadataJSON = "{}"
+	}
+	var metadata map[string]any
+	metadataErr := json.Unmarshal([]byte(input.MetadataJSON), &metadata)
 	if input.WorkspaceID == "" || input.AgentSessionID == "" || input.TurnID == "" ||
 		!json.Valid([]byte(input.ContentJSON)) ||
 		!json.Valid([]byte(input.CapabilityRefsJSON)) ||
-		!json.Valid([]byte(input.TuttiModeSnapshotJSON)) {
+		!json.Valid([]byte(input.TuttiModeSnapshotJSON)) ||
+		metadataErr != nil || metadata == nil {
 		return TurnSubmission{}, false, errors.New("record workspace agent turn submission: invalid envelope")
 	}
 	if input.CreatedAtUnixMS <= 0 {
@@ -132,12 +143,12 @@ func (s *Store) RecordTurnSubmission(ctx context.Context, input TurnSubmission) 
 	result, err := s.db.ExecContext(ctx, `
 INSERT INTO workspace_agent_turn_submissions (
   workspace_id, agent_session_id, turn_id, content_json, display_prompt,
-  capability_refs_json, tutti_mode_snapshot_json, client_submit_id,
+  capability_refs_json, tutti_mode_snapshot_json, metadata_json, client_submit_id,
   created_at_unix_ms, updated_at_unix_ms
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(workspace_id, agent_session_id, turn_id) DO NOTHING
 `, input.WorkspaceID, input.AgentSessionID, input.TurnID, input.ContentJSON, input.DisplayPrompt,
-		input.CapabilityRefsJSON, input.TuttiModeSnapshotJSON, input.ClientSubmitID,
+		input.CapabilityRefsJSON, input.TuttiModeSnapshotJSON, input.MetadataJSON, input.ClientSubmitID,
 		input.CreatedAtUnixMS, input.UpdatedAtUnixMS)
 	if err != nil {
 		return TurnSubmission{}, false, fmt.Errorf("record workspace agent turn submission: %w", err)
@@ -170,14 +181,14 @@ func (s *Store) GetTurnSubmission(ctx context.Context, workspaceID, agentSession
 	var result TurnSubmission
 	err := s.db.QueryRowContext(ctx, `
 SELECT workspace_id, agent_session_id, turn_id, content_json, display_prompt,
-       capability_refs_json, tutti_mode_snapshot_json, client_submit_id,
+       capability_refs_json, tutti_mode_snapshot_json, metadata_json, client_submit_id,
        created_at_unix_ms, updated_at_unix_ms
 FROM workspace_agent_turn_submissions
 WHERE workspace_id = ? AND agent_session_id = ? AND turn_id = ?
 `, workspaceID, agentSessionID, turnID).Scan(
 		&result.WorkspaceID, &result.AgentSessionID, &result.TurnID,
 		&result.ContentJSON, &result.DisplayPrompt, &result.CapabilityRefsJSON,
-		&result.TuttiModeSnapshotJSON, &result.ClientSubmitID,
+		&result.TuttiModeSnapshotJSON, &result.MetadataJSON, &result.ClientSubmitID,
 		&result.CreatedAtUnixMS, &result.UpdatedAtUnixMS,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -197,5 +208,6 @@ func sameTurnSubmissionEnvelope(left, right TurnSubmission) bool {
 		left.DisplayPrompt == right.DisplayPrompt &&
 		left.CapabilityRefsJSON == right.CapabilityRefsJSON &&
 		left.TuttiModeSnapshotJSON == right.TuttiModeSnapshotJSON &&
+		left.MetadataJSON == right.MetadataJSON &&
 		left.ClientSubmitID == right.ClientSubmitID
 }

--- a/packages/agent/store-sqlite/effective_history_test.go
+++ b/packages/agent/store-sqlite/effective_history_test.go
@@ -10,7 +10,7 @@ func TestEffectiveHistoryMigrationRunsAfterImportedTurnsAndBackfills(t *testing.
 	t.Parallel()
 	store := openTestStore(t, testOptions(&staticProjectPaths{}))
 	ctx := context.Background()
-	var importedRowID, historyRowID int64
+	var importedRowID, historyRowID, metadataRowID int64
 	if err := store.db.QueryRowContext(ctx, `
 SELECT rowid FROM agent_store_schema_migrations WHERE id = ?
 `, schemaMigrationWorkspaceAgentImportedTurnsV1).Scan(&importedRowID); err != nil {
@@ -23,6 +23,14 @@ SELECT rowid FROM agent_store_schema_migrations WHERE id = ?
 	}
 	if historyRowID <= importedRowID {
 		t.Fatalf("effective history migration row=%d, want after imported turns row=%d", historyRowID, importedRowID)
+	}
+	if err := store.db.QueryRowContext(ctx, `
+SELECT rowid FROM agent_store_schema_migrations WHERE id = ?
+`, schemaMigrationWorkspaceAgentEffectiveHistoryV2).Scan(&metadataRowID); err != nil {
+		t.Fatal(err)
+	}
+	if metadataRowID <= historyRowID {
+		t.Fatalf("effective history metadata migration row=%d, want after history row=%d", metadataRowID, historyRowID)
 	}
 
 	seedTurnTestSession(t, store, "ws-1", "session-new")
@@ -51,19 +59,24 @@ func TestEffectiveHistorySubmissionIsLosslessIdempotentAndConflictFenced(t *test
 		WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-1",
 		ContentJSON:   `[{"type":"text","text":"hello"},{"type":"image","attachmentId":"attachment-1"}]`,
 		DisplayPrompt: "hello", CapabilityRefsJSON: `[{"Capability":"browser"}]`,
-		TuttiModeSnapshotJSON: `{"Revision":2}`, ClientSubmitID: "submit-1",
+		TuttiModeSnapshotJSON: `{"Revision":2}`, MetadataJSON: `{"uiMode":"agent"}`, ClientSubmitID: "submit-1",
 		CreatedAtUnixMS: 21, UpdatedAtUnixMS: 21,
 	}
 	if _, created, err := store.RecordTurnSubmission(ctx, input); err != nil || !created {
 		t.Fatalf("first submission created=%v error=%v", created, err)
 	}
-	if stored, created, err := store.RecordTurnSubmission(ctx, input); err != nil || created || stored.ContentJSON != input.ContentJSON {
+	if stored, created, err := store.RecordTurnSubmission(ctx, input); err != nil || created || stored.ContentJSON != input.ContentJSON || stored.MetadataJSON != input.MetadataJSON {
 		t.Fatalf("replayed submission created=%v stored=%#v error=%v", created, stored, err)
 	}
 	conflict := input
 	conflict.ContentJSON = `[{"type":"text","text":"changed"}]`
 	if _, _, err := store.RecordTurnSubmission(ctx, conflict); !errors.Is(err, ErrTurnSubmissionConflict) {
 		t.Fatalf("conflicting submission error=%v", err)
+	}
+	conflict = input
+	conflict.MetadataJSON = `{"uiMode":"os"}`
+	if _, _, err := store.RecordTurnSubmission(ctx, conflict); !errors.Is(err, ErrTurnSubmissionConflict) {
+		t.Fatalf("conflicting submission metadata error=%v", err)
 	}
 }
 

--- a/packages/agent/store-sqlite/migrations.go
+++ b/packages/agent/store-sqlite/migrations.go
@@ -82,6 +82,7 @@ const schemaMigrationWorkspaceAgentSessionForkV3 = "workspace_agent_session_fork
 const schemaMigrationWorkspaceAgentSessionForkV4 = "workspace_agent_session_fork_v4"
 const schemaMigrationWorkspaceAgentSessionForkV5 = "workspace_agent_session_fork_v5"
 const schemaMigrationWorkspaceAgentEffectiveHistoryV1 = "workspace_agent_effective_history_v1"
+const schemaMigrationWorkspaceAgentEffectiveHistoryV2 = "workspace_agent_effective_history_v2_submission_metadata"
 const schemaMigrationWorkspaceAgentSessionForkV6 = "workspace_agent_session_fork_v6_optimistic"
 const schemaMigrationWorkspaceAgentSessionForkV7 = "workspace_agent_session_fork_v7_full_turn_bindings"
 const schemaMigrationWorkspaceAgentProviderCheckpointV1 = "workspace_agent_provider_checkpoint_v1"
@@ -306,6 +307,9 @@ CREATE TABLE IF NOT EXISTS `+schemaMigrationsTable+` (
 		return err
 	}
 	if err := s.applyWorkspaceAgentEffectiveHistoryV1(ctx); err != nil {
+		return err
+	}
+	if err := s.applyWorkspaceAgentEffectiveHistoryV2(ctx); err != nil {
 		return err
 	}
 	if err := s.applyWorkspaceAgentSessionForkV6(ctx); err != nil {

--- a/packages/agent/store-sqlite/migrations_effective_history.go
+++ b/packages/agent/store-sqlite/migrations_effective_history.go
@@ -133,3 +133,36 @@ END;
 	}
 	return nil
 }
+
+func (s *Store) applyWorkspaceAgentEffectiveHistoryV2(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentEffectiveHistoryV2)
+	if err != nil || applied {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin workspace agent effective history v2 migration: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	hasMetadata, err := hasColumnTx(ctx, tx, "workspace_agent_turn_submissions", "metadata_json")
+	if err != nil {
+		return err
+	}
+	if !hasMetadata {
+		if _, err := tx.ExecContext(ctx, `
+ALTER TABLE workspace_agent_turn_submissions
+ADD COLUMN metadata_json TEXT NOT NULL DEFAULT '{}'
+  CHECK (json_valid(metadata_json) AND json_type(metadata_json) = 'object')
+`); err != nil {
+			return fmt.Errorf("add workspace agent turn submission metadata: %w", err)
+		}
+	}
+	if err := recordMigrationTx(ctx, tx, schemaMigrationWorkspaceAgentEffectiveHistoryV2); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit workspace agent effective history v2 migration: %w", err)
+	}
+	return nil
+}

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -3506,6 +3506,7 @@ export type AgentSubmitDiagnostics = {
   promptLength?: number;
   queued?: boolean;
   source?: string;
+  uiMode?: "os" | "agent";
 };
 
 export type AgentPromptContentBlock = {

--- a/services/tuttid/api/daemon_agent_submit_handlers.go
+++ b/services/tuttid/api/daemon_agent_submit_handlers.go
@@ -54,6 +54,11 @@ func (api DaemonAPI) CreateWorkspaceAgentSession(ctx context.Context, request tu
 	}
 	initialGoalControl := initialGoalControlFromGenerated(request.Body.InitialGoalControl)
 	clientSubmitID := strings.TrimSpace(request.Body.ClientSubmitId)
+	if diagnosticsErr := validateAgentSubmitDiagnostics(request.Body.SubmitDiagnostics); diagnosticsErr != nil {
+		return tuttigenerated.CreateWorkspaceAgentSession400JSONResponse{
+			InvalidRequestErrorJSONResponse: invalidRequestError(diagnosticsErr),
+		}, nil
+	}
 	metadata := agentSubmitMetadata(request.Body.SubmitDiagnostics)
 	isolation := ""
 	if request.Body.Isolation != nil {
@@ -245,6 +250,11 @@ func (api DaemonAPI) SendWorkspaceAgentSessionInput(ctx context.Context, request
 		}, nil
 	}
 	clientSubmitID := strings.TrimSpace(request.Body.ClientSubmitId)
+	if diagnosticsErr := validateAgentSubmitDiagnostics(request.Body.SubmitDiagnostics); diagnosticsErr != nil {
+		return tuttigenerated.SendWorkspaceAgentSessionInput400JSONResponse{
+			InvalidRequestErrorJSONResponse: invalidRequestError(diagnosticsErr),
+		}, nil
+	}
 	metadata := agentSubmitMetadata(request.Body.SubmitDiagnostics)
 	guidance := request.Body.Guidance != nil && *request.Body.Guidance
 	targetTurnID := ""
@@ -397,5 +407,17 @@ func agentSubmitMetadata(diagnostics *tuttigenerated.AgentSubmitDiagnostics) map
 	if diagnostics.Source != nil {
 		metadata["source"] = strings.TrimSpace(*diagnostics.Source)
 	}
+	if diagnostics.UiMode != nil {
+		metadata["uiMode"] = strings.TrimSpace(string(*diagnostics.UiMode))
+	}
 	return metadata
+}
+
+func validateAgentSubmitDiagnostics(diagnostics *tuttigenerated.AgentSubmitDiagnostics) *apierrors.ProtocolError {
+	if diagnostics != nil && diagnostics.UiMode != nil && !diagnostics.UiMode.Valid() {
+		return apierrors.MalformedRequest(
+			apierrors.WithDeveloperMessage("submitDiagnostics.uiMode is invalid"),
+		)
+	}
+	return nil
 }

--- a/services/tuttid/api/daemon_agent_submit_handlers_test.go
+++ b/services/tuttid/api/daemon_agent_submit_handlers_test.go
@@ -16,6 +16,7 @@ func TestAgentSubmitMetadataProjectsAllDiagnosticsFields(t *testing.T) {
 	promptLength := 42
 	queued := false
 	source := "  agent-gui  "
+	uiMode := tuttigenerated.AgentSubmitDiagnosticsUiModeAgent
 
 	got := agentSubmitMetadata(&tuttigenerated.AgentSubmitDiagnostics{
 		SubmittedAtUnixMs: &submittedAtUnixMs,
@@ -24,6 +25,7 @@ func TestAgentSubmitMetadataProjectsAllDiagnosticsFields(t *testing.T) {
 		PromptLength:      &promptLength,
 		Queued:            &queued,
 		Source:            &source,
+		UiMode:            &uiMode,
 	})
 	want := map[string]any{
 		"blockCount":              2,
@@ -32,6 +34,7 @@ func TestAgentSubmitMetadataProjectsAllDiagnosticsFields(t *testing.T) {
 		"promptLength":            42,
 		"queued":                  false,
 		"source":                  "agent-gui",
+		"uiMode":                  "agent",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("agentSubmitMetadata() = %#v, want %#v", got, want)
@@ -83,6 +86,21 @@ func TestApplyEffectiveCreateSessionLaunchPinsReplayInputs(t *testing.T) {
 func TestAgentSubmitMetadataWithoutDiagnosticsIsEmpty(t *testing.T) {
 	if got := agentSubmitMetadata(nil); got != nil {
 		t.Fatalf("agentSubmitMetadata() = %#v, want nil", got)
+	}
+}
+
+func TestValidateAgentSubmitDiagnosticsRejectsUnknownUiMode(t *testing.T) {
+	invalid := tuttigenerated.AgentSubmitDiagnosticsUiMode("unknown")
+	if err := validateAgentSubmitDiagnostics(&tuttigenerated.AgentSubmitDiagnostics{UiMode: &invalid}); err == nil {
+		t.Fatal("unknown uiMode accepted")
+	}
+	for _, mode := range []tuttigenerated.AgentSubmitDiagnosticsUiMode{
+		tuttigenerated.AgentSubmitDiagnosticsUiModeOs,
+		tuttigenerated.AgentSubmitDiagnosticsUiModeAgent,
+	} {
+		if err := validateAgentSubmitDiagnostics(&tuttigenerated.AgentSubmitDiagnostics{UiMode: &mode}); err != nil {
+			t.Fatalf("valid uiMode %q rejected: %v", mode, err)
+		}
 	}
 }
 

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -754,6 +754,24 @@ func (e AgentSlashCommandEffect) Valid() bool {
 	}
 }
 
+// Defines values for AgentSubmitDiagnosticsUiMode.
+const (
+	AgentSubmitDiagnosticsUiModeAgent AgentSubmitDiagnosticsUiMode = "agent"
+	AgentSubmitDiagnosticsUiModeOs    AgentSubmitDiagnosticsUiMode = "os"
+)
+
+// Valid indicates whether the value is a known member of the AgentSubmitDiagnosticsUiMode enum.
+func (e AgentSubmitDiagnosticsUiMode) Valid() bool {
+	switch e {
+	case AgentSubmitDiagnosticsUiModeAgent:
+		return true
+	case AgentSubmitDiagnosticsUiModeOs:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for AgentTargetBuiltinLocalLaunchRefType.
 const (
 	AgentTargetBuiltinLocalLaunchRefTypeBuiltinLocal AgentTargetBuiltinLocalLaunchRefType = "builtin_local"
@@ -3834,16 +3852,16 @@ func (e WorkspaceAgentSessionWorktreeSupportErrorCode) Valid() bool {
 
 // Defines values for WorkspaceAgentSource.
 const (
-	LegacyBinding WorkspaceAgentSource = "legacy_binding"
-	User          WorkspaceAgentSource = "user"
+	WorkspaceAgentSourceLegacyBinding WorkspaceAgentSource = "legacy_binding"
+	WorkspaceAgentSourceUser          WorkspaceAgentSource = "user"
 )
 
 // Valid indicates whether the value is a known member of the WorkspaceAgentSource enum.
 func (e WorkspaceAgentSource) Valid() bool {
 	switch e {
-	case LegacyBinding:
+	case WorkspaceAgentSourceLegacyBinding:
 		return true
-	case User:
+	case WorkspaceAgentSourceUser:
 		return true
 	default:
 		return false
@@ -5622,13 +5640,17 @@ type AgentSlashCommandPolicy struct {
 
 // AgentSubmitDiagnostics defines model for AgentSubmitDiagnostics.
 type AgentSubmitDiagnostics struct {
-	BlockCount        *int    `json:"blockCount,omitempty"`
-	HasImage          *bool   `json:"hasImage,omitempty"`
-	PromptLength      *int    `json:"promptLength,omitempty"`
-	Queued            *bool   `json:"queued,omitempty"`
-	Source            *string `json:"source,omitempty"`
-	SubmittedAtUnixMs *int64  `json:"submittedAtUnixMs,omitempty"`
+	BlockCount        *int                          `json:"blockCount,omitempty"`
+	HasImage          *bool                         `json:"hasImage,omitempty"`
+	PromptLength      *int                          `json:"promptLength,omitempty"`
+	Queued            *bool                         `json:"queued,omitempty"`
+	Source            *string                       `json:"source,omitempty"`
+	SubmittedAtUnixMs *int64                        `json:"submittedAtUnixMs,omitempty"`
+	UiMode            *AgentSubmitDiagnosticsUiMode `json:"uiMode,omitempty"`
 }
+
+// AgentSubmitDiagnosticsUiMode defines model for AgentSubmitDiagnostics.UiMode.
+type AgentSubmitDiagnosticsUiMode string
 
 // AgentTarget defines model for AgentTarget.
 type AgentTarget struct {

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -15168,6 +15168,11 @@ components:
           type: boolean
         source:
           type: string
+        uiMode:
+          type: string
+          enum:
+            - os
+            - agent
     AgentPromptContentBlock:
       type: object
       additionalProperties: false

--- a/services/tuttid/data/workspace/agent_store.go
+++ b/services/tuttid/data/workspace/agent_store.go
@@ -368,6 +368,10 @@ func (s *SQLiteStore) GetTurn(ctx context.Context, workspaceID string, agentSess
 	return s.agentReadStore().GetTurn(ctx, workspaceID, agentSessionID, turnID)
 }
 
+func (s *SQLiteStore) GetTurnSubmission(ctx context.Context, workspaceID string, agentSessionID string, turnID string) (agentactivitybiz.TurnSubmission, bool, error) {
+	return s.agentReadStore().GetTurnSubmission(ctx, workspaceID, agentSessionID, turnID)
+}
+
 func (s *SQLiteStore) GetLatestTurn(ctx context.Context, workspaceID string, agentSessionID string) (agentactivitybiz.Turn, bool, error) {
 	return s.agentReadStore().GetLatestTurn(ctx, workspaceID, agentSessionID)
 }

--- a/services/tuttid/data/workspace/store.go
+++ b/services/tuttid/data/workspace/store.go
@@ -58,6 +58,7 @@ type AgentActivityStore interface {
 	agentactivitybiz.Repository
 	agentactivitybiz.SessionTurnSummaryReader
 	agentactivitybiz.EffectiveSessionTurnReader
+	agentactivitybiz.TurnSubmissionReader
 	CheckpointRuntimeOperation(context.Context, agentactivitybiz.CheckpointRuntimeOperationInput) (agentactivitybiz.RuntimeOperation, bool, error)
 	CompletePlanDecisionRuntimeOperation(context.Context, agentactivitybiz.CompletePlanDecisionRuntimeOperationInput) (agentactivitybiz.RuntimeOperationCompletion, bool, error)
 	FindTurnByClientSubmitID(context.Context, string, string, string) (string, bool, error)

--- a/services/tuttid/service/agent/activity_projection_commits.go
+++ b/services/tuttid/service/agent/activity_projection_commits.go
@@ -50,6 +50,7 @@ func (p *ActivityProjection) ObserveCommitted(ctx context.Context, delta agentho
 		p.observeSessionMessages(ctx, committed.Input, committed.Reply)
 	}
 	for _, settled := range delta.RootTurnsSettled {
+		p.reportRootTurnTerminalEvent(ctx, settled)
 		if settled.StartupReconciled {
 			// Startup reconciliation force-settles every turn left on disk.
 			// Waking the Tutti-mode and automation observers for those would

--- a/services/tuttid/service/agent/activity_projection_turn_terminal.go
+++ b/services/tuttid/service/agent/activity_projection_turn_terminal.go
@@ -1,0 +1,85 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+	agentactivitybiz "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+	agentturnterminal "github.com/tutti-os/tutti/services/tuttid/service/reporter/events/agent/turn_terminal"
+)
+
+func (p *ActivityProjection) reportRootTurnTerminalEvent(ctx context.Context, settled agenthost.RootTurnSettled) {
+	if p == nil || p.analyticsReporter == nil || settled.IsChildSession {
+		return
+	}
+	turn := settled.Turn
+	if turn.Backfilled || strings.TrimSpace(turn.Origin) != agentactivitybiz.TurnOriginUserPrompt {
+		return
+	}
+	reader, ok := p.repo.(agentactivitybiz.TurnSubmissionReader)
+	if !ok {
+		logSkippedTurnTerminalEvent(ctx, settled, "submission_reader_unavailable")
+		return
+	}
+	submission, found, err := reader.GetTurnSubmission(
+		ctx,
+		settled.WorkspaceID,
+		settled.AgentSessionID,
+		turn.TurnID,
+	)
+	if err != nil {
+		logSkippedTurnTerminalEvent(ctx, settled, "submission_read_failed")
+		return
+	}
+	if !found {
+		logSkippedTurnTerminalEvent(ctx, settled, "submission_missing")
+		return
+	}
+	mode, ok := terminalSubmissionMode(submission.MetadataJSON)
+	if !ok {
+		logSkippedTurnTerminalEvent(ctx, settled, "submission_mode_invalid")
+		return
+	}
+	eventName, params, ok := agentturnterminal.Build(agentturnterminal.Input{
+		AgentSessionID:    settled.AgentSessionID,
+		ClientSubmitID:    submission.ClientSubmitID,
+		ErrorCode:         turn.ErrorCode,
+		Mode:              mode,
+		Origin:            turn.Origin,
+		Outcome:           turn.Outcome,
+		Provider:          settled.Provider,
+		SettledAtUnixMS:   turn.SettledAtUnixMS,
+		StartedAtUnixMS:   turn.StartedAtUnixMS,
+		StartupReconciled: settled.StartupReconciled,
+		TurnID:            turn.TurnID,
+	})
+	if !ok {
+		return
+	}
+	agentturnterminal.Track(ctx, p.analyticsReporter, eventName, params)
+}
+
+func terminalSubmissionMode(metadataJSON string) (string, bool) {
+	var metadata map[string]any
+	if err := json.Unmarshal([]byte(metadataJSON), &metadata); err != nil || metadata == nil {
+		return "", false
+	}
+	mode, ok := metadata["uiMode"].(string)
+	if !ok || (mode != "os" && mode != "agent") {
+		return "", false
+	}
+	return mode, true
+}
+
+func logSkippedTurnTerminalEvent(ctx context.Context, settled agenthost.RootTurnSettled, reason string) {
+	slog.DebugContext(
+		ctx,
+		"agent turn terminal analytics skipped",
+		"reason", reason,
+		"agent_session_id", strings.TrimSpace(settled.AgentSessionID),
+		"turn_id", strings.TrimSpace(settled.Turn.TurnID),
+	)
+}

--- a/services/tuttid/service/agent/activity_projection_turn_terminal_test.go
+++ b/services/tuttid/service/agent/activity_projection_turn_terminal_test.go
@@ -1,0 +1,137 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+	agentactivitybiz "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+func TestActivityProjectionReportsCanonicalUserTurnOutcomes(t *testing.T) {
+	tests := []struct {
+		name              string
+		outcome           string
+		wantEvent         string
+		startupReconciled bool
+	}{
+		{name: "completed", outcome: agentactivitybiz.TurnOutcomeCompleted, wantEvent: "agent.turn_completed"},
+		{name: "failed", outcome: agentactivitybiz.TurnOutcomeFailed, wantEvent: "agent.turn_failed"},
+		{name: "canceled", outcome: agentactivitybiz.TurnOutcomeCanceled, wantEvent: "agent.turn_cancelled"},
+		{name: "startup interrupted", outcome: agentactivitybiz.TurnOutcomeInterrupted, wantEvent: "agent.turn_cancelled", startupReconciled: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &activityProjectionRepoStub{
+				submission: agentactivitybiz.TurnSubmission{
+					ClientSubmitID: "submit-1",
+					MetadataJSON:   `{"uiMode":"agent"}`,
+				},
+				submissionFound: true,
+			}
+			reporter := &recordingAgentAnalyticsReporter{}
+			projection := NewActivityProjection(repo)
+			projection.SetAnalyticsReporter(reporter)
+
+			err := projection.ObserveCommitted(context.Background(), agenthost.CommittedDelta{
+				RootTurnsSettled: []agenthost.RootTurnSettled{{
+					WorkspaceID: "ws-1", AgentSessionID: "session-1", Provider: "codex",
+					StartupReconciled: tt.startupReconciled,
+					Turn: agentactivitybiz.Turn{
+						TurnID: "turn-1", Origin: agentactivitybiz.TurnOriginUserPrompt,
+						Outcome: tt.outcome, ErrorCode: "runtime_failed",
+						StartedAtUnixMS: 1_000, SettledAtUnixMS: 11_000,
+					},
+				}},
+			})
+			if err != nil {
+				t.Fatalf("ObserveCommitted() error=%v", err)
+			}
+			if len(reporter.events) != 1 || reporter.events[0].Name != tt.wantEvent {
+				t.Fatalf("events=%#v, want one %s", reporter.events, tt.wantEvent)
+			}
+			params := reporter.events[0].Params
+			for key, want := range map[string]any{
+				"agent_session_id": "session-1",
+				"client_submit_id": "submit-1",
+				"mode":             "agent",
+				"provider":         "codex",
+				"turn_id":          "turn-1",
+				"turn_origin":      agentactivitybiz.TurnOriginUserPrompt,
+				"turn_outcome":     tt.outcome,
+			} {
+				if got := params[key]; got != want {
+					t.Fatalf("params[%q]=%#v, want %#v in %#v", key, got, want, params)
+				}
+			}
+			if _, exists := params["error_message"]; exists {
+				t.Fatalf("params contain raw error message: %#v", params)
+			}
+			if _, exists := params["workspace_id"]; exists {
+				t.Fatalf("params contain workspace identity: %#v", params)
+			}
+		})
+	}
+}
+
+func TestActivityProjectionSkipsIneligibleTerminalTurns(t *testing.T) {
+	tests := []struct {
+		name       string
+		metadata   string
+		origin     string
+		backfilled bool
+		child      bool
+		found      bool
+	}{
+		{name: "child session", metadata: `{"uiMode":"agent"}`, origin: agentactivitybiz.TurnOriginUserPrompt, child: true, found: true},
+		{name: "goal turn", metadata: `{"uiMode":"agent"}`, origin: agentactivitybiz.TurnOriginGoalArm, found: true},
+		{name: "provider initiated", metadata: `{"uiMode":"agent"}`, origin: agentactivitybiz.TurnOriginProviderInitiated, found: true},
+		{name: "backfilled", metadata: `{"uiMode":"agent"}`, origin: agentactivitybiz.TurnOriginUserPrompt, backfilled: true, found: true},
+		{name: "legacy missing submission", origin: agentactivitybiz.TurnOriginUserPrompt},
+		{name: "missing mode", metadata: `{}`, origin: agentactivitybiz.TurnOriginUserPrompt, found: true},
+		{name: "invalid mode", metadata: `{"uiMode":"unknown"}`, origin: agentactivitybiz.TurnOriginUserPrompt, found: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &activityProjectionRepoStub{
+				submission:      agentactivitybiz.TurnSubmission{MetadataJSON: tt.metadata},
+				submissionFound: tt.found,
+			}
+			reporter := &recordingAgentAnalyticsReporter{}
+			projection := NewActivityProjection(repo)
+			projection.SetAnalyticsReporter(reporter)
+			_ = projection.ObserveCommitted(context.Background(), agenthost.CommittedDelta{
+				RootTurnsSettled: []agenthost.RootTurnSettled{{
+					WorkspaceID: "ws-1", AgentSessionID: "session-1", Provider: "codex", IsChildSession: tt.child,
+					Turn: agentactivitybiz.Turn{
+						TurnID: "turn-1", Origin: tt.origin, Backfilled: tt.backfilled,
+						Outcome: agentactivitybiz.TurnOutcomeCompleted,
+					},
+				}},
+			})
+			if len(reporter.events) != 0 {
+				t.Fatalf("events=%#v, want none", reporter.events)
+			}
+		})
+	}
+}
+
+func TestTerminalSubmissionModeRequiresClosedEnum(t *testing.T) {
+	for _, tt := range []struct {
+		metadata string
+		mode     string
+		ok       bool
+	}{
+		{metadata: `{"uiMode":"os"}`, mode: "os", ok: true},
+		{metadata: `{"uiMode":"agent"}`, mode: "agent", ok: true},
+		{metadata: `{"uiMode":" agent "}`},
+		{metadata: `{"uiMode":null}`},
+		{metadata: `{}`},
+		{metadata: `not-json`},
+	} {
+		mode, ok := terminalSubmissionMode(tt.metadata)
+		if mode != tt.mode || ok != tt.ok {
+			t.Fatalf("terminalSubmissionMode(%q)=(%q,%v), want (%q,%v)", tt.metadata, mode, ok, tt.mode, tt.ok)
+		}
+	}
+}

--- a/services/tuttid/service/agent/service_test_support_test.go
+++ b/services/tuttid/service/agent/service_test_support_test.go
@@ -25,23 +25,26 @@ func (f fakeAgentTargetLookup) GetAgentTarget(_ context.Context, id string) (age
 }
 
 type activityProjectionRepoStub struct {
-	clearResult    agentactivitybiz.ClearSessionsResult
-	settleStaleErr error
-	settlements    []agentactivitybiz.StaleTurnSettlement
-	stateResult    agentactivitybiz.StateReportResult
-	stateInput     agentactivitybiz.SessionStateReport
-	messageInput   agentactivitybiz.SessionMessageReport
-	messageResult  agentactivitybiz.MessageReportResult
-	messagePage    agentactivitybiz.MessagePage
-	messagePageOK  bool
-	messagePageErr error
-	turnResult     agentactivitybiz.Turn
-	turnResults    map[string]agentactivitybiz.Turn
-	turnFound      bool
-	turnErr        error
-	sectionsPage   agentactivitybiz.SessionSectionsPage
-	sectionsOK     bool
-	sectionsErr    error
+	clearResult     agentactivitybiz.ClearSessionsResult
+	settleStaleErr  error
+	settlements     []agentactivitybiz.StaleTurnSettlement
+	stateResult     agentactivitybiz.StateReportResult
+	stateInput      agentactivitybiz.SessionStateReport
+	messageInput    agentactivitybiz.SessionMessageReport
+	messageResult   agentactivitybiz.MessageReportResult
+	messagePage     agentactivitybiz.MessagePage
+	messagePageOK   bool
+	messagePageErr  error
+	turnResult      agentactivitybiz.Turn
+	turnResults     map[string]agentactivitybiz.Turn
+	turnFound       bool
+	turnErr         error
+	sectionsPage    agentactivitybiz.SessionSectionsPage
+	sectionsOK      bool
+	sectionsErr     error
+	submission      agentactivitybiz.TurnSubmission
+	submissionFound bool
+	submissionErr   error
 }
 
 func (r *activityProjectionRepoStub) ClearSessions(context.Context, string) (agentactivitybiz.ClearSessionsResult, error) {
@@ -171,6 +174,10 @@ func (r *activityProjectionRepoStub) GetTurn(_ context.Context, _ string, agentS
 		return turn, ok, r.turnErr
 	}
 	return r.turnResult, r.turnFound, r.turnErr
+}
+
+func (r *activityProjectionRepoStub) GetTurnSubmission(context.Context, string, string, string) (agentactivitybiz.TurnSubmission, bool, error) {
+	return r.submission, r.submissionFound, r.submissionErr
 }
 
 func (*activityProjectionRepoStub) GetLatestTurn(context.Context, string, string) (agentactivitybiz.Turn, bool, error) {

--- a/services/tuttid/service/reporter/events/agent/turn_terminal/event.go
+++ b/services/tuttid/service/reporter/events/agent/turn_terminal/event.go
@@ -1,0 +1,20 @@
+package turn_terminal
+
+import (
+	"context"
+
+	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
+	reporterevents "github.com/tutti-os/tutti/services/tuttid/service/reporter/events"
+)
+
+const (
+	EventCompleted = "agent.turn_completed"
+	EventFailed    = "agent.turn_failed"
+	EventCancelled = "agent.turn_cancelled"
+)
+
+type Params map[string]any
+
+func Track(ctx context.Context, reporter reporterservice.Reporter, eventName string, params Params) {
+	reporterevents.Track(ctx, reporter, eventName, map[string]any(params))
+}

--- a/services/tuttid/service/reporter/events/agent/turn_terminal/params.go
+++ b/services/tuttid/service/reporter/events/agent/turn_terminal/params.go
@@ -1,0 +1,129 @@
+package turn_terminal
+
+import "strings"
+
+const unknownErrorCode = "agent_unknown_error"
+
+type Input struct {
+	AgentSessionID    string
+	ClientSubmitID    string
+	ErrorCode         string
+	Mode              string
+	Outcome           string
+	Origin            string
+	Provider          string
+	StartupReconciled bool
+	StartedAtUnixMS   int64
+	SettledAtUnixMS   int64
+	TurnID            string
+}
+
+func Build(input Input) (string, Params, bool) {
+	mode := strings.TrimSpace(input.Mode)
+	if mode != "os" && mode != "agent" {
+		return "", nil, false
+	}
+	outcome := strings.TrimSpace(input.Outcome)
+	eventName, status := terminalEvent(outcome)
+	if eventName == "" {
+		return "", nil, false
+	}
+	provider := strings.TrimSpace(input.Provider)
+	if provider == "" {
+		provider = "unknown"
+	}
+	turnID := strings.TrimSpace(input.TurnID)
+	params := Params{
+		"agent_kind":          "local-agent",
+		"agent_session_id":    strings.TrimSpace(input.AgentSessionID),
+		"client_submit_id":    strings.TrimSpace(input.ClientSubmitID),
+		"event_source":        "canonical_turn_settled",
+		"interaction_source":  "user",
+		"invocation_id":       turnID,
+		"is_child_session":    false,
+		"mode":                mode,
+		"operation_id":        turnID,
+		"provider":            provider,
+		"startup_reconciled":  input.StartupReconciled,
+		"status":              status,
+		"surface":             "direct_session",
+		"turn_id":             turnID,
+		"turn_origin":         strings.TrimSpace(input.Origin),
+		"turn_outcome":        outcome,
+		"viewer_relationship": "self",
+		"viewer_role":         "owner",
+	}
+	if durationMS, ok := terminalDuration(input.StartedAtUnixMS, input.SettledAtUnixMS); ok {
+		params["duration_ms"] = durationMS
+		params["duration_bucket"] = durationBucket(durationMS)
+	}
+	switch eventName {
+	case EventCompleted:
+		params["value_enum"] = "completed"
+	case EventFailed:
+		params["error_category"] = "runtime"
+		params["error_code"] = safeErrorCode(input.ErrorCode)
+		params["failure_stage"] = "settled"
+	case EventCancelled:
+		if input.StartupReconciled {
+			params["source"] = "startup_reconciliation"
+		} else {
+			params["source"] = "runtime_event"
+		}
+	}
+	return eventName, params, true
+}
+
+func terminalEvent(outcome string) (string, string) {
+	switch outcome {
+	case "completed":
+		return EventCompleted, "completed"
+	case "failed":
+		return EventFailed, "failed"
+	case "canceled", "interrupted":
+		return EventCancelled, "cancelled"
+	default:
+		return "", ""
+	}
+}
+
+func terminalDuration(startedAtUnixMS, settledAtUnixMS int64) (int64, bool) {
+	if startedAtUnixMS <= 0 || settledAtUnixMS < startedAtUnixMS {
+		return 0, false
+	}
+	return settledAtUnixMS - startedAtUnixMS, true
+}
+
+func durationBucket(durationMS int64) string {
+	switch {
+	case durationMS < 1_000:
+		return "lt_1s"
+	case durationMS < 3_000:
+		return "1s_to_3s"
+	case durationMS < 10_000:
+		return "3s_to_10s"
+	case durationMS < 30_000:
+		return "10s_to_30s"
+	case durationMS < 60_000:
+		return "30s_to_60s"
+	default:
+		return "gte_60s"
+	}
+}
+
+func safeErrorCode(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" || len(value) > 128 {
+		return unknownErrorCode
+	}
+	for _, character := range value {
+		if (character >= 'a' && character <= 'z') ||
+			(character >= 'A' && character <= 'Z') ||
+			(character >= '0' && character <= '9') ||
+			character == '_' || character == '-' || character == '.' || character == ':' {
+			continue
+		}
+		return unknownErrorCode
+	}
+	return value
+}

--- a/services/tuttid/service/reporter/events/agent/turn_terminal/params_test.go
+++ b/services/tuttid/service/reporter/events/agent/turn_terminal/params_test.go
@@ -1,0 +1,65 @@
+package turn_terminal
+
+import "testing"
+
+func TestBuildMapsTerminalOutcomes(t *testing.T) {
+	tests := []struct {
+		name       string
+		outcome    string
+		eventName  string
+		status     string
+		extraKey   string
+		extraValue any
+	}{
+		{name: "completed", outcome: "completed", eventName: EventCompleted, status: "completed", extraKey: "value_enum", extraValue: "completed"},
+		{name: "failed", outcome: "failed", eventName: EventFailed, status: "failed", extraKey: "error_code", extraValue: "runtime_failed"},
+		{name: "canceled", outcome: "canceled", eventName: EventCancelled, status: "cancelled", extraKey: "source", extraValue: "runtime_event"},
+		{name: "interrupted", outcome: "interrupted", eventName: EventCancelled, status: "cancelled", extraKey: "source", extraValue: "startup_reconciliation"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eventName, params, ok := Build(Input{
+				AgentSessionID: "session-1", ClientSubmitID: "submit-1", ErrorCode: "runtime_failed",
+				Mode: "agent", Origin: "user_prompt", Outcome: tt.outcome, Provider: "codex",
+				StartupReconciled: tt.outcome == "interrupted", StartedAtUnixMS: 1_000,
+				SettledAtUnixMS: 11_000, TurnID: "turn-1",
+			})
+			if !ok || eventName != tt.eventName {
+				t.Fatalf("Build() event=%q ok=%v, want %q true", eventName, ok, tt.eventName)
+			}
+			for key, want := range map[string]any{
+				"agent_session_id": "session-1", "client_submit_id": "submit-1",
+				"duration_bucket": "10s_to_30s", "duration_ms": int64(10_000),
+				"mode": "agent", "provider": "codex", "status": tt.status,
+				"turn_id": "turn-1", "turn_origin": "user_prompt", "turn_outcome": tt.outcome,
+				tt.extraKey: tt.extraValue,
+			} {
+				if got := params[key]; got != want {
+					t.Fatalf("params[%q]=%#v, want %#v in %#v", key, got, want, params)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildRejectsMissingModeAndUnknownOutcome(t *testing.T) {
+	for _, input := range []Input{
+		{Mode: "", Outcome: "completed"},
+		{Mode: "unknown", Outcome: "completed"},
+		{Mode: "agent", Outcome: "running"},
+	} {
+		if eventName, params, ok := Build(input); ok || eventName != "" || params != nil {
+			t.Fatalf("Build(%#v)=(%q,%#v,%v), want rejected", input, eventName, params, ok)
+		}
+	}
+}
+
+func TestBuildUsesContentFreeErrorFallback(t *testing.T) {
+	_, params, ok := Build(Input{Mode: "os", Outcome: "failed", ErrorCode: "secret path /Users/example"})
+	if !ok || params["error_code"] != unknownErrorCode {
+		t.Fatalf("params=%#v ok=%v, want safe fallback", params, ok)
+	}
+	if _, exists := params["error_message"]; exists {
+		t.Fatalf("params contain raw error message: %#v", params)
+	}
+}


### PR DESCRIPTION
## Summary

- capture the exact workspace UI mode (`os` or `agent`) on Agent create/send requests
- persist submit metadata with the canonical Turn submission envelope
- emit `agent.turn_completed`, `agent.turn_failed`, and `agent.turn_cancelled` from canonical Host root-turn settlements
- exclude child sessions, Goal/provider-initiated turns, imported history, and legacy submissions without a valid mode
- keep raw prompts, responses, paths, workspace IDs, and error messages out of terminal analytics

## Why

The local desktop did not have a stable, canonical event for whether a user-submitted Agent turn completed, failed, or was cancelled. The renderer knows the UI mode, while the daemon owns the authoritative terminal outcome; without durable submission provenance, choosing either producer alone would lose settlements or create `mode=null` data.

This change joins those facts by persisting submission-time mode and reporting only after the canonical Turn settlement commits.

## Product impact

- every newly reported terminal event has `mode=os` or `mode=agent`; invalid or missing modes are skipped rather than guessed
- `completed` measures technical Turn completion, not whether the user's goal was semantically satisfied
- existing DataFinder dashboards are unchanged until they explicitly adopt the new event family
- startup-reconciled interruptions remain distinguishable through `startup_reconciled=true`

## Validation

- `pnpm check:changed` — 28 lanes passed after implementation
- pre-push `pnpm check:changed -- --push-ready` — 32 lanes passed
- focused desktop adapter tests for create/send mode propagation
- focused Host, store-sqlite, tuttid Agent/API, OpenAPI generation, and TypeScript type checks

## Post-release DataFinder checks

- verify `mode` contains only `os` and `agent`, with zero `null`
- verify a `turn_id` appears in at most one event across the three terminal events
- verify all rows have `turn_origin=user_prompt` and `is_child_session=false`
