### PR TITLE
feat(agent-gui): add GitHub clone starter prompt

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -730,6 +730,7 @@ function DesktopAgentGUISurfaceImpl({
         renderAgentsEmpty={renderAgentsEmpty}
         agentActivityRuntime={agentActivityRuntime}
         agentHostApi={agentHostApiWithToast}
+        disabled={["clone-github-repository"]}
         tuttiModePlanReviewRuntime={
           capabilityMenuState?.tuttiMode?.enabled === false
             ? null

--- a/packages/agent/gui/README.md
+++ b/packages/agent/gui/README.md
@@ -424,7 +424,7 @@ both properties keeps the filter off. An explicitly supplied catalog (including
 
 ## Home Suggestions
 
-The five starter entries below the empty new-session composer are enabled by
+The six starter entries below the empty new-session composer are enabled by
 default. External hosts can hide individual entries with the public
 `AgentGUI.disabled` array:
 
@@ -432,9 +432,9 @@ default. External hosts can hide individual entries with the public
 <AgentGUI disabled={["meet-tutti", "import-session"]} {...props} />
 ```
 
-The supported stable IDs are `meet-tutti`, `task-breakdown`, `quality-review`,
-`agent-interaction`, and `import-session`. Omitting `disabled` (or passing an
-empty array) renders all five entries.
+The supported stable IDs are `meet-tutti`, `clone-github-repository`,
+`task-breakdown`, `quality-review`, `agent-interaction`, and `import-session`.
+Omitting `disabled` (or passing an empty array) renders all six entries.
 
 ## Tutti Mode capability
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.labels.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.labels.spec.ts
@@ -12,6 +12,7 @@ describe("buildAgentHomeSuggestions", () => {
       )
     ).toEqual([
       "meet-tutti",
+      "clone-github-repository",
       "task-breakdown",
       "quality-review",
       "agent-interaction",
@@ -25,8 +26,20 @@ describe("buildAgentHomeSuggestions", () => {
         translate,
         "workspace-1",
         [],
-        ["task-breakdown", "agent-interaction"]
+        ["clone-github-repository", "task-breakdown", "agent-interaction"]
       ).map((category) => category.id)
     ).toEqual(["meet-tutti", "quality-review", "import-session"]);
+  });
+
+  it("builds the GitHub clone entry as a direct composer prefill", () => {
+    expect(
+      buildAgentHomeSuggestions(translate, "workspace-1", []).find(
+        (category) => category.id === "clone-github-repository"
+      )
+    ).toMatchObject({
+      icon: "github",
+      label: "agentHost.agentGui.homeSuggestions.cloneGithubRepository.title",
+      prompt: "agentHost.agentGui.homeSuggestions.cloneGithubRepository.prompt"
+    });
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentHomeSuggestions.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentHomeSuggestions.tsx
@@ -1,5 +1,13 @@
 import { memo, useState, type ComponentType, type SVGProps } from "react";
-import { ArrowLeftRight, Code, Compass, Import, Pencil, X } from "lucide-react";
+import {
+  ArrowLeftRight,
+  Code,
+  Compass,
+  Github,
+  Import,
+  Pencil,
+  X
+} from "lucide-react";
 import styles from "./AgentGUINode.styles";
 import type {
   AgentHomeSuggestionAction,
@@ -92,6 +100,7 @@ const CATEGORY_ICON = {
   breakdown: TaskBreakdownIcon,
   review: QualityReviewIcon,
   interaction: BattleIcon,
+  github: Github,
   about: TuttiIcon,
   import: Import
 } as const satisfies Record<

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
@@ -269,6 +269,7 @@ export type AgentHomeSuggestionIcon =
   | "breakdown"
   | "review"
   | "interaction"
+  | "github"
   | "about"
   | "import";
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentHomeSuggestions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentHomeSuggestions.ts
@@ -42,6 +42,12 @@ export function buildAgentHomeSuggestions(
       prompt: t(key("about.prompt"))
     },
     {
+      id: "clone-github-repository",
+      icon: "github",
+      label: t(key("cloneGithubRepository.title")),
+      prompt: t(key("cloneGithubRepository.prompt"))
+    },
+    {
       id: "task-breakdown",
       icon: "breakdown",
       label: t(key("breakdown.title")),

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
@@ -11,6 +11,7 @@ import { enAgentGuiCollaboration } from "./en.agentGuiCollaboration.ts";
 import { enAgentGuiUsageStatus } from "./en.agentGuiUsageStatus.ts";
 import { enAgentGuiComposer } from "./en.agentGuiComposer.ts";
 import { enAgentGuiProjectLaunch } from "./en.agentGuiProjectLaunch.ts";
+import { enAgentGuiHomeSuggestions } from "./en.agentGuiHomeSuggestions.ts";
 
 export const enAgentGui = {
   imageDownloaded: "Image downloaded",
@@ -395,31 +396,7 @@ export const enAgentGui = {
     }
   },
   empty: "What can {{provider}} help you with?",
-  homeSuggestionsClose: "Close suggestions",
-  homeSuggestions: {
-    about: {
-      title: "Meet Tutti",
-      prompt: "Tell me what Tutti can help me do"
-    },
-    breakdown: {
-      title: "Task breakdown",
-      taskCenterLabel: "Task management",
-      prompt:
-        "Use {{taskCenterMention}} to help me break down the task, topic { enter here }"
-    },
-    review: {
-      title: "Quality review",
-      prompt: "Have { @agent } review the output quality of { @agent session }"
-    },
-    interaction: {
-      title: "Agent interaction",
-      prompt:
-        "Have { @agent } and { @agent } work together to { do something }, topic { enter here }"
-    },
-    import: {
-      title: "Import session"
-    }
-  },
+  ...enAgentGuiHomeSuggestions,
   conversations: "Sessions",
   newConversation: "New session",
   agentConfig: "Check & Settings",

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGuiHomeSuggestions.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGuiHomeSuggestions.ts
@@ -1,0 +1,32 @@
+export const enAgentGuiHomeSuggestions = {
+  homeSuggestionsClose: "Close suggestions",
+  homeSuggestions: {
+    about: {
+      title: "Meet Tutti",
+      prompt: "Tell me what Tutti can help me do"
+    },
+    cloneGithubRepository: {
+      title: "Clone GitHub repository",
+      prompt:
+        "Help me clone a GitHub repository. First ask for the repository URL and destination directory. If it is private, help me verify GitHub authentication or access before cloning. Proceed only after you have the required information."
+    },
+    breakdown: {
+      title: "Task breakdown",
+      taskCenterLabel: "Task management",
+      prompt:
+        "Use {{taskCenterMention}} to help me break down the task, topic { enter here }"
+    },
+    review: {
+      title: "Quality review",
+      prompt: "Have { @agent } review the output quality of { @agent session }"
+    },
+    interaction: {
+      title: "Agent interaction",
+      prompt:
+        "Have { @agent } and { @agent } work together to { do something }, topic { enter here }"
+    },
+    import: {
+      title: "Import session"
+    }
+  }
+} as const;

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGuiHomeSuggestions.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGuiHomeSuggestions.ts
@@ -8,7 +8,7 @@ export const enAgentGuiHomeSuggestions = {
     cloneGithubRepository: {
       title: "Clone GitHub repository",
       prompt:
-        "Help me clone a GitHub repository. First ask for the repository URL and destination directory. If it is private, help me verify GitHub authentication or access before cloning. Proceed only after you have the required information."
+        "Help me clone the GitHub repository { repository URL }, then tell me its local directory"
     },
     breakdown: {
       title: "Task breakdown",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
@@ -10,6 +10,7 @@ import { zhCNAgentGuiCollaboration } from "./zh-CN.agentGuiCollaboration.ts";
 import { zhCNTuttiModePlan } from "./zh-CN.tuttiModePlan.ts";
 import { zhCNAgentGuiComposer } from "./zh-CN.agentGuiComposer.ts";
 import { zhCNAgentGuiProjectLaunch } from "./zh-CN.agentGuiProjectLaunch.ts";
+import { zhCNAgentGuiHomeSuggestions } from "./zh-CN.agentGuiHomeSuggestions.ts";
 export const zhCNAgentGui = {
   imageDownloaded: "图片已下载",
   imageLoadFailed: "图片加载失败",
@@ -426,29 +427,7 @@ export const zhCNAgentGui = {
     }
   },
   empty: "需要 {{provider}} 帮你做些什么？",
-  homeSuggestionsClose: "收起建议",
-  homeSuggestions: {
-    about: {
-      title: "认识 Tutti",
-      prompt: "介绍一下 Tutti 能帮我做些什么"
-    },
-    breakdown: {
-      title: "任务拆解",
-      taskCenterLabel: "任务管理",
-      prompt: "使用 {{taskCenterMention}} 帮我拆解任务，任务主题 { 请输入 }"
-    },
-    review: {
-      title: "质量审查",
-      prompt: "让 { @agent } 审查 { @agent 会话 } 的产物质量"
-    },
-    interaction: {
-      title: "Agent 互动",
-      prompt: "让 { @agent } 和 { @agent } 一起 { 做些什么 }，主题 { 请输入 }"
-    },
-    import: {
-      title: "导入会话"
-    }
-  },
+  ...zhCNAgentGuiHomeSuggestions,
   conversations: "会话",
   newConversation: "新建会话",
   agentConfig: "检测与设置",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGuiHomeSuggestions.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGuiHomeSuggestions.ts
@@ -7,8 +7,7 @@ export const zhCNAgentGuiHomeSuggestions = {
     },
     cloneGithubRepository: {
       title: "克隆 GitHub 仓库",
-      prompt:
-        "帮我克隆一个 GitHub 仓库。请先询问仓库地址和要克隆到的目录；如果是私有仓库，再引导我确认当前环境的 GitHub 登录或访问权限。获得必要信息后再执行克隆"
+      prompt: "帮我克隆 GitHub 仓库 { 仓库地址 }，完成后告诉我仓库目录"
     },
     breakdown: {
       title: "任务拆解",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGuiHomeSuggestions.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGuiHomeSuggestions.ts
@@ -1,0 +1,30 @@
+export const zhCNAgentGuiHomeSuggestions = {
+  homeSuggestionsClose: "收起建议",
+  homeSuggestions: {
+    about: {
+      title: "认识 Tutti",
+      prompt: "介绍一下 Tutti 能帮我做些什么"
+    },
+    cloneGithubRepository: {
+      title: "克隆 GitHub 仓库",
+      prompt:
+        "帮我克隆一个 GitHub 仓库。请先询问仓库地址和要克隆到的目录；如果是私有仓库，再引导我确认当前环境的 GitHub 登录或访问权限。获得必要信息后再执行克隆"
+    },
+    breakdown: {
+      title: "任务拆解",
+      taskCenterLabel: "任务管理",
+      prompt: "使用 {{taskCenterMention}} 帮我拆解任务，任务主题 { 请输入 }"
+    },
+    review: {
+      title: "质量审查",
+      prompt: "让 { @agent } 审查 { @agent 会话 } 的产物质量"
+    },
+    interaction: {
+      title: "Agent 互动",
+      prompt: "让 { @agent } 和 { @agent } 一起 { 做些什么 }，主题 { 请输入 }"
+    },
+    import: {
+      title: "导入会话"
+    }
+  }
+} as const;

--- a/packages/agent/gui/types.ts
+++ b/packages/agent/gui/types.ts
@@ -79,6 +79,7 @@ export type AgentGUIProvider = string;
  */
 export type AgentGUIHomeSuggestionId =
   | "meet-tutti"
+  | "clone-github-repository"
   | "task-breakdown"
   | "quality-review"
   | "agent-interaction"


### PR DESCRIPTION
## Summary

- add a `Clone GitHub repository` starter badge to the empty Agent GUI composer
- prefill the editable template `Help me clone the GitHub repository { repository URL }, then tell me its local directory`
- expose `clone-github-repository` as a stable public suggestion ID
- hide the new suggestion in the open-source local Desktop host while keeping it available to VM hosts such as TSH
- split home-suggestion locale content into dedicated fragments to stay within the Agent GUI file-size guard
- document the sixth built-in suggestion and its disable ID

## Why

VM first-run users should have a concise path from an empty Agent GUI to bringing an existing GitHub project into the workspace. The prompt follows the existing badge pattern: it provides a short fill-in placeholder and asks the Agent to report the resulting local directory. The open-source local version does not need this onboarding suggestion, so its Desktop host opts out through the existing `disabled` contract.

## Impact and risk

The package change is additive and hosts control visibility through the existing public suggestion ID. The local Desktop host explicitly disables it. Selecting the badge in an enabled VM host only fills the composer and never auto-submits. No persistence or Agent execution flow changes.

## Verification

- `pnpm check:changed` via the push-ready hook: 18 lanes passed
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm exec vitest run agent-gui/agentGuiNode/AgentGUINode.labels.spec.ts`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm check:agent-gui-degradation`

No E2E tests were run.