### PR TITLE
fix(workspace-files): canonicalize Windows logical paths

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.test.ts
@@ -250,7 +250,49 @@ test("workspace file manager service compares native Windows paths with daemon l
 
   assert.equal(
     await service.entryExists({
-      path: "C:\\README.md",
+      path: "c:\\README.md",
+      workspaceID: "workspace-1"
+    }),
+    true
+  );
+  assert.equal(requestedPath, "/C:/");
+});
+
+test("workspace file manager service maps Git Bash Windows paths to daemon logical paths", async () => {
+  const dependencies = createDependenciesStub();
+  dependencies.platformApi = {
+    homeDirectory: "C:\\Users\\demo",
+    os: "win32"
+  };
+  let requestedPath: string | undefined;
+  dependencies.tuttidClient.listWorkspaceFileDirectory = async (
+    workspaceId,
+    input
+  ) => {
+    requestedPath = input?.path;
+    return {
+      directoryPath: "/C:/",
+      entries: [
+        {
+          createdTimeMs: null,
+          hasChildren: false,
+          kind: "file",
+          lastOpenedMs: null,
+          mtimeMs: null,
+          name: "README.md",
+          path: "/C:/README.md",
+          sizeBytes: 12
+        }
+      ],
+      root: "/C:/",
+      workspaceId
+    };
+  };
+  const service = new WorkspaceFileManagerService(dependencies);
+
+  assert.equal(
+    await service.entryExists({
+      path: "/c/README.md",
       workspaceID: "workspace-1"
     }),
     true

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.ts
@@ -1,5 +1,6 @@
 import {
   createWorkspaceFileManagerService,
+  normalizeWorkspaceFilePath,
   type WorkspaceFileExternalLocation,
   type WorkspaceFileEntry,
   type WorkspaceFileLocationSection,
@@ -160,7 +161,11 @@ export class WorkspaceFileManagerService implements IWorkspaceFileManagerService
     path: string;
     workspaceID: string;
   }): Promise<boolean> {
-    const targetPath = normalizeComparableWorkspaceFilePath(input.path);
+    const comparisonRoot = this.dependencies.platformApi.homeDirectory;
+    const targetPath = normalizeComparableWorkspaceFilePath(
+      input.path,
+      comparisonRoot
+    );
     if (!targetPath) {
       return false;
     }
@@ -175,15 +180,19 @@ export class WorkspaceFileManagerService implements IWorkspaceFileManagerService
           }
         );
       if (
-        normalizeComparableWorkspaceFilePath(listing.directoryPath) ===
-          targetPath ||
-        normalizeComparableWorkspaceFilePath(listing.root) === targetPath
+        normalizeComparableWorkspaceFilePath(
+          listing.directoryPath,
+          comparisonRoot
+        ) === targetPath ||
+        normalizeComparableWorkspaceFilePath(listing.root, comparisonRoot) ===
+          targetPath
       ) {
         return true;
       }
       return listing.entries.some(
         (entry) =>
-          normalizeComparableWorkspaceFilePath(entry.path) === targetPath
+          normalizeComparableWorkspaceFilePath(entry.path, comparisonRoot) ===
+          targetPath
       );
     } catch {
       return false;
@@ -466,19 +475,14 @@ function dirnameForWorkspaceFilePath(path: string): string {
   return /^\/[A-Za-z]:$/.test(directory) ? `${directory}/` : directory;
 }
 
-function normalizeComparableWorkspaceFilePath(path: string): string {
-  const normalized = path
-    .trim()
-    .replaceAll("\\", "/")
-    .replace(/\/+/g, "/")
-    .replace(/^\/?([A-Za-z]:)(?=\/|$)/, "/$1");
-  if (!normalized) {
+function normalizeComparableWorkspaceFilePath(
+  path: string,
+  rootPath?: string | null
+): string {
+  if (!path.trim()) {
     return "";
   }
-  if (normalized === "/") {
-    return "/";
-  }
-  return normalized.replace(/\/+$/g, "");
+  return normalizeWorkspaceFilePath(path, rootPath).replace(/\/+$/g, "") || "/";
 }
 
 function serializeWorkspaceFileLocationRefreshSnapshot(input: {

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/ui/WorkspaceFileManagerPane.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/ui/WorkspaceFileManagerPane.tsx
@@ -194,6 +194,7 @@ export function WorkspaceFileManagerPane({
     <WorkspaceFileManager
       className={className}
       dateLocale={locale}
+      pathDisplayPlatform={featureService.hostOs}
       i18n={i18n}
       locationSidebarLayout={locationSidebarLayout}
       onCopyEntry={notifyEntryCopied}

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/ui/createDesktopWorkspaceFileManagerContextMenu.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/ui/createDesktopWorkspaceFileManagerContextMenu.ts
@@ -11,6 +11,7 @@ import {
 } from "@tutti-os/ui-system";
 import { createElement, type ReactElement } from "react";
 import {
+  formatWorkspaceFilePathForDisplay,
   isWorkspaceFileBrowserOpenable,
   resolveRevealInFolderLabel,
   type WorkspaceFileEntry,
@@ -184,11 +185,15 @@ export function createDesktopWorkspaceFileManagerContextMenu(input: {
       icon: createElement(CopyIcon, { className: "size-4" }),
       label: appI18n.t("workspaceFileManager.copyPathLabel"),
       onSelect: async () => {
+        const displayPath = formatWorkspaceFilePathForDisplay(
+          entry.path,
+          hostOs
+        );
         if (onCopyPath) {
-          await onCopyPath(entry.path);
+          await onCopyPath(displayPath);
           return;
         }
-        await navigator.clipboard.writeText(entry.path);
+        await navigator.clipboard.writeText(displayPath);
       }
     });
     if (capabilities.canRevealInFolder && !isExternalLocation) {

--- a/docs/conventions/troubleshooting/workspace-apps-files.md
+++ b/docs/conventions/troubleshooting/workspace-apps-files.md
@@ -364,8 +364,10 @@
   Reuse the shared FileManager path model and canonicalize drive-qualified
   paths to `/C:/...` at the AgentGUI and daemon boundaries. Treat `/c/...` as
   a Windows drive alias only when the active workspace root is Windows-shaped.
-  Strip the transport slash only at a native Electron or operating-system
-  file API boundary.
+  Keep `/C:/...` for API and state values. Convert it to `C:\\Users\\...`
+  only at native Electron/operating-system adapters or Windows user-facing
+  display boundaries; POSIX and daemon-facing values keep their logical
+  separators.
 - Validation:
   Cover native and Git Bash-shaped Windows inputs against daemon-shaped
   `/C:/...` responses in projection, existence, directory navigation, and

--- a/docs/conventions/troubleshooting/workspace-apps-files.md
+++ b/docs/conventions/troubleshooting/workspace-apps-files.md
@@ -351,18 +351,23 @@
   missing, fails to select the revealed entry, loses the matching sidebar
   location, or adds a duplicate back-navigation entry.
 - Quick checks:
-  Compare the desktop launch path with `tuttid`'s directory response. Native
-  input commonly arrives as `C:\\Users\\...` or `C:/Users/...`, while the
-  workspace API intentionally transports the same path as `/C:/Users/...`.
+  Compare the AgentGUI or desktop launch path with `tuttid`'s directory
+  response. Native input commonly arrives as `C:\\Users\\...` or
+  `C:/Users/...`; Git Bash-shaped input may arrive as `/c/Users/...`; the
+  workspace API intentionally transports all of these as `/C:/Users/...`.
 - Root cause:
-  Workspace file paths are logical API paths. Normalizing separators without
-  also adding the logical leading slash leaves native Windows input unequal to
-  daemon roots, directory paths, and entry paths.
+  Workspace file paths are logical API paths. Multiple local normalizers can
+  preserve different drive casing or omit the logical leading slash, leaving
+  native Windows input unequal to daemon roots, directory paths, and entry
+  paths.
 - Fix:
-  Canonicalize drive-qualified paths to `/C:/...` at the shared FileManager
-  path-model boundary. Strip that transport slash only at a native Electron or
-  operating-system file API boundary.
+  Reuse the shared FileManager path model and canonicalize drive-qualified
+  paths to `/C:/...` at the AgentGUI and daemon boundaries. Treat `/c/...` as
+  a Windows drive alias only when the active workspace root is Windows-shaped.
+  Strip the transport slash only at a native Electron or operating-system
+  file API boundary.
 - Validation:
-  Cover native Windows inputs against daemon-shaped `/C:/...` responses in
-  existence, directory navigation, and reveal-selection tests. Then run
-  `pnpm check:changed`.
+  Cover native and Git Bash-shaped Windows inputs against daemon-shaped
+  `/C:/...` responses in projection, existence, directory navigation, and
+  reveal-selection tests. Keep POSIX `/c/...` paths unchanged on a POSIX root.
+  Then run `pnpm check:changed`.

--- a/packages/agent/gui/actions/workspaceFilePathCandidate.ts
+++ b/packages/agent/gui/actions/workspaceFilePathCandidate.ts
@@ -1,3 +1,5 @@
+import { normalizeWorkspaceFilePath as normalizeLogicalWorkspaceFilePath } from "@tutti-os/workspace-file-manager/services";
+
 const URL_LIKE_LINK_PATTERN = /^[a-zA-Z][a-zA-Z\d+.-]*:|^#/;
 const LOCAL_ASSET_ROOT = "/var/cache/tsh/local-assets";
 
@@ -32,8 +34,12 @@ export function resolveWorkspaceFilePathCandidate({
     return null;
   }
 
+  const selectedRoot = normalizeWorkspaceFilePath(workspaceRoot?.trim() ?? "");
+  const sessionRoot = normalizeWorkspaceFilePath(basePath?.trim() ?? "");
+  const root = selectedRoot || sessionRoot;
   const normalizedPath = normalizeWorkspaceFilePath(
-    stripWorkspaceFileLineAnchor(rawPath)
+    stripWorkspaceFileLineAnchor(rawPath),
+    sessionRoot || root
   );
   if (isUnsupportedSpecialWorkspaceFilePath(normalizedPath)) {
     return null;
@@ -46,8 +52,7 @@ export function resolveWorkspaceFilePathCandidate({
     return {
       path: normalizedPath,
       directoryPath,
-      workspaceRoot:
-        normalizeWorkspaceFilePath(workspaceRoot?.trim() ?? "") || directoryPath
+      workspaceRoot: selectedRoot || directoryPath
     };
   }
   if (
@@ -59,14 +64,10 @@ export function resolveWorkspaceFilePathCandidate({
     return {
       path: normalizedPath,
       directoryPath,
-      workspaceRoot:
-        normalizeWorkspaceFilePath(workspaceRoot?.trim() ?? "") || directoryPath
+      workspaceRoot: selectedRoot || directoryPath
     };
   }
 
-  const selectedRoot = normalizeWorkspaceFilePath(workspaceRoot?.trim() ?? "");
-  const sessionRoot = normalizeWorkspaceFilePath(basePath?.trim() ?? "");
-  const root = selectedRoot || sessionRoot;
   if (!root) {
     return null;
   }
@@ -94,8 +95,18 @@ export function resolveWorkspaceFilePathCandidate({
   };
 }
 
-export function normalizeWorkspaceFilePath(path: string): string {
+export function normalizeWorkspaceFilePath(
+  path: string,
+  rootPath?: string | null
+): string {
   const normalizedPath = path.trim().replaceAll("\\", "/");
+  if (
+    isWindowsAbsolutePath(normalizedPath) ||
+    isGitBashWindowsAbsolutePath(normalizedPath, rootPath)
+  ) {
+    return normalizeLogicalWorkspaceFilePath(normalizedPath, rootPath);
+  }
+
   const drive = /^[A-Za-z]:/.exec(normalizedPath)?.[0] ?? "";
   const startsWithSlash = normalizedPath.startsWith("/");
   const pathBody = drive
@@ -207,7 +218,22 @@ function dirnameForHomeRelativePath(path: string): string {
 }
 
 function isWindowsAbsolutePath(path: string): boolean {
-  return /^[A-Za-z]:\//.test(path);
+  return /^\/?[A-Za-z]:\//.test(path);
+}
+
+function isGitBashWindowsAbsolutePath(
+  path: string,
+  rootPath?: string | null
+): boolean {
+  const rootDrive = readWindowsDrive(rootPath ?? "");
+  const pathDrive = /^\/([A-Za-z])(?=\/|$)/.exec(path)?.[1];
+  return Boolean(
+    rootDrive && pathDrive && `${pathDrive}:`.toUpperCase() === rootDrive
+  );
+}
+
+function readWindowsDrive(path: string): string {
+  return /^\/?([A-Za-z]:)(?=\/|$)/.exec(path)?.[1]?.toUpperCase() ?? "";
 }
 
 function isUncWorkspaceFilePath(path: string): boolean {

--- a/packages/agent/gui/actions/workspaceLinkActions.spec.ts
+++ b/packages/agent/gui/actions/workspaceLinkActions.spec.ts
@@ -65,9 +65,9 @@ describe("resolveWorkspaceFileLinkAction", () => {
       })
     ).toMatchObject({
       type: "open-workspace-file",
-      path: "C:/Users/test/project/tutti/src/App.tsx",
-      directoryPath: "C:/Users/test/project/tutti/src",
-      workspaceRoot: "C:/Users/test/project/tutti"
+      path: "/C:/Users/test/project/tutti/src/App.tsx",
+      directoryPath: "/C:/Users/test/project/tutti/src",
+      workspaceRoot: "/C:/Users/test/project/tutti"
     });
   });
 
@@ -331,9 +331,22 @@ describe("resolveWorkspaceFileLinkAction", () => {
       })
     ).toMatchObject({
       type: "open-workspace-file",
-      path: "C:/Users/test/project/tutti/src/App.tsx",
-      directoryPath: "C:/Users/test/project/tutti/src",
-      workspaceRoot: "C:/Users/test/project/tutti"
+      path: "/C:/Users/test/project/tutti/src/App.tsx",
+      directoryPath: "/C:/Users/test/project/tutti/src",
+      workspaceRoot: "/C:/Users/test/project/tutti"
+    });
+
+    expect(
+      resolveWorkspaceFileLinkAction({
+        path: "/c/Users/test/project/tutti/src/App.tsx",
+        workspaceRoot: "C:\\Users\\test\\project\\tutti",
+        source: "agent-file-change"
+      })
+    ).toMatchObject({
+      type: "open-workspace-file",
+      path: "/C:/Users/test/project/tutti/src/App.tsx",
+      directoryPath: "/C:/Users/test/project/tutti/src",
+      workspaceRoot: "/C:/Users/test/project/tutti"
     });
   });
 });

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -503,9 +503,9 @@ describe("AgentMessageMarkdown", () => {
 
     expect(onLinkAction).toHaveBeenCalledWith({
       type: "open-workspace-file",
-      path: "C:/Users/local/project/docs/README.md",
-      directoryPath: "C:/Users/local/project/docs",
-      workspaceRoot: "C:/Users/local/project",
+      path: "/C:/Users/local/project/docs/README.md",
+      directoryPath: "/C:/Users/local/project/docs",
+      workspaceRoot: "/C:/Users/local/project",
       source: "agent-markdown"
     });
   });

--- a/packages/agent/gui/shared/agentConversation/projection/agentTurnSummaryFileProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentTurnSummaryFileProjection.ts
@@ -15,13 +15,12 @@ export function normalizedFilePath(
   if (!path || isStructuredPayloadPath(path) || isIgnoredFilePath(path)) {
     return null;
   }
-  return resolveWorkspaceFilePathCandidate({
+  const candidate = resolveWorkspaceFilePathCandidate({
     path,
     workspaceRoot: options.workspaceRoot,
     basePath: options.defaultCwd
-  })
-    ? path
-    : null;
+  });
+  return candidate?.path ?? null;
 }
 
 function isIgnoredFilePath(path: string): boolean {

--- a/packages/agent/gui/shared/agentConversation/projection/agentTurnSummaryProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentTurnSummaryProjection.spec.ts
@@ -11,6 +11,26 @@ import {
 } from "./agentTurnSummaryProjection";
 
 describe("agent turn summary canonical projection", () => {
+  it("canonicalizes Windows drive aliases in changed-file paths", () => {
+    const rows = projectAgentTurnSummaryRowForTurn(
+      turn("turn-windows"),
+      {
+        files: [
+          {
+            path: "/c/Users/demo/project/0817.txt",
+            change: "added"
+          }
+        ]
+      },
+      {
+        workspaceRoot: "C:\\Users\\demo\\project",
+        defaultCwd: "C:\\Users\\demo\\project"
+      }
+    );
+
+    expect(rows[0]?.files[0]?.path).toBe("/C:/Users/demo/project/0817.txt");
+  });
+
   it("projects create, modify, and delete semantics from turn.fileChanges", () => {
     const rows = projectAgentTurnSummaryRowForTurn(
       turn("turn-1"),

--- a/packages/agent/gui/shared/agentConversation/rules/agentTurnSummaryPatchDiff.ts
+++ b/packages/agent/gui/shared/agentConversation/rules/agentTurnSummaryPatchDiff.ts
@@ -161,8 +161,8 @@ function modifiedFilePatch(
 }
 
 function patchPathRelativeToCwd(path: string, cwd: string | null): string {
-  const normalizedPath = normalizeWorkspaceFilePath(path);
   const normalizedCwd = normalizeWorkspaceFilePath(cwd ?? "");
+  const normalizedPath = normalizeWorkspaceFilePath(path, normalizedCwd);
   if (
     isAbsolutePatchPath(normalizedPath) &&
     normalizedCwd &&
@@ -179,7 +179,7 @@ function patchPathRelativeToCwd(path: string, cwd: string | null): string {
 }
 
 function isAbsolutePatchPath(path: string): boolean {
-  return path.startsWith("/") || /^[A-Za-z]:\//.test(path);
+  return path.startsWith("/") || /^\/?[A-Za-z]:\//.test(path);
 }
 
 function splitPatchContentLines(content: string): string[] {

--- a/packages/workspace/file-manager/src/i18n/workspaceFileManagerI18n.ts
+++ b/packages/workspace/file-manager/src/i18n/workspaceFileManagerI18n.ts
@@ -226,7 +226,7 @@ export function createWorkspaceFileManagerI18nRuntime(
 
 export function resolveRevealInFolderLabel(
   copy: WorkspaceFileManagerI18nRuntime,
-  platform: NodeJS.Platform
+  platform: string
 ): string {
   if (platform === "darwin") {
     return copy.t("revealInFinderLabel");

--- a/packages/workspace/file-manager/src/services/index.ts
+++ b/packages/workspace/file-manager/src/services/index.ts
@@ -47,6 +47,7 @@ export {
   resolveWorkspaceFileLocationDefaultId
 } from "./workspaceFileManagerLocations.ts";
 export {
+  formatWorkspaceFilePathForDisplay,
   normalizeWorkspaceFilePath,
   workspaceFileName
 } from "./internal/model/paths.ts";

--- a/packages/workspace/file-manager/src/services/index.ts
+++ b/packages/workspace/file-manager/src/services/index.ts
@@ -46,7 +46,10 @@ export {
   isWorkspaceFileRecentLocation,
   resolveWorkspaceFileLocationDefaultId
 } from "./workspaceFileManagerLocations.ts";
-export { workspaceFileName } from "./internal/model/paths.ts";
+export {
+  normalizeWorkspaceFilePath,
+  workspaceFileName
+} from "./internal/model/paths.ts";
 export {
   type WorkspaceFileActivationTarget,
   type WorkspaceFileDirectoryListing,

--- a/packages/workspace/file-manager/src/services/internal/model/paths.ts
+++ b/packages/workspace/file-manager/src/services/internal/model/paths.ts
@@ -8,9 +8,12 @@ export function normalizeWorkspaceFilePath(
   rootPath?: string | null
 ): string {
   const root = normalizeWorkspaceFileAbsolutePath(rootPath);
-  const raw = String(value ?? "")
-    .trim()
-    .replaceAll("\\", "/");
+  const raw = normalizeGitBashDrivePath(
+    String(value ?? "")
+      .trim()
+      .replaceAll("\\", "/"),
+    root
+  );
   if (!raw) {
     return root;
   }
@@ -57,6 +60,15 @@ function normalizeWorkspaceFileAbsolutePath(value?: string | null): string {
     return `/${drive}/${result.join("/")}`;
   }
   return `/${result.join("/")}`;
+}
+
+function normalizeGitBashDrivePath(value: string, root: string): string {
+  const drive = readWindowsDrive(root);
+  const match = /^\/([A-Za-z])(?=\/|$)/.exec(value);
+  if (!drive || !match || `${match[1]}:`.toUpperCase() !== drive) {
+    return value;
+  }
+  return `/${drive}${value.slice(2)}`;
 }
 
 export function workspaceFileName(path: string): string {
@@ -184,7 +196,7 @@ function isWorkspaceFileAbsolutePath(path: string): boolean {
 }
 
 function readWindowsDrive(path: string): string {
-  return /^\/?([A-Za-z]:)(?=\/|$)/.exec(path)?.[1] ?? "";
+  return /^\/?([A-Za-z]:)(?=\/|$)/.exec(path)?.[1]?.toUpperCase() ?? "";
 }
 
 function stripWindowsDrivePrefix(path: string, drive: string): string {

--- a/packages/workspace/file-manager/src/services/internal/model/paths.ts
+++ b/packages/workspace/file-manager/src/services/internal/model/paths.ts
@@ -25,6 +25,30 @@ export function normalizeWorkspaceFilePath(
   return normalizeWorkspaceFileAbsolutePath(raw);
 }
 
+export function formatWorkspaceFilePathForDisplay(
+  value?: string | null,
+  platform?: string | null
+): string {
+  const raw = String(value ?? "").trim();
+  if (!raw || platform !== "win32") {
+    return raw;
+  }
+
+  const normalizedInput = raw.replaceAll("\\", "/");
+  const gitBashDrive = /^\/([A-Za-z])(?=\/|$)/.exec(normalizedInput)?.[1];
+  const logicalInput = gitBashDrive
+    ? `/${gitBashDrive.toUpperCase()}:${normalizedInput.slice(2)}`
+    : normalizedInput;
+  const normalized = normalizeWorkspaceFilePath(logicalInput);
+  const drive = readWindowsDrive(normalized);
+  if (!drive) {
+    return raw;
+  }
+
+  const body = stripWindowsDrivePrefix(normalized, drive);
+  return `${drive}\\${body.replaceAll("/", "\\")}`;
+}
+
 function normalizeWorkspaceFileAbsolutePath(value?: string | null): string {
   const raw = String(value ?? "")
     .trim()

--- a/packages/workspace/file-manager/src/services/workspaceFileManagerModel.test.ts
+++ b/packages/workspace/file-manager/src/services/workspaceFileManagerModel.test.ts
@@ -37,6 +37,20 @@ test("normalizes Windows drive paths without treating them as relative", () => {
     "/C:/tmp/report.txt"
   );
   assert.equal(
+    normalizeWorkspaceFilePath(
+      "c:\\Users\\demo\\project\\src\\main.ts",
+      "C:\\Users\\demo\\project"
+    ),
+    "/C:/Users/demo/project/src/main.ts"
+  );
+  assert.equal(
+    normalizeWorkspaceFilePath(
+      "/c/Users/demo/project/src/main.ts",
+      "C:\\Users\\demo\\project"
+    ),
+    "/C:/Users/demo/project/src/main.ts"
+  );
+  assert.equal(
     normalizeWorkspaceFilePath("/C:/tmp/report.txt"),
     "/C:/tmp/report.txt"
   );

--- a/packages/workspace/file-manager/src/services/workspaceFileManagerModel.test.ts
+++ b/packages/workspace/file-manager/src/services/workspaceFileManagerModel.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   filterVisibleWorkspaceEntries,
+  formatWorkspaceFilePathForDisplay,
   formatWorkspaceFileModifiedTime,
   normalizeWorkspaceFilePath,
   resolveWorkspaceFileActivationTarget,
@@ -53,6 +54,41 @@ test("normalizes Windows drive paths without treating them as relative", () => {
   assert.equal(
     normalizeWorkspaceFilePath("/C:/tmp/report.txt"),
     "/C:/tmp/report.txt"
+  );
+});
+
+test("formats Windows logical paths for user-facing display", () => {
+  assert.equal(
+    formatWorkspaceFilePathForDisplay(
+      "/C:/Users/demo/project/README.md",
+      "win32"
+    ),
+    "C:\\Users\\demo\\project\\README.md"
+  );
+  assert.equal(
+    formatWorkspaceFilePathForDisplay(
+      "C:/Users/demo/project/README.md",
+      "win32"
+    ),
+    "C:\\Users\\demo\\project\\README.md"
+  );
+  assert.equal(
+    formatWorkspaceFilePathForDisplay(
+      "/c/Users/demo/project/README.md",
+      "win32"
+    ),
+    "C:\\Users\\demo\\project\\README.md"
+  );
+  assert.equal(
+    formatWorkspaceFilePathForDisplay(
+      "/c/Users/demo/project/README.md",
+      "linux"
+    ),
+    "/c/Users/demo/project/README.md"
+  );
+  assert.equal(
+    formatWorkspaceFilePathForDisplay("/Users/demo/project/README.md", "win32"),
+    "/Users/demo/project/README.md"
   );
 });
 

--- a/packages/workspace/file-manager/src/services/workspaceFileManagerModel.ts
+++ b/packages/workspace/file-manager/src/services/workspaceFileManagerModel.ts
@@ -6,6 +6,7 @@ export {
 } from "./internal/model/formatters.ts";
 export {
   buildWorkspaceFileBreadcrumbs,
+  formatWorkspaceFilePathForDisplay,
   filterVisibleWorkspaceEntries,
   isHiddenWorkspaceDirectoryEntry,
   normalizeWorkspaceFilePath,

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManager.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManager.tsx
@@ -84,6 +84,8 @@ export interface WorkspaceFileManagerLocationSidebarLayout {
 export interface WorkspaceFileManagerProps {
   className?: string;
   dateLocale?: TuttiDateLocale;
+  /** Formats physical Windows paths for user-facing labels and copy actions. */
+  pathDisplayPlatform?: string | null;
   entryDragMode?: WorkspaceFileManagerEntryDragMode;
   onCopyEntry?: () => Promise<void> | void;
   onDirectoryExpanded?: (path: string) => void;
@@ -127,6 +129,7 @@ export interface WorkspaceFileManagerProps {
 export function WorkspaceFileManager({
   className,
   dateLocale,
+  pathDisplayPlatform,
   entryDragMode,
   i18n,
   locationSidebarLayout,
@@ -518,6 +521,7 @@ export function WorkspaceFileManager({
           <>
             <WorkspaceFileManagerToolbarContainer
               i18n={i18n}
+              pathDisplayPlatform={pathDisplayPlatform}
               arrangeMode={arrangeMode}
               layoutMode={layoutMode}
               onArrangeModeChange={setArrangeMode}
@@ -529,6 +533,7 @@ export function WorkspaceFileManager({
             <div className="@max-[600px]/workspace-file-manager:flex-col @max-[600px]/workspace-file-manager:gap-3 flex min-h-0 min-w-0 flex-1 overflow-hidden">
               <WorkspaceFileManagerPanelsContainer
                 dateLocale={dateLocale}
+                pathDisplayPlatform={pathDisplayPlatform}
                 entryDragMode={entryDragMode}
                 arrangeMode={arrangeMode}
                 i18n={i18n}
@@ -562,6 +567,7 @@ export function WorkspaceFileManager({
 function WorkspaceFileManagerToolbarContainer({
   arrangeMode,
   i18n,
+  pathDisplayPlatform,
   layoutMode,
   onArrangeModeChange,
   onDirectoryExpanded,
@@ -571,6 +577,7 @@ function WorkspaceFileManagerToolbarContainer({
 }: {
   arrangeMode: WorkspaceFileManagerArrangeMode;
   i18n: WorkspaceFileManagerI18nRuntime;
+  pathDisplayPlatform?: string | null;
   layoutMode: WorkspaceFileManagerLayoutMode;
   onArrangeModeChange: (arrangeMode: WorkspaceFileManagerArrangeMode) => void;
   onDirectoryExpanded?: (path: string) => void;
@@ -617,6 +624,7 @@ function WorkspaceFileManagerToolbarContainer({
   return (
     <WorkspaceFileManagerToolbar
       breadcrumbs={view.breadcrumbs}
+      pathDisplayPlatform={pathDisplayPlatform}
       canSearch={view.canSearch}
       canGoBack={view.canGoBack}
       canGoForward={view.canGoForward}

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanels.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanels.tsx
@@ -39,6 +39,7 @@ import {
 import {
   formatWorkspaceFileBytes,
   formatWorkspaceFileModifiedTime,
+  formatWorkspaceFilePathForDisplay,
   splitWorkspaceFileName
 } from "../services/workspaceFileManagerModel.ts";
 import type {
@@ -106,6 +107,7 @@ export function WorkspaceFileManagerPanels({
   inlineRenameValidation,
   isRenaming,
   layoutMode,
+  pathDisplayPlatform,
   pendingDirectoryPath,
   previewActions,
   previewState,
@@ -140,6 +142,7 @@ export function WorkspaceFileManagerPanels({
   inlineRenameValidation: WorkspaceFileManagerInlineRenameValidation | null;
   isRenaming: boolean;
   layoutMode: WorkspaceFileManagerLayoutMode;
+  pathDisplayPlatform?: string | null;
   pendingDirectoryPath: string | null;
   previewActions?: readonly WorkspaceFileManagerPreviewAction[];
   previewState: WorkspaceFilePreviewState;
@@ -750,6 +753,7 @@ export function WorkspaceFileManagerPanels({
         copy={copy}
         dateLocale={dateLocale}
         entry={selectedEntry}
+        pathDisplayPlatform={pathDisplayPlatform}
         previewActions={previewActions}
         previewState={previewState}
       />
@@ -1655,12 +1659,14 @@ function PreviewPane({
   copy,
   dateLocale,
   entry,
+  pathDisplayPlatform,
   previewActions,
   previewState
 }: {
   copy: WorkspaceFileManagerI18nRuntime;
   dateLocale?: TuttiDateLocale;
   entry: WorkspaceFileEntry | null;
+  pathDisplayPlatform?: string | null;
   previewActions?: readonly WorkspaceFileManagerPreviewAction[];
   previewState: WorkspaceFilePreviewState;
 }): ReactElement {
@@ -1687,7 +1693,7 @@ function PreviewPane({
             {entry.name}
           </strong>
           <p className="min-w-0 truncate text-xs text-[var(--text-secondary)]">
-            {entry.path}
+            {formatWorkspaceFilePathForDisplay(entry.path, pathDisplayPlatform)}
           </p>
         </div>
         <dl className="border-t border-[var(--border-1)]">

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanelsContainer.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanelsContainer.tsx
@@ -7,7 +7,10 @@ import {
 import type { TuttiDateLocale } from "@tutti-os/ui-system/date-format";
 import type { WorkspaceFileManagerI18nRuntime } from "../i18n/workspaceFileManagerI18n.ts";
 import type { WorkspaceFileManagerSession } from "../services/workspaceFileManagerService.interface.ts";
-import { workspaceFileSearchEntryToEntry } from "../services/workspaceFileManagerModel.ts";
+import {
+  formatWorkspaceFilePathForDisplay,
+  workspaceFileSearchEntryToEntry
+} from "../services/workspaceFileManagerModel.ts";
 import type { WorkspaceFileEntry } from "../services/workspaceFileManagerTypes.ts";
 import {
   type WorkspaceFileManagerEntryDragMode,
@@ -31,6 +34,7 @@ import { useWorkspaceFileManagerPanelsView } from "./useWorkspaceFileManagerServ
 export function WorkspaceFileManagerPanelsContainer({
   arrangeMode,
   dateLocale,
+  pathDisplayPlatform,
   entryDragMode,
   i18n,
   layoutMode,
@@ -45,6 +49,7 @@ export function WorkspaceFileManagerPanelsContainer({
 }: {
   arrangeMode: WorkspaceFileManagerArrangeMode;
   dateLocale?: TuttiDateLocale;
+  pathDisplayPlatform?: string | null;
   entryDragMode?: WorkspaceFileManagerEntryDragMode;
   i18n: WorkspaceFileManagerI18nRuntime;
   layoutMode: WorkspaceFileManagerLayoutMode;
@@ -77,10 +82,16 @@ export function WorkspaceFileManagerPanelsContainer({
   const searchEntryContextByPath = useMemo(() => {
     const contextByPath = new Map<string, string>();
     for (const entry of view.searchEntries) {
-      contextByPath.set(entry.path, entry.directoryPath);
+      contextByPath.set(
+        entry.path,
+        formatWorkspaceFilePathForDisplay(
+          entry.directoryPath,
+          pathDisplayPlatform
+        )
+      );
     }
     return contextByPath;
-  }, [view.searchEntries]);
+  }, [pathDisplayPlatform, view.searchEntries]);
   const treeRows = useMemo(
     () =>
       buildWorkspaceFileManagerVisibleTreeRows({
@@ -201,6 +212,7 @@ export function WorkspaceFileManagerPanelsContainer({
       contextMenuEntryPath={view.contextMenuEntryPath}
       copy={i18n}
       dateLocale={dateLocale}
+      pathDisplayPlatform={pathDisplayPlatform}
       entryContextByPath={view.isSearchMode ? searchEntryContextByPath : null}
       entryDragMode={entryDragMode}
       iconUrlByCacheKey={iconUrlByCacheKey}

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerToolbar.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerToolbar.tsx
@@ -24,6 +24,7 @@ import {
 } from "@tutti-os/ui-system";
 import { useEffect, useRef, useState, type ReactElement } from "react";
 import type { WorkspaceFileManagerI18nRuntime } from "../i18n/workspaceFileManagerI18n.ts";
+import { formatWorkspaceFilePathForDisplay } from "../services/workspaceFileManagerModel.ts";
 import type { WorkspaceFileManagerArrangeMode } from "./workspaceFileManagerArrangeMode.ts";
 import type { WorkspaceFileManagerLayoutMode } from "./workspaceFileManagerLayoutMode.ts";
 import type { RenderWorkspaceFileManagerToolbarTrailingActions } from "./workspaceFileManagerToolbarTypes.ts";
@@ -35,6 +36,7 @@ export function WorkspaceFileManagerToolbar({
   canGoForward,
   copy,
   currentDirectoryPath,
+  pathDisplayPlatform,
   isBusy,
   isLoading,
   isMutating,
@@ -58,6 +60,7 @@ export function WorkspaceFileManagerToolbar({
   canGoForward: boolean;
   copy: WorkspaceFileManagerI18nRuntime;
   currentDirectoryPath: string;
+  pathDisplayPlatform?: string | null;
   isBusy: boolean;
   isLoading: boolean;
   isMutating: boolean;
@@ -76,6 +79,10 @@ export function WorkspaceFileManagerToolbar({
   onSearchQueryChange: (query: string) => void;
 }): ReactElement {
   const [refreshAnimationKey, setRefreshAnimationKey] = useState(0);
+  const displayPath = formatWorkspaceFilePathForDisplay(
+    currentDirectoryPath,
+    pathDisplayPlatform
+  );
 
   const handleRefresh = (): void => {
     setRefreshAnimationKey((currentKey) => currentKey + 1);
@@ -101,7 +108,7 @@ export function WorkspaceFileManagerToolbar({
         <ArrowRightIcon className="size-4" />
       </ToolbarIconButton>
       <nav
-        aria-label={currentDirectoryPath}
+        aria-label={displayPath}
         className="@max-[600px]/workspace-file-manager:flex-auto flex min-w-0 flex-1 overflow-hidden pr-2"
         data-workspace-file-manager-path=""
       >

--- a/packages/workspace/files/path.go
+++ b/packages/workspace/files/path.go
@@ -16,7 +16,7 @@ func NormalizeLogicalRoot(root string) LogicalPath {
 	if normalized == "." || normalized == "/" {
 		return DefaultLogicalRoot
 	}
-	return LogicalPath(normalized)
+	return LogicalPath(canonicalizeWindowsDriveLogicalPath(normalized))
 }
 
 func NormalizeLogicalPath(value string) (LogicalPath, error) {
@@ -47,7 +47,9 @@ func NormalizeLogicalPathWithinRoot(value string, root string) (LogicalPath, err
 	if !strings.HasPrefix(candidate, "/") {
 		candidate = "/" + candidate
 	}
-	if logicalRoot.String() != "/" && candidate != logicalRoot.String() && !strings.HasPrefix(candidate, logicalRoot.String()+"/") {
+	candidate = canonicalizeWindowsDriveLogicalPath(candidate)
+	candidate = normalizeGitBashDriveLogicalPath(candidate, logicalRoot.String())
+	if logicalRoot.String() != "/" && !isLogicalPathWithinRoot(candidate, logicalRoot.String()) {
 		return "", fmt.Errorf("%w: %q", ErrPathEscapesRoot, value)
 	}
 	return LogicalPath(candidate), nil
@@ -105,7 +107,51 @@ func LogicalRelativePath(value LogicalPath, root string) (string, error) {
 	if logicalRoot.String() == "/" {
 		return strings.TrimPrefix(normalized.String(), "/"), nil
 	}
+	if isWindowsDriveLogicalPath(logicalRoot.String()) {
+		prefix := logicalRoot.String() + "/"
+		if strings.HasPrefix(strings.ToLower(normalized.String()), strings.ToLower(prefix)) {
+			return normalized.String()[len(prefix):], nil
+		}
+	}
 	return strings.TrimPrefix(normalized.String(), logicalRoot.String()+"/"), nil
+}
+
+func canonicalizeWindowsDriveLogicalPath(value string) string {
+	if !isWindowsDriveLogicalPath(value) {
+		return value
+	}
+	return "/" + strings.ToUpper(value[1:2]) + value[2:]
+}
+
+func normalizeGitBashDriveLogicalPath(value string, root string) string {
+	if !isWindowsDriveLogicalPath(root) || len(value) < 2 || value[0] != '/' || !isASCIIAlpha(value[1]) {
+		return value
+	}
+	if len(value) > 2 && value[2] != '/' {
+		return value
+	}
+	drive := strings.ToUpper(root[1:2])
+	if !strings.EqualFold(value[1:2], drive) {
+		return value
+	}
+	return "/" + drive + ":" + value[2:]
+}
+
+func isLogicalPathWithinRoot(value string, root string) bool {
+	if isWindowsDriveLogicalPath(root) || isWindowsDriveLogicalPath(value) {
+		value = strings.ToLower(value)
+		root = strings.ToLower(root)
+	}
+	return value == root || strings.HasPrefix(value, root+"/")
+}
+
+func isWindowsDriveLogicalPath(value string) bool {
+	return len(value) >= 3 && value[0] == '/' && isASCIIAlpha(value[1]) && value[2] == ':' &&
+		(len(value) == 3 || value[3] == '/')
+}
+
+func isASCIIAlpha(value byte) bool {
+	return (value >= 'a' && value <= 'z') || (value >= 'A' && value <= 'Z')
 }
 
 func JoinPhysicalPath(root WorkspaceRoot, value LogicalPath) (string, error) {

--- a/packages/workspace/files/path_test.go
+++ b/packages/workspace/files/path_test.go
@@ -41,15 +41,46 @@ func TestNormalizeLogicalPathWithinRoot(t *testing.T) {
 }
 
 func TestNormalizeLogicalPathWithinWindowsRootAcceptsDriveAbsolutePath(t *testing.T) {
-	got, err := NormalizeLogicalPathWithinRoot(
+	for _, input := range []string{
 		`C:\\Users\\test\\project`,
-		`C:\\Users\\test\\project`,
-	)
+		`c:/Users/test/project`,
+		`/c/Users/test/project`,
+	} {
+		t.Run(input, func(t *testing.T) {
+			got, err := NormalizeLogicalPathWithinRoot(
+				input,
+				`C:\\Users\\test\\project`,
+			)
+			if err != nil {
+				t.Fatalf("NormalizeLogicalPathWithinRoot() error = %v", err)
+			}
+			if got != "/C:/Users/test/project" {
+				t.Fatalf("NormalizeLogicalPathWithinRoot() = %q, want /C:/Users/test/project", got)
+			}
+		})
+	}
+}
+
+func TestNormalizeLogicalPathWithinWindowsRootKeepsPosixDriveLikePathPosix(t *testing.T) {
+	got, err := NormalizeLogicalPathWithinRoot("/c/Users/test/project", "/")
 	if err != nil {
 		t.Fatalf("NormalizeLogicalPathWithinRoot() error = %v", err)
 	}
-	if got != "/C:/Users/test/project" {
-		t.Fatalf("NormalizeLogicalPathWithinRoot() = %q, want /C:/Users/test/project", got)
+	if got != "/c/Users/test/project" {
+		t.Fatalf("NormalizeLogicalPathWithinRoot() = %q, want /c/Users/test/project", got)
+	}
+}
+
+func TestLogicalRelativePathMatchesWindowsDrivePathsCaseInsensitively(t *testing.T) {
+	got, err := LogicalRelativePath(
+		"/c:/users/test/project/src/App.tsx",
+		`C:\\Users\\test\\project`,
+	)
+	if err != nil {
+		t.Fatalf("LogicalRelativePath() error = %v", err)
+	}
+	if got != "src/App.tsx" {
+		t.Fatalf("LogicalRelativePath() = %q, want src/App.tsx", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Reuse the shared workspace-file path model across AgentGUI and Desktop.
- Canonicalize Windows drive paths to `/C:/...` and recognize `/c/...` Git Bash aliases only under Windows-shaped roots.
- Return canonical changed-file paths and add Go, workspace-file-manager, AgentGUI, and Desktop regression coverage.

## Tests
- `pnpm check:changed -- --push-ready`
- `go test ./packages/workspace/files`
- Focused AgentGUI, workspace-file-manager, and Desktop tests: 40/40, 11/11, 22/22

## Notes
- The original 8/17 reproduction was analyzed from the attached Windows logs; the remaining native Windows acceptance gate is left to CI/manual Windows verification.
- Updated `docs/conventions/troubleshooting/workspace-apps-files.md` with the path-shape diagnosis.