### PR TITLE
feat(desktop): add reviewed stable release promotion

### DIFF
--- a/.github/workflows/desktop-release-promote.yml
+++ b/.github/workflows/desktop-release-promote.yml
@@ -63,6 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_channel: ${{ steps.release.outputs.release_channel }}
+      release_already_published: ${{ steps.release.outputs.release_already_published }}
       approval_digest: ${{ steps.release.outputs.approval_digest }}
       release_candidate_id: ${{ steps.release.outputs.release_candidate_id }}
       release_draft_tag: ${{ steps.release.outputs.release_draft_tag }}
@@ -117,7 +118,11 @@ jobs:
           fi
 
           gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" > releases.json
-          jq "[.[] | select(.draft and (.tag_name == \"${release_tag}\" or .tag_name == \"${release_candidate_tag}\"))] | first // empty" releases.json > release.json
+          if [[ "${release_channel}" == "stable" ]]; then
+            jq "[.[] | select((.draft and (.tag_name == \"${release_tag}\" or .tag_name == \"${release_candidate_tag}\")) or ((.draft | not) and .tag_name == \"${release_tag}\" and (.prerelease | not)))] | first // empty" releases.json > release.json
+          else
+            jq "[.[] | select(.draft and .tag_name == \"${release_tag}\")] | first // empty" releases.json > release.json
+          fi
           if ! jq -e . release.json >/dev/null 2>&1; then
             echo "GitHub release ${release_tag} does not exist." >&2
             exit 1
@@ -138,9 +143,14 @@ jobs:
             echo "GitHub release ${release_tag} has no staged assets." >&2
             exit 1
           fi
+          release_already_published=false
           if [[ "${is_draft}" != "true" ]]; then
-            echo "Release ${release_tag} must still be a GitHub draft." >&2
-            exit 1
+            if [[ "${release_channel}" == "stable" && "${actual_tag}" == "${release_tag}" ]]; then
+              release_already_published=true
+            else
+              echo "Release ${release_tag} must still be a GitHub draft." >&2
+              exit 1
+            fi
           fi
           if ! jq -e '.assets[] | select(.name == "SHA256SUMS.txt")' release.json >/dev/null; then
             echo "GitHub release ${release_tag} is missing SHA256SUMS.txt." >&2
@@ -191,6 +201,7 @@ jobs:
 
           release_url="$(jq -r .html_url release.json)"
           echo "approval_digest=${approval_digest}" >> "$GITHUB_OUTPUT"
+          echo "release_already_published=${release_already_published}" >> "$GITHUB_OUTPUT"
           echo "release_candidate_id=${release_candidate_id}" >> "$GITHUB_OUTPUT"
           echo "release_draft_tag=${actual_tag}" >> "$GITHUB_OUTPUT"
           echo "release_id=$(jq -r .id release.json)" >> "$GITHUB_OUTPUT"
@@ -219,7 +230,7 @@ jobs:
     if: ${{ always() && needs.resolve.result == 'success' && (needs.approve-stable.result == 'success' || needs.approve-stable.result == 'skipped') }}
     runs-on: ubuntu-latest
     outputs:
-      release_url: ${{ steps.release-url.outputs.release_url }}
+      release_url: ${{ needs.resolve.outputs.release_url }}
     env:
       AWS_REGION: ${{ vars.AWS_REGION }}
       TUTTI_ARTIFACTS_AWS_ROLE_ARN: ${{ vars.TUTTI_ARTIFACTS_AWS_ROLE_ARN }}
@@ -228,6 +239,7 @@ jobs:
       TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX }}
       TUTTI_DESKTOP_RELEASE_CHANNEL: ${{ needs.resolve.outputs.release_channel }}
       TUTTI_DESKTOP_RELEASE_APPROVAL_DIGEST: ${{ needs.resolve.outputs.approval_digest }}
+      TUTTI_DESKTOP_RELEASE_ALREADY_PUBLISHED: ${{ needs.resolve.outputs.release_already_published }}
       TUTTI_DESKTOP_RELEASE_CANDIDATE_ID: ${{ needs.resolve.outputs.release_candidate_id }}
       TUTTI_DESKTOP_RELEASE_DRAFT_TAG: ${{ needs.resolve.outputs.release_draft_tag }}
       TUTTI_DESKTOP_RELEASE_ID: ${{ needs.resolve.outputs.release_id }}
@@ -301,8 +313,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
-            --jq ".[] | select(.draft and .tag_name == \"${TUTTI_DESKTOP_RELEASE_DRAFT_TAG}\") | .body" > approved-release-body.md
+          gh api "repos/${GITHUB_REPOSITORY}/releases/${TUTTI_DESKTOP_RELEASE_ID}" \
+            --jq .body > approved-release-body.md
           node apps/desktop/scripts/extract-approved-release-summary.mjs \
             approved-release-body.md \
             release-assets/release-summary.json \
@@ -445,7 +457,7 @@ jobs:
           fi
 
       - name: Attach approved draft to the stable tag
-        if: ${{ needs.resolve.outputs.release_channel == 'stable' }}
+        if: ${{ needs.resolve.outputs.release_channel == 'stable' && needs.resolve.outputs.release_already_published != 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -535,9 +547,6 @@ jobs:
             release-assets/release-summary.json \
             release-assets/SHA256SUMS.txt \
             --clobber
-          if [[ "${TUTTI_DESKTOP_RELEASE_CHANNEL}" == "stable" ]]; then
-            gh release delete-asset "${RELEASE_TAG}" release-candidate.json --yes
-          fi
           gh release view "${RELEASE_TAG}" --json body --jq .body > release-body.md
           node apps/desktop/scripts/upsert-release-summary.mjs \
             release-body.md \
@@ -582,7 +591,7 @@ jobs:
             --cache-control "public, max-age=60"
 
       - name: Publish stable GitHub release
-        if: ${{ needs.resolve.outputs.release_channel == 'stable' }}
+        if: ${{ needs.resolve.outputs.release_channel == 'stable' && needs.resolve.outputs.release_already_published != 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release edit "${TUTTI_DESKTOP_RELEASE_TAG}" --draft=false --latest
@@ -710,13 +719,11 @@ jobs:
           echo "Public release pointer did not resolve to ${RELEASE_TAG}: ${pointer_url}" >&2
           exit 1
 
-      - name: Resolve final GitHub release URL
-        id: release-url
+      - name: Remove internal candidate manifest from published release
+        if: ${{ needs.resolve.outputs.release_channel == 'stable' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          release_url="$(gh release view "${TUTTI_DESKTOP_RELEASE_TAG}" --json url --jq .url)"
-          echo "release_url=${release_url}" >> "$GITHUB_OUTPUT"
+        run: gh release delete-asset "${TUTTI_DESKTOP_RELEASE_TAG}" release-candidate.json --yes
 
   notify-feishu:
     name: Notify Feishu

--- a/.github/workflows/desktop-release-promote.yml
+++ b/.github/workflows/desktop-release-promote.yml
@@ -63,6 +63,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_channel: ${{ steps.release.outputs.release_channel }}
+      approval_digest: ${{ steps.release.outputs.approval_digest }}
+      release_candidate_id: ${{ steps.release.outputs.release_candidate_id }}
+      release_draft_tag: ${{ steps.release.outputs.release_draft_tag }}
+      release_id: ${{ steps.release.outputs.release_id }}
       release_make_latest: ${{ steps.release.outputs.release_make_latest }}
       release_prerelease: ${{ steps.release.outputs.release_prerelease }}
       release_tag: ${{ steps.release.outputs.release_tag }}
@@ -106,19 +110,24 @@ jobs:
           fi
 
           release_version="${release_tag#v}"
+          release_candidate_tag="candidate-${release_tag}"
           if [[ -n "${EXPECTED_CHANNEL}" && "${EXPECTED_CHANNEL}" != "${release_channel}" ]]; then
             echo "Release channel mismatch: expected ${EXPECTED_CHANNEL}, got ${release_channel}." >&2
             exit 1
           fi
 
-          gh release view "${release_tag}" \
-            --json assets,isDraft,isPrerelease,tagName,targetCommitish,url > release.json
-          actual_tag="$(jq -r .tagName release.json)"
-          is_draft="$(jq -r .isDraft release.json)"
-          actual_prerelease="$(jq -r .isPrerelease release.json)"
+          gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" > releases.json
+          jq "[.[] | select(.draft and (.tag_name == \"${release_tag}\" or .tag_name == \"${release_candidate_tag}\"))] | first // empty" releases.json > release.json
+          if ! jq -e . release.json >/dev/null 2>&1; then
+            echo "GitHub release ${release_tag} does not exist." >&2
+            exit 1
+          fi
+          actual_tag="$(jq -r .tag_name release.json)"
+          is_draft="$(jq -r .draft release.json)"
+          actual_prerelease="$(jq -r .prerelease release.json)"
           asset_count="$(jq '.assets | length' release.json)"
-          if [[ "${actual_tag}" != "${release_tag}" ]]; then
-            echo "GitHub release tag mismatch: expected ${release_tag}, got ${actual_tag}." >&2
+          if [[ "${actual_tag}" != "${release_tag}" && "${actual_tag}" != "${release_candidate_tag}" ]]; then
+            echo "GitHub release tag mismatch: expected ${release_candidate_tag}, got ${actual_tag}." >&2
             exit 1
           fi
           if [[ "${actual_prerelease}" != "${release_prerelease}" ]]; then
@@ -130,28 +139,48 @@ jobs:
             exit 1
           fi
           if [[ "${is_draft}" != "true" ]]; then
-            if [[ "${release_channel}" != "stable" ]]; then
-              echo "Prerelease ${release_tag} must remain a GitHub draft." >&2
-              exit 1
-            fi
-            latest_stable_tag="$(gh release list \
-              --exclude-drafts \
-              --exclude-pre-releases \
-              --limit 200 \
-              --json tagName,isLatest \
-              --jq '[.[] | select(.tagName != "stable")] | (map(select(.isLatest)) | first) // first | .tagName // ""')"
-            if [[ "${latest_stable_tag}" != "${release_tag}" ]]; then
-              echo "Only the current public stable release may be promoted again." >&2
-              exit 1
-            fi
+            echo "Release ${release_tag} must still be a GitHub draft." >&2
+            exit 1
           fi
           if ! jq -e '.assets[] | select(.name == "SHA256SUMS.txt")' release.json >/dev/null; then
             echo "GitHub release ${release_tag} is missing SHA256SUMS.txt." >&2
             exit 1
           fi
 
-          git fetch --force origin "refs/tags/${release_tag}:refs/tags/${release_tag}"
-          release_target="$(git rev-list -n 1 "${release_tag}")"
+          release_target="$(jq -r '.target_commitish // ""' release.json)"
+          source_ref="${INPUT_SOURCE_REF:-${release_target}}"
+          release_candidate_id=""
+          approval_digest=""
+          if [[ "${release_channel}" == "stable" ]]; then
+            draft_target_sha="$(git rev-parse "${release_target}^{commit}")"
+            RELEASE_TARGET="${draft_target_sha}" gh release download "${actual_tag}" \
+              --pattern release-candidate.json \
+              --pattern release-summary.json \
+              --pattern SHA256SUMS.txt \
+              --dir candidate-validation
+            jq -r .body release.json > candidate-release-body.md
+            node apps/desktop/scripts/extract-approved-release-summary.mjs \
+              candidate-release-body.md \
+              candidate-validation/release-summary.json \
+              approved-release-summary.json
+            verification="$(RELEASE_TAG="${release_tag}" RELEASE_TARGET="${draft_target_sha}" node apps/desktop/scripts/verify-release-candidate.mjs \
+              candidate-validation/release-candidate.json \
+              candidate-validation/SHA256SUMS.txt \
+              candidate-validation/release-summary.json \
+              approved-release-summary.json)"
+            release_target="$(node -e 'process.stdout.write(JSON.parse(process.argv[1]).targetCommit)' "${verification}")"
+            release_candidate_id="$(node -e 'process.stdout.write(JSON.parse(process.argv[1]).candidateId)' "${verification}")"
+            approval_digest="$(node -e 'process.stdout.write(JSON.parse(process.argv[1]).approvalDigest)' "${verification}")"
+            source_ref="$(jq -r .sourceRef candidate-validation/release-candidate.json)"
+            remote_tag_sha="$(git ls-remote --tags origin "refs/tags/${release_tag}" | awk '{print $1}')"
+            if [[ -n "${remote_tag_sha}" && "${remote_tag_sha}" != "${release_target}" ]]; then
+              echo "Stable tag ${release_tag} points to another commit; select a new version." >&2
+              exit 1
+            fi
+          else
+            git fetch --force origin "refs/tags/${release_tag}:refs/tags/${release_tag}"
+            release_target="$(git rev-list -n 1 "${release_tag}")"
+          fi
           if [[ -n "${EXPECTED_TARGET}" ]]; then
             expected_target_sha="$(git rev-parse "${EXPECTED_TARGET}^{commit}")"
             if [[ "${release_target}" != "${expected_target_sha}" ]]; then
@@ -160,8 +189,11 @@ jobs:
             fi
           fi
 
-          source_ref="${INPUT_SOURCE_REF:-$(jq -r '.targetCommitish // ""' release.json)}"
-          release_url="$(jq -r .url release.json)"
+          release_url="$(jq -r .html_url release.json)"
+          echo "approval_digest=${approval_digest}" >> "$GITHUB_OUTPUT"
+          echo "release_candidate_id=${release_candidate_id}" >> "$GITHUB_OUTPUT"
+          echo "release_draft_tag=${actual_tag}" >> "$GITHUB_OUTPUT"
+          echo "release_id=$(jq -r .id release.json)" >> "$GITHUB_OUTPUT"
           echo "release_channel=${release_channel}" >> "$GITHUB_OUTPUT"
           echo "release_make_latest=${release_make_latest}" >> "$GITHUB_OUTPUT"
           echo "release_prerelease=${release_prerelease}" >> "$GITHUB_OUTPUT"
@@ -171,9 +203,20 @@ jobs:
           echo "release_version=${release_version}" >> "$GITHUB_OUTPUT"
           echo "source_ref=${source_ref}" >> "$GITHUB_OUTPUT"
 
+  approve-stable:
+    name: Approve Stable Release
+    needs: resolve
+    if: ${{ needs.resolve.outputs.release_channel == 'stable' }}
+    runs-on: ubuntu-latest
+    environment: desktop-stable-release
+    steps:
+      - name: Record approval
+        run: echo "Stable candidate ${{ needs.resolve.outputs.release_candidate_id }} approved by ${{ github.actor }}."
+
   promote:
     name: Publish External Release
-    needs: resolve
+    needs: [resolve, approve-stable]
+    if: ${{ always() && needs.resolve.result == 'success' && (needs.approve-stable.result == 'success' || needs.approve-stable.result == 'skipped') }}
     runs-on: ubuntu-latest
     outputs:
       release_url: ${{ steps.release-url.outputs.release_url }}
@@ -184,6 +227,10 @@ jobs:
       TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET }}
       TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX }}
       TUTTI_DESKTOP_RELEASE_CHANNEL: ${{ needs.resolve.outputs.release_channel }}
+      TUTTI_DESKTOP_RELEASE_APPROVAL_DIGEST: ${{ needs.resolve.outputs.approval_digest }}
+      TUTTI_DESKTOP_RELEASE_CANDIDATE_ID: ${{ needs.resolve.outputs.release_candidate_id }}
+      TUTTI_DESKTOP_RELEASE_DRAFT_TAG: ${{ needs.resolve.outputs.release_draft_tag }}
+      TUTTI_DESKTOP_RELEASE_ID: ${{ needs.resolve.outputs.release_id }}
       TUTTI_DESKTOP_RELEASE_MAKE_LATEST: ${{ needs.resolve.outputs.release_make_latest }}
       TUTTI_DESKTOP_RELEASE_PRERELEASE: ${{ needs.resolve.outputs.release_prerelease }}
       TUTTI_DESKTOP_RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
@@ -208,7 +255,7 @@ jobs:
       - name: Download staged GitHub release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release download "${TUTTI_DESKTOP_RELEASE_TAG}" --dir release-assets
+        run: gh release download "${TUTTI_DESKTOP_RELEASE_DRAFT_TAG}" --dir release-assets
 
       - name: Verify staged release assets
         run: |
@@ -248,6 +295,33 @@ jobs:
           RELEASE_TAG: ${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
           RELEASE_TARGET: ${{ env.TUTTI_DESKTOP_RELEASE_TARGET }}
         run: node apps/desktop/scripts/validate-release-summary.mjs release-assets/release-summary.json
+
+      - name: Freeze approved stable release summary
+        if: ${{ needs.resolve.outputs.release_channel == 'stable' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+            --jq ".[] | select(.draft and .tag_name == \"${TUTTI_DESKTOP_RELEASE_DRAFT_TAG}\") | .body" > approved-release-body.md
+          node apps/desktop/scripts/extract-approved-release-summary.mjs \
+            approved-release-body.md \
+            release-assets/release-summary.json \
+            approved-release-summary.json
+          verification="$(RELEASE_TAG="${TUTTI_DESKTOP_RELEASE_TAG}" RELEASE_TARGET="${TUTTI_DESKTOP_RELEASE_TARGET}" node apps/desktop/scripts/verify-release-candidate.mjs \
+            release-assets/release-candidate.json \
+            release-assets/SHA256SUMS.txt \
+            release-assets/release-summary.json \
+            approved-release-summary.json)"
+          actual_digest="$(node -e 'process.stdout.write(JSON.parse(process.argv[1]).approvalDigest)' "${verification}")"
+          if [[ "${actual_digest}" != "${TUTTI_DESKTOP_RELEASE_APPROVAL_DIGEST}" ]]; then
+            echo "Release notes or candidate assets changed after approval; submit approval again." >&2
+            exit 1
+          fi
+          cp release-assets/release-candidate.json promotion-candidate.json
+          mv approved-release-summary.json release-assets/release-summary.json
+          rm release-assets/release-candidate.json
+          node apps/desktop/scripts/generate-checksums.mjs release-assets
+          node apps/desktop/scripts/validate-release-summary.mjs release-assets/release-summary.json
 
       - name: Install AWS CLI
         run: |
@@ -327,12 +401,87 @@ jobs:
             exit 1
           fi
 
+      - name: Protect immutable stable asset path
+        if: ${{ needs.resolve.outputs.release_channel == 'stable' }}
+        run: |
+          prefix="${TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX%/}/${TUTTI_DESKTOP_RELEASE_TAG}"
+          marker="s3://${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}/${prefix}/.promotion-candidate.json"
+          checksum="s3://${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}/${prefix}/SHA256SUMS.txt"
+          if aws s3 cp "${marker}" existing-promotion-candidate.json 2>/dev/null; then
+            if ! cmp -s promotion-candidate.json existing-promotion-candidate.json; then
+              echo "Formal asset path belongs to another release candidate." >&2
+              exit 1
+            fi
+          else
+            aws s3 cp promotion-candidate.json "${marker}" \
+              --content-type "application/json" \
+              --cache-control "no-store"
+          fi
+          if aws s3 cp "${checksum}" existing-formal-checksums.txt 2>/dev/null; then
+            if ! cmp -s release-assets/SHA256SUMS.txt existing-formal-checksums.txt; then
+              echo "Published stable asset checksums are immutable and do not match this candidate." >&2
+              exit 1
+            fi
+            echo "TUTTI_DESKTOP_FORMAL_ASSETS_COMPLETE=true" >> "$GITHUB_ENV"
+          else
+            echo "TUTTI_DESKTOP_FORMAL_ASSETS_COMPLETE=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: Create stable release tag after approval
+        if: ${{ needs.resolve.outputs.release_channel == 'stable' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          remote_tag_sha="$(git ls-remote --tags origin "refs/tags/${TUTTI_DESKTOP_RELEASE_TAG}" | awk '{print $1}')"
+          if [[ -z "${remote_tag_sha}" ]]; then
+            node apps/desktop/scripts/reserve-release-tag.mjs \
+              --strategy explicit_tag \
+              --tag "${TUTTI_DESKTOP_RELEASE_TAG}" \
+              --target "${TUTTI_DESKTOP_RELEASE_TARGET}" \
+              --json >/dev/null
+          elif [[ "${remote_tag_sha}" != "${TUTTI_DESKTOP_RELEASE_TARGET}" ]]; then
+            echo "Stable tag ${TUTTI_DESKTOP_RELEASE_TAG} points to another commit." >&2
+            exit 1
+          fi
+
+      - name: Attach approved draft to the stable tag
+        if: ${{ needs.resolve.outputs.release_channel == 'stable' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${TUTTI_DESKTOP_RELEASE_ID}" \
+            -f tag_name="${TUTTI_DESKTOP_RELEASE_TAG}" \
+            -f target_commitish="${TUTTI_DESKTOP_RELEASE_TARGET}" \
+            -f name="${TUTTI_DESKTOP_RELEASE_TAG}" \
+            -F draft=true \
+            -F prerelease=false >/dev/null
+          if [[ "${TUTTI_DESKTOP_RELEASE_DRAFT_TAG}" != "${TUTTI_DESKTOP_RELEASE_TAG}" ]]; then
+            git push origin ":refs/tags/${TUTTI_DESKTOP_RELEASE_DRAFT_TAG}" || true
+          fi
+
       - name: Upload immutable release assets to AWS S3
         run: |
           remote_dir="s3://${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}/${TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX%/}/${TUTTI_DESKTOP_RELEASE_TAG}"
-          aws s3 sync release-assets "${remote_dir}" \
-            --size-only \
-            --cache-control "public, max-age=31536000, immutable"
+          if [[ "${TUTTI_DESKTOP_RELEASE_CHANNEL}" == "stable" ]]; then
+            if [[ "${TUTTI_DESKTOP_FORMAL_ASSETS_COMPLETE}" != "true" ]]; then
+              candidate_dir="s3://${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}/${TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX%/}/candidates/${TUTTI_DESKTOP_RELEASE_CANDIDATE_ID}"
+              aws s3 sync "${candidate_dir}" "${remote_dir}" \
+                --exclude "release-summary.json" \
+                --exclude "SHA256SUMS.txt" \
+                --exclude "release-candidate.json" \
+                --copy-props metadata-directive
+              aws s3 cp release-assets/release-summary.json "${remote_dir}/release-summary.json" \
+                --content-type "application/json" \
+                --cache-control "public, max-age=31536000, immutable"
+              aws s3 cp release-assets/SHA256SUMS.txt "${remote_dir}/SHA256SUMS.txt" \
+                --content-type "text/plain" \
+                --cache-control "public, max-age=31536000, immutable"
+            fi
+          else
+            aws s3 sync release-assets "${remote_dir}" \
+              --size-only \
+              --cache-control "public, max-age=31536000, immutable"
+          fi
 
       - name: Verify mirrored Windows release assets
         shell: bash
@@ -381,6 +530,14 @@ jobs:
           RELEASE_TAG: ${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
         run: |
           export RELEASE_ASSET_BASE_URL="${TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL}"
+          export RELEASE_SUMMARY_MODE=published
+          gh release upload "${RELEASE_TAG}" \
+            release-assets/release-summary.json \
+            release-assets/SHA256SUMS.txt \
+            --clobber
+          if [[ "${TUTTI_DESKTOP_RELEASE_CHANNEL}" == "stable" ]]; then
+            gh release delete-asset "${RELEASE_TAG}" release-candidate.json --yes
+          fi
           gh release view "${RELEASE_TAG}" --json body --jq .body > release-body.md
           node apps/desktop/scripts/upsert-release-summary.mjs \
             release-body.md \
@@ -396,6 +553,7 @@ jobs:
         env:
           RELEASE_CHANNEL: ${{ env.TUTTI_DESKTOP_RELEASE_CHANNEL }}
           RELEASE_GIT_SHA: ${{ env.TUTTI_DESKTOP_RELEASE_TARGET }}
+          RELEASE_NOTES_URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
           RELEASE_SOURCE_REF: ${{ needs.resolve.outputs.source_ref }}
           RELEASE_TAG: ${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
         run: |
@@ -608,3 +766,15 @@ jobs:
       - name: Skip Feishu card
         if: env.FEISHU_WEBHOOK_URL == ''
         run: echo "FEISHU_RELEASE_WEBHOOK_URL is not configured; skipping Feishu notification."
+
+  submit-store:
+    name: Submit stable package to Microsoft Store
+    needs: [resolve, promote]
+    if: ${{ needs.resolve.outputs.release_channel == 'stable' && needs.promote.result == 'success' && vars.TUTTI_WINDOWS_STORE_SUBMISSION_ENABLED == 'true' }}
+    uses: ./.github/workflows/desktop-store-submit.yml
+    with:
+      release_tag: ${{ needs.resolve.outputs.release_tag }}
+      store_environment: microsoft-store-production
+      submit: true
+      target_commit: ${{ needs.resolve.outputs.release_target }}
+    secrets: inherit

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -35,7 +35,7 @@ on:
         required: false
         type: string
       publication_mode:
-        description: Publish externally now or keep the signed build as a GitHub draft
+        description: Prerelease publication mode; stable builds always stop for approval
         required: true
         type: choice
         default: publish
@@ -52,6 +52,10 @@ permissions:
   contents: write
   id-token: write
 
+concurrency:
+  group: desktop-release-${{ github.event_name }}-${{ inputs.release_mode || github.ref_name }}-${{ inputs.version || github.ref_name }}
+  cancel-in-progress: false
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
@@ -64,9 +68,13 @@ jobs:
       release_make_latest: ${{ steps.release.outputs.release_make_latest }}
       release_prerelease: ${{ steps.release.outputs.release_prerelease }}
       release_tag: ${{ steps.release.outputs.release_tag }}
-      release_target: ${{ steps.target.outputs.release_target }}
+      release_target: ${{ steps.release.outputs.release_target }}
       release_version: ${{ steps.release.outputs.release_version }}
       release_channel: ${{ steps.release.outputs.release_channel }}
+      release_candidate: ${{ steps.release.outputs.release_candidate }}
+      release_candidate_id: ${{ steps.release.outputs.release_candidate_id }}
+      release_candidate_tag: ${{ steps.release.outputs.release_candidate_tag }}
+      source_ref: ${{ steps.target.outputs.source_ref }}
       publication_mode: ${{ steps.publication.outputs.publication_mode }}
       notify_feishu: ${{ steps.notify.outputs.notify_feishu }}
 
@@ -95,6 +103,7 @@ jobs:
         run: |
           release_target="${{ inputs.target_commitish || github.sha }}"
           echo "release_target=${release_target}" >> "$GITHUB_OUTPUT"
+          echo "source_ref=${{ github.ref_type == 'branch' && github.ref_name || '' }}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@v6
@@ -230,12 +239,7 @@ jobs:
               version="${INPUT_VERSION:-0.1.0}"
               args+=(--version "${version}")
             fi
-            if [[ "${RELEASE_DRY_RUN}" == "true" ]]; then
-              args=(node apps/desktop/scripts/resolve-release-tag.mjs "${args[@]}")
-            else
-              args+=(--target "${{ steps.target.outputs.release_target }}")
-              args=(node apps/desktop/scripts/reserve-release-tag.mjs "${args[@]}")
-            fi
+            args=(node apps/desktop/scripts/resolve-release-tag.mjs "${args[@]}")
           fi
 
           if [[ "${{ github.event_name }}" == "push" ]]; then
@@ -248,11 +252,29 @@ jobs:
           release_tag="$(node -e "process.stdout.write(JSON.parse(process.argv[1]).tag)" "${release_json}")"
           release_version="$(node -e "process.stdout.write(JSON.parse(process.argv[1]).version)" "${release_json}")"
           release_channel="$(node -e "process.stdout.write(JSON.parse(process.argv[1]).channel)" "${release_json}")"
+          release_candidate=false
+          if [[ "${release_channel}" == "stable" && "${RELEASE_DRY_RUN}" != "true" && "${{ github.event_name }}" != "push" ]]; then
+            release_candidate=true
+            if git ls-remote --exit-code --tags origin "refs/tags/${release_tag}" >/dev/null 2>&1; then
+              echo "Stable tag ${release_tag} already exists; retry promotion or choose a new version." >&2
+              exit 1
+            fi
+          elif [[ "${{ github.event_name }}" != "push" && "${RELEASE_DRY_RUN}" != "true" ]]; then
+            reserve_args=(--strategy explicit_tag --tag "${release_tag}" --target "$(git rev-parse HEAD)" --json)
+            node apps/desktop/scripts/reserve-release-tag.mjs "${reserve_args[@]}" >/dev/null
+          fi
+          release_target="$(git rev-parse HEAD)"
+          release_candidate_id="${release_tag}-$(git rev-parse --short=7 HEAD)-run${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          release_candidate_tag="candidate-${release_tag}"
           echo "release_make_latest=${release_make_latest}" >> "$GITHUB_OUTPUT"
           echo "release_prerelease=${release_prerelease}" >> "$GITHUB_OUTPUT"
           echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
           echo "release_version=${release_version}" >> "$GITHUB_OUTPUT"
           echo "release_channel=${release_channel}" >> "$GITHUB_OUTPUT"
+          echo "release_candidate=${release_candidate}" >> "$GITHUB_OUTPUT"
+          echo "release_candidate_id=${release_candidate_id}" >> "$GITHUB_OUTPUT"
+          echo "release_candidate_tag=${release_candidate_tag}" >> "$GITHUB_OUTPUT"
+          echo "release_target=${release_target}" >> "$GITHUB_OUTPUT"
 
       - name: Resolve Feishu notification
         id: notify
@@ -294,6 +316,9 @@ jobs:
       TUTTI_DESKTOP_RELEASE_TARGET: ${{ needs.resolve.outputs.release_target }}
       TUTTI_DESKTOP_DRY_RUN: ${{ needs.resolve.outputs.release_dry_run }}
       TUTTI_DESKTOP_RELEASE_CHANNEL: ${{ needs.resolve.outputs.release_channel }}
+      TUTTI_DESKTOP_RELEASE_CANDIDATE: ${{ needs.resolve.outputs.release_candidate }}
+      TUTTI_DESKTOP_RELEASE_CANDIDATE_ID: ${{ needs.resolve.outputs.release_candidate_id }}
+      TUTTI_DESKTOP_RELEASE_CANDIDATE_TAG: ${{ needs.resolve.outputs.release_candidate_tag }}
 
     steps:
       - name: Checkout
@@ -520,6 +545,7 @@ jobs:
     if: >-
       ${{ needs.resolve.outputs.release_channel == 'stable' &&
           needs.resolve.outputs.release_dry_run != 'true' &&
+          needs.resolve.outputs.release_candidate != 'true' &&
           needs.resolve.outputs.publication_mode == 'publish' &&
           vars.TUTTI_WINDOWS_STORE_SUBMISSION_ENABLED == 'true' }}
     uses: ./.github/workflows/desktop-store-submit.yml
@@ -540,7 +566,7 @@ jobs:
           needs.build-windows.result == 'success' }}
     runs-on: ubuntu-latest
     outputs:
-      release_url: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ needs.resolve.outputs.release_tag }}
+      release_url: ${{ needs.resolve.outputs.release_candidate == 'true' && steps.stage-candidate-release.outputs.release_url || steps.stage-release.outputs.url }}
     env:
       AWS_REGION: ${{ vars.AWS_REGION }}
       TUTTI_ARTIFACTS_AWS_ROLE_ARN: ${{ vars.TUTTI_ARTIFACTS_AWS_ROLE_ARN }}
@@ -630,6 +656,21 @@ jobs:
       - name: Generate checksums
         run: node apps/desktop/scripts/generate-checksums.mjs release-assets
 
+      - name: Build stable release candidate manifest
+        if: ${{ needs.resolve.outputs.release_candidate == 'true' }}
+        env:
+          RELEASE_CANDIDATE_ID: ${{ needs.resolve.outputs.release_candidate_id }}
+          RELEASE_SOURCE_REF: ${{ needs.resolve.outputs.source_ref }}
+          RELEASE_TAG: ${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
+          RELEASE_TARGET: ${{ env.TUTTI_DESKTOP_RELEASE_TARGET }}
+          RELEASE_VERSION: ${{ env.TUTTI_DESKTOP_RELEASE_VERSION }}
+          RELEASE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          node apps/desktop/scripts/build-release-candidate-manifest.mjs \
+            release-assets/SHA256SUMS.txt \
+            release-assets/release-summary.json \
+            release-assets/release-candidate.json
+
       - id: previous-release-tag
         name: Resolve previous GitHub release tag
         env:
@@ -641,6 +682,7 @@ jobs:
 
       - id: stage-release
         name: Stage GitHub release assets
+        if: ${{ needs.resolve.outputs.release_candidate != 'true' }}
         uses: softprops/action-gh-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -654,6 +696,41 @@ jobs:
           previous_tag: ${{ steps.previous-release-tag.outputs.tag }}
           files: |
             release-assets/*
+
+      - id: stage-candidate-release
+        name: Create or refresh stable GitHub draft
+        if: ${{ needs.resolve.outputs.release_candidate == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          release_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+            --paginate \
+            --jq ".[] | select(.draft and .tag_name == \"${TUTTI_DESKTOP_RELEASE_CANDIDATE_TAG}\") | .id" | head -1)"
+          if [[ -z "${release_id}" ]]; then
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/releases" \
+              -f tag_name="${TUTTI_DESKTOP_RELEASE_CANDIDATE_TAG}" \
+              -f target_commitish="${TUTTI_DESKTOP_RELEASE_TARGET}" \
+              -f name="${TUTTI_DESKTOP_RELEASE_TAG}" \
+              -F draft=true \
+              -F prerelease=false \
+              -F generate_release_notes=true > staged-release.json
+          else
+            git tag -f "${TUTTI_DESKTOP_RELEASE_CANDIDATE_TAG}" "${TUTTI_DESKTOP_RELEASE_TARGET}"
+            git push origin "refs/tags/${TUTTI_DESKTOP_RELEASE_CANDIDATE_TAG}" --force
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
+              -f target_commitish="${TUTTI_DESKTOP_RELEASE_TARGET}" \
+              -f name="${TUTTI_DESKTOP_RELEASE_TAG}" \
+              -F draft=true \
+              -F prerelease=false > staged-release.json
+            gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets?per_page=100" \
+              --jq '.[].id' |
+              while IFS= read -r asset_id; do
+                gh api --method DELETE "repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}"
+              done
+          fi
+          gh release upload "${TUTTI_DESKTOP_RELEASE_CANDIDATE_TAG}" release-assets/*
+          echo "release_url=$(jq -r .html_url staged-release.json)" >> "$GITHUB_OUTPUT"
 
       - name: Install AWS CLI
         run: |
@@ -698,7 +775,11 @@ jobs:
 
       - name: Upload immutable draft assets to AWS S3
         run: |
-          remote_dir="s3://${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}/${TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX%/}/${TUTTI_DESKTOP_RELEASE_TAG}"
+          release_asset_path="${TUTTI_DESKTOP_RELEASE_TAG}"
+          if [[ "${TUTTI_DESKTOP_RELEASE_CANDIDATE}" == "true" ]]; then
+            release_asset_path="candidates/${TUTTI_DESKTOP_RELEASE_CANDIDATE_ID}"
+          fi
+          remote_dir="s3://${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}/${TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX%/}/${release_asset_path}"
           aws s3 cp release-assets "${remote_dir}" \
             --recursive \
             --cache-control "public, max-age=31536000, immutable"
@@ -715,7 +796,14 @@ jobs:
         run: |
           export RELEASE_TAG="${TUTTI_DESKTOP_RELEASE_TAG}"
           export RELEASE_ASSET_BASE_URL="${TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL}"
-          gh release view "${TUTTI_DESKTOP_RELEASE_TAG}" --json body --jq .body > release-body.md
+          if [[ "${TUTTI_DESKTOP_RELEASE_CANDIDATE}" == "true" ]]; then
+            export RELEASE_ASSET_PATH="candidates/${TUTTI_DESKTOP_RELEASE_CANDIDATE_ID}"
+          fi
+          github_release_tag="${TUTTI_DESKTOP_RELEASE_TAG}"
+          if [[ "${TUTTI_DESKTOP_RELEASE_CANDIDATE}" == "true" ]]; then
+            github_release_tag="${TUTTI_DESKTOP_RELEASE_CANDIDATE_TAG}"
+          fi
+          gh release view "${github_release_tag}" --json body --jq .body > release-body.md
           node apps/desktop/scripts/upsert-release-summary.mjs \
             release-body.md \
             release-assets/release-summary.json \
@@ -724,12 +812,12 @@ jobs:
             release-body-with-summary.md \
             release-assets \
             updated-release-body.md
-          gh release edit "${TUTTI_DESKTOP_RELEASE_TAG}" --notes-file updated-release-body.md
+          gh release edit "${github_release_tag}" --notes-file updated-release-body.md
 
   promote:
     name: Promote Release
     needs: [resolve, stage]
-    if: ${{ always() && needs.stage.result == 'success' && needs.resolve.outputs.publication_mode == 'publish' }}
+    if: ${{ always() && needs.stage.result == 'success' && needs.resolve.outputs.release_candidate != 'true' && needs.resolve.outputs.publication_mode == 'publish' }}
     uses: ./.github/workflows/desktop-release-promote.yml
     with:
       release_tag: ${{ needs.resolve.outputs.release_tag }}
@@ -741,9 +829,9 @@ jobs:
       FEISHU_RELEASE_WEBHOOK_URL: ${{ secrets.FEISHU_RELEASE_WEBHOOK_URL }}
 
   notify-draft-feishu:
-    name: Notify Draft Release
+    name: Notify Release Candidate
     needs: [resolve, stage]
-    if: ${{ always() && needs.stage.result == 'success' && needs.resolve.outputs.publication_mode == 'draft_only' && needs.resolve.outputs.notify_feishu == 'true' }}
+    if: ${{ always() && needs.stage.result == 'success' && needs.resolve.outputs.notify_feishu == 'true' && (needs.resolve.outputs.release_candidate == 'true' || needs.resolve.outputs.publication_mode == 'draft_only') }}
     runs-on: ubuntu-latest
     env:
       FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_RELEASE_WEBHOOK_URL }}
@@ -753,11 +841,15 @@ jobs:
       TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX }}
       RELEASE_ACTOR: ${{ github.actor }}
       RELEASE_BRANCH: ${{ github.ref_type == 'branch' && github.ref_name || '' }}
-      RELEASE_PUBLICATION_STATUS: draft
+      RELEASE_ASSET_PATH: ${{ needs.resolve.outputs.release_candidate == 'true' && format('candidates/{0}', needs.resolve.outputs.release_candidate_id) || needs.resolve.outputs.release_tag }}
+      RELEASE_CANDIDATE_ID: ${{ needs.resolve.outputs.release_candidate_id }}
+      RELEASE_LOOKUP_TAG: ${{ needs.resolve.outputs.release_candidate == 'true' && needs.resolve.outputs.release_candidate_tag || needs.resolve.outputs.release_tag }}
+      RELEASE_PUBLICATION_STATUS: ${{ needs.resolve.outputs.release_candidate == 'true' && 'candidate' || 'draft' }}
       RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
       RELEASE_TARGET: ${{ needs.resolve.outputs.release_target }}
       RELEASE_URL: ${{ needs.stage.outputs.release_url }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      PROMOTION_URL: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/desktop-release-promote.yml
 
     steps:
       - name: Checkout notification script

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -2,7 +2,7 @@ name: Desktop Release
 
 run-name: >-
   ${{ github.event_name == 'workflow_dispatch'
-      && format('Desktop Release · {0} · {1} · {2}', inputs.release_mode, inputs.publication_mode, github.ref_name)
+      && format('Desktop Release · {0} · {1}', inputs.release_mode, github.ref_name)
       || format('Desktop Release · {0} · {1}', github.event_name, github.ref_name) }}
 
 on:
@@ -34,14 +34,6 @@ on:
         description: Optional commit-ish override
         required: false
         type: string
-      publication_mode:
-        description: Prerelease publication mode; stable builds always stop for approval
-        required: true
-        type: choice
-        default: publish
-        options:
-          - publish
-          - draft_only
       notify_feishu:
         description: Send a Feishu card after publishing
         required: false
@@ -75,7 +67,6 @@ jobs:
       release_candidate_id: ${{ steps.release.outputs.release_candidate_id }}
       release_candidate_tag: ${{ steps.release.outputs.release_candidate_tag }}
       source_ref: ${{ steps.target.outputs.source_ref }}
-      publication_mode: ${{ steps.publication.outputs.publication_mode }}
       notify_feishu: ${{ steps.notify.outputs.notify_feishu }}
 
     steps:
@@ -280,27 +271,6 @@ jobs:
         id: notify
         shell: bash
         run: echo "notify_feishu=${{ github.event_name != 'workflow_dispatch' || inputs.notify_feishu != false }}" >> "$GITHUB_OUTPUT"
-
-      - name: Resolve publication mode
-        id: publication
-        shell: bash
-        env:
-          INPUT_PUBLICATION_MODE: ${{ inputs.publication_mode }}
-          RELEASE_EVENT_NAME: ${{ github.event_name }}
-        run: |
-          publication_mode=publish
-          if [[ "${RELEASE_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            publication_mode="${INPUT_PUBLICATION_MODE:-publish}"
-          fi
-          case "${publication_mode}" in
-            publish|draft_only)
-              ;;
-            *)
-              echo "Unknown publication_mode: ${publication_mode}" >&2
-              exit 1
-              ;;
-          esac
-          echo "publication_mode=${publication_mode}" >> "$GITHUB_OUTPUT"
 
   build-macos:
     name: Build macOS (${{ matrix.arch }})
@@ -546,7 +516,6 @@ jobs:
       ${{ needs.resolve.outputs.release_channel == 'stable' &&
           needs.resolve.outputs.release_dry_run != 'true' &&
           needs.resolve.outputs.release_candidate != 'true' &&
-          needs.resolve.outputs.publication_mode == 'publish' &&
           vars.TUTTI_WINDOWS_STORE_SUBMISSION_ENABLED == 'true' }}
     uses: ./.github/workflows/desktop-store-submit.yml
     with:
@@ -817,7 +786,7 @@ jobs:
   promote:
     name: Promote Release
     needs: [resolve, stage]
-    if: ${{ always() && needs.stage.result == 'success' && needs.resolve.outputs.release_candidate != 'true' && needs.resolve.outputs.publication_mode == 'publish' }}
+    if: ${{ always() && needs.stage.result == 'success' && needs.resolve.outputs.release_candidate != 'true' }}
     uses: ./.github/workflows/desktop-release-promote.yml
     with:
       release_tag: ${{ needs.resolve.outputs.release_tag }}
@@ -828,10 +797,10 @@ jobs:
     secrets:
       FEISHU_RELEASE_WEBHOOK_URL: ${{ secrets.FEISHU_RELEASE_WEBHOOK_URL }}
 
-  notify-draft-feishu:
+  notify-candidate-feishu:
     name: Notify Release Candidate
     needs: [resolve, stage]
-    if: ${{ always() && needs.stage.result == 'success' && needs.resolve.outputs.notify_feishu == 'true' && (needs.resolve.outputs.release_candidate == 'true' || needs.resolve.outputs.publication_mode == 'draft_only') }}
+    if: ${{ always() && needs.stage.result == 'success' && needs.resolve.outputs.notify_feishu == 'true' && needs.resolve.outputs.release_candidate == 'true' }}
     runs-on: ubuntu-latest
     env:
       FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_RELEASE_WEBHOOK_URL }}
@@ -841,10 +810,10 @@ jobs:
       TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX }}
       RELEASE_ACTOR: ${{ github.actor }}
       RELEASE_BRANCH: ${{ github.ref_type == 'branch' && github.ref_name || '' }}
-      RELEASE_ASSET_PATH: ${{ needs.resolve.outputs.release_candidate == 'true' && format('candidates/{0}', needs.resolve.outputs.release_candidate_id) || needs.resolve.outputs.release_tag }}
+      RELEASE_ASSET_PATH: candidates/${{ needs.resolve.outputs.release_candidate_id }}
       RELEASE_CANDIDATE_ID: ${{ needs.resolve.outputs.release_candidate_id }}
-      RELEASE_LOOKUP_TAG: ${{ needs.resolve.outputs.release_candidate == 'true' && needs.resolve.outputs.release_candidate_tag || needs.resolve.outputs.release_tag }}
-      RELEASE_PUBLICATION_STATUS: ${{ needs.resolve.outputs.release_candidate == 'true' && 'candidate' || 'draft' }}
+      RELEASE_LOOKUP_TAG: ${{ needs.resolve.outputs.release_candidate_tag }}
+      RELEASE_PUBLICATION_STATUS: candidate
       RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
       RELEASE_TARGET: ${{ needs.resolve.outputs.release_target }}
       RELEASE_URL: ${{ needs.stage.outputs.release_url }}
@@ -871,7 +840,7 @@ jobs:
           name: tutti-desktop-release-summary
           path: release-summary
 
-      - name: Send draft release card
+      - name: Send candidate release card
         if: env.FEISHU_WEBHOOK_URL != ''
         env:
           RELEASE_SUMMARY_PATH: release-summary/release-summary.json
@@ -879,4 +848,4 @@ jobs:
 
       - name: Skip Feishu card
         if: env.FEISHU_WEBHOOK_URL == ''
-        run: echo "FEISHU_RELEASE_WEBHOOK_URL is not configured; skipping draft notification."
+        run: echo "FEISHU_RELEASE_WEBHOOK_URL is not configured; skipping candidate notification."

--- a/apps/desktop/scripts/build-release-candidate-manifest.mjs
+++ b/apps/desktop/scripts/build-release-candidate-manifest.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+import {
+  createReleaseCandidateManifest,
+  validateReleaseCandidateManifest
+} from "./lib/releaseCandidate.mjs";
+
+async function main() {
+  const [checksumsPath, summaryPath, outputPath] = process.argv.slice(2);
+  if (!checksumsPath || !summaryPath || !outputPath) {
+    throw new Error(
+      "Usage: build-release-candidate-manifest.mjs <checksums> <generated-summary> <output>"
+    );
+  }
+  const checksums = await readFile(checksumsPath, "utf8");
+  const generatedSummary = await readFile(summaryPath, "utf8");
+  const manifest = createReleaseCandidateManifest({
+    candidateId: process.env.RELEASE_CANDIDATE_ID,
+    tag: process.env.RELEASE_TAG,
+    version: process.env.RELEASE_VERSION,
+    targetCommit: process.env.RELEASE_TARGET,
+    sourceRef: process.env.RELEASE_SOURCE_REF,
+    createdAt: process.env.RELEASE_CREATED_AT ?? new Date().toISOString(),
+    workflowRunUrl: process.env.RELEASE_RUN_URL,
+    checksums,
+    generatedSummary
+  });
+  validateReleaseCandidateManifest(manifest, { checksums, generatedSummary });
+  await writeFile(outputPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  void main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/apps/desktop/scripts/build-release-latest.mjs
+++ b/apps/desktop/scripts/build-release-latest.mjs
@@ -168,6 +168,7 @@ async function buildDesktopReleaseLatest(options) {
   );
   const gitSha = String(options.gitSha ?? "").trim();
   const sourceRef = String(options.sourceRef ?? "").trim();
+  const releaseNotesUrl = String(options.releaseNotesUrl ?? "").trim();
   const releasedAt =
     options.releasedAt instanceof Date
       ? options.releasedAt.toISOString()
@@ -203,6 +204,7 @@ async function buildDesktopReleaseLatest(options) {
     releasedAt,
     gitSha: gitSha || null,
     sourceRef: sourceRef || null,
+    releaseNotesUrl: releaseNotesUrl || null,
     baseUrl,
     preferredDownloads: {
       macosUniversalDmg,
@@ -220,6 +222,7 @@ async function main() {
     gitSha: process.env.RELEASE_GIT_SHA,
     releaseAssetBaseUrl: process.env.RELEASE_ASSET_BASE_URL,
     releaseTag: process.env.RELEASE_TAG,
+    releaseNotesUrl: process.env.RELEASE_NOTES_URL,
     releasedAt: process.env.RELEASED_AT,
     sourceRef: process.env.RELEASE_SOURCE_REF
   });

--- a/apps/desktop/scripts/extract-approved-release-summary.mjs
+++ b/apps/desktop/scripts/extract-approved-release-summary.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+import { buildApprovedReleaseSummary } from "./upsert-release-summary.mjs";
+import { validateReleaseSummary } from "./validate-release-summary.mjs";
+
+async function main() {
+  const [bodyPath, generatedSummaryPath, outputPath] = process.argv.slice(2);
+  if (!bodyPath || !generatedSummaryPath || !outputPath) {
+    throw new Error(
+      "Usage: extract-approved-release-summary.mjs <release-body> <generated-summary> <output>"
+    );
+  }
+  const body = await readFile(bodyPath, "utf8");
+  const generatedSummary = JSON.parse(
+    await readFile(generatedSummaryPath, "utf8")
+  );
+  const approved = buildApprovedReleaseSummary({ body, generatedSummary });
+  validateReleaseSummary(approved, {
+    tag: process.env.RELEASE_TAG,
+    channel: process.env.RELEASE_CHANNEL,
+    targetCommit: process.env.RELEASE_TARGET
+  });
+  await writeFile(outputPath, `${JSON.stringify(approved, null, 2)}\n`, "utf8");
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  void main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/apps/desktop/scripts/lib/releaseCandidate.mjs
+++ b/apps/desktop/scripts/lib/releaseCandidate.mjs
@@ -1,0 +1,99 @@
+import { createHash } from "node:crypto";
+
+const candidateSchemaVersion = "tutti.desktop.release.candidate.v1";
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function requireString(value, label) {
+  const normalized = String(value ?? "").trim();
+  if (!normalized) {
+    throw new Error(`${label} is required`);
+  }
+  return normalized;
+}
+
+function createReleaseCandidateManifest(input) {
+  const tag = requireString(input.tag, "tag");
+  const version = requireString(input.version, "version");
+  const candidateId = requireString(input.candidateId, "candidateId");
+  if (tag !== `v${version}` || !/^v\d+\.\d+\.\d+$/u.test(tag)) {
+    throw new Error("stable candidate tag and version must match");
+  }
+  if (!candidateId.startsWith(`${tag}-`)) {
+    throw new Error("candidateId must start with the planned tag");
+  }
+
+  const targetCommit = requireString(input.targetCommit, "targetCommit");
+  if (!/^[a-f0-9]{40}$/u.test(targetCommit)) {
+    throw new Error("targetCommit must be a full Git commit SHA");
+  }
+
+  return {
+    schemaVersion: candidateSchemaVersion,
+    candidateId,
+    tag,
+    version,
+    channel: "stable",
+    targetCommit,
+    sourceRef: requireString(input.sourceRef, "sourceRef"),
+    createdAt: requireString(input.createdAt, "createdAt"),
+    workflowRunUrl: requireString(input.workflowRunUrl, "workflowRunUrl"),
+    checksumsSha256: sha256(requireString(input.checksums, "checksums")),
+    generatedSummarySha256: sha256(
+      requireString(input.generatedSummary, "generatedSummary")
+    )
+  };
+}
+
+function validateReleaseCandidateManifest(manifest, expected = {}) {
+  if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) {
+    throw new Error("candidate manifest must be an object");
+  }
+  if (manifest.schemaVersion !== candidateSchemaVersion) {
+    throw new Error(`unexpected candidate schema: ${manifest.schemaVersion}`);
+  }
+  const normalized = createReleaseCandidateManifest({
+    ...manifest,
+    checksums: expected.checksums,
+    generatedSummary: expected.generatedSummary
+  });
+  for (const [field, expectedValue] of Object.entries(expected)) {
+    if (
+      field !== "checksums" &&
+      field !== "generatedSummary" &&
+      expectedValue &&
+      normalized[field] !== expectedValue
+    ) {
+      throw new Error(`candidate manifest ${field} does not match`);
+    }
+  }
+  if (manifest.checksumsSha256 !== normalized.checksumsSha256) {
+    throw new Error("candidate checksums digest does not match");
+  }
+  if (manifest.generatedSummarySha256 !== normalized.generatedSummarySha256) {
+    throw new Error("candidate summary digest does not match");
+  }
+  return manifest;
+}
+
+function buildReleaseApprovalDigest(manifest, approvedSummary) {
+  return sha256(
+    JSON.stringify({
+      candidateId: manifest.candidateId,
+      checksumsSha256: manifest.checksumsSha256,
+      generatedSummarySha256: manifest.generatedSummarySha256,
+      tag: manifest.tag,
+      targetCommit: manifest.targetCommit,
+      approvedSummary
+    })
+  );
+}
+
+export {
+  buildReleaseApprovalDigest,
+  candidateSchemaVersion,
+  createReleaseCandidateManifest,
+  validateReleaseCandidateManifest
+};

--- a/apps/desktop/scripts/send-release-feishu-card.mjs
+++ b/apps/desktop/scripts/send-release-feishu-card.mjs
@@ -48,23 +48,23 @@ function resolveDisplayValue(value, fallback = "unknown") {
 
 function resolveReleaseKind(tag, publicationStatus = "published") {
   if (/-rc\.(0|[1-9]\d*)$/i.test(tag)) {
-    return publicationStatus === "draft"
+    return publicationStatus === "candidate" || publicationStatus === "draft"
       ? "Draft release candidate prerelease"
       : "Release candidate prerelease";
   }
   if (/-beta\.(0|[1-9]\d*)$/i.test(tag)) {
-    return publicationStatus === "draft"
+    return publicationStatus === "candidate" || publicationStatus === "draft"
       ? "Draft beta prerelease"
       : "Beta prerelease";
   }
-  return publicationStatus === "draft"
-    ? "Draft stable candidate"
+  return publicationStatus === "candidate" || publicationStatus === "draft"
+    ? "Stable candidate"
     : "Stable latest release";
 }
 
 function resolveIntroText(tag, publicationStatus = "published") {
-  if (publicationStatus === "draft") {
-    return `**${tag}** 已构建并上传版本固定下载目录，GitHub Release 仍为 Draft，尚未更新公开下载通道。`;
+  if (publicationStatus === "candidate" || publicationStatus === "draft") {
+    return `**${tag}** 候选版本已构建完成，请体验安装包并确认更新说明；当前尚未向用户开放更新。`;
   }
   if (/-rc\.(0|[1-9]\d*)$/i.test(tag)) {
     return `**${tag}** 已构建并同步到 RC 预览通道，可从下方入口下载安装包。`;
@@ -176,7 +176,12 @@ function findPreferredAssetName(assetNames, pattern) {
   );
 }
 
-function findAssetUrl(release, pattern, releaseAssetBaseUrl = "") {
+function findAssetUrl(
+  release,
+  pattern,
+  releaseAssetBaseUrl = "",
+  releaseAssetPath = ""
+) {
   const assets = Array.isArray(release?.assets) ? release.assets : [];
   const assetName = findPreferredAssetName(
     assets.map((candidate) => candidate.name ?? ""),
@@ -188,14 +193,19 @@ function findAssetUrl(release, pattern, releaseAssetBaseUrl = "") {
   }
 
   if (releaseAssetBaseUrl) {
-    const releaseTag = release.tag_name ?? "";
-    if (!releaseTag) {
+    const assetPath = releaseAssetPath || release.tag_name || "";
+    if (!assetPath) {
       throw new Error(
         "Release tag name is missing from the GitHub release payload"
       );
     }
 
-    return `${normalizeBaseUrl(releaseAssetBaseUrl)}/${encodeURIComponent(releaseTag)}/${encodeURIComponent(asset.name)}`;
+    const normalizedAssetPath = assetPath
+      .split("/")
+      .filter(Boolean)
+      .map(encodeURIComponent)
+      .join("/");
+    return `${normalizeBaseUrl(releaseAssetBaseUrl)}/${normalizedAssetPath}/${encodeURIComponent(asset.name)}`;
   }
 
   return asset.browser_download_url;
@@ -213,7 +223,7 @@ function resolveMirroredAssetUrl(
   assetNames,
   pattern,
   releaseAssetBaseUrl,
-  tag
+  assetPath
 ) {
   if (!releaseAssetBaseUrl || assetNames.length === 0) {
     return "";
@@ -224,7 +234,12 @@ function resolveMirroredAssetUrl(
     return "";
   }
 
-  return `${normalizeBaseUrl(releaseAssetBaseUrl)}/${encodeURIComponent(tag)}/${encodeURIComponent(assetName)}`;
+  const normalizedAssetPath = assetPath
+    .split("/")
+    .filter(Boolean)
+    .map(encodeURIComponent)
+    .join("/");
+  return `${normalizeBaseUrl(releaseAssetBaseUrl)}/${normalizedAssetPath}/${encodeURIComponent(assetName)}`;
 }
 
 async function loadReleaseSummary(summaryPath) {
@@ -247,19 +262,16 @@ function buildSummaryElements(summary) {
 
   const updateLines = [];
   for (const section of zh.sections.slice(0, 4)) {
-    const items = Array.isArray(section.items) ? section.items.slice(0, 3) : [];
+    const items = Array.isArray(section.items) ? section.items : [];
     for (const item of items) {
       updateLines.push(`- ${section.title}：${item}`);
+      if (updateLines.length === 6) break;
     }
+    if (updateLines.length === 6) break;
   }
-
-  const qaLines = Array.isArray(zh.qaFocus)
-    ? zh.qaFocus.slice(0, 3).map((item) => `- ${item}`)
-    : [];
   const content = [
     `**本次更新**\n${zh.headline}`,
-    updateLines.length > 0 ? updateLines.join("\n") : "",
-    qaLines.length > 0 ? `\n**QA 重点**\n${qaLines.join("\n")}` : ""
+    updateLines.length > 0 ? updateLines.join("\n") : ""
   ]
     .filter(Boolean)
     .join("\n");
@@ -278,24 +290,30 @@ function buildSummaryElements(summary) {
 
 function buildCardPayload({
   actor,
-  branch,
   macUrl,
   winUrl,
   publicationStatus = "published",
+  promotionUrl,
   releaseUrl,
   runUrl,
   summary,
-  tag,
-  target
+  tag
 }) {
-  const shortTarget = target ? target.slice(0, 7) : "unknown";
-  const deployBranch = resolveDisplayValue(branch);
   const deployActor = resolveDisplayValue(actor);
+  const candidate =
+    publicationStatus === "candidate" || publicationStatus === "draft";
   const actions = [
-    { label: "下载 macOS", url: macUrl },
-    { label: "下载 Windows（未签名）", url: winUrl },
-    { label: "打开 Release 页面", url: releaseUrl },
-    { label: "查看流水线", url: runUrl }
+    { label: candidate ? "下载 macOS 体验版" : "下载 macOS", url: macUrl },
+    {
+      label: candidate ? "下载 Windows 体验版" : "下载 Windows（未签名）",
+      url: winUrl
+    },
+    {
+      label: candidate ? "编辑更新说明" : "查看完整更新日志",
+      url: releaseUrl
+    },
+    ...(candidate ? [{ label: "提交发布审核", url: promotionUrl }] : []),
+    { label: "查看技术详情", url: runUrl }
   ]
     .filter((action) => action.url)
     .map((action, index) => ({
@@ -333,17 +351,6 @@ function buildCardPayload({
             },
             {
               is_short: true,
-              text: { content: `**Commit**\n${shortTarget}`, tag: "lark_md" }
-            },
-            {
-              is_short: true,
-              text: {
-                content: `**部署分支**\n${deployBranch}`,
-                tag: "lark_md"
-              }
-            },
-            {
-              is_short: true,
               text: {
                 content: `**部署人**\n${deployActor}`,
                 tag: "lark_md"
@@ -362,12 +369,9 @@ function buildCardPayload({
         { actions, tag: "action" }
       ],
       header: {
-        template: publicationStatus === "draft" ? "orange" : "blue",
+        template: candidate ? "orange" : "blue",
         title: {
-          content:
-            publicationStatus === "draft"
-              ? "Tutti Draft 构建完成"
-              : "Tutti 发布完成",
+          content: candidate ? "Tutti 候选版本待确认" : "Tutti 发布完成",
           tag: "plain_text"
         }
       }
@@ -403,6 +407,7 @@ async function main() {
     readOption(args, "tag", "RELEASE_TAG"),
     "RELEASE_TAG"
   );
+  const lookupTag = readOption(args, "lookup-tag", "RELEASE_LOOKUP_TAG", tag);
   const target = readOption(args, "target", "RELEASE_TARGET");
   const branch = readOption(args, "branch", "RELEASE_BRANCH");
   const actor = readOption(args, "actor", "RELEASE_ACTOR");
@@ -412,8 +417,14 @@ async function main() {
     "RELEASE_PUBLICATION_STATUS",
     "published"
   );
-  if (publicationStatus !== "draft" && publicationStatus !== "published") {
-    throw new Error("RELEASE_PUBLICATION_STATUS must be draft or published");
+  if (
+    publicationStatus !== "candidate" &&
+    publicationStatus !== "draft" &&
+    publicationStatus !== "published"
+  ) {
+    throw new Error(
+      "RELEASE_PUBLICATION_STATUS must be candidate or published"
+    );
   }
   const releaseUrl = readOption(
     args,
@@ -422,6 +433,7 @@ async function main() {
     `https://github.com/${repository}/releases/tag/${encodeURIComponent(tag)}`
   );
   const runUrl = readOption(args, "run-url", "RUN_URL");
+  const promotionUrl = readOption(args, "promotion-url", "PROMOTION_URL");
   const webhookUrl = readOption(args, "webhook-url", "FEISHU_WEBHOOK_URL");
   const releaseAssetDirectory = readOption(
     args,
@@ -445,23 +457,29 @@ async function main() {
       "TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX"
     )
   });
+  const releaseAssetPath = readOption(
+    args,
+    "release-asset-path",
+    "RELEASE_ASSET_PATH",
+    tag
+  );
   const mirroredAssetNames = await listAssetNames(releaseAssetDirectory);
   const mirroredMacUrl = resolveMirroredAssetUrl(
     mirroredAssetNames,
     /\.dmg$/i,
     releaseAssetBaseUrl,
-    tag
+    releaseAssetPath
   );
   const mirroredWinUrl = resolveMirroredAssetUrl(
     mirroredAssetNames,
     /-win-x64\.exe$/i,
     releaseAssetBaseUrl,
-    tag
+    releaseAssetPath
   );
   const release =
     mirroredMacUrl && mirroredWinUrl
       ? null
-      : await loadRelease(repository, tag, resolveGithubToken());
+      : await loadRelease(repository, lookupTag, resolveGithubToken());
   const summary = await loadReleaseSummary(
     readOption(args, "summary", "RELEASE_SUMMARY_PATH")
   );
@@ -469,11 +487,18 @@ async function main() {
     actor,
     branch,
     macUrl:
-      mirroredMacUrl || findAssetUrl(release, /\.dmg$/i, releaseAssetBaseUrl),
+      mirroredMacUrl ||
+      findAssetUrl(release, /\.dmg$/i, releaseAssetBaseUrl, releaseAssetPath),
     winUrl:
       mirroredWinUrl ||
-      findAssetUrl(release, /-win-x64\.exe$/i, releaseAssetBaseUrl),
+      findAssetUrl(
+        release,
+        /-win-x64\.exe$/i,
+        releaseAssetBaseUrl,
+        releaseAssetPath
+      ),
     publicationStatus,
+    promotionUrl,
     releaseUrl,
     runUrl,
     summary,

--- a/apps/desktop/scripts/send-release-feishu-card.mjs
+++ b/apps/desktop/scripts/send-release-feishu-card.mjs
@@ -48,22 +48,22 @@ function resolveDisplayValue(value, fallback = "unknown") {
 
 function resolveReleaseKind(tag, publicationStatus = "published") {
   if (/-rc\.(0|[1-9]\d*)$/i.test(tag)) {
-    return publicationStatus === "candidate" || publicationStatus === "draft"
+    return publicationStatus === "candidate"
       ? "Draft release candidate prerelease"
       : "Release candidate prerelease";
   }
   if (/-beta\.(0|[1-9]\d*)$/i.test(tag)) {
-    return publicationStatus === "candidate" || publicationStatus === "draft"
+    return publicationStatus === "candidate"
       ? "Draft beta prerelease"
       : "Beta prerelease";
   }
-  return publicationStatus === "candidate" || publicationStatus === "draft"
+  return publicationStatus === "candidate"
     ? "Stable candidate"
     : "Stable latest release";
 }
 
 function resolveIntroText(tag, publicationStatus = "published") {
-  if (publicationStatus === "candidate" || publicationStatus === "draft") {
+  if (publicationStatus === "candidate") {
     return `**${tag}** 候选版本已构建完成，请体验安装包并确认更新说明；当前尚未向用户开放更新。`;
   }
   if (/-rc\.(0|[1-9]\d*)$/i.test(tag)) {
@@ -300,8 +300,7 @@ function buildCardPayload({
   tag
 }) {
   const deployActor = resolveDisplayValue(actor);
-  const candidate =
-    publicationStatus === "candidate" || publicationStatus === "draft";
+  const candidate = publicationStatus === "candidate";
   const actions = [
     { label: candidate ? "下载 macOS 体验版" : "下载 macOS", url: macUrl },
     {
@@ -417,11 +416,7 @@ async function main() {
     "RELEASE_PUBLICATION_STATUS",
     "published"
   );
-  if (
-    publicationStatus !== "candidate" &&
-    publicationStatus !== "draft" &&
-    publicationStatus !== "published"
-  ) {
+  if (publicationStatus !== "candidate" && publicationStatus !== "published") {
     throw new Error(
       "RELEASE_PUBLICATION_STATUS must be candidate or published"
     );

--- a/apps/desktop/scripts/upsert-release-download-links.mjs
+++ b/apps/desktop/scripts/upsert-release-download-links.mjs
@@ -34,7 +34,7 @@ function findAssetName(assetNames, pattern) {
 
 function resolveDesktopDownloadLinks(
   assetNames,
-  releaseTag,
+  releaseAssetPath,
   releaseAssetBaseUrl
 ) {
   const desktopAssets = [
@@ -56,6 +56,11 @@ function resolveDesktopDownloadLinks(
     }
   ];
   const normalizedBaseUrl = normalizeBaseUrl(releaseAssetBaseUrl);
+  const normalizedAssetPath = releaseAssetPath
+    .split("/")
+    .filter(Boolean)
+    .map(encodeURIComponent)
+    .join("/");
 
   return desktopAssets
     .map(({ label, pattern }) => {
@@ -64,7 +69,7 @@ function resolveDesktopDownloadLinks(
         return null;
       }
 
-      const assetUrl = `${normalizedBaseUrl}/${encodeURIComponent(releaseTag)}/${encodeURIComponent(assetName)}`;
+      const assetUrl = `${normalizedBaseUrl}/${normalizedAssetPath}/${encodeURIComponent(assetName)}`;
       return `- [${label}](${assetUrl})`;
     })
     .filter(Boolean);
@@ -74,17 +79,18 @@ function buildUpdatedReleaseBody({
   assetNames,
   existingBody,
   releaseAssetBaseUrl,
-  releaseTag
+  releaseTag,
+  releaseAssetPath = releaseTag
 }) {
   const cleanedBody = removeManagedSection(existingBody);
 
-  if (!releaseTag || !releaseAssetBaseUrl) {
+  if (!releaseAssetPath || !releaseAssetBaseUrl) {
     return buildLimitedGithubReleaseBody({ existingBody: cleanedBody });
   }
 
   const directDownloadLinks = resolveDesktopDownloadLinks(
     [...assetNames].sort((left, right) => left.localeCompare(right)),
-    releaseTag,
+    releaseAssetPath,
     releaseAssetBaseUrl
   );
 
@@ -115,6 +121,9 @@ async function main() {
   }
 
   const releaseTag = (process.env.RELEASE_TAG ?? "").trim();
+  const releaseAssetPath = (
+    process.env.RELEASE_ASSET_PATH ?? releaseTag
+  ).trim();
   const releaseAssetBaseUrl = (process.env.RELEASE_ASSET_BASE_URL ?? "").trim();
   const existingBody = await readFile(existingBodyPath, "utf8");
   const assetNames = (await readdir(assetDirPath)).map((name) =>
@@ -124,6 +133,7 @@ async function main() {
     assetNames,
     existingBody,
     releaseAssetBaseUrl,
+    releaseAssetPath,
     releaseTag
   });
 

--- a/apps/desktop/scripts/upsert-release-summary.mjs
+++ b/apps/desktop/scripts/upsert-release-summary.mjs
@@ -6,25 +6,32 @@ import { buildLimitedGithubReleaseBody } from "./lib/githubReleaseBody.mjs";
 
 const SECTION_START = "<!-- tutti-desktop-release-summary:start -->";
 const SECTION_END = "<!-- tutti-desktop-release-summary:end -->";
+const REVIEW_START = "<!-- tutti-desktop-release-review:start -->";
+const REVIEW_END = "<!-- tutti-desktop-release-review:end -->";
+const SUGGESTION_START = "<!-- tutti-desktop-release-suggestion:start -->";
+const SUGGESTION_END = "<!-- tutti-desktop-release-suggestion:end -->";
 
 function escapeRegex(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function removeManagedSection(body) {
-  const managedSectionPattern = new RegExp(
-    `\\n*${escapeRegex(SECTION_START)}[\\s\\S]*?${escapeRegex(SECTION_END)}\\n*`,
+function sectionPattern(start, end) {
+  return new RegExp(
+    `\\n*${escapeRegex(start)}[\\s\\S]*?${escapeRegex(end)}\\n*`,
     "g"
   );
-
-  return body.replace(managedSectionPattern, "\n").trimEnd();
 }
 
-function renderLocaleSummary(
-  title,
-  localeSummary,
-  { includeQaFocus = true } = {}
-) {
+function removeSection(body, start, end) {
+  return body.replace(sectionPattern(start, end), "\n").trimEnd();
+}
+
+function extractSection(body, start, end) {
+  const match = body.match(sectionPattern(start, end));
+  return match?.[0]?.trim() ?? "";
+}
+
+function renderLocaleSummary(title, localeSummary) {
   const lines = [`### ${title}`, "", localeSummary.headline, ""];
   for (const section of localeSummary.sections ?? []) {
     lines.push(`#### ${section.title}`);
@@ -33,50 +40,119 @@ function renderLocaleSummary(
     }
     lines.push("");
   }
-  const qaFocus = localeSummary.qaFocus ?? [];
-  if (includeQaFocus && qaFocus.length > 0) {
-    lines.push(title === "中文" ? "#### QA 重点" : "#### QA Focus");
-    for (const item of qaFocus) {
-      lines.push(`- ${item}`);
-    }
-    lines.push("");
-  }
   return lines;
 }
 
-function renderReleaseSummarySection(summary) {
+function renderReviewSection(summary) {
   return [
-    SECTION_START,
-    "## Release Summary",
+    REVIEW_START,
+    "## Release Notes",
     "",
-    ...renderLocaleSummary("Highlights", summary.en, {
-      includeQaFocus: false
-    }),
-    SECTION_END
+    ...renderLocaleSummary("中文", summary.zh),
+    ...renderLocaleSummary("English", summary.en),
+    REVIEW_END
   ].join("\n");
 }
 
+function renderSuggestionSection(summary) {
+  return [
+    SUGGESTION_START,
+    "<details>",
+    "<summary>Current generated suggestions (review only)</summary>",
+    "",
+    ...renderLocaleSummary("中文建议", summary.zh),
+    ...renderLocaleSummary("English suggestions", summary.en),
+    "</details>",
+    SUGGESTION_END
+  ].join("\n");
+}
+
+function removeManagedSection(body) {
+  return removeSection(body, SECTION_START, SECTION_END);
+}
+
+function renderReleaseSummarySection(summary) {
+  return renderReviewSection(summary);
+}
+
 function buildUpdatedReleaseBody({ existingBody, summary }) {
-  const cleanedBody = removeManagedSection(existingBody);
+  const existingReview = extractSection(existingBody, REVIEW_START, REVIEW_END);
+  let cleanedBody = removeManagedSection(existingBody);
+  cleanedBody = removeSection(cleanedBody, REVIEW_START, REVIEW_END);
+  cleanedBody = removeSection(cleanedBody, SUGGESTION_START, SUGGESTION_END);
   return buildLimitedGithubReleaseBody({
     existingBody: cleanedBody,
-    leadingSections: [renderReleaseSummarySection(summary)]
+    leadingSections: [
+      existingReview || renderReviewSection(summary),
+      renderSuggestionSection(summary)
+    ]
   });
+}
+
+function buildPublishedReleaseBody(body) {
+  return removeSection(body, SUGGESTION_START, SUGGESTION_END);
+}
+
+function parseLocaleSection(sectionBody, title, nextTitle = null) {
+  const start = sectionBody.indexOf(`### ${title}`);
+  if (start < 0) throw new Error(`Missing review locale: ${title}`);
+  const contentStart = start + `### ${title}`.length;
+  const next = nextTitle
+    ? sectionBody.indexOf(`### ${nextTitle}`, contentStart)
+    : sectionBody.length;
+  const lines = sectionBody
+    .slice(contentStart, next < 0 ? sectionBody.length : next)
+    .split("\n")
+    .map((line) => line.trim());
+  const headline = lines.find((line) => line && !line.startsWith("#"));
+  if (!headline) throw new Error(`${title} review headline is required`);
+  const sections = [];
+  let current = null;
+  for (const line of lines) {
+    if (line.startsWith("#### ")) {
+      current = { title: line.slice(5).trim(), items: [] };
+      sections.push(current);
+    } else if (line.startsWith("- ") && current) {
+      current.items.push(line.slice(2).trim());
+    }
+  }
+  const validSections = sections.filter(
+    (section) => section.title && section.items.length > 0
+  );
+  if (validSections.length === 0) {
+    throw new Error(`${title} review must contain at least one section`);
+  }
+  return { headline, sections: validSections, qaFocus: [] };
+}
+
+function buildApprovedReleaseSummary({ body, generatedSummary, reviewedAt }) {
+  const review = extractSection(body, REVIEW_START, REVIEW_END);
+  if (!review) throw new Error("Release review section is missing");
+  return {
+    ...generatedSummary,
+    generatedAt: reviewedAt ?? generatedSummary.generatedAt,
+    summarySource: "human-reviewed",
+    warning: undefined,
+    zh: parseLocaleSection(review, "中文", "English"),
+    en: parseLocaleSection(review, "English")
+  };
 }
 
 async function main() {
   const [existingBodyPath, summaryPath, outputBodyPath] = process.argv.slice(2);
   if (!existingBodyPath || !summaryPath || !outputBodyPath) {
     throw new Error(
-      "Usage: node apps/desktop/scripts/upsert-release-summary.mjs <existing-body-path> <summary-json-path> <output-body-path>"
+      "Usage: upsert-release-summary.mjs <existing-body> <summary-json> <output-body>"
     );
   }
-
   const existingBody = await readFile(existingBodyPath, "utf8");
   const summary = JSON.parse(await readFile(summaryPath, "utf8"));
+  const updated = buildUpdatedReleaseBody({ existingBody, summary });
   await writeFile(
     outputBodyPath,
-    buildUpdatedReleaseBody({ existingBody, summary }),
+    process.env.RELEASE_SUMMARY_MODE === "published"
+      ? buildPublishedReleaseBody(updated)
+      : updated,
     "utf8"
   );
 }
@@ -92,8 +168,14 @@ if (
 }
 
 export {
+  REVIEW_END,
+  REVIEW_START,
   SECTION_END,
   SECTION_START,
+  SUGGESTION_END,
+  SUGGESTION_START,
+  buildApprovedReleaseSummary,
+  buildPublishedReleaseBody,
   buildUpdatedReleaseBody,
   removeManagedSection,
   renderReleaseSummarySection

--- a/apps/desktop/scripts/validate-release-summary.mjs
+++ b/apps/desktop/scripts/validate-release-summary.mjs
@@ -81,9 +81,12 @@ function validateReleaseSummary(summary, expected = {}) {
   }
   if (
     summary.summarySource !== "agnes" &&
-    summary.summarySource !== "fallback"
+    summary.summarySource !== "fallback" &&
+    summary.summarySource !== "human-reviewed"
   ) {
-    throw new Error("release summary summarySource must be agnes or fallback");
+    throw new Error(
+      "release summary summarySource must be agnes, fallback, or human-reviewed"
+    );
   }
   if (
     !summary.compare ||

--- a/apps/desktop/scripts/verify-release-candidate.mjs
+++ b/apps/desktop/scripts/verify-release-candidate.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+import {
+  buildReleaseApprovalDigest,
+  validateReleaseCandidateManifest
+} from "./lib/releaseCandidate.mjs";
+
+async function main() {
+  const [
+    manifestPath,
+    checksumsPath,
+    generatedSummaryPath,
+    approvedSummaryPath
+  ] = process.argv.slice(2);
+  if (!manifestPath || !checksumsPath || !generatedSummaryPath) {
+    throw new Error(
+      "Usage: verify-release-candidate.mjs <manifest> <checksums> <generated-summary> [approved-summary]"
+    );
+  }
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  const checksums = await readFile(checksumsPath, "utf8");
+  const generatedSummary = await readFile(generatedSummaryPath, "utf8");
+  validateReleaseCandidateManifest(manifest, {
+    tag: process.env.RELEASE_TAG,
+    targetCommit: process.env.RELEASE_TARGET,
+    checksums,
+    generatedSummary
+  });
+  if (!approvedSummaryPath) {
+    process.stdout.write(`${JSON.stringify(manifest)}\n`);
+    return;
+  }
+  const approvedSummary = JSON.parse(
+    await readFile(approvedSummaryPath, "utf8")
+  );
+  process.stdout.write(
+    `${JSON.stringify({
+      ...manifest,
+      approvalDigest: buildReleaseApprovalDigest(manifest, approvedSummary)
+    })}\n`
+  );
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  void main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/apps/desktop/src/main/update/appUpdateService.test.ts
+++ b/apps/desktop/src/main/update/appUpdateService.test.ts
@@ -180,6 +180,7 @@ test("createAppUpdateService configures the static RC feed before checking", asy
         return {
           feedUrl: "https://updates.example.test/v0.0.1-rc.17",
           releasedAt: "2026-06-15T00:00:00.000Z",
+          releaseNotesUrl: null,
           tag: "v0.0.1-rc.17",
           updaterChannel: "rc",
           version: "0.0.1-rc.17"
@@ -200,6 +201,44 @@ test("createAppUpdateService configures the static RC feed before checking", asy
     ]);
   } finally {
     service?.dispose();
+  }
+});
+
+test("createAppUpdateService exposes release notes for the resolved update", async () => {
+  let notifyAvailable: ((info: UpdateInfo) => void) | null = null;
+  const releaseNotesUrl =
+    "https://github.com/tutti-os/tutti/releases/tag/v1.2.3";
+  const driver = createFakeDriver({
+    async checkForUpdates() {
+      notifyAvailable?.(createUpdateInfoFixture("1.2.3"));
+    },
+    onUpdateAvailable(listener) {
+      notifyAvailable = listener;
+      return noop;
+    }
+  });
+  const service = createAppUpdateService(driver, {
+    currentVersion: "1.2.2",
+    releaseFeedResolver: async () => ({
+      feedUrl: "https://updates.example.test/v1.2.3",
+      releasedAt: "2026-08-17T00:00:00.000Z",
+      releaseNotesUrl,
+      tag: "v1.2.3",
+      updaterChannel: "latest",
+      version: "1.2.3"
+    }),
+    supportsUpdates: true
+  });
+
+  try {
+    await service.configure({ channel: "stable", policy: "prompt" });
+    await waitFor(
+      () => service.getState().status === "available",
+      "update did not become available"
+    );
+    assert.equal(service.getState().releaseNotesUrl, releaseNotesUrl);
+  } finally {
+    service.dispose();
   }
 });
 
@@ -289,6 +328,7 @@ test("createAppUpdateService shares static feed resolution across concurrent che
   const deferredFeed = createDeferred<{
     feedUrl: string;
     releasedAt: string;
+    releaseNotesUrl: string | null;
     tag: string;
     updaterChannel: "latest" | "rc";
     version: string;
@@ -311,6 +351,7 @@ test("createAppUpdateService shares static feed resolution across concurrent che
     deferredFeed.resolve({
       feedUrl: "https://updates.example.test/v0.0.1-rc.17",
       releasedAt: "2026-06-15T00:00:00.000Z",
+      releaseNotesUrl: null,
       tag: "v0.0.1-rc.17",
       updaterChannel: "rc",
       version: "0.0.1-rc.17"

--- a/apps/desktop/src/main/update/appUpdateService.ts
+++ b/apps/desktop/src/main/update/appUpdateService.ts
@@ -31,6 +31,7 @@ import {
 } from "./macosUpdaterSupport.ts";
 import {
   createDesktopReleaseFeedResolver,
+  type DesktopReleaseFeed,
   type DesktopReleaseFeedResolver
 } from "./desktopReleaseFeed.ts";
 
@@ -350,6 +351,7 @@ export function createAppUpdateService(
   let activeDownloadPromise: Promise<void> | null = null;
   let preserveAvailableStateDuringCheck = false;
   let quitAndInstallPending = false;
+  let activeReleaseFeed: DesktopReleaseFeed | null = null;
   const stateChangedListeners = new Set<
     (state: AppUpdateState, previousState: AppUpdateState) => void
   >();
@@ -494,7 +496,11 @@ export function createAppUpdateService(
         checkedAt: new Date().toISOString(),
         latestVersion: info.version ?? null,
         releaseDate: normalizeReleaseDate(info.releaseDate),
-        releaseName: info.releaseName ?? null
+        releaseName: info.releaseName ?? null,
+        releaseNotesUrl:
+          activeReleaseFeed?.version === info.version
+            ? activeReleaseFeed.releaseNotesUrl
+            : null
       });
     }),
     resolvedDriver.onUpdateNotAvailable(() => {
@@ -752,6 +758,7 @@ export function createAppUpdateService(
     try {
       if (releaseFeedResolver) {
         const feed = await releaseFeedResolver({ channel: state.channel });
+        activeReleaseFeed = feed;
         resolvedDriver.setFeedUrl(feed.feedUrl);
         getDesktopLogger().info("application updater static feed configured", {
           channel: state.channel,

--- a/apps/desktop/src/main/update/desktopReleaseFeed.test.ts
+++ b/apps/desktop/src/main/update/desktopReleaseFeed.test.ts
@@ -25,6 +25,7 @@ test("desktop release feed resolves the stable pointer to its immutable feed", a
   assert.deepEqual(feed, {
     feedUrl: `${baseUrl}/v1.2.3`,
     releasedAt: "2026-07-13T10:00:00.000Z",
+    releaseNotesUrl: null,
     tag: "v1.2.3",
     updaterChannel: "latest",
     version: "1.2.3"
@@ -58,6 +59,20 @@ test("desktop release feed rejects malformed pointer JSON", async () => {
   });
 
   await assert.rejects(resolver({ channel: "stable" }), /not valid JSON/);
+});
+
+test("desktop release feed exposes a validated release notes URL", async () => {
+  const releaseNotesUrl =
+    "https://github.com/tutti-os/tutti/releases/tag/v1.2.3";
+  const resolver = createDesktopReleaseFeedResolver({
+    baseUrl,
+    fetch: async () => jsonResponse(createPointerDocument({ releaseNotesUrl }))
+  });
+
+  assert.equal(
+    (await resolver({ channel: "stable" })).releaseNotesUrl,
+    releaseNotesUrl
+  );
 });
 
 test("desktop release feed rejects an unsupported schema, origin, channel, and tag", async (t) => {

--- a/apps/desktop/src/main/update/desktopReleaseFeed.ts
+++ b/apps/desktop/src/main/update/desktopReleaseFeed.ts
@@ -10,6 +10,7 @@ export const desktopReleaseFeedBaseUrl =
 export interface DesktopReleaseFeed {
   feedUrl: string;
   releasedAt: string;
+  releaseNotesUrl: string | null;
   tag: string;
   updaterChannel: "latest" | "rc";
   version: string;
@@ -29,6 +30,7 @@ interface DesktopReleaseLatestDocument {
   channel: string;
   prerelease: boolean;
   releasedAt: string;
+  releaseNotesUrl: string | null;
   schemaVersion: string;
   tag: string;
   version: string;
@@ -62,6 +64,7 @@ export function createDesktopReleaseFeedResolver(
     return {
       feedUrl: `${baseUrl}/${encodeURIComponent(document.tag)}`,
       releasedAt: document.releasedAt,
+      releaseNotesUrl: document.releaseNotesUrl,
       tag: document.tag,
       updaterChannel: channel === "rc" ? "rc" : "latest",
       version: document.version
@@ -110,6 +113,7 @@ function parseDesktopReleaseLatestDocument(
     channel: readRequiredString(parsed, "channel"),
     prerelease: readBoolean(parsed, "prerelease"),
     releasedAt: readRequiredString(parsed, "releasedAt"),
+    releaseNotesUrl: readOptionalHttpsUrl(parsed, "releaseNotesUrl"),
     schemaVersion: readRequiredString(parsed, "schemaVersion"),
     tag: readRequiredString(parsed, "tag"),
     version: readRequiredString(parsed, "version")
@@ -194,6 +198,24 @@ function readBoolean(value: Record<string, unknown>, key: string): boolean {
     throw new Error(`Desktop update pointer ${key} must be a boolean`);
   }
   return candidate;
+}
+
+function readOptionalHttpsUrl(
+  value: Record<string, unknown>,
+  key: string
+): string | null {
+  const candidate = value[key];
+  if (candidate === undefined || candidate === null) {
+    return null;
+  }
+  if (typeof candidate !== "string") {
+    throw new Error(`Desktop update pointer ${key} must be an HTTPS URL`);
+  }
+  const parsed = new URL(candidate.trim());
+  if (parsed.protocol !== "https:" || parsed.username || parsed.password) {
+    throw new Error(`Desktop update pointer ${key} must be an HTTPS URL`);
+  }
+  return parsed.href;
 }
 
 function releaseVersionFromTag(tag: string): string | null {

--- a/apps/desktop/src/renderer/src/features/app-update/services/appUpdateService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/app-update/services/appUpdateService.interface.ts
@@ -7,6 +7,7 @@ export interface IAppUpdateService {
 
   load(): Promise<void>;
   checkForUpdates(): Promise<void>;
+  openReleaseNotes(): Promise<void>;
   runPrimaryAction(): Promise<void>;
 }
 

--- a/apps/desktop/src/renderer/src/features/app-update/services/internal/appUpdateService.test.ts
+++ b/apps/desktop/src/renderer/src/features/app-update/services/internal/appUpdateService.test.ts
@@ -61,6 +61,33 @@ test("AppUpdateService tracks primary update actions", async () => {
   ]);
 });
 
+test("AppUpdateService opens the release notes exposed by the update state", async () => {
+  const opened: string[] = [];
+  const releaseNotesUrl =
+    "https://github.com/tutti-os/tutti/releases/tag/v1.3.0";
+  const service = new AppUpdateService(
+    createClient({
+      getState: async () =>
+        createState({ releaseNotesUrl, status: "available" })
+    }),
+    null,
+    undefined,
+    undefined,
+    {
+      hostFilesApi: {
+        async openExternal(url) {
+          opened.push(url);
+        }
+      }
+    }
+  );
+  await service.load();
+
+  await service.openReleaseNotes();
+
+  assert.deepEqual(opened, [releaseNotesUrl]);
+});
+
 test("AppUpdateService keeps install action pending after IPC succeeds", async () => {
   let installCalls = 0;
   const service = new AppUpdateService(

--- a/apps/desktop/src/renderer/src/features/app-update/services/internal/appUpdateService.ts
+++ b/apps/desktop/src/renderer/src/features/app-update/services/internal/appUpdateService.ts
@@ -4,7 +4,7 @@ import type { IReporterService } from "../../../analytics/services/reporterServi
 import { resolveDesktopErrorMessage } from "../../../../lib/desktopErrors.ts";
 import { isSameAppUpdateState } from "../../../../../../shared/contracts/appUpdateState.ts";
 import type { AppUpdateState } from "@shared/contracts/ipc";
-import type { DesktopRuntimeApi } from "@preload/types";
+import type { DesktopHostFilesApi, DesktopRuntimeApi } from "@preload/types";
 import type { IAppUpdateService } from "../appUpdateService.interface";
 import type { DesktopAppUpdateClient } from "./adapters/desktopAppUpdateClient";
 import { createAppUpdateStore } from "./appUpdateStore.ts";
@@ -33,19 +33,24 @@ export class AppUpdateService implements IAppUpdateService {
     "logRendererDiagnostic"
   >;
   private readonly updateClient: DesktopAppUpdateClient;
+  private readonly hostFilesApi?: Pick<DesktopHostFilesApi, "openExternal">;
 
   constructor(
     updateClient: DesktopAppUpdateClient,
     reporterService: Pick<IReporterService, "trackEvents"> | null = null,
     reporterNow?: () => number,
     runtimeApi?: Pick<DesktopRuntimeApi, "logRendererDiagnostic">,
-    options: { supportsReleaseChannels?: boolean } = {}
+    options: {
+      hostFilesApi?: Pick<DesktopHostFilesApi, "openExternal">;
+      supportsReleaseChannels?: boolean;
+    } = {}
   ) {
     this.store = createAppUpdateStore(options.supportsReleaseChannels ?? true);
     this.updateClient = updateClient;
     this.reporterService = reporterService;
     this.reporterNow = reporterNow;
     this.runtimeApi = runtimeApi;
+    this.hostFilesApi = options.hostFilesApi;
   }
 
   async load(): Promise<void> {
@@ -109,6 +114,13 @@ export class AppUpdateService implements IAppUpdateService {
         this.updateView();
         this.recordDiagnostic("app_update.check_finished");
       }
+    }
+  }
+
+  async openReleaseNotes(): Promise<void> {
+    const url = this.store.updateState?.releaseNotesUrl;
+    if (url && this.hostFilesApi) {
+      await this.hostFilesApi.openExternal(url);
     }
   }
 

--- a/apps/desktop/src/renderer/src/features/app-update/services/registerAppUpdateServices.ts
+++ b/apps/desktop/src/renderer/src/features/app-update/services/registerAppUpdateServices.ts
@@ -29,6 +29,7 @@ export function registerAppUpdateServices(
     undefined,
     desktopApi.runtime,
     {
+      hostFilesApi: desktopApi.host?.files,
       supportsReleaseChannels: desktopApi.platform?.distribution !== "store"
     }
   );

--- a/apps/desktop/src/renderer/src/features/app-update/ui/AppUpdateStatus.tsx
+++ b/apps/desktop/src/renderer/src/features/app-update/ui/AppUpdateStatus.tsx
@@ -59,30 +59,42 @@ export function AppUpdateStatus({
       </div>
 
       {view.action && view.actionKey ? (
-        <Button
-          disabled={view.busy}
-          onClick={() => {
-            void service.runPrimaryAction();
-          }}
-          size={compact ? "xs" : "sm"}
-          variant="secondary"
-          className={cn(
-            "text-[var(--workbench-chrome-foreground)] hover:text-[var(--workbench-chrome-foreground)] disabled:opacity-60",
-            compact
-              ? "h-7 rounded-[4px] px-2 text-[13px] font-semibold"
-              : "h-7 rounded-[4px] px-2.5 text-[13px] font-semibold max-[700px]:px-2"
-          )}
-        >
-          {state.isActing ? (
-            <LoadingIcon
-              className={cn(
-                "animate-spin",
-                compact ? "size-3" : "size-4 max-[700px]:size-3.5"
-              )}
-            />
+        <>
+          {state.updateState?.releaseNotesUrl ? (
+            <Button
+              onClick={() => void service.openReleaseNotes()}
+              size={compact ? "xs" : "sm"}
+              type="button"
+              variant="ghost"
+            >
+              {t("updates.releaseNotesAction")}
+            </Button>
           ) : null}
-          <span>{t(view.actionKey)}</span>
-        </Button>
+          <Button
+            disabled={view.busy}
+            onClick={() => {
+              void service.runPrimaryAction();
+            }}
+            size={compact ? "xs" : "sm"}
+            variant="secondary"
+            className={cn(
+              "text-[var(--workbench-chrome-foreground)] hover:text-[var(--workbench-chrome-foreground)] disabled:opacity-60",
+              compact
+                ? "h-7 rounded-[4px] px-2 text-[13px] font-semibold"
+                : "h-7 rounded-[4px] px-2.5 text-[13px] font-semibold max-[700px]:px-2"
+            )}
+          >
+            {state.isActing ? (
+              <LoadingIcon
+                className={cn(
+                  "animate-spin",
+                  compact ? "size-3" : "size-4 max-[700px]:size-3.5"
+                )}
+              />
+            ) : null}
+            <span>{t(view.actionKey)}</span>
+          </Button>
+        </>
       ) : null}
     </div>
   );

--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -78,6 +78,7 @@ export const en = {
     errorTitle: "Unable to check for updates",
     restartAction: "Restart & install",
     retryAction: "Retry",
+    releaseNotesAction: "What's new",
     storeManaged: "Updates are managed by Microsoft Store."
   },
   desktop: {

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -78,6 +78,7 @@ export const zhCN = {
     errorTitle: "无法检查更新",
     restartAction: "重启安装",
     retryAction: "重试",
+    releaseNotesAction: "更新内容",
     storeManaged: "更新由 Microsoft Store 管理"
   },
   desktop: {

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -443,6 +443,12 @@ manual promotion cannot bypass this ordering.
 
 It then extracts the human-reviewed summary, copies stable candidate objects from `candidates/<candidate-id>/` to the immutable `<tag>/` path, creates the formal stable tag, updates release notes and assets, publishes the GitHub Release, writes the channel pointer and changelog, refreshes the stable alias, verifies the public pointer, and sends the published card. Promotion never rebuilds installers or calls the summary model. Editing notes or replacing assets after submission changes the approval digest and forces a new approval run. Promotion is serialized because channel pointers are shared mutable state.
 
+The internal candidate manifest remains attached until every fallible promotion
+check succeeds. If a run stops after the stable GitHub Release becomes public,
+the next Promotion run may select that same published release, revalidate the
+candidate and reviewed notes, and resume the idempotent remaining steps. The
+manifest is removed only as the final successful promotion action.
+
 RC and beta promotions preserve the existing GitHub policy: their GitHub Releases remain drafts while their AWS channel pointers become available. Stable promotion changes the GitHub Release from draft to public and marks it Latest.
 
 ## Release Summaries

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -78,8 +78,8 @@ Supported manual modes:
 
 Manual runs also expose `publication_mode`:
 
-- `publish` keeps the existing end-to-end behavior. The workflow stages a GitHub Draft Release, uploads immutable assets, then calls the promotion workflow to update public channel metadata and publish the stable GitHub Release.
-- `draft_only` builds the same signed and notarized artifacts, keeps the GitHub Release as a draft, uploads immutable assets under the versioned S3/CloudFront `<tag>/` directory, and stops before changing any public channel pointer, changelog, stable alias, or GitHub visibility.
+- For RC and beta releases, `publish` keeps the existing automatic promotion behavior and `draft_only` stops at the Draft Release.
+- Stable releases always stop as a candidate, regardless of this compatibility input. They require the separate Promotion workflow and its protected Environment approval before publication.
 
 For an RC draft, dispatch `patch_rc_release` from `main` or `release/*` and
 select `draft_only`; Windows is included by default. Windows is intentionally
@@ -315,9 +315,9 @@ After a successful stage or promotion, the workflow sends a Feishu card when:
 
 If the webhook secret is missing, the workflow skips notification instead of failing the release.
 
-For `draft_only`, the card links to the authorized GitHub Draft Release and uses the immutable AWS/CloudFront asset URLs. Sending the card does not update `latest.json`, a prerelease channel pointer, `changelog.json`, or the floating `stable` release.
+For a stable candidate, the card shows up to six user-facing Chinese changes, links to candidate downloads and the editable Draft Release, and opens the Promotion workflow for review submission. It deliberately omits commit IDs, candidate IDs, compare ranges, branches, and QA-only notes. Sending the card does not update `latest.json`, `changelog.json`, or the floating `stable` release.
 
-The card links to available macOS, Windows, Linux, GitHub Release, and workflow run URLs.
+The card links to available macOS and Windows downloads, the GitHub Release, the workflow run, and—for stable candidates—the Promotion workflow.
 
 When `TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL` is configured, the download buttons prefer the mirrored release asset base URL instead of GitHub asset URLs. If the explicit base URL is absent but S3 mirroring is configured, the workflow falls back to the S3 accelerate base URL.
 
@@ -424,15 +424,19 @@ https://<asset-base-url>/changelog.json
 
 ## Draft Promotion
 
-External publication is owned by `.github/workflows/desktop-release-promote.yml`. It can be called by the normal desktop release workflow for `publication_mode=publish`, or run manually with an existing Draft Release tag after a `draft_only` build has been approved.
+External publication is owned by `.github/workflows/desktop-release-promote.yml`. RC and beta builds may call it automatically. A stable candidate must be submitted manually from the Feishu link and then pass the `desktop-stable-release` GitHub Environment approval.
+
+Configure that Environment with only `SingleMai`, `jomeswang`, and `vorshen` as required reviewers, with self-review allowed. This reviewer policy is repository configuration rather than workflow YAML; keep it synchronized with this convention.
 
 Promotion performs these checks before changing public state:
 
 - the GitHub Release exists and its stable, RC, or beta shape matches the tag
-- the tag still points to the staged commit
+- for stable candidates, the formal tag is absent or already points to the candidate commit after an interrupted promotion
 - the production managed app runtime catalog publishes at least the target
   commit's locked `runtimeVersion` for every supported platform
+- `release-candidate.json` binds the planned tag, target commit, source ref, generated summary, checksums, and candidate asset path
 - `SHA256SUMS.txt` exists and the downloaded draft assets match it
+- the reviewed bilingual notes still produce the approval digest captured before the Environment gate
 - the target version does not move the selected public channel backwards
 
 When `config/tutti.app-runtime.lock.json` changes, run `Publish Tutti App
@@ -440,7 +444,7 @@ Runtime` and verify the production catalog before promoting the desktop release.
 The promotion gate reads the lock from the exact release target, so a later
 manual promotion cannot bypass this ordering.
 
-It then consumes the checksummed `release-summary.json` staged with the Draft Release, repairs or uploads the immutable AWS objects, updates release notes, publishes a stable GitHub Release when applicable, writes the selected stable/RC/beta pointer, refreshes the stable alias, verifies the public CloudFront pointer, and sends the promoted release notification. Promotion never regenerates the summary or calls the summary model. GitHub Draft assets remain mutable until promotion, so any restage or asset replacement invalidates the prior human approval and requires another review of the current `SHA256SUMS.txt`; cryptographic binding to an external approval record or immutable candidate ID is not implemented. Promotion is serialized with the `desktop-release-promotion` concurrency group because stable and prerelease pointers are mutable shared state.
+It then extracts the human-reviewed summary, copies stable candidate objects from `candidates/<candidate-id>/` to the immutable `<tag>/` path, creates the formal stable tag, updates release notes and assets, publishes the GitHub Release, writes the channel pointer and changelog, refreshes the stable alias, verifies the public pointer, and sends the published card. Promotion never rebuilds installers or calls the summary model. Editing notes or replacing assets after submission changes the approval digest and forces a new approval run. Promotion is serialized because channel pointers are shared mutable state.
 
 RC and beta promotions preserve the existing GitHub policy: their GitHub Releases remain drafts while their AWS channel pointers become available. Stable promotion changes the GitHub Release from draft to public and marks it Latest.
 
@@ -453,13 +457,9 @@ Summary generation is best-effort:
 - if `AGNES_API_KEY` is configured, the workflow asks Agnes to summarize commits and diff stats
 - if the key is missing, the API fails, or the response is invalid, the workflow falls back to a deterministic commit-based summary
 
-The Stage job adds the summary to the Draft Release assets before generating
-`SHA256SUMS.txt`. The summary and installable archives are therefore in the
-same checksummed candidate set. Electron updater `.yml` and `.blockmap` files
-remain outside `SHA256SUMS.txt` under the existing checksum policy. The summary
-is used to:
+The Stage job adds the generated summary before checksums and seeds a clearly marked bilingual review section in the Draft Release body. Operators edit only that review section; rebuilding the same unpublished version refreshes generated suggestions while preserving the edited review. Promotion converts the review section to a `human-reviewed` `release-summary.json` and removes machine suggestions from the public Release body. The summary is used to:
 
-- upsert a managed English `Release Summary` section into the GitHub Release body
+- maintain editable Chinese and English release notes in the GitHub Release body
 - enrich the Feishu release card with the Chinese summary when Feishu notification is enabled
 - update `changelog.json` for stable releases
 
@@ -475,6 +475,8 @@ notes approach GitHub's 125,000-character body limit. Trim only the generated
 detail entries and leave a visible truncation notice.
 
 Do not commit real model API keys. Configure `AGNES_API_KEY` as a GitHub secret.
+
+Stable drafts use a mutable internal `candidate-vX.Y.Z` tag; the formal `vX.Y.Z` tag is created only after approval. Before that point, dispatching the same explicit version moves the internal candidate tag, replaces the Draft's exact asset set, and writes a new candidate path without invalidating public caches. Once the formal stable tag exists, do not rebuild different code under that version; retry the same promotion or use a new patch version.
 
 ## Required Secrets
 
@@ -530,6 +532,7 @@ Recommended setup:
 
 - set `TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL` to the CloudFront distribution path, such as `https://d111111abcdef8.cloudfront.net/desktop-release-assets`
 - keep the S3 bucket and prefix configured so the workflow can upload mirrored assets
+- apply a 30-day lifecycle expiration to objects under `<prefix>/candidates/`; never apply that rule to formal `<tag>/` paths
 
 If `TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL` is omitted, the workflow falls back to:
 

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -76,17 +76,14 @@ Supported manual modes:
 - `explicit_version_release`: publish an explicit release semver such as `0.1.0`, `0.1.0-beta.0`, `0.1.0-rc.0`, `1.13.0-rc.0`, or `2.0.0`
 - `unsigned_dry_run`: build unsigned artifacts without publishing a GitHub Release
 
-Manual runs also expose `publication_mode`:
+RC and beta releases promote automatically after staging. Stable releases
+always stop as a candidate and require the separate Promotion workflow and its
+protected Environment approval before publication. There is no manual
+publication-mode switch.
 
-- For RC and beta releases, `publish` keeps the existing automatic promotion behavior and `draft_only` stops at the Draft Release.
-- Stable releases always stop as a candidate, regardless of this compatibility input. They require the separate Promotion workflow and its protected Environment approval before publication.
-
-For an RC draft, dispatch `patch_rc_release` from `main` or `release/*` and
-select `draft_only`; Windows is included by default. Windows is intentionally
-unsigned for now. A Windows build or artifact validation failure blocks staging
-so an RC or stable release cannot silently publish only macOS assets.
-
-Draft-only assets are unlisted, not private. Anyone who knows the immutable CloudFront URL can download them. This is intentional so internal release notifications can carry working QA download links. Do not use the desktop release asset prefix for confidential artifacts.
+Windows is included by default and is intentionally unsigned for now. A
+Windows build or artifact validation failure blocks staging so an RC or stable
+release cannot silently publish only macOS assets.
 
 Manual RC and stable release modes (`patch_rc_release`, `patch_release`, `minor_release`, and `major_release`) are branch-gated before tag resolution or artifact builds:
 
@@ -227,11 +224,11 @@ TUTTI_WINDOWS_STORE_SUBMISSION_ENABLED=true
 ```
 
 It always selects the protected `microsoft-store-production` Environment and
-accepts only plain stable tags. It runs only for `publication_mode=publish` and
-starts after Direct promotion succeeds. RC, beta, and draft-only runs continue
-through the existing Direct NSIS/CDN flow without a production Store
-submission. The Store job is downstream from Direct promotion, so Store
-certification delay or failure cannot block or roll back Direct promotion.
+accepts only plain stable tags and starts after Direct promotion succeeds. RC
+and beta runs continue through the existing Direct NSIS/CDN flow without a
+production Store submission. The Store job is downstream from Direct
+promotion, so Store certification delay or failure cannot block or roll back
+Direct promotion.
 
 The release workflow builds macOS x64, arm64, and universal packages as a
 three-entry GitHub Actions matrix. Each architecture uploads an isolated

--- a/tools/scripts/desktop-release-candidate-e2e.test.mjs
+++ b/tools/scripts/desktop-release-candidate-e2e.test.mjs
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+
+import { buildUpdatedReleaseBody } from "../../apps/desktop/scripts/upsert-release-summary.mjs";
+
+const execFileAsync = promisify(execFile);
+const scriptsDir = path.resolve("apps/desktop/scripts");
+
+test("stable candidate survives build, human edit, extraction, and approval verification", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "desktop-release-candidate-"));
+  const env = {
+    ...process.env,
+    RELEASE_CANDIDATE_ID: "v1.2.3-abcdef0-run42-1",
+    RELEASE_CHANNEL: "stable",
+    RELEASE_RUN_URL: "https://github.example/runs/42",
+    RELEASE_SOURCE_REF: "release/1.2",
+    RELEASE_TAG: "v1.2.3",
+    RELEASE_TARGET: "abcdef0123456789abcdef0123456789abcdef01",
+    RELEASE_VERSION: "1.2.3"
+  };
+  const generated = createSummary();
+
+  try {
+    await writeFile(path.join(dir, "SHA256SUMS.txt"), "hash  Tutti.dmg\n");
+    await writeFile(
+      path.join(dir, "generated.json"),
+      `${JSON.stringify(generated)}\n`
+    );
+    await execFileAsync(
+      "node",
+      [
+        path.join(scriptsDir, "build-release-candidate-manifest.mjs"),
+        path.join(dir, "SHA256SUMS.txt"),
+        path.join(dir, "generated.json"),
+        path.join(dir, "candidate.json")
+      ],
+      { env }
+    );
+
+    const seededBody = buildUpdatedReleaseBody({
+      existingBody: "Generated GitHub notes",
+      summary: generated
+    });
+    await writeFile(
+      path.join(dir, "release-body.md"),
+      seededBody.replace("生成的功能说明", "人工确认后的功能说明")
+    );
+    await execFileAsync(
+      "node",
+      [
+        path.join(scriptsDir, "extract-approved-release-summary.mjs"),
+        path.join(dir, "release-body.md"),
+        path.join(dir, "generated.json"),
+        path.join(dir, "approved.json")
+      ],
+      { env }
+    );
+    const { stdout } = await execFileAsync(
+      "node",
+      [
+        path.join(scriptsDir, "verify-release-candidate.mjs"),
+        path.join(dir, "candidate.json"),
+        path.join(dir, "SHA256SUMS.txt"),
+        path.join(dir, "generated.json"),
+        path.join(dir, "approved.json")
+      ],
+      { env }
+    );
+
+    const verified = JSON.parse(stdout);
+    const approved = JSON.parse(
+      await readFile(path.join(dir, "approved.json"))
+    );
+    assert.equal(verified.candidateId, env.RELEASE_CANDIDATE_ID);
+    assert.match(verified.approvalDigest, /^[a-f0-9]{64}$/);
+    assert.equal(approved.summarySource, "human-reviewed");
+    assert.equal(approved.zh.sections[0].items[0], "人工确认后的功能说明");
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+});
+
+function createSummary() {
+  return {
+    schemaVersion: "tutti.desktop.release.summary.v1",
+    tag: "v1.2.3",
+    version: "1.2.3",
+    channel: "stable",
+    prerelease: false,
+    targetCommit: "abcdef0123456789abcdef0123456789abcdef01",
+    generatedAt: "2026-08-17T00:00:00.000Z",
+    summarySource: "agnes",
+    compare: {
+      from: "v1.2.2",
+      to: "abcdef0123456789abcdef0123456789abcdef01",
+      range: "v1.2.2..abcdef0123456789abcdef0123456789abcdef01"
+    },
+    zh: {
+      headline: "本次更新改善了桌面体验。",
+      sections: [{ title: "新功能", items: ["生成的功能说明"] }],
+      qaFocus: []
+    },
+    en: {
+      headline: "This update improves the desktop experience.",
+      sections: [{ title: "Features", items: ["Generated feature note"] }],
+      qaFocus: []
+    }
+  };
+}

--- a/tools/scripts/desktop-release-candidate.test.mjs
+++ b/tools/scripts/desktop-release-candidate.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildReleaseApprovalDigest,
+  createReleaseCandidateManifest,
+  validateReleaseCandidateManifest
+} from "../../apps/desktop/scripts/lib/releaseCandidate.mjs";
+
+function createManifest() {
+  return createReleaseCandidateManifest({
+    candidateId: "v1.2.3-abcdef0-run42-1",
+    tag: "v1.2.3",
+    version: "1.2.3",
+    targetCommit: "abcdef0123456789abcdef0123456789abcdef01",
+    sourceRef: "release/1.2",
+    createdAt: "2026-08-17T00:00:00.000Z",
+    workflowRunUrl: "https://github.example/runs/42",
+    checksums: "hash  Tutti.dmg\n",
+    generatedSummary: '{"tag":"v1.2.3"}\n'
+  });
+}
+
+test("stable candidate manifest binds the planned version, artifacts, and generated summary", () => {
+  const manifest = createManifest();
+  assert.equal(manifest.tag, "v1.2.3");
+  assert.equal(manifest.channel, "stable");
+  assert.equal(
+    validateReleaseCandidateManifest(manifest, {
+      tag: "v1.2.3",
+      targetCommit: "abcdef0123456789abcdef0123456789abcdef01",
+      checksums: "hash  Tutti.dmg\n",
+      generatedSummary: '{"tag":"v1.2.3"}\n'
+    }),
+    manifest
+  );
+  assert.throws(
+    () =>
+      validateReleaseCandidateManifest(manifest, {
+        checksums: "different",
+        generatedSummary: '{"tag":"v1.2.3"}\n'
+      }),
+    /checksums digest/
+  );
+});
+
+test("approval digest changes when either reviewed notes or the candidate changes", () => {
+  const manifest = createManifest();
+  const approved = { summarySource: "human-reviewed", zh: { headline: "A" } };
+  const digest = buildReleaseApprovalDigest(manifest, approved);
+  assert.notEqual(
+    digest,
+    buildReleaseApprovalDigest(manifest, {
+      ...approved,
+      zh: { headline: "B" }
+    })
+  );
+  assert.notEqual(
+    digest,
+    buildReleaseApprovalDigest({ ...manifest, candidateId: "other" }, approved)
+  );
+});
+
+test("stable candidate manifest requires an immutable full commit SHA", () => {
+  assert.throws(
+    () =>
+      createReleaseCandidateManifest({
+        candidateId: "v1.2.3-abcdef0-run42-1",
+        tag: "v1.2.3",
+        version: "1.2.3",
+        targetCommit: "main",
+        sourceRef: "main",
+        createdAt: "2026-08-17T00:00:00.000Z",
+        workflowRunUrl: "https://github.example/runs/42",
+        checksums: "hash  Tutti.dmg\n",
+        generatedSummary: '{"tag":"v1.2.3"}\n'
+      }),
+    /full Git commit SHA/
+  );
+});

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -206,7 +206,7 @@ test("desktop release submits only stable builds to an isolated Store workflow",
     workflow,
     /vars\.TUTTI_WINDOWS_STORE_SUBMISSION_ENABLED == 'true'/
   );
-  assert.match(workflow, /publication_mode == 'publish'/);
+  assert.doesNotMatch(workflow, /publication_mode|draft_only/);
   assert.match(workflow, /needs:\s*\[resolve, promote\]/);
   assert.match(
     workflow,
@@ -531,11 +531,11 @@ test("desktop release post-stage jobs tolerate skipped optional dependencies", a
     /promote:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
   )?.[0];
   const notifyJob = workflow.match(
-    /notify-draft-feishu:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
+    /notify-candidate-feishu:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
   )?.[0];
 
   assert.ok(promoteJob, "promote job should exist");
-  assert.ok(notifyJob, "draft notify job should exist");
+  assert.ok(notifyJob, "candidate notify job should exist");
   assert.match(promoteJob, /if:\s+\${{\s*always\(\)\s*&&/);
   assert.match(promoteJob, /needs\.stage\.result\s*==\s*'success'/);
   assert.match(notifyJob, /if:\s+\${{\s*always\(\)\s*&&/);
@@ -545,16 +545,16 @@ test("desktop release post-stage jobs tolerate skipped optional dependencies", a
 test("desktop release workflow does not redownload release assets for Feishu", async () => {
   const workflow = await readFile(workflowPath, "utf8");
   const notifyJobMatch = workflow.match(
-    /notify-draft-feishu:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
+    /notify-candidate-feishu:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
   );
 
-  assert.ok(notifyJobMatch, "draft notify job should exist");
+  assert.ok(notifyJobMatch, "candidate notify job should exist");
 
   const notifyJob = notifyJobMatch[0];
   const checkoutIndex = notifyJob.indexOf("name: Checkout notification script");
   const setupNodeIndex = notifyJob.indexOf("name: Setup Node.js");
   const summaryIndex = notifyJob.indexOf("name: Download release summary");
-  const sendIndex = notifyJob.indexOf("name: Send draft release card");
+  const sendIndex = notifyJob.indexOf("name: Send candidate release card");
 
   assert.notEqual(checkoutIndex, -1, "notify job should checkout the script");
   assert.notEqual(setupNodeIndex, -1, "notify job should setup Node.js");
@@ -615,13 +615,10 @@ test("desktop release workflow only publishes root latest metadata for stable re
   const workflow = await readFile(workflowPath, "utf8");
   const promoteWorkflow = await readFile(promoteWorkflowPath, "utf8");
 
+  assert.doesNotMatch(workflow, /publication_mode|draft_only/);
   assert.match(
     workflow,
-    /publication_mode:[\s\S]*?- publish\r?\n\s*- draft_only/
-  );
-  assert.match(
-    workflow,
-    /needs\.resolve\.outputs\.publication_mode\s*==\s*'publish'/
+    /needs\.stage\.result == 'success' && needs\.resolve\.outputs\.release_candidate != 'true'/
   );
   assert.doesNotMatch(workflow, /channels\/rc\/latest\.json/);
   assert.doesNotMatch(workflow, /aws s3 cp release-latest\.json/);
@@ -783,10 +780,7 @@ test("desktop release workflow keeps prereleases as drafts and reserves the publ
     workflow,
     /uses:\s+\.\/\.github\/workflows\/desktop-release-promote\.yml/
   );
-  assert.match(
-    workflow,
-    /needs\.resolve\.outputs\.publication_mode\s*==\s*'publish'/
-  );
+  assert.doesNotMatch(workflow, /publication_mode|draft_only/);
   assert.match(
     promoteWorkflow,
     /if:\s*\$\{\{\s*needs\.resolve\.outputs\.release_channel\s*==\s*'stable'\s*\}\}/
@@ -949,11 +943,11 @@ test("desktop release workflow always builds Windows and stages unsigned assets"
     /stage:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
   );
   const notifyJobMatch = workflow.match(
-    /notify-draft-feishu:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
+    /notify-candidate-feishu:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
   );
 
   assert.ok(stageJobMatch, "stage job should exist");
-  assert.ok(notifyJobMatch, "draft notify job should exist");
+  assert.ok(notifyJobMatch, "candidate notify job should exist");
   assert.doesNotMatch(workflow, /include_windows/);
   assert.match(workflow, /\r?\n\s{2}build-windows:\r?\n/);
   assert.doesNotMatch(workflow, /\r?\n\s{2}build-linux:\r?\n/);

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -442,15 +442,16 @@ test("desktop release workflow keeps less common rc bumps behind explicit versio
   assert.doesNotMatch(workflow, /tag_name:\s*\n/);
 });
 
-test("desktop release workflow reserves unique tags instead of serializing whole runs", async () => {
+test("desktop release workflow defers stable tags but still reserves prerelease tags", async () => {
   const workflow = await readFile(workflowPath, "utf8");
 
-  assert.doesNotMatch(workflow, /^concurrency:/m);
+  assert.match(workflow, /^concurrency:\s*$/m);
+  assert.match(workflow, /cancel-in-progress:\s+false/);
   assert.match(workflow, /apps\/desktop\/scripts\/reserve-release-tag\.mjs/);
-  assert.match(
-    workflow,
-    /args\+=\(--target "\${{\s*steps\.target\.outputs\.release_target\s*}}"\)/
-  );
+  assert.match(workflow, /release_candidate=true/);
+  assert.match(workflow, /release_channel.*stable/);
+  assert.match(workflow, /reserve_args=.*--strategy explicit_tag/);
+  assert.match(workflow, /release_candidate != 'true'/);
 });
 
 test("desktop release workflow passes tsh-aligned Feishu card context", async () => {
@@ -471,7 +472,7 @@ test("desktop release workflow passes tsh-aligned Feishu card context", async ()
   );
   assert.match(
     workflow,
-    /outputs:\s*\n\s*release_url:\s*\${{\s*github\.server_url\s*}}\/\${{\s*github\.repository\s*}}\/releases\/tag\/\${{\s*needs\.resolve\.outputs\.release_tag\s*}}/
+    /release_url:\s*\${{\s*needs\.resolve\.outputs\.release_candidate\s*==\s*'true'[\s\S]*steps\.stage-candidate-release\.outputs\.release_url/
   );
   assert.match(
     workflow,
@@ -819,7 +820,7 @@ test("desktop promotion validates draft identity, checksums, and channel orderin
   assert.match(promoteWorkflow, /group:\s+desktop-release-promotion/);
   assert.match(
     promoteWorkflow,
-    /gh release view "\$\{release_tag\}"[\s\S]*assets,isDraft,isPrerelease,tagName,targetCommitish,url/
+    /\.tag_name == \\"\$\{release_tag\}\\" or \.tag_name == \\"\$\{release_candidate_tag\}\\"/
   );
   assert.match(
     promoteWorkflow,
@@ -829,6 +830,34 @@ test("desktop promotion validates draft identity, checksums, and channel orderin
   assert.match(promoteWorkflow, /name:\s+Prevent release channel rollback/);
   assert.match(promoteWorkflow, /Refusing to move/);
   assert.match(promoteWorkflow, /name:\s+Verify public release pointer/);
+});
+
+test("stable candidates require environment approval and bind the reviewed notes", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+  const promoteWorkflow = await readFile(promoteWorkflowPath, "utf8");
+
+  assert.match(workflow, /build-release-candidate-manifest\.mjs/);
+  assert.match(workflow, /release_candidate_tag="candidate-\$\{release_tag\}"/);
+  assert.match(workflow, /releases\/assets\/\$\{asset_id\}/);
+  assert.match(
+    workflow,
+    /candidates\/\$\{TUTTI_DESKTOP_RELEASE_CANDIDATE_ID\}/
+  );
+  assert.match(workflow, /PROMOTION_URL:/);
+  assert.match(promoteWorkflow, /environment:\s+desktop-stable-release/);
+  assert.match(promoteWorkflow, /extract-approved-release-summary\.mjs/);
+  assert.match(promoteWorkflow, /verify-release-candidate\.mjs/);
+  assert.match(
+    promoteWorkflow,
+    /RELEASE_TAG="\$\{release_tag\}" RELEASE_TARGET="\$\{draft_target_sha\}"/
+  );
+  assert.match(
+    promoteWorkflow,
+    /Release notes or candidate assets changed after approval/
+  );
+  assert.match(promoteWorkflow, /Create stable release tag after approval/);
+  assert.match(promoteWorkflow, /Protect immutable stable asset path/);
+  assert.match(promoteWorkflow, /\.promotion-candidate\.json/);
 });
 
 test("desktop release workflow refreshes the stable alias without taking Latest", async () => {

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -854,6 +854,41 @@ test("stable candidates require environment approval and bind the reviewed notes
   assert.match(promoteWorkflow, /\.promotion-candidate\.json/);
 });
 
+test("stable promotion can resume after the GitHub release becomes public", async () => {
+  const promoteWorkflow = await readFile(promoteWorkflowPath, "utf8");
+  const publishIndex = promoteWorkflow.indexOf(
+    "name: Publish stable GitHub release"
+  );
+  const verifyPointerIndex = promoteWorkflow.indexOf(
+    "name: Verify public release pointer"
+  );
+  const cleanupIndex = promoteWorkflow.indexOf(
+    "name: Remove internal candidate manifest from published release"
+  );
+
+  assert.match(
+    promoteWorkflow,
+    /\(\.draft \| not\) and \.tag_name == \\"\$\{release_tag\}\\" and \(\.prerelease \| not\)/
+  );
+  assert.match(
+    promoteWorkflow,
+    /release_already_published=true[\s\S]*release_already_published=\$\{release_already_published\}/
+  );
+  assert.match(
+    promoteWorkflow,
+    /Attach approved draft to the stable tag[\s\S]*release_already_published != 'true'/
+  );
+  assert.ok(publishIndex >= 0, "stable publish step should exist");
+  assert.ok(
+    verifyPointerIndex > publishIndex,
+    "public pointer verification should remain retryable after publication"
+  );
+  assert.ok(
+    cleanupIndex > verifyPointerIndex,
+    "candidate recovery metadata should be removed only after all fallible promotion checks"
+  );
+});
+
 test("desktop release workflow refreshes the stable alias without taking Latest", async () => {
   const promoteWorkflow = await readFile(promoteWorkflowPath, "utf8");
   const stableAliasStep = promoteWorkflow.match(

--- a/tools/scripts/desktop-release-download-links.test.mjs
+++ b/tools/scripts/desktop-release-download-links.test.mjs
@@ -77,6 +77,20 @@ test("desktop release notes replace the managed direct download section in place
   );
 });
 
+test("desktop release notes support immutable candidate paths", () => {
+  const nextBody = buildUpdatedReleaseBody({
+    assetNames: ["Tutti-1.2.3-mac-universal.dmg"],
+    existingBody: "",
+    releaseAssetBaseUrl: "https://downloads.example.com/desktop",
+    releaseAssetPath: "candidates/v1.2.3-abcdef0-run42",
+    releaseTag: "v1.2.3"
+  });
+  assert.match(
+    nextBody,
+    /desktop\/candidates\/v1\.2\.3-abcdef0-run42\/Tutti-1\.2\.3-mac-universal\.dmg/
+  );
+});
+
 test("desktop release notes remove the managed section when no mirrored base URL is configured", () => {
   const existingBody = [
     "## What's Changed",

--- a/tools/scripts/desktop-release-feishu-card.test.mjs
+++ b/tools/scripts/desktop-release-feishu-card.test.mjs
@@ -74,31 +74,29 @@ test("release Feishu card marks beta tags as prereleases", () => {
   assert.match(resolveIntroText("v1.12.19-beta.0"), /Beta 预览通道/);
 });
 
-test("release Feishu card clearly marks draft builds without claiming public publication", () => {
-  assert.equal(
-    resolveReleaseKind("v1.12.20", "draft"),
-    "Draft stable candidate"
-  );
-  assert.match(resolveIntroText("v1.12.20", "draft"), /仍为 Draft/);
-  assert.match(resolveIntroText("v1.12.20", "draft"), /尚未更新公开下载通道/);
+test("release Feishu card clearly marks candidates without claiming public publication", () => {
+  assert.equal(resolveReleaseKind("v1.12.20", "candidate"), "Stable candidate");
+  assert.match(resolveIntroText("v1.12.20", "candidate"), /候选版本/);
+  assert.match(resolveIntroText("v1.12.20", "candidate"), /尚未向用户开放更新/);
 
   const payload = buildCardPayload({
     actor: "jomeswang",
     branch: "release/0704",
     macUrl: "https://example.com/tutti.dmg",
-    publicationStatus: "draft",
+    publicationStatus: "candidate",
+    promotionUrl:
+      "https://github.com/tutti-os/tutti/actions/workflows/desktop-release-promote.yml",
     releaseUrl: "https://github.com/tutti-os/tutti/releases/tag/v1.12.20",
     runUrl: "https://github.com/tutti-os/tutti/actions/runs/1",
     tag: "v1.12.20",
     target: "4039186abcdef0"
   });
 
-  assert.equal(payload.card.header.title.content, "Tutti Draft 构建完成");
+  assert.equal(payload.card.header.title.content, "Tutti 候选版本待确认");
   assert.equal(payload.card.header.template, "orange");
-  assert.equal(
-    extractFieldMap(payload).get("构建类型"),
-    "Draft stable candidate"
-  );
+  assert.equal(extractFieldMap(payload).get("构建类型"), "Stable candidate");
+  assert.equal(extractFieldMap(payload).has("Commit"), false);
+  assert.equal(extractFieldMap(payload).has("部署分支"), false);
 });
 
 test("release Feishu card includes tsh-aligned release context fields", () => {
@@ -119,8 +117,6 @@ test("release Feishu card includes tsh-aligned release context fields", () => {
   assert.equal(payload.card.header.title.content, "Tutti 发布完成");
   assert.equal(fields.get("版本号"), "v1.12.20");
   assert.equal(fields.get("构建类型"), "Stable latest release");
-  assert.equal(fields.get("Commit"), "4039186");
-  assert.equal(fields.get("部署分支"), "main");
   assert.equal(fields.get("部署人"), "jomeswang");
 
   const actionLabels = payload.card.elements
@@ -130,8 +126,8 @@ test("release Feishu card includes tsh-aligned release context fields", () => {
   assert.deepEqual(actionLabels, [
     "下载 macOS",
     "下载 Windows（未签名）",
-    "打开 Release 页面",
-    "查看流水线"
+    "查看完整更新日志",
+    "查看技术详情"
   ]);
 });
 
@@ -144,7 +140,8 @@ test("release Feishu card uses the mirrored Windows installer URL", () => {
     runUrl: "https://github.com/tutti-os/tutti/actions/runs/1",
     tag: "v1.12.20-rc.0",
     target: "4039186abcdef0",
-    winUrl: "https://downloads.example.com/v1.12.20-rc.0/Tutti-1.12.20-rc.0-win-x64.exe"
+    winUrl:
+      "https://downloads.example.com/v1.12.20-rc.0/Tutti-1.12.20-rc.0-win-x64.exe"
   });
 
   const windowsAction = payload.card.elements
@@ -185,7 +182,7 @@ test("release Feishu card includes Chinese release summary when available", () =
 
   assert.ok(summaryElement);
   assert.match(summaryElement.text.content, /稳定包下载入口只指向正式 release/);
-  assert.match(summaryElement.text.content, /QA 重点/);
+  assert.doesNotMatch(summaryElement.text.content, /QA 重点/);
 });
 
 test("release Feishu card skips summary elements when summary is missing", () => {
@@ -241,5 +238,17 @@ test("release Feishu card resolves mirrored macOS URLs from local artifact names
       "v0.1.0-rc.4"
     ),
     "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-desktop-release-assets/v0.1.0-rc.4/Tutti-0.1.0-rc.4-win-x64.exe"
+  );
+});
+
+test("release Feishu card keeps candidate path segments while encoding asset names", () => {
+  assert.equal(
+    resolveMirroredAssetUrl(
+      ["Tutti 1.2.3-mac-universal.dmg"],
+      /\.dmg$/i,
+      "https://downloads.example.com/desktop",
+      "candidates/v1.2.3-abcdef0-run42"
+    ),
+    "https://downloads.example.com/desktop/candidates/v1.2.3-abcdef0-run42/Tutti%201.2.3-mac-universal.dmg"
   );
 });

--- a/tools/scripts/desktop-release-latest.test.mjs
+++ b/tools/scripts/desktop-release-latest.test.mjs
@@ -21,6 +21,7 @@ test("desktop release latest metadata exposes CloudFront URLs for every asset", 
       releaseAssetBaseUrl:
         "https://d111111abcdef8.cloudfront.net/desktop-release-assets/",
       releaseTag: "v1.2.3",
+      releaseNotesUrl: "https://github.com/tutti-os/tutti/releases/tag/v1.2.3",
       releasedAt: "2026-07-04T12:00:00.000Z",
       sourceRef: "main"
     });
@@ -33,6 +34,10 @@ test("desktop release latest metadata exposes CloudFront URLs for every asset", 
     assert.equal(latest.releasedAt, "2026-07-04T12:00:00.000Z");
     assert.equal(latest.gitSha, "537327a1");
     assert.equal(latest.sourceRef, "main");
+    assert.equal(
+      latest.releaseNotesUrl,
+      "https://github.com/tutti-os/tutti/releases/tag/v1.2.3"
+    );
     assert.equal(
       latest.baseUrl,
       "https://d111111abcdef8.cloudfront.net/desktop-release-assets"

--- a/tools/scripts/desktop-release-summary.test.mjs
+++ b/tools/scripts/desktop-release-summary.test.mjs
@@ -14,8 +14,12 @@ import {
 } from "../../apps/desktop/scripts/lib/githubReleaseBody.mjs";
 import { resolvePreviousReleaseTag } from "../../apps/desktop/scripts/lib/previousReleaseTag.mjs";
 import {
+  REVIEW_END,
+  REVIEW_START,
   SECTION_END,
   SECTION_START,
+  SUGGESTION_START,
+  buildApprovedReleaseSummary,
   buildUpdatedReleaseBody
 } from "../../apps/desktop/scripts/upsert-release-summary.mjs";
 import { validateReleaseSummary } from "../../apps/desktop/scripts/validate-release-summary.mjs";
@@ -120,7 +124,7 @@ test("desktop release summary fallback emits zh and en sections", () => {
   assert.ok(summary.en.sections.length >= 2);
 });
 
-test("desktop release summary upserts a managed GitHub release section", () => {
+test("desktop release summary creates editable review and replaceable suggestion sections", () => {
   const nextBody = buildUpdatedReleaseBody({
     existingBody: [
       "## What's Changed",
@@ -151,14 +155,59 @@ test("desktop release summary upserts a managed GitHub release section", () => {
     }
   });
 
-  assert.equal(nextBody.match(new RegExp(SECTION_START, "g"))?.length, 1);
-  assert.doesNotMatch(nextBody, /本次版本聚焦发布链路稳定性/);
+  assert.equal(nextBody.match(new RegExp(REVIEW_START, "g"))?.length, 1);
+  assert.equal(nextBody.match(new RegExp(SUGGESTION_START, "g"))?.length, 1);
+  assert.match(nextBody, /本次版本聚焦发布链路稳定性/);
   assert.match(nextBody, /Stable downloads only point to official releases/);
-  assert.match(nextBody, /Highlights/);
+  assert.match(nextBody, /Release Notes/);
   assert.doesNotMatch(nextBody, /QA Focus/);
   assert.doesNotMatch(nextBody, /Verify the download entry/);
   assert.match(nextBody, /Raw GitHub note/);
   assert.doesNotMatch(nextBody, /old summary/);
+});
+
+test("desktop release summary preserves human review when a candidate is rebuilt", () => {
+  const humanReview = [
+    REVIEW_START,
+    "## Release Notes",
+    "### 中文",
+    "人工确认标题",
+    "#### 问题修复",
+    "- 人工确认内容",
+    "### English",
+    "Reviewed headline",
+    "#### Bug Fixes",
+    "- Reviewed item",
+    REVIEW_END
+  ].join("\n");
+  const nextBody = buildUpdatedReleaseBody({
+    existingBody: `${humanReview}\n\n## What's Changed\n- keep me`,
+    summary: validReleaseSummary({
+      zh: {
+        headline: "新的机器建议",
+        sections: [{ title: "功能变更", items: ["机器内容"] }],
+        qaFocus: []
+      }
+    })
+  });
+  assert.match(nextBody, /人工确认内容/);
+  assert.match(nextBody, /新的机器建议/);
+  assert.match(nextBody, /keep me/);
+});
+
+test("approved summary is parsed from the human review instead of generated suggestions", () => {
+  const body = buildUpdatedReleaseBody({
+    existingBody: "",
+    summary: validReleaseSummary()
+  }).replace("验证候选版本。", "人工筛选后的更新内容");
+  const approved = buildApprovedReleaseSummary({
+    body,
+    generatedSummary: validReleaseSummary(),
+    reviewedAt: "2026-08-17T01:00:00.000Z"
+  });
+  assert.equal(approved.summarySource, "human-reviewed");
+  assert.deepEqual(approved.zh.sections[0].items, ["人工筛选后的更新内容"]);
+  assert.equal(approved.generatedAt, "2026-08-17T01:00:00.000Z");
 });
 
 test("desktop release summary trims only generated notes at GitHub's body limit", () => {
@@ -171,12 +220,13 @@ test("desktop release summary trims only generated notes at GitHub's body limit"
   ].join("\n");
   const nextBody = buildUpdatedReleaseBody({
     existingBody: oversizedNotes,
-    summary: {
+    summary: validReleaseSummary({
       en: {
         headline: "A concise release summary.",
-        sections: [{ title: "Bug Fixes", items: ["Kept releases reliable."] }]
+        sections: [{ title: "Bug Fixes", items: ["Kept releases reliable."] }],
+        qaFocus: []
       }
-    }
+    })
   });
 
   assert.ok(nextBody.length <= GITHUB_RELEASE_BODY_MAX_LENGTH);
@@ -195,6 +245,14 @@ test("desktop release summary validator accepts a complete staged summary", () =
       targetCommit: summary.targetCommit
     }),
     summary
+  );
+});
+
+test("desktop release summary validator accepts a human-reviewed summary", () => {
+  assert.doesNotThrow(() =>
+    validateReleaseSummary(
+      validReleaseSummary({ summarySource: "human-reviewed" })
+    )
   );
 });
 


### PR DESCRIPTION
## Summary

- stage stable desktop builds as replaceable candidates under an internal candidate tag
- preserve an operator-edited bilingual release summary and require GitHub Environment approval before promotion
- bind approval to the candidate manifest, target commit, artifact hashes, and reviewed summary digest
- publish immutable formal-tag assets, retag the approved draft, update the stable feed, submit stores, and send user-facing Feishu cards
- expose the release notes URL beside the desktop update action

## Release flow

1. Run Desktop Release for a stable version/ref.
2. Build and upload a candidate, then notify Feishu with user-facing changes and links to edit the draft / open Promotion Workflow.
3. An operator edits the bilingual review section and manually starts Promotion Workflow.
4. GitHub Environment `desktop-stable-release` allows approval by SingleMai, jomeswang, or vorshen, including self-review.
5. Approval automatically re-verifies the exact candidate and publishes the formal immutable tag/assets/release/feed/store submission.

Rebuilding the same unpromoted version replaces the internal candidate and its draft assets. A published formal version remains immutable.

## Validation

- `pnpm check:changed` — 12/12 lanes passed after the final commit
- pre-push `pnpm check:changed -- --push-ready` — 13/13 lanes passed
- `pnpm --filter desktop test` — 1746 tests, 1744 passed, 2 skipped, 0 failed
- focused release pipeline tests — 95/95 passed
- focused app-update tests — 42/42 passed
- desktop typecheck, Oxlint, Prettier, YAML parse, and `git diff --check` passed
- candidate CLI E2E covers manifest build → human summary edit → approved extraction → digest verification

An unrelated replay timing test failed once during the first push-ready run and passed on both failed-only rerun and the subsequent full 13-lane push-ready run.

## Independent review

Independent subagent review identified and the implementation fixes:

- formal tags must not be consumed by draft candidates
- formal S3 asset paths must reject different bytes and support only idempotent resume
- approval verification must bind the planned version and full target SHA
- same candidate build inputs must be serialized

## Operations

- GitHub Environment `desktop-stable-release` is configured with only SingleMai, jomeswang, and vorshen as reviewers; self-review is allowed.
- Candidate S3 objects are written under `tutti-desktop-release-assets/candidates/`.
- Follow-up: apply/confirm a 30-day lifecycle rule for that candidate prefix in AWS. Local AWS credentials were unavailable, so this infrastructure setting was not changed by this PR.
- No production release was triggered during validation.
