### PR TITLE
fix(connectors): show authorized composer preview

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1876,7 +1876,9 @@ infer installation from a remote market response.
 
 Authorization and draft selection are separate facts. Selected connectors are
 stored as semantic draft blocks, rendered as removable chips, and submitted as
-structured prompt content without synthesizing slash text.
+structured prompt content without synthesizing slash text. The compact Composer
+trigger previews installed and authorized connectors independently from draft
+selection, while preserving selected connectors first in that bounded preview.
 
 The device-global `lab.connectors` UI-preference flag controls whether that
 projection is returned. The daemon fails closed when the preference is absent

--- a/docs/architecture/connector-market.md
+++ b/docs/architecture/connector-market.md
@@ -572,8 +572,10 @@ authoritative market view, rejects invalid or unknown keys, and then advances
 the package-owned dialog state machine. Before applying the bounded quick-list
 limit, the shared menu stably groups connected connectors ahead of connectors
 that still require authorization or setup; each group preserves host catalog
-order. Selecting “more” remains host navigation because settings/workbench
-location is product-owned.
+order. Its compact trigger previews the installed and authorized group without
+requiring those connectors to be selected in the current draft; draft selection
+continues to control only structured prompt content. Selecting “more” remains
+host navigation because settings/workbench location is product-owned.
 
 Every renderer window mounts exactly one `ConnectorMarketDialogHost` alongside
 its other window-level panel hosts. Composer entries and catalog cards never

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerConnectorsMenu.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerConnectorsMenu.spec.tsx
@@ -81,7 +81,7 @@ describe("ComposerConnectorsMenu", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("summarizes connected connectors in a compact preview group", () => {
+  it("summarizes authorized connectors without requiring draft selection", () => {
     const connectedConnectors = Array.from({ length: 5 }, (_, index) => ({
       ...connector(`connected-${index}`, "available"),
       iconUrl: `/connector-${index}.png`
@@ -93,9 +93,7 @@ describe("ComposerConnectorsMenu", () => {
         labels={labels}
         onOpenConnector={vi.fn()}
         onOpenConnectors={vi.fn()}
-        selectedConnectorKeys={connectedConnectors.map(
-          (item) => item.connectorKey ?? ""
-        )}
+        selectedConnectorKeys={[]}
       />
     );
 
@@ -191,6 +189,10 @@ describe("ComposerConnectorsMenu", () => {
         selectedConnectorKeys={[]}
       />
     );
+
+    expect(
+      screen.getByTestId("connector-market-composer-preview-notion")
+    ).toBeInTheDocument();
 
     fireEvent.pointerDown(screen.getByRole("button", { name: "Connectors" }), {
       button: 0,

--- a/packages/connector/market/README.md
+++ b/packages/connector/market/README.md
@@ -141,8 +141,10 @@ must be routed through `openConnectorMarketDialog` from
 `@tutti-os/connector-market/services`, which loads the authoritative View before
 opening the package-owned installation, authorization, management, or blocked
 dialog. The bounded quick list places connected connectors first while
-preserving the host order within connected and remaining groups. “More
-connectors” is a separate host navigation callback.
+preserving the host order within connected and remaining groups. The compact
+trigger previews authorized connected connectors independently from the current
+draft selection; selection continues to control only structured prompt content.
+“More connectors” is a separate host navigation callback.
 
 Mount one `ConnectorMarketDialogHost` per renderer window/application
 container, not per composer entry or settings page. Multiple entries share the

--- a/packages/connector/market/src/ui/composer/ConnectorComposerMenu.tsx
+++ b/packages/connector/market/src/ui/composer/ConnectorComposerMenu.tsx
@@ -69,11 +69,11 @@ export function ConnectorComposerMenu({
   const [open, setOpen] = useState(false);
   const normalizedItems = normalizeConnectorItems(items);
   const quickItems = normalizedItems.slice(0, QUICK_CONNECTOR_LIMIT);
-  const selectedItems = normalizedItems.filter(
-    (item) => item.status === "connected" && item.selected === true
+  const connectedItems = normalizedItems.filter(
+    (item) => item.status === "connected"
   );
-  const previewItems = selectedItems.slice(0, CONNECTOR_PREVIEW_LIMIT);
-  const additionalConnectorCount = selectedItems.length - previewItems.length;
+  const previewItems = connectedItems.slice(0, CONNECTOR_PREVIEW_LIMIT);
+  const additionalConnectorCount = connectedItems.length - previewItems.length;
   const closeAndRun = (action: () => void): void => {
     setOpen(false);
     onOpenChange?.(false);


### PR DESCRIPTION
## Summary
- show installed and authorized connectors in the compact Composer trigger even when they are not selected in the current draft
- preserve selected-first ordering, the three-icon preview limit, and structured draft selection semantics
- document the authorization/selection boundary and add regression coverage

## Validation
- `pnpm --dir packages/agent/gui exec vitest run agent-gui/agentGuiNode/composer/ComposerConnectorsMenu.spec.tsx`
- `pnpm --filter @tutti-os/connector-market test`
- `pnpm --filter @tutti-os/connector-market typecheck`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready` (14 lanes)
