### PR TITLE
feat(connector): support device-code authorization

### DIFF
--- a/packages/connector/host/authorization_view.go
+++ b/packages/connector/host/authorization_view.go
@@ -9,6 +9,7 @@ import (
 const (
 	AuthorizationViewProtocolV1       = "tutti.connector.authorization.view.v1"
 	AuthorizationViewTypeExternalLink = "external_link"
+	AuthorizationViewTypeDeviceCode   = "device_code"
 	AuthorizationViewTypeQRCode       = "qr_code"
 	AuthorizationQRCodeSourcePayload  = "payload"
 )
@@ -22,10 +23,12 @@ type AuthorizationViewEnvelope struct {
 }
 
 type AuthorizationView struct {
-	Type      string                     `json:"type"`
-	URL       string                     `json:"url,omitempty"`
-	Source    *AuthorizationQRCodeSource `json:"source,omitempty"`
-	ExpiresAt string                     `json:"expiresAt,omitempty"`
+	Type            string                     `json:"type"`
+	URL             string                     `json:"url,omitempty"`
+	VerificationURL string                     `json:"verificationUrl,omitempty"`
+	UserCode        string                     `json:"userCode,omitempty"`
+	Source          *AuthorizationQRCodeSource `json:"source,omitempty"`
+	ExpiresAt       string                     `json:"expiresAt,omitempty"`
 }
 
 type AuthorizationQRCodeSource struct {
@@ -40,7 +43,13 @@ func authorizationViewForSession(release Release, session AuthorizationSession) 
 
 	view := AuthorizationView{Type: AuthorizationViewTypeExternalLink, URL: session.AuthorizationURL}
 	managed := release.Manifest.Implementation.ManagedStdio
-	if managed != nil && managed.CredentialBroker != nil &&
+	if strings.TrimSpace(session.UserCode) != "" {
+		view = AuthorizationView{
+			Type:            AuthorizationViewTypeDeviceCode,
+			VerificationURL: session.AuthorizationURL,
+			UserCode:        session.UserCode,
+		}
+	} else if managed != nil && managed.CredentialBroker != nil &&
 		managed.CredentialBroker.Presentation == CredentialBrokerPresentationQRCode {
 		view = AuthorizationView{
 			Type: AuthorizationViewTypeQRCode,
@@ -53,7 +62,7 @@ func authorizationViewForSession(release Release, session AuthorizationSession) 
 	if !session.ExpiresAt.IsZero() {
 		view.ExpiresAt = session.ExpiresAt.UTC().Format("2006-01-02T15:04:05.999999999Z07:00")
 	}
-	viewDigest := sha256.Sum256([]byte(session.SessionID + "\x00" + session.AuthorizationURL))
+	viewDigest := sha256.Sum256([]byte(session.SessionID + "\x00" + session.AuthorizationURL + "\x00" + session.UserCode))
 	return &AuthorizationViewEnvelope{
 		Protocol: AuthorizationViewProtocolV1,
 		ViewID:   "authorization-" + hex.EncodeToString(viewDigest[:16]),

--- a/packages/connector/host/authorization_view_test.go
+++ b/packages/connector/host/authorization_view_test.go
@@ -1,9 +1,38 @@
 package host
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
+
+func TestAuthorizationViewForSessionProjectsDeviceCodeWithV1Protocol(t *testing.T) {
+	session := AuthorizationSession{
+		SessionID:        "session-device-code",
+		AuthorizationURL: "https://github.com/login/device",
+		UserCode:         "ABCD-EFGH",
+		State:            AuthorizationStatePending,
+	}
+
+	view := authorizationViewForSession(Release{}, session)
+	if view == nil || view.Protocol != AuthorizationViewProtocolV1 || view.View.Type != AuthorizationViewTypeDeviceCode {
+		t.Fatalf("authorization view = %#v, want V1 device-code view", view)
+	}
+	if view.View.VerificationURL != session.AuthorizationURL || view.View.UserCode != session.UserCode || view.View.URL != "" {
+		t.Fatalf("device-code view = %#v", view.View)
+	}
+}
+
+func TestAuthorizationSessionDoesNotPersistDeviceCode(t *testing.T) {
+	payload, err := json.Marshal(AuthorizationSession{UserCode: "ABCD-EFGH"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(payload), "ABCD-EFGH") {
+		t.Fatalf("authorization session persisted device code: %s", payload)
+	}
+}
 
 func TestAuthorizationViewForSessionProjectsQRCodeWithV1Protocol(t *testing.T) {
 	release := Release{Manifest: Manifest{Implementation: Implementation{

--- a/packages/connector/host/types.go
+++ b/packages/connector/host/types.go
@@ -525,6 +525,7 @@ type AuthorizationSession struct {
 	SessionID        string                         `json:"sessionId"`
 	ActionType       string                         `json:"actionType"`
 	AuthorizationURL string                         `json:"-"`
+	UserCode         string                         `json:"-"`
 	ExpiresAt        time.Time                      `json:"expiresAt"`
 	State            AuthorizationState             `json:"-"`
 	Resolution       AuthorizationSessionResolution `json:"resolution"`

--- a/packages/connector/market/README.md
+++ b/packages/connector/market/README.md
@@ -39,6 +39,11 @@ same protocol with its UI System-based default renderer. A missing interaction
 on a legacy `api_key` Connector uses the centralized one-secret compatibility
 adapter; an explicitly invalid interaction fails closed.
 
+When a newly received Authorization View is an `external_link` or
+`device_code`, Connector Market opens its activation or verification URL once.
+The `device_code` View stays visible so the user can copy its code, and the
+dialog action remains available if the browser must be opened again manually.
+
 ## Renderer usage
 
 ```ts

--- a/packages/connector/market/src/services/connectorMarketService.test.ts
+++ b/packages/connector/market/src/services/connectorMarketService.test.ts
@@ -1638,6 +1638,74 @@ test("keeps QR authorization in app state without opening its payload", async ()
   service.dispose();
 });
 
+test("opens a device-code verification page once while keeping the code visible", async () => {
+  const continueAuthorization = deferred<void>();
+  const openedUrls: string[] = [];
+  let step = 0;
+  const initial = connector("github-cli", 1);
+  initial.authorization = { state: "disconnected" };
+  const service = new ConnectorMarketService({
+    backend: backendWith({
+      getSnapshot: async () => snapshot(1, [initial]),
+      beginAuthorization: async () => {
+        step += 1;
+        if (step > 1) {
+          await continueAuthorization.promise;
+        }
+        const next = connector("github-cli", step + 1);
+        next.authorization = { state: step === 1 ? "pending" : "connected" };
+        return {
+          connector: next,
+          operation: {
+            ...operation("start_authorization", step + 1),
+            connectorKey: "github-cli",
+            state: "completed" as const
+          },
+          ...(step === 1
+            ? {
+                authorizationView: {
+                  protocol: "tutti.connector.authorization.view.v1" as const,
+                  viewId: "github-device-code-1",
+                  view: {
+                    type: "device_code" as const,
+                    verificationUrl: "https://github.com/login/device",
+                    userCode: "ABCD-EFGH"
+                  }
+                }
+              }
+            : {}),
+          revision: step + 1
+        };
+      }
+    }),
+    openAuthorizationUrl: async (url) => {
+      openedUrls.push(url);
+    }
+  });
+  await service.ensureLoaded();
+
+  const authorization = service.beginAuthorization("github-cli");
+  await waitFor(
+    () =>
+      service.dataStore.authorizationViewsByConnectorKey["github-cli"]?.view
+        .type === "device_code"
+  );
+  assert.deepEqual(openedUrls, ["https://github.com/login/device"]);
+  assert.equal(
+    service.dataStore.authorizationViewsByConnectorKey["github-cli"]?.view
+      .type === "device_code"
+      ? service.dataStore.authorizationViewsByConnectorKey["github-cli"]?.view
+          .userCode
+      : undefined,
+    "ABCD-EFGH"
+  );
+
+  continueAuthorization.resolve();
+  await authorization;
+  assert.deepEqual(openedUrls, ["https://github.com/login/device"]);
+  service.dispose();
+});
+
 test("fails closed when the host returns an invalid authorization view", async () => {
   const initial = connector("wecom-cli", 1);
   initial.authorization = { state: "disconnected" };

--- a/packages/connector/market/src/services/connectorMarketService.ts
+++ b/packages/connector/market/src/services/connectorMarketService.ts
@@ -545,8 +545,14 @@ export class ConnectorMarketService implements IConnectorMarketService {
           seenAuthorizationViewIds.add(authorizationView.viewId);
           this.dataStore.authorizationViewsByConnectorKey[connectorKey] =
             authorizationView;
-          if (authorizationView.view.type === "external_link") {
-            await this.openAuthorizationUrl(authorizationView.view.url);
+          const activationUrl =
+            authorizationView.view.type === "external_link"
+              ? authorizationView.view.url
+              : authorizationView.view.type === "device_code"
+                ? authorizationView.view.verificationUrl
+                : null;
+          if (activationUrl) {
+            await this.openAuthorizationUrl(activationUrl);
           }
         }
         if (this.authorizationState(connectorKey) === "connected") {

--- a/packages/connector/runtime/README.md
+++ b/packages/connector/runtime/README.md
@@ -100,6 +100,13 @@ credentials and configuration remain in the Connector-private state directory;
 the CLI itself is installed only in Tutti's private managed directory and is
 never added to the system `PATH`.
 
+An `authorization_url` event may include the V1 event's existing `code` field
+when the provider requires a short-lived user-facing device code. The runtime
+keeps that code only in the in-memory broker session and projects it into the
+existing V1 `device_code` Authorization View. It is never persisted or written
+to diagnostics. Brokers without a code and older hosts retain the external-link
+fallback.
+
 Credential-broker sessions are owned by the durable authorization operation,
 not only by the Connector route. Repeating that operation may resume its
 session; a different operation must first cancel the previous session and wait

--- a/packages/connector/runtime/implementationhost/credential_authorization.go
+++ b/packages/connector/runtime/implementationhost/credential_authorization.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
 	market "github.com/tutti-os/tutti/packages/connector/host"
@@ -81,12 +82,13 @@ type credentialBrokerSession struct {
 	cancel      context.CancelFunc
 	done        chan struct{}
 
-	mu      sync.Mutex
-	state   market.AuthorizationState
-	url     string
-	err     error
-	version uint64
-	changed chan struct{}
+	mu       sync.Mutex
+	state    market.AuthorizationState
+	url      string
+	userCode string
+	err      error
+	version  uint64
+	changed  chan struct{}
 }
 
 func newManagedCredentialAuthorizationProvider(host managedCredentialAuthorizationHost) *managedCredentialAuthorizationProvider {
@@ -143,7 +145,7 @@ func (provider *managedCredentialAuthorizationProvider) Begin(
 		cancelCleanup()
 		return market.AuthorizationSession{}, errors.Join(err, cleanupErr)
 	}
-	state, authorizationURL, sessionErr := session.snapshot()
+	state, authorizationURL, userCode, sessionErr := session.snapshot()
 	if sessionErr != nil {
 		provider.clearAuthorizationSession(request.OperationID, session)
 		provider.host.releaseAuthorizationRoute(route)
@@ -155,6 +157,7 @@ func (provider *managedCredentialAuthorizationProvider) Begin(
 		ConnectionID:     route.connectionID,
 		SessionID:        request.OperationID + "/credential-broker",
 		AuthorizationURL: authorizationURL,
+		UserCode:         userCode,
 		State:            state,
 	}
 	if state == market.AuthorizationStateConnected {
@@ -266,7 +269,7 @@ func (provider *managedCredentialAuthorizationProvider) authorizationSessionOrSt
 	operationID = strings.TrimSpace(operationID)
 	provider.mu.Lock()
 	if session := provider.sessions[operationID]; session != nil {
-		_, _, sessionErr := session.snapshot()
+		_, _, _, sessionErr := session.snapshot()
 		if sessionErr == nil {
 			provider.mu.Unlock()
 			return session, nil
@@ -282,7 +285,7 @@ func (provider *managedCredentialAuthorizationProvider) authorizationSessionOrSt
 	if activeOperationID := provider.activeByRoute[route.id]; activeOperationID != "" {
 		active := provider.sessions[activeOperationID]
 		if active != nil {
-			_, _, activeErr := active.snapshot()
+			_, _, _, activeErr := active.snapshot()
 			if activeErr != nil {
 				select {
 				case <-active.done:
@@ -388,10 +391,14 @@ func applyCredentialBrokerEvent(host managedCredentialAuthorizationHost, route *
 		if !safeCredentialBrokerURL(event.URL, route.credentialBrokerLaunch.allowedHosts) {
 			return errors.New("connector credential broker returned an unauthorized URL")
 		}
-		session.update(market.AuthorizationStatePending, event.URL, nil)
+		userCode, err := normalizeCredentialBrokerUserCode(event.Code)
+		if err != nil {
+			return err
+		}
+		session.update(market.AuthorizationStatePending, event.URL, userCode, nil)
 		host.observeAuthorization(route, market.AuthorizationStatePending)
 	case "connected":
-		session.update(market.AuthorizationStateConnected, "", nil)
+		session.update(market.AuthorizationStateConnected, "", "", nil)
 		host.observeAuthorization(route, market.AuthorizationStateConnected)
 	case "error":
 		return credentialBrokerEventError(event, "authorize")
@@ -709,6 +716,14 @@ func boundedBrokerMessage(message string) string {
 	return message
 }
 
+func normalizeCredentialBrokerUserCode(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if utf8.RuneCountInString(value) > 128 {
+		return "", errors.New("connector credential broker returned an oversized device code")
+	}
+	return value, nil
+}
+
 func (session *credentialBrokerSession) awaitInitialEvent(ctx context.Context) error {
 	session.mu.Lock()
 	version := session.version
@@ -729,10 +744,11 @@ func (session *credentialBrokerSession) awaitInitialEvent(ctx context.Context) e
 	}
 }
 
-func (session *credentialBrokerSession) update(state market.AuthorizationState, authorizationURL string, err error) {
+func (session *credentialBrokerSession) update(state market.AuthorizationState, authorizationURL, userCode string, err error) {
 	session.mu.Lock()
 	session.state = state
 	session.url = authorizationURL
+	session.userCode = userCode
 	session.err = err
 	session.version++
 	close(session.changed)
@@ -741,13 +757,13 @@ func (session *credentialBrokerSession) update(state market.AuthorizationState, 
 }
 
 func (session *credentialBrokerSession) fail(err error) {
-	session.update(market.AuthorizationStateFailed, "", err)
+	session.update(market.AuthorizationStateFailed, "", "", err)
 }
 
-func (session *credentialBrokerSession) snapshot() (market.AuthorizationState, string, error) {
+func (session *credentialBrokerSession) snapshot() (market.AuthorizationState, string, string, error) {
 	session.mu.Lock()
 	defer session.mu.Unlock()
-	return session.state, session.url, session.err
+	return session.state, session.url, session.userCode, session.err
 }
 
 func (session *credentialBrokerSession) terminal() bool {

--- a/packages/connector/runtime/implementationhost/credential_authorization_test.go
+++ b/packages/connector/runtime/implementationhost/credential_authorization_test.go
@@ -159,6 +159,35 @@ func TestManagedCredentialAuthorizationContinuesConnectorOwnedBroker(t *testing.
 	}
 }
 
+func TestManagedCredentialAuthorizationReturnsDeviceCodeFromBroker(t *testing.T) {
+	connection := newCredentialBrokerConnection()
+	host := &credentialAuthorizationHostStub{
+		route: &connectorRoute{id: "default\x00github-cli", credentialBrokerLaunch: &managedCredentialBrokerLaunch{
+			timeout: 5 * time.Minute, allowedHosts: map[string]struct{}{"github.com": {}},
+		}},
+		connections: []agentruntime.ProcessConnection{connection},
+	}
+	provider := newManagedCredentialAuthorizationProvider(host)
+	result := make(chan market.AuthorizationSession, 1)
+	resultErr := make(chan error, 1)
+	go func() {
+		session, err := provider.Begin(context.Background(), market.AuthorizationStartRequest{
+			OperationID: "authorize-github", Connector: market.Connector{Key: "github-cli"},
+		})
+		result <- session
+		resultErr <- err
+	}()
+	connection.frames <- agentruntime.ProcessFrame{Stdout: []byte(`{"type":"authorization_url","url":"https://github.com/login/device","code":"ABCD-EFGH"}` + "\n")}
+
+	if err := <-resultErr; err != nil {
+		t.Fatal(err)
+	}
+	session := <-result
+	if session.AuthorizationURL != "https://github.com/login/device" || session.UserCode != "ABCD-EFGH" {
+		t.Fatalf("authorization session = %#v", session)
+	}
+}
+
 func TestManagedCredentialAuthorizationDisconnectUsesBrokerProtocol(t *testing.T) {
 	exitCode := 0
 	connection := newCredentialBrokerConnection()
@@ -417,7 +446,7 @@ func awaitCachedAuthorizationFailure(t *testing.T, provider *managedCredentialAu
 		session := provider.sessions[operationID]
 		provider.mu.Unlock()
 		if session != nil {
-			_, _, err := session.snapshot()
+			_, _, _, err := session.snapshot()
 			if err != nil {
 				return
 			}


### PR DESCRIPTION
## Summary

GitHub CLI's credential broker emits a device code together with its verification URL, but the host previously discarded the code and exposed only an external-link authorization view. Users were sent to GitHub without seeing the code they needed to enter.

- Preserve the optional credential-broker `code` in the in-memory authorization session and map it to the existing V1 `device_code` Authorization View.
- Keep the device code ephemeral and validate its size before exposing it to the renderer.
- Open a newly received device-code verification URL once by default while keeping the code visible and the manual reopen action available.
- Add Go and TypeScript regression coverage and document the authorization behavior.

## Verification

- Added a Connector Market regression test proving that the GitHub verification page opens once and `ABCD-EFGH` remains visible in the authorization View; all 75 package tests pass.
- Added host/runtime tests covering device-code mapping, URL validation, ephemeral serialization, and oversized-code rejection.
- `pnpm check:changed` passed all 13 affected lanes after rebasing onto the latest `origin/main`.

## Checklist

- [x] This PR does not change agent lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] No README/CONTRIBUTING language variants are affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
