### PR TITLE
feat(agent): track terminal turn outcomes durably

### DIFF
--- a/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
+++ b/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
@@ -138,9 +138,10 @@ export async function createWorkspaceWindowContainer(): Promise<WorkspaceWindowC
     available: analyticsDebugAvailable,
     eventStreamClient: tuttidEventStreamClient
   });
+  const workspaceUiMode = routeView === "agent" ? "agent" : "os";
   const reporterService = registerReporterServices(registry, {
     tuttidClient,
-    mode: routeView === "agent" ? "agent" : "os"
+    mode: workspaceUiMode
   });
   const reportPredefinePageview = shouldReportPredefinePageview(
     window.location.search
@@ -261,6 +262,7 @@ export async function createWorkspaceWindowContainer(): Promise<WorkspaceWindowC
     terminalCommandRunner: createAgentProviderTerminalCommandRunner(
       desktopApi.runtime
     ),
+    uiMode: workspaceUiMode,
     windowLifecycle,
     workspaceId: activeWorkspaceID,
     workspaceUserProjectService

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -456,7 +456,8 @@ test("desktop agent activity adapter forwards typed submit diagnostics", async (
         };
       }
     }),
-    runtimeApi: createRuntimeApi()
+    runtimeApi: createRuntimeApi(),
+    uiMode: "os"
   });
 
   const result = await adapter.sendInput({
@@ -484,7 +485,8 @@ test("desktop agent activity adapter forwards typed submit diagnostics", async (
         guidance: true,
         submitDiagnostics: {
           submittedAtUnixMs: 1234,
-          source: "agent-gui"
+          source: "agent-gui",
+          uiMode: "os"
         }
       } satisfies SendWorkspaceAgentSessionInputRequest,
       signal: controller.signal,
@@ -1363,7 +1365,8 @@ test("desktop agent activity adapter sends plan mode when creating sessions", as
         });
       }
     }),
-    runtimeApi: createRuntimeApi()
+    runtimeApi: createRuntimeApi(),
+    uiMode: "agent"
   });
 
   const session = await adapter.createSession({
@@ -1400,7 +1403,8 @@ test("desktop agent activity adapter sends plan mode when creating sessions", as
         submitDiagnostics: {
           blockCount: 1,
           submittedAtUnixMs: 12345,
-          source: "agent-gui"
+          source: "agent-gui",
+          uiMode: "agent"
         },
         model: "gpt-5.5-codex-spark",
         noProject: null,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -39,6 +39,7 @@ import {
   TuttidProtocolError
 } from "@tutti-os/client-tuttid-ts";
 import type { DesktopRuntimeApi } from "@preload/types";
+import type { DesktopWorkspaceUiMode } from "@shared/preferences";
 import { getActiveLocale } from "../../../i18n/runtime.ts";
 import { wrapLocalizedTuttidErrorIfSpecific } from "../../../lib/desktopErrors.ts";
 import { agentActivityComposerOptionsFromTuttidResult } from "../../../lib/agentComposerOptionsProjection.ts";
@@ -54,6 +55,21 @@ export interface CreateDesktopAgentActivityAdapterInput {
     workspaceId: string,
     recordingId: string
   ) => void;
+  uiMode?: DesktopWorkspaceUiMode;
+}
+
+function submitDiagnosticsWithUiMode<T extends { submitDiagnostics?: object }>(
+  input: T,
+  uiMode: DesktopWorkspaceUiMode | undefined
+): T {
+  if (!uiMode) return input;
+  return {
+    ...input,
+    submitDiagnostics: {
+      ...input.submitDiagnostics,
+      uiMode
+    }
+  };
 }
 
 // Cold ACP/model discovery is materially slower on Windows (Cursor can take
@@ -126,7 +142,8 @@ export function createDesktopAgentActivityAdapter({
   tuttidClient,
   runtimeApi,
   takePendingSessionRecording,
-  restorePendingSessionRecording
+  restorePendingSessionRecording,
+  uiMode
 }: CreateDesktopAgentActivityAdapterInput): DesktopAgentActivityCommandAdapter {
   return {
     async listSessions(input) {
@@ -286,13 +303,16 @@ export function createDesktopAgentActivityAdapter({
         const agentTargetId = requiredAgentTargetId(input.agentTargetId);
         recordingId = takePendingSessionRecording?.(input.workspaceId) ?? null;
         const request = tuttiCreateWorkspaceAgentSessionRequestFromActivity(
-          {
-            ...input,
-            agentSessionId,
-            agentTargetId,
-            noProject:
-              input.noProject ?? (normalizeText(input.cwd) ? null : true)
-          },
+          submitDiagnosticsWithUiMode(
+            {
+              ...input,
+              agentSessionId,
+              agentTargetId,
+              noProject:
+                input.noProject ?? (normalizeText(input.cwd) ? null : true)
+            },
+            uiMode
+          ),
           { recordingId }
         );
         const session = await tuttidClient.createWorkspaceAgentSession(
@@ -348,8 +368,9 @@ export function createDesktopAgentActivityAdapter({
         submitDiagnostics: input.submitDiagnostics,
         workspaceId: input.workspaceId
       });
-      const request =
-        tuttiSendWorkspaceAgentSessionInputRequestFromActivity(input);
+      const request = tuttiSendWorkspaceAgentSessionInputRequestFromActivity(
+        submitDiagnosticsWithUiMode(input, uiMode)
+      );
       let result: Awaited<
         ReturnType<TuttidClient["sendWorkspaceAgentSessionInput"]>
       >;

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -21,6 +21,7 @@ import type {
   WorkspaceAgentProvider
 } from "@tutti-os/client-tuttid-ts";
 import type { DesktopHostFilesApi, DesktopRuntimeApi } from "@preload/types";
+import type { DesktopWorkspaceUiMode } from "@shared/preferences";
 import type { IReporterService } from "../../../analytics/services/reporterService.interface.ts";
 import {
   normalizeComposerSettings,
@@ -98,6 +99,7 @@ export interface WorkspaceAgentActivityServiceDependencies {
   ) => WorkspaceAgentProvider | null;
   workspaceUserProjectService?: IWorkspaceUserProjectService;
   sessionReplayEnabled?: boolean;
+  uiMode?: DesktopWorkspaceUiMode;
 }
 
 type WorkspaceAgentActivityEntry = WorkspaceAgentSessionEngineHost;
@@ -1074,6 +1076,7 @@ export class WorkspaceAgentActivityService
       reconcileSession: (command, signal) =>
         this.executeSessionReconcileCommand(command, signal),
       runtimeApi: this.dependencies.runtimeApi,
+      uiMode: this.dependencies.uiMode,
       executeEngineSendInput: async (input, options) => {
         try {
           const result = await this.executeSendInputEffect(input, options);

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.ts
@@ -20,6 +20,7 @@ import {
 import type { AgentActivityRuntimeActivateSessionInput } from "@tutti-os/agent-gui";
 import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
 import type { DesktopRuntimeApi } from "@preload/types";
+import type { DesktopWorkspaceUiMode } from "@shared/preferences";
 import type { AgentHostAgentSessionComposerSettings } from "@shared/contracts/dto";
 import {
   createDesktopAgentActivityAdapter,
@@ -68,6 +69,7 @@ interface CreateWorkspaceAgentSessionEngineHostInput {
     signal?: AbortSignal
   ): Promise<unknown>;
   runtimeApi: Pick<DesktopRuntimeApi, "logTerminalDiagnostic">;
+  uiMode?: DesktopWorkspaceUiMode;
   takePendingSessionRecording?(workspaceId: string): string | null;
   restorePendingSessionRecording?(
     workspaceId: string,
@@ -162,6 +164,7 @@ export function createWorkspaceAgentSessionEngineHost(
   const adapter = createDesktopAgentActivityAdapter({
     tuttidClient: input.tuttidClient,
     runtimeApi: input.runtimeApi,
+    uiMode: input.uiMode,
     takePendingSessionRecording: input.takePendingSessionRecording,
     restorePendingSessionRecording: input.restorePendingSessionRecording
   });

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/registerWorkspaceAgentServices.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/registerWorkspaceAgentServices.ts
@@ -10,6 +10,7 @@ import type { IReporterService } from "../../analytics/services/reporterService.
 import type { IWorkspaceUserProjectService } from "../../workspace-user-project/index.ts";
 import type { IDesktopPreferencesService } from "../../desktop-preferences/services/desktopPreferencesService.interface.ts";
 import type { NotificationService } from "@tutti-os/ui-notifications";
+import type { DesktopWorkspaceUiMode } from "@shared/preferences";
 import {
   AGENT_SESSION_RECORDING_FLAG,
   EARLY_ACCESS_AGENT_INTEGRATIONS_FLAG,
@@ -65,6 +66,7 @@ export interface WorkspaceAgentServiceRegistrationInput {
     provider: string;
   }) => string;
   terminalCommandRunner: AgentProviderTerminalCommandRunner;
+  uiMode: DesktopWorkspaceUiMode;
   windowLifecycle: WorkspaceWindowLifecycle;
   workspaceId: string;
   workspaceUserProjectService?: IWorkspaceUserProjectService;

--- a/docs/superpowers/specs/2026-08-17-agent-turn-terminal-analytics-design.md
+++ b/docs/superpowers/specs/2026-08-17-agent-turn-terminal-analytics-design.md
@@ -1,0 +1,195 @@
+# Agent Turn Terminal Analytics Design
+
+## Summary
+
+Add reliable local-desktop analytics for the terminal result of a user-submitted Agent turn. The implementation reuses the VM event family without the VM suffix:
+
+- `agent.turn_completed`
+- `agent.turn_failed`
+- `agent.turn_cancelled`
+
+The canonical Host turn settlement is the only terminal trigger. The desktop UI mode is captured when the user submits the turn, persisted with the turn submission envelope, and reused when the daemon reports the terminal event. Therefore every reported event has `mode=os` or `mode=agent`; the implementation never reports a terminal event with a missing, `null`, inferred, or hard-coded mode.
+
+This event measures a technical terminal result. `completed` means that the canonical Agent turn completed successfully; it does not prove that the answer satisfied the user's goal.
+
+## Motivation and VM Evidence
+
+The VM implementation established the useful three-event model, but its current data has two producers:
+
+- a renderer producer that knows the UI mode but can miss a settlement after its window closes;
+- a daemon producer that observes canonical settlements but does not know the submitting window's mode.
+
+A diagnostic DataFinder query for 2026-08-03 through 2026-08-16 found a `null` mode on 286 of 970 VM completed events, 33 of 103 failed events, and 38 of 61 cancelled events. Copying either VM producer alone would retain one of those defects.
+
+The local implementation must combine the useful properties of both paths: durable submission-time mode and canonical daemon-side settlement.
+
+## Goals
+
+- Report one terminal analytics event for each newly submitted, user-prompt root turn that reaches a canonical terminal outcome.
+- Preserve the exact submitting window mode, even if the window closes, the user changes modes, or the daemon restarts before settlement.
+- Keep completion, failure, and cancellation definitions aligned with canonical Host outcomes.
+- Exclude child Agent turns, automatic Goal turns, provider-initiated turns, imported history, and legacy turns that have no validated submission mode from the product completion metric.
+- Reuse VM-compatible parameter names where the local product has an authoritative value.
+- Keep prompts, responses, paths, raw error messages, and other content out of analytics.
+
+## Non-goals
+
+- Semantic grading of whether the Agent solved the user's problem.
+- User feedback, thumbs-up/down, or answer-quality analytics.
+- Retrofitting terminal events for turns created before this release.
+- Measuring provider-native child/subagent success with the product event family.
+- Changing Host turn lifecycle or settlement semantics.
+- Updating the existing DataFinder dashboard in this pull request.
+
+## Considered Approaches
+
+### 1. Persist submission mode and report canonical settlement (selected)
+
+Capture `os` or `agent` on create/send, persist it with the canonical turn's submission envelope, and report from `CommittedDelta.RootTurnsSettled`.
+
+This remains correct when the renderer disappears and preserves mode across restarts. It adds a narrow request-contract and persistence change, but it is the only approach that satisfies both reliability and mode completeness.
+
+### 2. Port the VM renderer observer
+
+Observe settled turns in the renderer and rely on the renderer reporter's common `mode` parameter. This is smaller, but it misses turns that settle after the window closes and risks duplicate reports across reloads or multiple observers.
+
+### 3. Report directly from the daemon without submission mode
+
+Observe canonical settlements in the daemon without adding submission provenance. This gives reliable outcomes but reproduces the VM `mode=null` bucket and makes OS-versus-Agent rollout analysis incomplete.
+
+## Architecture and Ownership
+
+The change does not define when a turn becomes terminal. `packages/agent/host` remains the sole owner of lifecycle semantics and already exposes exhaustive post-commit settlements through `CommittedDelta.RootTurnsSettled`.
+
+The implementation has three bounded responsibilities:
+
+1. **Desktop submission context**: the workspace window composition passes its already-authoritative route mode (`os` or `agent`) into the desktop Agent activity adapter. The adapter adds that value to typed submit diagnostics for create and send requests.
+2. **Durable submission provenance**: the daemon validates the mode, carries it in Host submission metadata, and persists the metadata JSON in the existing `TurnSubmission` envelope. The Host does not interpret the product mode or change lifecycle behavior.
+3. **Analytics adapter**: `services/tuttid/service/agent` consumes `RootTurnsSettled`, reads the matching submission envelope, applies the product population rules, and emits one terminal event through the existing daemon analytics reporter.
+
+The analytics adapter belongs in `services/tuttid` because event naming, population policy, and DataFinder parameters are product analytics concerns. No second settlement state machine is introduced.
+
+## Data Flow
+
+1. A user submits an initial prompt or follow-up from a workspace window.
+2. The desktop adapter sends `submitDiagnostics.uiMode` with the exact route mode.
+3. The daemon accepts only `os` or `agent` and adds the value to submission metadata.
+4. Host admits the turn and persists the existing turn submission envelope, including the metadata JSON and client submit ID.
+5. The canonical turn reaches `settled` with outcome `completed`, `failed`, `canceled`, or `interrupted`.
+6. Host publishes the committed `RootTurnSettled` fact after the canonical transaction commits.
+7. The tuttid analytics adapter reads the persisted envelope by workspace, session, and turn ID.
+8. If the turn is eligible and has a valid mode, the adapter reports exactly one event. Missing or invalid mode causes the event to be skipped and logged as a content-free diagnostic; it is never replaced with a guessed value.
+
+## Product Population
+
+A terminal event is reported only when all of the following are true:
+
+- the committed entity is a canonical root turn;
+- `is_child_session` is false;
+- `turn.origin` is `user_prompt`;
+- `turn.backfilled` is false;
+- the persisted submission mode is exactly `os` or `agent`.
+
+Goal arm/continuation turns, provider-initiated turns, child sessions, imported turns, and legacy turns without mode are excluded. This keeps the terminal numerator compatible with user-submission analytics and prevents automatic work from inflating completion counts.
+
+## Outcome Mapping
+
+| Canonical outcome | Event | `status` | Notes |
+| --- | --- | --- | --- |
+| `completed` | `agent.turn_completed` | `completed` | Technical completion |
+| `failed` | `agent.turn_failed` | `failed` | Canonical failure |
+| `canceled` | `agent.turn_cancelled` | `cancelled` | User/runtime cancellation |
+| `interrupted` | `agent.turn_cancelled` | `cancelled` | Distinguished by `turn_outcome=interrupted`; startup recovery is identified separately |
+
+The event family is mutually exclusive for a canonical turn. A repeated observation that does not represent a newly accepted canonical settlement must not create another event.
+
+## Event Parameters
+
+All three events include:
+
+| Parameter | Value |
+| --- | --- |
+| `mode` | Required `os` or `agent` captured at submission |
+| `agent_session_id` | Canonical Agent session ID |
+| `turn_id` | Canonical turn ID |
+| `client_submit_id` | Stable submit correlation ID when present |
+| `invocation_id` | Canonical turn ID for VM-compatible correlation |
+| `operation_id` | Canonical turn ID for VM-compatible correlation |
+| `provider` | Canonical provider, normalized to `unknown` only if absent |
+| `duration_ms` | Non-negative `settled_at - started_at` when timestamps are valid |
+| `duration_bucket` | Stable bounded duration category |
+| `turn_outcome` | Exact canonical outcome |
+| `turn_origin` | `user_prompt` |
+| `status` | Event-family status from the mapping above |
+| `event_source` | `canonical_turn_settled` |
+| `interaction_source` | `user` |
+| `surface` | `direct_session` |
+| `agent_kind` | `local-agent` |
+| `is_child_session` | `false` |
+| `startup_reconciled` | Whether Host settled the turn during startup recovery |
+| `viewer_relationship` | `self` |
+| `viewer_role` | `owner` |
+
+`agent.turn_completed` additionally includes `value_enum=completed`.
+
+`agent.turn_failed` additionally includes:
+
+- `failure_stage=settled`;
+- `error_category=runtime` for VM compatibility in the first version;
+- a bounded, content-free `error_code`, falling back to `agent_unknown_error`.
+
+It does not include the canonical raw error message. Provider error messages may contain paths, prompts, command output, or credentials and are not safe analytics dimensions.
+
+`agent.turn_cancelled` additionally includes `source=runtime_event` or `source=startup_reconciliation`.
+
+Workspace IDs, prompt/response content, file paths, command output, and raw errors are not reported.
+
+## Reliability and Failure Handling
+
+- Terminal analytics is triggered only after canonical commit and cannot affect the command result.
+- The existing analytics reporter remains best effort and owns transport buffering/retry behavior.
+- Failure to read a submission envelope or validate its mode skips the event and emits only a local structured diagnostic with correlation IDs. It does not produce a `null`, `unknown`, or fabricated mode.
+- A startup-reconciled interrupted turn is eligible only if its original user submission already persisted a valid mode. It reports as cancelled with `startup_reconciled=true`.
+- Old rows receive an empty metadata value during migration and are intentionally excluded.
+
+## Storage and Compatibility
+
+The existing turn-submission table gains a non-null metadata JSON column with an empty-object default. Record/get conflict checks include the new field so an idempotent replay cannot silently change the submitting mode.
+
+The OpenAPI submit diagnostics schema gains optional `uiMode` with the closed enum `os | agent`; generated Go and TypeScript clients are regenerated from the schema. Older clients remain compatible because the field is optional. New desktop requests always populate it for user submissions.
+
+The storage and transport changes are platform-neutral. They add no paths, process behavior, shell behavior, native dependencies, or OS branches, so Windows and POSIX behavior are identical.
+
+## Testing
+
+Focused tests cover:
+
+- desktop create and send requests include the exact workspace window mode;
+- the OpenAPI adapter accepts `os` and `agent` and rejects/omits invalid values;
+- turn submission metadata persists and is preserved across reads and idempotent replay;
+- completed, failed, canceled, and interrupted canonical settlements map to the expected event and parameters;
+- child, Goal, provider-initiated, backfilled, missing-mode, and invalid-mode turns produce no product terminal event;
+- startup-reconciled interruption reports cancellation with the recovery marker;
+- raw error messages are never present in event parameters;
+- repeated/non-accepted settlement projections do not double-report.
+
+Validation uses the repository's changed-aware check plus focused desktop, store-sqlite, and tuttid Agent package tests. The Agent Host boundary check must pass because the change observes existing lifecycle facts rather than adding adapter-owned lifecycle behavior.
+
+## Rollout and Data Validation
+
+After a build containing this change reaches production, DataFinder validation should use that app version or later and verify:
+
+- `mode` contains only `os` and `agent`; `null` is zero;
+- a `turn_id` appears in at most one event across the three-event family;
+- `turn_origin=user_prompt` and `is_child_session=false` for all rows;
+- completed, failed, and cancelled event totals reconcile with canonical user-turn terminal outcomes;
+- the dashboard excludes `startup_reconciled=true` from ordinary user cancellation-rate interpretation.
+
+Recommended product metrics are:
+
+- technical completion rate = completed terminal turns / all terminal turns;
+- failure rate = failed terminal turns / all terminal turns;
+- cancellation rate = cancelled terminal turns / all terminal turns;
+- terminal coverage = terminal turns / submissions after applying an observation window long enough for active work to settle.
+
+OS-versus-Agent comparisons group these metrics by the required submission-time `mode`. Existing dashboards are unaffected until they explicitly add the new event family.

--- a/packages/agent/activity-core/src/types.ts
+++ b/packages/agent/activity-core/src/types.ts
@@ -440,6 +440,7 @@ export interface AgentActivitySubmitDiagnostics {
   promptLength?: number;
   queued?: boolean;
   source?: string;
+  uiMode?: "os" | "agent";
 }
 
 export type AgentActivitySendInputResult =

--- a/packages/agent/activity-tuttid-adapter/src/requests.ts
+++ b/packages/agent/activity-tuttid-adapter/src/requests.ts
@@ -218,7 +218,8 @@ function tuttiSubmitDiagnosticsFromActivity(
     ...(input.source !== undefined ? { source: input.source } : {}),
     ...(input.submittedAtUnixMs !== undefined
       ? { submittedAtUnixMs: input.submittedAtUnixMs }
-      : {})
+      : {}),
+    ...(input.uiMode !== undefined ? { uiMode: input.uiMode } : {})
   };
 }
 

--- a/packages/agent/host/committed_delta.go
+++ b/packages/agent/host/committed_delta.go
@@ -122,7 +122,7 @@ func ActivityStateDelta(input canonical.ReportSessionStateInput, reply canonical
 		delta.RootTurnsSettled = append(delta.RootTurnsSettled, RootTurnSettled{
 			WorkspaceID: result.RootTurn.WorkspaceID, AgentSessionID: result.RootTurn.AgentSessionID, Turn: result.RootTurn,
 			Provider:       firstNonEmptyTrimmed(result.State.Session.Provider, input.State.Provider, input.Source.Provider),
-			IsChildSession: sessionStateIsChild(input.State),
+			IsChildSession: rootTurnOwnerIsChild(input, result),
 		})
 	}
 	if goalOp := goalOperationFromActivityState(input, result); goalOp != nil {
@@ -133,6 +133,27 @@ func ActivityStateDelta(input canonical.ReportSessionStateInput, reply canonical
 		delta.addView(input.WorkspaceID, result.RootTurn.AgentSessionID)
 	}
 	return delta
+}
+
+func rootTurnOwnerIsChild(
+	input canonical.ReportSessionStateInput,
+	result storesqlite.ActivityStateReportResult,
+) bool {
+	ownerSessionID := strings.TrimSpace(result.RootTurn.AgentSessionID)
+	reportingSessionID := strings.TrimSpace(result.State.Session.ID)
+	if reportingSessionID == "" {
+		reportingSessionID = strings.TrimSpace(input.AgentSessionID)
+	}
+	if ownerSessionID == "" || ownerSessionID != reportingSessionID {
+		// A child terminal report may settle its canonical root Turn. The
+		// persisted Session in this result still belongs to the reporting child,
+		// so its kind must not be projected onto the root owner.
+		return false
+	}
+	if strings.TrimSpace(result.State.Session.ID) != "" {
+		return canonicalSessionIsChild(result.State.Session)
+	}
+	return sessionStateIsChild(input.State)
 }
 
 func sessionStateIsChild(state canonical.WorkspaceAgentSessionStateUpdate) bool {
@@ -216,16 +237,17 @@ func StaleTurnSettlementDelta(settlements []storesqlite.StaleTurnSettlement) Com
 	}
 	for _, settlement := range settlements {
 		delta.addView(settlement.WorkspaceID, settlement.AgentSessionID)
-		turnID := strings.TrimSpace(settlement.TurnID)
+		turn := settlement.Turn
+		turnID := firstNonEmptyTrimmed(turn.TurnID, settlement.TurnID)
 		if turnID == "" {
 			continue
 		}
-		workspaceID := strings.TrimSpace(settlement.WorkspaceID)
-		agentSessionID := strings.TrimSpace(settlement.AgentSessionID)
-		delta.RootTurnsSettled = append(delta.RootTurnsSettled, RootTurnSettled{
-			WorkspaceID:    workspaceID,
-			AgentSessionID: agentSessionID,
-			Turn: storesqlite.Turn{
+		workspaceID := firstNonEmptyTrimmed(turn.WorkspaceID, settlement.WorkspaceID)
+		agentSessionID := firstNonEmptyTrimmed(turn.AgentSessionID, settlement.AgentSessionID)
+		if strings.TrimSpace(turn.TurnID) == "" {
+			// Compatibility for callers that construct the legacy scalar-only
+			// settlement value. The SQLite startup path always supplies Turn.
+			turn = storesqlite.Turn{
 				WorkspaceID:     workspaceID,
 				AgentSessionID:  agentSessionID,
 				TurnID:          turnID,
@@ -234,7 +256,12 @@ func StaleTurnSettlementDelta(settlements []storesqlite.StaleTurnSettlement) Com
 				ErrorMessage:    "stale turn settled on daemon startup",
 				StartedAtUnixMS: settlement.StartedAtUnixMS,
 				SettledAtUnixMS: settlement.SettledAtUnixMS,
-			},
+			}
+		}
+		delta.RootTurnsSettled = append(delta.RootTurnsSettled, RootTurnSettled{
+			WorkspaceID:       workspaceID,
+			AgentSessionID:    agentSessionID,
+			Turn:              turn,
 			Provider:          strings.TrimSpace(settlement.Provider),
 			IsChildSession:    settlement.IsChildSession,
 			StartupReconciled: true,

--- a/packages/agent/host/committed_delta_goal_test.go
+++ b/packages/agent/host/committed_delta_goal_test.go
@@ -119,6 +119,38 @@ func TestActivityStateDeltaCarriesCanonicalProviderIntoRootSettlement(t *testing
 	}
 }
 
+func TestActivityStateDeltaClassifiesSettledRootByOwnerWhenChildReportsTerminal(t *testing.T) {
+	t.Parallel()
+
+	delta := ActivityStateDelta(
+		canonical.ReportSessionStateInput{
+			WorkspaceID: "ws-1", AgentSessionID: "child-1",
+			State: canonical.WorkspaceAgentSessionStateUpdate{
+				Kind:             storesqlite.SessionKindChild,
+				ParentToolCallID: "call-1",
+			},
+		},
+		canonical.ReportSessionStateReply{Accepted: true, StateApplied: true},
+		storesqlite.ActivityStateReportResult{
+			State: storesqlite.StateReportResult{Session: storesqlite.Session{
+				ID: "child-1", WorkspaceID: "ws-1", Kind: storesqlite.SessionKindChild,
+				ParentToolCallID: "call-1", Provider: "codex",
+			}},
+			RootTurnAccepted: true,
+			RootTurn: storesqlite.Turn{
+				WorkspaceID: "ws-1", AgentSessionID: "root-1", TurnID: "root-turn",
+				Phase: storesqlite.TurnPhaseSettled, Outcome: storesqlite.TurnOutcomeCompleted,
+			},
+		},
+	)
+	if len(delta.RootTurnsSettled) != 1 {
+		t.Fatalf("root settlements = %#v, want one", delta.RootTurnsSettled)
+	}
+	if settled := delta.RootTurnsSettled[0]; settled.AgentSessionID != "root-1" || settled.IsChildSession {
+		t.Fatalf("root settlement identity = %#v, want canonical root owner", settled)
+	}
+}
+
 func TestTerminalFailureIdentityEnrichmentSkipsSuccessfulCommits(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/host/edit_retry_projection.go
+++ b/packages/agent/host/edit_retry_projection.go
@@ -110,9 +110,15 @@ func editRetryReplacementInput(
 	if err := json.Unmarshal([]byte(envelope.TuttiModeSnapshotJSON), &tuttiModeSnapshot); err != nil {
 		return SendInput{}, err
 	}
+	var metadata map[string]any
+	if strings.TrimSpace(envelope.MetadataJSON) != "" {
+		if err := json.Unmarshal([]byte(envelope.MetadataJSON), &metadata); err != nil {
+			return SendInput{}, err
+		}
+	}
 	return SendInput{
 		Content: normalized, DisplayPrompt: editedText,
-		CapabilityRefs: capabilityRefs, TuttiModeSnapshot: tuttiModeSnapshot,
+		CapabilityRefs: capabilityRefs, Metadata: metadata, TuttiModeSnapshot: tuttiModeSnapshot,
 	}, nil
 }
 

--- a/packages/agent/host/edit_retry_projection_test.go
+++ b/packages/agent/host/edit_retry_projection_test.go
@@ -1,0 +1,22 @@
+package agenthost
+
+import (
+	"testing"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+func TestEditRetryReplacementInputPreservesSubmissionMetadata(t *testing.T) {
+	input, err := editRetryReplacementInput(storesqlite.TurnSubmission{
+		ContentJSON:           `[{"type":"text","text":"before"}]`,
+		CapabilityRefsJSON:    `[]`,
+		TuttiModeSnapshotJSON: `null`,
+		MetadataJSON:          `{"uiMode":"agent"}`,
+	}, "after")
+	if err != nil {
+		t.Fatalf("editRetryReplacementInput() error=%v", err)
+	}
+	if input.Metadata["uiMode"] != "agent" {
+		t.Fatalf("metadata=%#v, want submission uiMode", input.Metadata)
+	}
+}

--- a/packages/agent/host/edit_retry_projection_test.go
+++ b/packages/agent/host/edit_retry_projection_test.go
@@ -19,4 +19,8 @@ func TestEditRetryReplacementInputPreservesSubmissionMetadata(t *testing.T) {
 	if input.Metadata["uiMode"] != "agent" {
 		t.Fatalf("metadata=%#v, want submission uiMode", input.Metadata)
 	}
+	claimMetadata, err := submitClaimMetadataJSON(input.Metadata)
+	if err != nil || claimMetadata != `{"uiMode":"agent"}` {
+		t.Fatalf("replacement claim metadata=%q err=%v", claimMetadata, err)
+	}
 }

--- a/packages/agent/host/edit_retry_replacement.go
+++ b/packages/agent/host/edit_retry_replacement.go
@@ -165,10 +165,16 @@ func (h *Host) dispatchEditRetryReplacement(
 			ctx, operation, owner, storesqlite.EditRetryReasonRecoveryRequired, err,
 		)
 	}
+	claimMetadataJSON, err := submitClaimMetadataJSON(input.Metadata)
+	if err != nil {
+		return h.failEditRetryRecovery(
+			ctx, operation, owner, storesqlite.EditRetryReasonOperationConflict, err,
+		)
+	}
 	claim, created, err := h.store.PrepareSubmitClaim(ctx, storesqlite.SubmitClaimPrepare{
 		WorkspaceID: operation.WorkspaceID, AgentSessionID: operation.AgentSessionID,
 		ClientSubmitID: payload.ClientSubmitID, CanonicalTurnID: payload.ReplacementTurnID,
-		NowUnixMS: h.now().UnixMilli(),
+		MetadataJSON: claimMetadataJSON, NowUnixMS: h.now().UnixMilli(),
 	})
 	if err != nil {
 		return h.failEditRetryRecovery(

--- a/packages/agent/host/edit_retry_replacement.go
+++ b/packages/agent/host/edit_retry_replacement.go
@@ -362,7 +362,7 @@ func (h *Host) recordEditRetryReplacementSubmission(
 		ctx,
 		SessionRef{WorkspaceID: operation.WorkspaceID, AgentSessionID: operation.AgentSessionID},
 		payload.ReplacementTurnID, payload.ClientSubmitID, input.Content,
-		input.DisplayPrompt, input.CapabilityRefs, input.TuttiModeSnapshot,
+		input.DisplayPrompt, input.CapabilityRefs, input.Metadata, input.TuttiModeSnapshot,
 	); err != nil {
 		return err
 	}

--- a/packages/agent/host/lifecycle.go
+++ b/packages/agent/host/lifecycle.go
@@ -2,7 +2,6 @@ package agenthost
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -286,7 +285,7 @@ func (h *Host) createSession(ctx context.Context, workspaceID string, input Crea
 				ctx, SessionRef{WorkspaceID: workspaceID, AgentSessionID: session.ID}, execResult,
 				firstNonEmpty(claim.ClientSubmitID, input.ClientSubmitID, legacyClientSubmitID(metadata)),
 				claim.CreatedAtUnixMS, preparedContent, displayPrompt, input.CapabilityRefs,
-				input.TuttiModeSnapshot,
+				metadata, input.TuttiModeSnapshot,
 			); persistErr != nil {
 				claimPending = false
 				return createSessionCreatedErrorResult(input, session, canonicalSession, errors.Join(ErrSubmitDeliveryUnknown, err, persistErr))
@@ -333,7 +332,7 @@ func (h *Host) createSession(ctx context.Context, workspaceID string, input Crea
 	}
 	if err := h.recordTurnSubmission(
 		ctx, ref, turnID, input.ClientSubmitID, preparedContent.Persisted,
-		displayPrompt, input.CapabilityRefs, input.TuttiModeSnapshot,
+		displayPrompt, input.CapabilityRefs, metadata, input.TuttiModeSnapshot,
 	); err != nil {
 		claimPending = false
 		return createSessionCreatedErrorResult(input, session, canonicalSession, errors.Join(ErrSubmitDeliveryUnknown, err))
@@ -650,7 +649,7 @@ func (h *Host) sendInputSerialized(
 				ctx, ref, execResult,
 				firstNonEmpty(claim.ClientSubmitID, input.ClientSubmitID, legacyClientSubmitID(metadata)),
 				claim.CreatedAtUnixMS, preparedContent, displayPrompt, input.CapabilityRefs,
-				input.TuttiModeSnapshot,
+				metadata, input.TuttiModeSnapshot,
 			); persistErr != nil {
 				claimPending = false
 				return SendInputResult{}, errors.Join(ErrSubmitDeliveryUnknown, err, persistErr)
@@ -707,7 +706,7 @@ func (h *Host) sendInputSerialized(
 	if !input.Guidance {
 		if err := h.recordTurnSubmission(
 			ctx, ref, turnID, input.ClientSubmitID, preparedContent.Persisted,
-			displayPrompt, input.CapabilityRefs, input.TuttiModeSnapshot,
+			displayPrompt, input.CapabilityRefs, metadata, input.TuttiModeSnapshot,
 		); err != nil {
 			claimPending = false
 			return SendInputResult{}, errors.Join(ErrSubmitDeliveryUnknown, err)
@@ -767,47 +766,6 @@ func (h *Host) UpdateTitle(ctx context.Context, input UpdateTitleInput) (UpdateT
 	}
 	result.Session = runtimeSession
 	return result, nil
-}
-
-func (h *Host) recordTurnSubmission(
-	ctx context.Context,
-	ref SessionRef,
-	turnID string,
-	clientSubmitID string,
-	content []PromptContentBlock,
-	displayPrompt string,
-	capabilityRefs []CapabilityReference,
-	tuttiModeSnapshot *TuttiModeTurnSnapshot,
-) error {
-	if h == nil || h.turnSubmissions == nil {
-		return nil
-	}
-	contentJSON, err := json.Marshal(content)
-	if err != nil {
-		return fmt.Errorf("encode turn submission content: %w", err)
-	}
-	capabilityRefsJSON, err := json.Marshal(capabilityRefs)
-	if err != nil {
-		return fmt.Errorf("encode turn submission capability refs: %w", err)
-	}
-	tuttiModeSnapshotJSON, err := json.Marshal(tuttiModeSnapshot)
-	if err != nil {
-		return fmt.Errorf("encode turn submission tutti mode snapshot: %w", err)
-	}
-	now := h.now().UnixMilli()
-	_, _, err = h.turnSubmissions.RecordTurnSubmission(ctx, storesqlite.TurnSubmission{
-		WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
-		TurnID: strings.TrimSpace(turnID), ContentJSON: string(contentJSON),
-		DisplayPrompt:         strings.TrimSpace(displayPrompt),
-		CapabilityRefsJSON:    string(capabilityRefsJSON),
-		TuttiModeSnapshotJSON: string(tuttiModeSnapshotJSON),
-		ClientSubmitID:        strings.TrimSpace(clientSubmitID),
-		CreatedAtUnixMS:       now, UpdatedAtUnixMS: now,
-	})
-	if err != nil {
-		return fmt.Errorf("record turn submission envelope: %w", err)
-	}
-	return nil
 }
 
 func (h *Host) requireSendAllowedByEffectiveHistory(ctx context.Context, ref SessionRef) error {

--- a/packages/agent/host/observed_stores.go
+++ b/packages/agent/host/observed_stores.go
@@ -172,7 +172,10 @@ func (s *observedRuntimeOperationStore) settledRootTurns(ctx context.Context, co
 	}
 	rootSessionID := metadataString(completion.Event.Payload, "rootAgentSessionId")
 	candidates := make([]map[string]any, 0)
-	if targets, ok := completion.Event.Payload["targets"].([]any); ok {
+	// The full targets list also contains Turns settled by a concurrent provider
+	// terminal commit. Only targets transitioned by this completion belong in
+	// this transaction's RootTurnsSettled delta.
+	if targets, ok := completion.Event.Payload["settledTargets"].([]any); ok {
 		for _, raw := range targets {
 			candidate, _ := raw.(map[string]any)
 			if metadataString(candidate, "agentSessionId") == rootSessionID {

--- a/packages/agent/host/observed_stores_test.go
+++ b/packages/agent/host/observed_stores_test.go
@@ -2,9 +2,12 @@ package agenthost
 
 import (
 	"context"
+	"database/sql"
+	"path/filepath"
 	"testing"
 
 	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+	_ "modernc.org/sqlite"
 )
 
 type goalCommitStageStore struct {
@@ -116,7 +119,7 @@ func TestObservedCancelCompletionReportsRootSettlementOnce(t *testing.T) {
 			Kind: storesqlite.RuntimeOperationEventTurnCanceled,
 			Payload: map[string]any{
 				"rootAgentSessionId": "root-session",
-				"targets": []any{map[string]any{
+				"settledTargets": []any{map[string]any{
 					"agentSessionId": "root-session", "turnId": "root-turn",
 				}},
 				"reconciledRoot": map[string]any{
@@ -138,5 +141,86 @@ func TestObservedCancelCompletionReportsRootSettlementOnce(t *testing.T) {
 	settled := recorder.deltas[0].RootTurnsSettled[0]
 	if settled.Provider != "codex" || !settled.IsChildSession {
 		t.Fatalf("root settlement identity=%#v, want canonical provider and child marker", settled)
+	}
+}
+
+func TestObservedCancelCompletionDoesNotRepeatAlreadySettledRoot(t *testing.T) {
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "cancel-already-settled.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+	store := storesqlite.New(db, storesqlite.Options{})
+	if err := store.Migrate(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.ReportActivityState(t.Context(), storesqlite.ActivityStateReport{
+		Session: storesqlite.SessionStateReport{
+			WorkspaceID: "ws-1", AgentSessionID: "root-session", Kind: storesqlite.SessionKindRoot,
+			Provider: "codex", OccurredAtUnixMS: 10,
+		},
+		Turn: &storesqlite.TurnTransition{
+			WorkspaceID: "ws-1", AgentSessionID: "root-session", TurnID: "root-turn",
+			Phase: storesqlite.TurnPhaseRunning, Origin: storesqlite.TurnOriginUserPrompt,
+			OccurredAtUnixMS: 10,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, created, err := store.PrepareRuntimeOperation(t.Context(), storesqlite.RuntimeOperationPrepare{
+		OperationID: "cancel-1", WorkspaceID: "ws-1", AgentSessionID: "root-session",
+		Kind: storesqlite.RuntimeOperationKindCancelTurn, TurnID: "root-turn", OccurredAtMS: 20,
+		Payload: map[string]any{
+			"rootAgentSessionId": "root-session",
+			"targets": []any{map[string]any{
+				"agentSessionId": "root-session", "turnId": "root-turn",
+			}},
+		},
+	}); err != nil || !created {
+		t.Fatalf("prepare cancel created=%v err=%v", created, err)
+	}
+	if _, claimed, err := store.ClaimRuntimeOperationLease(t.Context(), storesqlite.ClaimRuntimeOperationLeaseInput{
+		WorkspaceID: "ws-1", OperationID: "cancel-1", LeaseOwner: "worker-a",
+		NowUnixMS: 21, LeaseExpiresAtMS: 100,
+	}); err != nil || !claimed {
+		t.Fatalf("claim cancel claimed=%v err=%v", claimed, err)
+	}
+	if _, err := store.ReportActivityState(t.Context(), storesqlite.ActivityStateReport{
+		Session: storesqlite.SessionStateReport{
+			WorkspaceID: "ws-1", AgentSessionID: "root-session", Kind: storesqlite.SessionKindRoot,
+			Provider: "codex", OccurredAtUnixMS: 25,
+		},
+		Turn: &storesqlite.TurnTransition{
+			WorkspaceID: "ws-1", AgentSessionID: "root-session", TurnID: "root-turn",
+			Phase: storesqlite.TurnPhaseSettled, Outcome: storesqlite.TurnOutcomeCanceled,
+			Origin: storesqlite.TurnOriginUserPrompt, OccurredAtUnixMS: 25,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := &committedDeltaRecorder{}
+	canonicalStore := &SQLiteWorkspaceStore{StoreForWorkspace: func(workspaceID string) *storesqlite.Store {
+		if workspaceID != "ws-1" {
+			return nil
+		}
+		return store
+	}}
+	host := New(Config{CanonicalStore: canonicalStore, RuntimeOperations: store, CommitObserver: recorder})
+	if _, changed, err := host.operations.CompleteCancelRuntimeOperation(t.Context(), storesqlite.CompleteCancelRuntimeOperationInput{
+		WorkspaceID: "ws-1", OperationID: "cancel-1", LeaseOwner: "worker-a",
+		TargetOutcomes: []storesqlite.CancelRuntimeOperationTargetOutcome{{
+			AgentSessionID: "root-session", TurnID: "root-turn", Outcome: storesqlite.TurnOutcomeCanceled,
+		}},
+		NowUnixMS: 30,
+	}); err != nil || !changed {
+		t.Fatalf("complete cancel changed=%v err=%v", changed, err)
+	}
+	if len(recorder.deltas) != 1 {
+		t.Fatalf("committed deltas=%#v, want the runtime-operation completion", recorder.deltas)
+	}
+	if settlements := recorder.deltas[0].RootTurnsSettled; len(settlements) != 0 {
+		t.Fatalf("root settlements=%#v, want no repeat for the already-settled root", settlements)
 	}
 }

--- a/packages/agent/host/stale_turn_settlement_test.go
+++ b/packages/agent/host/stale_turn_settlement_test.go
@@ -17,7 +17,14 @@ func (o *recordingStaleTurnFailureObserver) ObserveTerminalFailure(_ context.Con
 
 func TestStaleTurnSettlementDeltaDoesNotReportInterruptedAsFailure(t *testing.T) {
 	delta := StaleTurnSettlementDelta([]storesqlite.StaleTurnSettlement{
-		{WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-stale"},
+		{
+			WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-stale",
+			Turn: storesqlite.Turn{
+				WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-stale",
+				Phase: storesqlite.TurnPhaseSettled, Outcome: storesqlite.TurnOutcomeInterrupted,
+				Origin: storesqlite.TurnOriginUserPrompt, Backfilled: true,
+			},
+		},
 		{WorkspaceID: "ws-1", AgentSessionID: "session-2", TurnID: ""},
 	})
 	if len(delta.RootTurnsSettled) != 1 {
@@ -29,6 +36,9 @@ func TestStaleTurnSettlementDeltaDoesNotReportInterruptedAsFailure(t *testing.T)
 	}
 	if !settled.StartupReconciled {
 		t.Fatalf("settled turn = %#v, want the startup reconciliation marker", settled)
+	}
+	if settled.Turn.Origin != storesqlite.TurnOriginUserPrompt || !settled.Turn.Backfilled {
+		t.Fatalf("settled turn provenance = %#v, want canonical origin and backfilled marker", settled.Turn)
 	}
 
 	observer := &recordingStaleTurnFailureObserver{}

--- a/packages/agent/host/submit_claims.go
+++ b/packages/agent/host/submit_claims.go
@@ -2,6 +2,8 @@ package agenthost
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -26,14 +28,35 @@ func submissionMetadata(metadata map[string]any, typedClientSubmitID string) map
 	return result
 }
 
+// submitClaimMetadataJSON deliberately persists only the closed analytics
+// provenance needed before provider dispatch. Submit claims are long-lived;
+// copying the full submission metadata here would expand both storage and the
+// privacy surface of this admission fence.
+func submitClaimMetadataJSON(metadata map[string]any) (string, error) {
+	claimMetadata := make(map[string]any, 1)
+	if mode, ok := metadata["uiMode"].(string); ok && (mode == "os" || mode == "agent") {
+		claimMetadata["uiMode"] = mode
+	}
+	encoded, err := json.Marshal(claimMetadata)
+	if err != nil {
+		return "", fmt.Errorf("encode submit claim metadata: %w", err)
+	}
+	return string(encoded), nil
+}
+
 func (h *Host) prepareSubmitClaim(ctx context.Context, ref SessionRef, metadata map[string]any, canonicalTurnID string) (storesqlite.SubmitClaim, bool, error) {
 	clientID := legacyClientSubmitID(metadata)
 	if h == nil || h.store == nil || clientID == "" {
 		return storesqlite.SubmitClaim{}, false, nil
 	}
+	metadataJSON, err := submitClaimMetadataJSON(metadata)
+	if err != nil {
+		return storesqlite.SubmitClaim{}, false, err
+	}
 	claim, created, err := h.store.PrepareSubmitClaim(ctx, storesqlite.SubmitClaimPrepare{
 		WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
-		ClientSubmitID: clientID, CanonicalTurnID: strings.TrimSpace(canonicalTurnID), NowUnixMS: h.now().UnixMilli(),
+		ClientSubmitID: clientID, CanonicalTurnID: strings.TrimSpace(canonicalTurnID),
+		MetadataJSON: metadataJSON, NowUnixMS: h.now().UnixMilli(),
 	})
 	if err != nil || created || claim.Status != "prepared" {
 		return claim, created, err

--- a/packages/agent/host/submit_claims_test.go
+++ b/packages/agent/host/submit_claims_test.go
@@ -19,3 +19,23 @@ func TestSubmissionMetadataPreservesLegacyIdentityWhenTypedValueIsEmpty(t *testi
 		t.Fatalf("submission metadata = %#v", got)
 	}
 }
+
+func TestSubmitClaimMetadataPersistsOnlyValidatedUIMode(t *testing.T) {
+	for _, testCase := range []struct {
+		name     string
+		metadata map[string]any
+		want     string
+	}{
+		{name: "agent", metadata: map[string]any{"uiMode": "agent", "clientSubmitId": "secret", "trace": "private"}, want: `{"uiMode":"agent"}`},
+		{name: "os", metadata: map[string]any{"uiMode": "os"}, want: `{"uiMode":"os"}`},
+		{name: "invalid", metadata: map[string]any{"uiMode": "unknown"}, want: `{}`},
+		{name: "missing", metadata: nil, want: `{}`},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			got, err := submitClaimMetadataJSON(testCase.metadata)
+			if err != nil || got != testCase.want {
+				t.Fatalf("submitClaimMetadataJSON()=%q err=%v, want %q", got, err, testCase.want)
+			}
+		})
+	}
+}

--- a/packages/agent/host/submit_provenance_recovery.go
+++ b/packages/agent/host/submit_provenance_recovery.go
@@ -56,6 +56,7 @@ func (h *Host) persistRuntimeSubmitOutcome(
 	prepared preparedPromptContent,
 	displayPrompt string,
 	capabilityRefs []CapabilityReference,
+	metadata map[string]any,
 	tuttiModeSnapshot *TuttiModeTurnSnapshot,
 ) error {
 	return h.persistSubmitAfterRuntimeOutcome(
@@ -70,6 +71,7 @@ func (h *Host) persistRuntimeSubmitOutcome(
 		displayPrompt,
 		false,
 		capabilityRefs,
+		metadata,
 		tuttiModeSnapshot,
 	)
 }
@@ -90,6 +92,7 @@ func (h *Host) persistSubmitAfterRuntimeOutcome(
 	displayPrompt string,
 	guidance bool,
 	capabilityRefs []CapabilityReference,
+	metadata map[string]any,
 	tuttiModeSnapshot *TuttiModeTurnSnapshot,
 ) error {
 	if h == nil || strings.TrimSpace(turnID) == "" {
@@ -126,6 +129,7 @@ func (h *Host) persistSubmitAfterRuntimeOutcome(
 		persistedContent,
 		displayPrompt,
 		capabilityRefs,
+		metadata,
 		tuttiModeSnapshot,
 	)
 }

--- a/packages/agent/host/turn_submission.go
+++ b/packages/agent/host/turn_submission.go
@@ -1,0 +1,60 @@
+package agenthost
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+func (h *Host) recordTurnSubmission(
+	ctx context.Context,
+	ref SessionRef,
+	turnID string,
+	clientSubmitID string,
+	content []PromptContentBlock,
+	displayPrompt string,
+	capabilityRefs []CapabilityReference,
+	metadata map[string]any,
+	tuttiModeSnapshot *TuttiModeTurnSnapshot,
+) error {
+	if h == nil || h.turnSubmissions == nil {
+		return nil
+	}
+	contentJSON, err := json.Marshal(content)
+	if err != nil {
+		return fmt.Errorf("encode turn submission content: %w", err)
+	}
+	capabilityRefsJSON, err := json.Marshal(capabilityRefs)
+	if err != nil {
+		return fmt.Errorf("encode turn submission capability refs: %w", err)
+	}
+	metadataJSON := []byte("{}")
+	if len(metadata) > 0 {
+		metadataJSON, err = json.Marshal(metadata)
+		if err != nil {
+			return fmt.Errorf("encode turn submission metadata: %w", err)
+		}
+	}
+	tuttiModeSnapshotJSON, err := json.Marshal(tuttiModeSnapshot)
+	if err != nil {
+		return fmt.Errorf("encode turn submission tutti mode snapshot: %w", err)
+	}
+	now := h.now().UnixMilli()
+	_, _, err = h.turnSubmissions.RecordTurnSubmission(ctx, storesqlite.TurnSubmission{
+		WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
+		TurnID: strings.TrimSpace(turnID), ContentJSON: string(contentJSON),
+		DisplayPrompt:         strings.TrimSpace(displayPrompt),
+		CapabilityRefsJSON:    string(capabilityRefsJSON),
+		TuttiModeSnapshotJSON: string(tuttiModeSnapshotJSON),
+		MetadataJSON:          string(metadataJSON),
+		ClientSubmitID:        strings.TrimSpace(clientSubmitID),
+		CreatedAtUnixMS:       now, UpdatedAtUnixMS: now,
+	})
+	if err != nil {
+		return fmt.Errorf("record turn submission envelope: %w", err)
+	}
+	return nil
+}

--- a/packages/agent/store-sqlite/activity.go
+++ b/packages/agent/store-sqlite/activity.go
@@ -114,6 +114,8 @@ func (s *Store) reportActivityStateOnce(
 		LastEventUnixMS: lastEventUnixMS,
 		Session:         session,
 	}}
+	turnTerminalTransition := false
+	rootTurnTerminalTransition := false
 	result.Messages.LatestVersion = session.MessageVersion
 	if !accepted && len(input.Messages) > 0 {
 		return ActivityStateReportResult{}, errors.New("workspace agent activity session rejected atomic messages")
@@ -130,6 +132,8 @@ func (s *Store) reportActivityStateOnce(
 		if !result.TurnAccepted && !turnTransitionAlreadyApplied(result.Turn, *input.Turn) {
 			return ActivityStateReportResult{}, errors.New("workspace agent activity turn transition was rejected")
 		}
+		turnTerminalTransition = result.TurnAccepted &&
+			strings.TrimSpace(input.Turn.Phase) == TurnPhaseSettled
 	}
 	// RootProviderTurn may arrive on an exact-replay session envelope after Exec
 	// already set CurrentPhase (Claude Code identity_resolved). Apply whenever the
@@ -140,8 +144,10 @@ func (s *Store) reportActivityStateOnce(
 		if err != nil {
 			return ActivityStateReportResult{}, err
 		}
+		rootTurnTerminalTransition = result.RootTurnAccepted &&
+			result.RootTurn.Phase == TurnPhaseSettled
 	}
-	if result.TurnAccepted && result.Turn.Phase == TurnPhaseSettled {
+	if turnTerminalTransition {
 		rootTurn, rootAccepted, err := s.reconcileRootTurnAfterChildTerminalTx(ctx, tx, result.Turn, now)
 		if err != nil {
 			return ActivityStateReportResult{}, err
@@ -149,6 +155,7 @@ func (s *Store) reportActivityStateOnce(
 		if rootTurn.TurnID != "" {
 			result.RootTurn = rootTurn
 			result.RootTurnAccepted = rootAccepted
+			rootTurnTerminalTransition = rootAccepted && rootTurn.Phase == TurnPhaseSettled
 		}
 	}
 	// Interaction transitions have their own monotonic identity/state machine.
@@ -193,7 +200,7 @@ func (s *Store) reportActivityStateOnce(
 			result.Messages.Messages = append(result.Messages.Messages, acceptedMessage)
 		}
 	}
-	mutations := activityStateMutations(result)
+	mutations := activityStateMutations(result, turnTerminalTransition, rootTurnTerminalTransition)
 	goalMutations, err := sessionGoalMutationsTx(ctx, tx, input.Session, goalBefore)
 	if err != nil {
 		return ActivityStateReportResult{}, err
@@ -213,17 +220,29 @@ func (s *Store) reportActivityStateOnce(
 	return result, nil
 }
 
-func activityStateMutations(result ActivityStateReportResult) []TransactionMutation {
+func activityStateMutations(
+	result ActivityStateReportResult,
+	turnTerminalTransition bool,
+	rootTurnTerminalTransition bool,
+) []TransactionMutation {
 	mutations := make([]TransactionMutation, 0, 4+len(result.Messages.Messages))
 	if result.State.Accepted {
 		session := result.State.Session
 		mutations = append(mutations, transactionMutation(session.WorkspaceID, session.ID, MutationEntitySession, session.ID, "upsert", session.UpdatedAtUnixMS))
 	}
 	if result.TurnAccepted {
-		mutations = append(mutations, transactionMutation(result.Turn.WorkspaceID, result.Turn.AgentSessionID, MutationEntityTurn, result.Turn.TurnID, "upsert", result.Turn.UpdatedAtUnixMS))
+		turnMutation := transactionMutation(result.Turn.WorkspaceID, result.Turn.AgentSessionID, MutationEntityTurn, result.Turn.TurnID, "upsert", result.Turn.UpdatedAtUnixMS)
+		if turnTerminalTransition {
+			turnMutation = terminalTurnMutation(result.Turn.WorkspaceID, result.Turn.AgentSessionID, result.Turn.TurnID, "upsert", result.Turn.UpdatedAtUnixMS, false)
+		}
+		mutations = append(mutations, turnMutation)
 	}
 	if result.RootTurnAccepted || result.RootProviderTurnAccepted {
-		mutations = append(mutations, transactionMutation(result.RootTurn.WorkspaceID, result.RootTurn.AgentSessionID, MutationEntityTurn, result.RootTurn.TurnID, "upsert", result.RootTurn.UpdatedAtUnixMS))
+		rootMutation := transactionMutation(result.RootTurn.WorkspaceID, result.RootTurn.AgentSessionID, MutationEntityTurn, result.RootTurn.TurnID, "upsert", result.RootTurn.UpdatedAtUnixMS)
+		if rootTurnTerminalTransition {
+			rootMutation = terminalTurnMutation(result.RootTurn.WorkspaceID, result.RootTurn.AgentSessionID, result.RootTurn.TurnID, "upsert", result.RootTurn.UpdatedAtUnixMS, false)
+		}
+		mutations = append(mutations, rootMutation)
 	}
 	if result.InteractionResult == InteractionTransitionApplied {
 		mutations = append(mutations, transactionMutation(

--- a/packages/agent/store-sqlite/activity_delete.go
+++ b/packages/agent/store-sqlite/activity_delete.go
@@ -121,10 +121,11 @@ func (s *Store) DeleteSessionWithCommit(
 	if err != nil {
 		return DeleteSessionResult{}, err
 	}
-	removedMessages, removedSessions, removedSessionIDs, err := deleteSessionTreeRowsTx(ctx, tx, workspaceID, sessionClosureIDs, now)
+	removedMessages, removedSessions, removedSessionIDs, terminalMutations, err := deleteSessionTreeRowsTx(ctx, tx, workspaceID, sessionClosureIDs, now)
 	if err != nil {
 		return DeleteSessionResult{}, err
 	}
+	mutations = append(mutations, terminalMutations...)
 	delta, err := s.commitTransaction(ctx, tx, workspaceID, mutations)
 	if err != nil {
 		return DeleteSessionResult{}, fmt.Errorf("commit delete workspace agent session: %w", err)
@@ -197,10 +198,11 @@ func (s *Store) DeleteSessionsBatchTx(ctx context.Context, tx *sql.Tx, input Del
 	if err != nil {
 		return DeleteSessionsBatchResult{}, err
 	}
-	removedMessages, removedSessions, removedSessionIDs, err := deleteSessionTreeRowsTx(ctx, tx, workspaceID, sessionClosureIDs, now)
+	removedMessages, removedSessions, removedSessionIDs, terminalMutations, err := deleteSessionTreeRowsTx(ctx, tx, workspaceID, sessionClosureIDs, now)
 	if err != nil {
 		return DeleteSessionsBatchResult{}, err
 	}
+	mutations = append(mutations, terminalMutations...)
 	delta, err := s.participateTransaction(ctx, tx, workspaceID, mutations)
 	if err != nil {
 		return DeleteSessionsBatchResult{}, fmt.Errorf("participate in delete workspace agent sessions batch: %w", err)

--- a/packages/agent/store-sqlite/activity_delete_tree.go
+++ b/packages/agent/store-sqlite/activity_delete_tree.go
@@ -68,13 +68,14 @@ func deleteSessionTreeRowsTx(
 	workspaceID string,
 	sessionIDs []string,
 	now int64,
-) (int, int, []string, error) {
+) (int, int, []string, []TransactionMutation, error) {
 	removedMessages := int64(0)
 	removedSessions := int64(0)
 	removedSessionIDs := make([]string, 0, len(sessionIDs))
+	terminalMutations := make([]TransactionMutation, 0)
 	plan, err := recoverableDeletePlanTx(ctx, tx, workspaceID, sessionIDs)
 	if err != nil {
-		return 0, 0, nil, err
+		return 0, 0, nil, nil, err
 	}
 	for _, agentSessionID := range sessionIDs {
 		if plan.activeBySession[agentSessionID] {
@@ -83,12 +84,14 @@ func deleteSessionTreeRowsTx(
 SELECT COUNT(*) FROM workspace_agent_messages
 WHERE workspace_id = ? AND agent_session_id = ? AND deleted_at_unix_ms = 0
 `, workspaceID, agentSessionID).Scan(&messageCount); err != nil {
-				return 0, 0, nil, fmt.Errorf("count workspace agent session tree messages: %w", err)
+				return 0, 0, nil, nil, fmt.Errorf("count workspace agent session tree messages: %w", err)
 			}
 			removedMessages += messageCount
-			if err := settleDeletedSessionWorkTx(ctx, tx, workspaceID, agentSessionID, now); err != nil {
-				return 0, 0, nil, err
+			settledTurns, err := settleDeletedSessionWorkTx(ctx, tx, workspaceID, agentSessionID, now)
+			if err != nil {
+				return 0, 0, nil, nil, err
 			}
+			terminalMutations = append(terminalMutations, settledTurns...)
 		}
 		if !plan.activeBySession[agentSessionID] && !plan.mergeBySession[agentSessionID] {
 			continue
@@ -108,21 +111,21 @@ WHERE workspace_id = ? AND agent_session_id = ?`+deletedPredicate,
 			now, recoverableDeleteVersionCurrent, plan.sizeBySession[agentSessionID], workspaceID, agentSessionID,
 		)
 		if err != nil {
-			return 0, 0, nil, fmt.Errorf("delete workspace agent session tree member: %w", err)
+			return 0, 0, nil, nil, fmt.Errorf("delete workspace agent session tree member: %w", err)
 		}
 		sessionCount, err := sessionResult.RowsAffected()
 		if err != nil {
-			return 0, 0, nil, fmt.Errorf("delete workspace agent session tree rows affected: %w", err)
+			return 0, 0, nil, nil, fmt.Errorf("delete workspace agent session tree rows affected: %w", err)
 		}
 		if sessionCount == 0 {
-			return 0, 0, nil, fmt.Errorf("delete workspace agent session tree member %q: row disappeared", agentSessionID)
+			return 0, 0, nil, nil, fmt.Errorf("delete workspace agent session tree member %q: row disappeared", agentSessionID)
 		}
 		if plan.activeBySession[agentSessionID] {
 			removedSessions++
 			removedSessionIDs = append(removedSessionIDs, agentSessionID)
 		}
 	}
-	return int(removedMessages), int(removedSessions), removedSessionIDs, nil
+	return int(removedMessages), int(removedSessions), removedSessionIDs, terminalMutations, nil
 }
 
 type recoverableDeleteMember struct {
@@ -275,7 +278,34 @@ func settleDeletedSessionWorkTx(
 	workspaceID string,
 	agentSessionID string,
 	now int64,
-) error {
+) ([]TransactionMutation, error) {
+	rows, err := tx.QueryContext(ctx, `
+SELECT turn_id
+FROM workspace_agent_turns
+WHERE workspace_id = ? AND agent_session_id = ? AND phase <> 'settled'
+ORDER BY turn_id
+`, workspaceID, agentSessionID)
+	if err != nil {
+		return nil, fmt.Errorf("list live turns for deleted workspace agent session: %w", err)
+	}
+	terminalMutations := make([]TransactionMutation, 0)
+	for rows.Next() {
+		var turnID string
+		if err := rows.Scan(&turnID); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("scan live turn for deleted workspace agent session: %w", err)
+		}
+		terminalMutations = append(terminalMutations, terminalTurnMutation(
+			workspaceID, agentSessionID, turnID, "upsert", now, false,
+		))
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, fmt.Errorf("iterate live turns for deleted workspace agent session: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("close live turns for deleted workspace agent session: %w", err)
+	}
 	statements := []struct {
 		name  string
 		query string
@@ -360,8 +390,8 @@ WHERE workspace_id = ? AND agent_session_id = ?
 	}
 	for _, statement := range statements {
 		if _, err := tx.ExecContext(ctx, statement.query, statement.args...); err != nil {
-			return fmt.Errorf("settle deleted workspace agent session %s: %w", statement.name, err)
+			return nil, fmt.Errorf("settle deleted workspace agent session %s: %w", statement.name, err)
 		}
 	}
-	return nil
+	return terminalMutations, nil
 }

--- a/packages/agent/store-sqlite/activity_turns.go
+++ b/packages/agent/store-sqlite/activity_turns.go
@@ -38,10 +38,21 @@ func (s *Store) RecordTurnTransition(ctx context.Context, transition TurnTransit
 	}
 	mutations := []TransactionMutation{}
 	if accepted {
-		mutations = append(mutations,
-			transactionMutation(turn.WorkspaceID, turn.AgentSessionID, MutationEntityTurn, turn.TurnID, "upsert", turn.UpdatedAtUnixMS),
-			transactionMutation(turn.WorkspaceID, turn.AgentSessionID, MutationEntitySession, turn.AgentSessionID, "upsert", turn.UpdatedAtUnixMS),
+		turnMutation := transactionMutation(
+			turn.WorkspaceID, turn.AgentSessionID, MutationEntityTurn,
+			turn.TurnID, "upsert", turn.UpdatedAtUnixMS,
 		)
+		// The persisted row may already be settled when a late capability-only
+		// merge is accepted. Only the incoming lifecycle fact can identify a
+		// terminal transition; the final row shape cannot.
+		if strings.TrimSpace(transition.Phase) == TurnPhaseSettled {
+			turnMutation = terminalTurnMutation(
+				turn.WorkspaceID, turn.AgentSessionID, turn.TurnID,
+				"upsert", turn.UpdatedAtUnixMS, false,
+			)
+		}
+		mutations = append(mutations, turnMutation,
+			transactionMutation(turn.WorkspaceID, turn.AgentSessionID, MutationEntitySession, turn.AgentSessionID, "upsert", turn.UpdatedAtUnixMS))
 	}
 	if _, err := s.commitTransaction(ctx, tx, transition.WorkspaceID, mutations); err != nil {
 		return Turn{}, false, fmt.Errorf("commit workspace agent turn transition: %w", err)
@@ -534,6 +545,22 @@ WHERE phase != ?
 		RuntimeOperationStatusPrepared, RuntimeOperationStatusLeased); err != nil {
 		return nil, fmt.Errorf("settle stale workspace agent turns: %w", err)
 	}
+	for index := range settlements {
+		turn, found, err := getAgentTurnTx(
+			ctx,
+			tx,
+			settlements[index].WorkspaceID,
+			settlements[index].AgentSessionID,
+			settlements[index].TurnID,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("read settled stale workspace agent turn: %w", err)
+		}
+		if !found {
+			return nil, errors.New("settled stale workspace agent turn disappeared")
+		}
+		settlements[index].Turn = turn
+	}
 	if _, err := tx.ExecContext(ctx, `
 UPDATE workspace_agent_sessions AS s
 SET active_turn_id = NULL, updated_at_unix_ms = ?
@@ -597,7 +624,7 @@ WHERE status = ?
 	mutations := make([]TransactionMutation, 0, len(settlements)*3+len(pendingInteractions))
 	for _, settlement := range settlements {
 		mutations = append(mutations,
-			transactionMutation(settlement.WorkspaceID, settlement.AgentSessionID, MutationEntityTurn, settlement.TurnID, "settle", now),
+			terminalTurnMutation(settlement.WorkspaceID, settlement.AgentSessionID, settlement.TurnID, "settle", now, true),
 			transactionMutation(settlement.WorkspaceID, settlement.AgentSessionID, MutationEntitySession, settlement.AgentSessionID, "upsert", now),
 		)
 	}

--- a/packages/agent/store-sqlite/activity_turns_test.go
+++ b/packages/agent/store-sqlite/activity_turns_test.go
@@ -2,6 +2,7 @@ package storesqlite
 
 import (
 	"context"
+	"reflect"
 	"testing"
 )
 
@@ -231,6 +232,44 @@ func TestSettleStaleTurnsClosesSplitRuntimeSuccessStateOnRestart(t *testing.T) {
 	message := page.Messages[0]
 	if message.MessageID != "system-stale-turn-turn-1" || message.TurnID != "turn-1" || message.Payload["noticeKind"] != "stale_turn_reconciled" {
 		t.Fatalf("startup system message = %#v", message)
+	}
+}
+
+func TestSettleStaleTurnsReturnsCanonicalSettledTurn(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	seedTurnTestSession(t, store, "ws-1", "session-1")
+	if _, accepted, err := store.RecordTurnTransition(ctx, TurnTransition{
+		WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-1",
+		Phase: TurnPhaseRunning, Origin: TurnOriginUserPrompt, OccurredAtUnixMS: 100,
+	}); err != nil || !accepted {
+		t.Fatalf("RecordTurnTransition() accepted=%v error=%v", accepted, err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+UPDATE workspace_agent_turns
+SET backfilled = 1
+WHERE workspace_id = 'ws-1' AND agent_session_id = 'session-1' AND turn_id = 'turn-1'
+`); err != nil {
+		t.Fatalf("mark turn backfilled: %v", err)
+	}
+
+	settlements, err := store.SettleStaleTurns(ctx)
+	if err != nil {
+		t.Fatalf("SettleStaleTurns() error = %v", err)
+	}
+	if len(settlements) != 1 {
+		t.Fatalf("settlements = %#v, want one", settlements)
+	}
+	persisted, found, err := store.GetTurn(ctx, "ws-1", "session-1", "turn-1")
+	if err != nil || !found {
+		t.Fatalf("GetTurn() found=%v error=%v turn=%#v", found, err, persisted)
+	}
+	if !reflect.DeepEqual(settlements[0].Turn, persisted) {
+		t.Fatalf("settlement turn = %#v, want canonical persisted turn %#v", settlements[0].Turn, persisted)
+	}
+	if settlements[0].Turn.Origin != TurnOriginUserPrompt || !settlements[0].Turn.Backfilled {
+		t.Fatalf("settlement turn provenance = %#v, want user_prompt/backfilled", settlements[0].Turn)
 	}
 }
 

--- a/packages/agent/store-sqlite/effective_history.go
+++ b/packages/agent/store-sqlite/effective_history.go
@@ -50,9 +50,14 @@ type TurnSubmission struct {
 	DisplayPrompt         string
 	CapabilityRefsJSON    string
 	TuttiModeSnapshotJSON string
+	MetadataJSON          string
 	ClientSubmitID        string
 	CreatedAtUnixMS       int64
 	UpdatedAtUnixMS       int64
+}
+
+type TurnSubmissionReader interface {
+	GetTurnSubmission(context.Context, string, string, string) (TurnSubmission, bool, error)
 }
 
 func (s *Store) GetSessionHistory(ctx context.Context, workspaceID, agentSessionID string) (SessionHistory, bool, error) {
@@ -117,10 +122,16 @@ func (s *Store) RecordTurnSubmission(ctx context.Context, input TurnSubmission) 
 	input.AgentSessionID = strings.TrimSpace(input.AgentSessionID)
 	input.TurnID = strings.TrimSpace(input.TurnID)
 	input.ClientSubmitID = strings.TrimSpace(input.ClientSubmitID)
+	if strings.TrimSpace(input.MetadataJSON) == "" {
+		input.MetadataJSON = "{}"
+	}
+	var metadata map[string]any
+	metadataErr := json.Unmarshal([]byte(input.MetadataJSON), &metadata)
 	if input.WorkspaceID == "" || input.AgentSessionID == "" || input.TurnID == "" ||
 		!json.Valid([]byte(input.ContentJSON)) ||
 		!json.Valid([]byte(input.CapabilityRefsJSON)) ||
-		!json.Valid([]byte(input.TuttiModeSnapshotJSON)) {
+		!json.Valid([]byte(input.TuttiModeSnapshotJSON)) ||
+		metadataErr != nil || metadata == nil {
 		return TurnSubmission{}, false, errors.New("record workspace agent turn submission: invalid envelope")
 	}
 	if input.CreatedAtUnixMS <= 0 {
@@ -132,12 +143,12 @@ func (s *Store) RecordTurnSubmission(ctx context.Context, input TurnSubmission) 
 	result, err := s.db.ExecContext(ctx, `
 INSERT INTO workspace_agent_turn_submissions (
   workspace_id, agent_session_id, turn_id, content_json, display_prompt,
-  capability_refs_json, tutti_mode_snapshot_json, client_submit_id,
+  capability_refs_json, tutti_mode_snapshot_json, metadata_json, client_submit_id,
   created_at_unix_ms, updated_at_unix_ms
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(workspace_id, agent_session_id, turn_id) DO NOTHING
 `, input.WorkspaceID, input.AgentSessionID, input.TurnID, input.ContentJSON, input.DisplayPrompt,
-		input.CapabilityRefsJSON, input.TuttiModeSnapshotJSON, input.ClientSubmitID,
+		input.CapabilityRefsJSON, input.TuttiModeSnapshotJSON, input.MetadataJSON, input.ClientSubmitID,
 		input.CreatedAtUnixMS, input.UpdatedAtUnixMS)
 	if err != nil {
 		return TurnSubmission{}, false, fmt.Errorf("record workspace agent turn submission: %w", err)
@@ -170,14 +181,14 @@ func (s *Store) GetTurnSubmission(ctx context.Context, workspaceID, agentSession
 	var result TurnSubmission
 	err := s.db.QueryRowContext(ctx, `
 SELECT workspace_id, agent_session_id, turn_id, content_json, display_prompt,
-       capability_refs_json, tutti_mode_snapshot_json, client_submit_id,
+       capability_refs_json, tutti_mode_snapshot_json, metadata_json, client_submit_id,
        created_at_unix_ms, updated_at_unix_ms
 FROM workspace_agent_turn_submissions
 WHERE workspace_id = ? AND agent_session_id = ? AND turn_id = ?
 `, workspaceID, agentSessionID, turnID).Scan(
 		&result.WorkspaceID, &result.AgentSessionID, &result.TurnID,
 		&result.ContentJSON, &result.DisplayPrompt, &result.CapabilityRefsJSON,
-		&result.TuttiModeSnapshotJSON, &result.ClientSubmitID,
+		&result.TuttiModeSnapshotJSON, &result.MetadataJSON, &result.ClientSubmitID,
 		&result.CreatedAtUnixMS, &result.UpdatedAtUnixMS,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -197,5 +208,6 @@ func sameTurnSubmissionEnvelope(left, right TurnSubmission) bool {
 		left.DisplayPrompt == right.DisplayPrompt &&
 		left.CapabilityRefsJSON == right.CapabilityRefsJSON &&
 		left.TuttiModeSnapshotJSON == right.TuttiModeSnapshotJSON &&
+		left.MetadataJSON == right.MetadataJSON &&
 		left.ClientSubmitID == right.ClientSubmitID
 }

--- a/packages/agent/store-sqlite/effective_history_test.go
+++ b/packages/agent/store-sqlite/effective_history_test.go
@@ -10,7 +10,7 @@ func TestEffectiveHistoryMigrationRunsAfterImportedTurnsAndBackfills(t *testing.
 	t.Parallel()
 	store := openTestStore(t, testOptions(&staticProjectPaths{}))
 	ctx := context.Background()
-	var importedRowID, historyRowID int64
+	var importedRowID, historyRowID, metadataRowID int64
 	if err := store.db.QueryRowContext(ctx, `
 SELECT rowid FROM agent_store_schema_migrations WHERE id = ?
 `, schemaMigrationWorkspaceAgentImportedTurnsV1).Scan(&importedRowID); err != nil {
@@ -23,6 +23,14 @@ SELECT rowid FROM agent_store_schema_migrations WHERE id = ?
 	}
 	if historyRowID <= importedRowID {
 		t.Fatalf("effective history migration row=%d, want after imported turns row=%d", historyRowID, importedRowID)
+	}
+	if err := store.db.QueryRowContext(ctx, `
+SELECT rowid FROM agent_store_schema_migrations WHERE id = ?
+`, schemaMigrationWorkspaceAgentEffectiveHistoryV2).Scan(&metadataRowID); err != nil {
+		t.Fatal(err)
+	}
+	if metadataRowID <= historyRowID {
+		t.Fatalf("effective history metadata migration row=%d, want after history row=%d", metadataRowID, historyRowID)
 	}
 
 	seedTurnTestSession(t, store, "ws-1", "session-new")
@@ -51,19 +59,24 @@ func TestEffectiveHistorySubmissionIsLosslessIdempotentAndConflictFenced(t *test
 		WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-1",
 		ContentJSON:   `[{"type":"text","text":"hello"},{"type":"image","attachmentId":"attachment-1"}]`,
 		DisplayPrompt: "hello", CapabilityRefsJSON: `[{"Capability":"browser"}]`,
-		TuttiModeSnapshotJSON: `{"Revision":2}`, ClientSubmitID: "submit-1",
+		TuttiModeSnapshotJSON: `{"Revision":2}`, MetadataJSON: `{"uiMode":"agent"}`, ClientSubmitID: "submit-1",
 		CreatedAtUnixMS: 21, UpdatedAtUnixMS: 21,
 	}
 	if _, created, err := store.RecordTurnSubmission(ctx, input); err != nil || !created {
 		t.Fatalf("first submission created=%v error=%v", created, err)
 	}
-	if stored, created, err := store.RecordTurnSubmission(ctx, input); err != nil || created || stored.ContentJSON != input.ContentJSON {
+	if stored, created, err := store.RecordTurnSubmission(ctx, input); err != nil || created || stored.ContentJSON != input.ContentJSON || stored.MetadataJSON != input.MetadataJSON {
 		t.Fatalf("replayed submission created=%v stored=%#v error=%v", created, stored, err)
 	}
 	conflict := input
 	conflict.ContentJSON = `[{"type":"text","text":"changed"}]`
 	if _, _, err := store.RecordTurnSubmission(ctx, conflict); !errors.Is(err, ErrTurnSubmissionConflict) {
 		t.Fatalf("conflicting submission error=%v", err)
+	}
+	conflict = input
+	conflict.MetadataJSON = `{"uiMode":"os"}`
+	if _, _, err := store.RecordTurnSubmission(ctx, conflict); !errors.Is(err, ErrTurnSubmissionConflict) {
+		t.Fatalf("conflicting submission metadata error=%v", err)
 	}
 }
 

--- a/packages/agent/store-sqlite/migrations.go
+++ b/packages/agent/store-sqlite/migrations.go
@@ -50,6 +50,7 @@ const schemaMigrationWorkspaceAgentRuntimeOperationsV5 = "workspace_agent_runtim
 const schemaMigrationWorkspaceAgentSubmitClaimsV1 = "workspace_agent_submit_claims_v1"
 const schemaMigrationWorkspaceAgentSubmitClaimsV2 = "workspace_agent_submit_claims_v2"
 const schemaMigrationWorkspaceAgentSubmitClaimsV3 = "workspace_agent_submit_claims_v3"
+const schemaMigrationWorkspaceAgentSubmitClaimsV4 = "workspace_agent_submit_claims_v4_submission_metadata"
 const schemaMigrationAgentTargetsV1 = "agent_targets_v1"
 const schemaMigrationAgentTargetsV2 = "agent_targets_v2"
 const schemaMigrationAgentTargetsV3 = "agent_targets_v3"
@@ -223,6 +224,9 @@ CREATE TABLE IF NOT EXISTS `+schemaMigrationsTable+` (
 		return err
 	}
 	if err := s.applyWorkspaceAgentSubmitClaimsV3(ctx); err != nil {
+		return err
+	}
+	if err := s.applyWorkspaceAgentSubmitClaimsV4(ctx); err != nil {
 		return err
 	}
 	if err := s.applyWorkspaceAgentSessionTitlesV1(ctx); err != nil {

--- a/packages/agent/store-sqlite/migrations.go
+++ b/packages/agent/store-sqlite/migrations.go
@@ -82,6 +82,7 @@ const schemaMigrationWorkspaceAgentSessionForkV3 = "workspace_agent_session_fork
 const schemaMigrationWorkspaceAgentSessionForkV4 = "workspace_agent_session_fork_v4"
 const schemaMigrationWorkspaceAgentSessionForkV5 = "workspace_agent_session_fork_v5"
 const schemaMigrationWorkspaceAgentEffectiveHistoryV1 = "workspace_agent_effective_history_v1"
+const schemaMigrationWorkspaceAgentEffectiveHistoryV2 = "workspace_agent_effective_history_v2_submission_metadata"
 const schemaMigrationWorkspaceAgentSessionForkV6 = "workspace_agent_session_fork_v6_optimistic"
 const schemaMigrationWorkspaceAgentSessionForkV7 = "workspace_agent_session_fork_v7_full_turn_bindings"
 const schemaMigrationWorkspaceAgentProviderCheckpointV1 = "workspace_agent_provider_checkpoint_v1"
@@ -306,6 +307,9 @@ CREATE TABLE IF NOT EXISTS `+schemaMigrationsTable+` (
 		return err
 	}
 	if err := s.applyWorkspaceAgentEffectiveHistoryV1(ctx); err != nil {
+		return err
+	}
+	if err := s.applyWorkspaceAgentEffectiveHistoryV2(ctx); err != nil {
 		return err
 	}
 	if err := s.applyWorkspaceAgentSessionForkV6(ctx); err != nil {

--- a/packages/agent/store-sqlite/migrations_effective_history.go
+++ b/packages/agent/store-sqlite/migrations_effective_history.go
@@ -133,3 +133,36 @@ END;
 	}
 	return nil
 }
+
+func (s *Store) applyWorkspaceAgentEffectiveHistoryV2(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentEffectiveHistoryV2)
+	if err != nil || applied {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin workspace agent effective history v2 migration: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	hasMetadata, err := hasColumnTx(ctx, tx, "workspace_agent_turn_submissions", "metadata_json")
+	if err != nil {
+		return err
+	}
+	if !hasMetadata {
+		if _, err := tx.ExecContext(ctx, `
+ALTER TABLE workspace_agent_turn_submissions
+ADD COLUMN metadata_json TEXT NOT NULL DEFAULT '{}'
+  CHECK (json_valid(metadata_json) AND json_type(metadata_json) = 'object')
+`); err != nil {
+			return fmt.Errorf("add workspace agent turn submission metadata: %w", err)
+		}
+	}
+	if err := recordMigrationTx(ctx, tx, schemaMigrationWorkspaceAgentEffectiveHistoryV2); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit workspace agent effective history v2 migration: %w", err)
+	}
+	return nil
+}

--- a/packages/agent/store-sqlite/migrations_submit_claims.go
+++ b/packages/agent/store-sqlite/migrations_submit_claims.go
@@ -114,3 +114,39 @@ CREATE INDEX idx_workspace_agent_submit_claims_canonical_turn
 	}
 	return nil
 }
+
+// V4 retains the small submission-metadata envelope that must cross the
+// provider-admission barrier. The complete TurnSubmission is still persisted
+// after Exec, but metadata needed by durable post-commit consumers must survive
+// a process crash between provider settlement and that later envelope write.
+func (s *Store) applyWorkspaceAgentSubmitClaimsV4(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentSubmitClaimsV4)
+	if err != nil || applied {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin workspace agent submit claims v4 migration: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	hasMetadata, err := hasColumnTx(ctx, tx, "workspace_agent_submit_claims", "metadata_json")
+	if err != nil {
+		return err
+	}
+	if !hasMetadata {
+		if _, err := tx.ExecContext(ctx, `
+ALTER TABLE workspace_agent_submit_claims
+  ADD COLUMN metadata_json TEXT NOT NULL DEFAULT '{}'
+  CHECK (json_valid(metadata_json) AND json_type(metadata_json) = 'object');
+`); err != nil {
+			return fmt.Errorf("migrate workspace agent submit claims v4: %w", err)
+		}
+	}
+	if err := recordMigrationTx(ctx, tx, schemaMigrationWorkspaceAgentSubmitClaimsV4); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit workspace agent submit claims v4 migration: %w", err)
+	}
+	return nil
+}

--- a/packages/agent/store-sqlite/repository.go
+++ b/packages/agent/store-sqlite/repository.go
@@ -681,8 +681,12 @@ type ListSessionInteractionsInput struct {
 // StaleTurnSettlement identifies one turn that startup reconciliation
 // force-settled with outcome interrupted.
 type StaleTurnSettlement struct {
-	TransactionID   string           `json:"-"`
-	CommitDelta     TransactionDelta `json:"-"`
+	TransactionID string           `json:"-"`
+	CommitDelta   TransactionDelta `json:"-"`
+	// Turn is the complete canonical row after startup reconciliation commits
+	// its settled/interrupted transition. Consumers must use this copy instead
+	// of reconstructing provenance from the scalar notification identity.
+	Turn            Turn
 	WorkspaceID     string
 	AgentSessionID  string
 	TurnID          string

--- a/packages/agent/store-sqlite/runtime_operation_completion.go
+++ b/packages/agent/store-sqlite/runtime_operation_completion.go
@@ -66,6 +66,7 @@ func (s *Store) CompleteCancelRuntimeOperation(ctx context.Context, input Comple
 			}
 			result := RuntimeOperationResultAlreadySettled
 			eventTargets := make([]any, 0, len(targets))
+			settledTargets := make([]any, 0, len(targets))
 			rootAgentSessionID := payloadString(op.Payload, "rootAgentSessionId")
 			rootTargeted := false
 			for _, target := range targets {
@@ -84,7 +85,8 @@ func (s *Store) CompleteCancelRuntimeOperation(ctx context.Context, input Comple
 					return "", "", nil, ErrRuntimeOperationSubjectState
 				}
 				outcome := turn.Outcome
-				if turn.Phase != TurnPhaseSettled {
+				settledByCompletion := turn.Phase != TurnPhaseSettled
+				if settledByCompletion {
 					outcome = requestedOutcomes[cancelTargetKey(target.AgentSessionID, target.TurnID)]
 					var activeTurnID sql.NullString
 					if err := tx.QueryRowContext(ctx, `
@@ -147,14 +149,19 @@ WHERE workspace_id = ? AND agent_session_id = ? AND turn_id = ? AND status = ?
 					target.TurnID, InteractionStatusPending); err != nil {
 					return "", "", nil, fmt.Errorf("supersede canceled runtime operation interactions: %w", err)
 				}
-				eventTargets = append(eventTargets, map[string]any{
+				eventTarget := map[string]any{
 					"agentSessionId": target.AgentSessionID,
 					"turnId":         target.TurnID,
 					"outcome":        outcome,
-				})
+				}
+				eventTargets = append(eventTargets, eventTarget)
+				if settledByCompletion {
+					settledTargets = append(settledTargets, eventTarget)
+				}
 			}
 			eventPayload := map[string]any{
-				"turnId": op.TurnID, "result": result, "rootAgentSessionId": rootAgentSessionID, "targets": eventTargets,
+				"turnId": op.TurnID, "result": result, "rootAgentSessionId": rootAgentSessionID,
+				"targets": eventTargets, "settledTargets": settledTargets,
 			}
 			if reconciledRoot.TurnID != "" {
 				eventPayload["reconciledRoot"] = map[string]any{
@@ -386,12 +393,24 @@ func runtimeOperationCompletionMutations(ctx context.Context, tx *sql.Tx, op Run
 			interactionMutationEntityID(op.TurnID, op.RequestID), "upsert", op.UpdatedAtUnixMS,
 		))
 	case RuntimeOperationEventTurnCanceled:
+		settledTargetKeys := make(map[string]struct{})
+		if settledTargets, ok := event.Payload["settledTargets"].([]any); ok {
+			for _, raw := range settledTargets {
+				target, _ := raw.(map[string]any)
+				key := payloadString(target, "agentSessionId") + "\x00" + payloadString(target, "turnId")
+				settledTargetKeys[key] = struct{}{}
+			}
+		}
 		if targets, ok := event.Payload["targets"].([]any); ok {
 			for _, raw := range targets {
 				target, _ := raw.(map[string]any)
 				sessionID, turnID := payloadString(target, "agentSessionId"), payloadString(target, "turnId")
+				turnMutation := transactionMutation(op.WorkspaceID, sessionID, MutationEntityTurn, turnID, "upsert", op.UpdatedAtUnixMS)
+				if _, settled := settledTargetKeys[sessionID+"\x00"+turnID]; settled {
+					turnMutation = terminalTurnMutation(op.WorkspaceID, sessionID, turnID, "upsert", op.UpdatedAtUnixMS, false)
+				}
 				mutations = append(mutations,
-					transactionMutation(op.WorkspaceID, sessionID, MutationEntityTurn, turnID, "upsert", op.UpdatedAtUnixMS),
+					turnMutation,
 					transactionMutation(op.WorkspaceID, sessionID, MutationEntitySession, sessionID, "upsert", op.UpdatedAtUnixMS),
 				)
 				interactionMutations, err := canceledInteractionMutations(ctx, tx, op.WorkspaceID, sessionID, turnID, op.UpdatedAtUnixMS)
@@ -404,7 +423,7 @@ func runtimeOperationCompletionMutations(ctx context.Context, tx *sql.Tx, op Run
 		if root, ok := event.Payload["reconciledRoot"].(map[string]any); ok {
 			sessionID, turnID := payloadString(root, "agentSessionId"), payloadString(root, "turnId")
 			mutations = append(mutations,
-				transactionMutation(op.WorkspaceID, sessionID, MutationEntityTurn, turnID, "upsert", op.UpdatedAtUnixMS),
+				terminalTurnMutation(op.WorkspaceID, sessionID, turnID, "upsert", op.UpdatedAtUnixMS, false),
 				transactionMutation(op.WorkspaceID, sessionID, MutationEntitySession, sessionID, "upsert", op.UpdatedAtUnixMS),
 			)
 		}

--- a/packages/agent/store-sqlite/runtime_operations_test.go
+++ b/packages/agent/store-sqlite/runtime_operations_test.go
@@ -385,6 +385,10 @@ func TestCompleteCancelRuntimeOperationSettlesExactTurnAndSupersedesPending(t *t
 	if err != nil || !changed || completion.Operation.Result != RuntimeOperationResultCanceled {
 		t.Fatalf("cancel completion=%#v changed=%v err=%v", completion, changed, err)
 	}
+	settledTargets, ok := completion.Event.Payload["settledTargets"].([]any)
+	if !ok || len(settledTargets) != 0 {
+		t.Fatalf("settled targets=%#v, want none for an already-settled turn", settledTargets)
+	}
 	turn, found, err := store.GetTurn(context.Background(), "ws-1", "session-1", "turn-1")
 	if err != nil || !found || turn.Phase != TurnPhaseSettled || turn.Outcome != TurnOutcomeCanceled || turn.ErrorMessage != "" {
 		t.Fatalf("turn=%#v found=%v err=%v", turn, found, err)
@@ -426,15 +430,20 @@ func TestCompleteCancelRuntimeOperationSettlesRootAndUnconfirmedChildAtomically(
 		t.Fatalf("prepare aggregate cancel created=%v err=%v", created, err)
 	}
 	claimRuntimeOperation(t, store, "cancel-tree", "worker-a")
-	if _, changed, err := store.CompleteCancelRuntimeOperation(context.Background(), CompleteCancelRuntimeOperationInput{
+	completion, changed, err := store.CompleteCancelRuntimeOperation(context.Background(), CompleteCancelRuntimeOperationInput{
 		WorkspaceID: "ws-1", OperationID: "cancel-tree", LeaseOwner: "worker-a",
 		TargetOutcomes: []CancelRuntimeOperationTargetOutcome{
 			{AgentSessionID: "child", TurnID: "child-turn", Outcome: TurnOutcomeInterrupted},
 			{AgentSessionID: "root", TurnID: "root-turn", Outcome: TurnOutcomeCanceled},
 		},
 		NowUnixMS: 30,
-	}); err != nil || !changed {
+	})
+	if err != nil || !changed {
 		t.Fatalf("complete aggregate cancel changed=%v err=%v", changed, err)
+	}
+	settledTargets, ok := completion.Event.Payload["settledTargets"].([]any)
+	if !ok || len(settledTargets) != 2 {
+		t.Fatalf("settled targets=%#v, want both targets settled by this transaction", settledTargets)
 	}
 	for sessionID, expected := range map[string]struct {
 		turnID  string

--- a/packages/agent/store-sqlite/submit_claims.go
+++ b/packages/agent/store-sqlite/submit_claims.go
@@ -3,6 +3,7 @@ package storesqlite
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -17,6 +18,7 @@ type SubmitClaim struct {
 	Status          string
 	CanonicalTurnID string
 	TurnID          string
+	MetadataJSON    string
 	CreatedAtUnixMS int64
 	UpdatedAtUnixMS int64
 }
@@ -26,6 +28,7 @@ type SubmitClaimPrepare struct {
 	AgentSessionID  string
 	ClientSubmitID  string
 	CanonicalTurnID string
+	MetadataJSON    string
 	NowUnixMS       int64
 }
 
@@ -34,9 +37,29 @@ func (s *Store) PrepareSubmitClaim(ctx context.Context, input SubmitClaimPrepare
 	input.AgentSessionID = strings.TrimSpace(input.AgentSessionID)
 	input.ClientSubmitID = strings.TrimSpace(input.ClientSubmitID)
 	input.CanonicalTurnID = strings.TrimSpace(input.CanonicalTurnID)
+	if strings.TrimSpace(input.MetadataJSON) == "" {
+		input.MetadataJSON = "{}"
+	}
+	var metadata map[string]any
+	metadataErr := json.Unmarshal([]byte(input.MetadataJSON), &metadata)
 	if input.WorkspaceID == "" || input.AgentSessionID == "" || input.ClientSubmitID == "" || input.CanonicalTurnID == "" || input.NowUnixMS <= 0 {
 		return SubmitClaim{}, false, fmt.Errorf("invalid workspace agent submit claim")
 	}
+	if metadataErr != nil || metadata == nil {
+		return SubmitClaim{}, false, fmt.Errorf("invalid workspace agent submit claim metadata")
+	}
+	// Enforce the privacy boundary at the durable API as well as at Host call
+	// sites: claims retain only the closed provenance needed before the full
+	// submission envelope is available.
+	claimMetadata := make(map[string]any, 1)
+	if mode, ok := metadata["uiMode"].(string); ok && (mode == "os" || mode == "agent") {
+		claimMetadata["uiMode"] = mode
+	}
+	encodedMetadata, err := json.Marshal(claimMetadata)
+	if err != nil {
+		return SubmitClaim{}, false, fmt.Errorf("encode workspace agent submit claim metadata: %w", err)
+	}
+	input.MetadataJSON = string(encodedMetadata)
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return SubmitClaim{}, false, fmt.Errorf("begin prepare submit claim: %w", err)
@@ -65,8 +88,8 @@ func (s *Store) PrepareSubmitClaim(ctx context.Context, input SubmitClaimPrepare
 		return SubmitClaim{}, false, err
 	}
 	result, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO workspace_agent_submit_claims
-		(workspace_id, agent_session_id, client_submit_id, status, turn_id, created_at_unix_ms, updated_at_unix_ms, canonical_turn_id)
-		VALUES (?, ?, ?, 'prepared', NULL, ?, ?, ?)`, input.WorkspaceID, input.AgentSessionID, input.ClientSubmitID, input.NowUnixMS, input.NowUnixMS, input.CanonicalTurnID)
+		(workspace_id, agent_session_id, client_submit_id, status, turn_id, created_at_unix_ms, updated_at_unix_ms, canonical_turn_id, metadata_json)
+		VALUES (?, ?, ?, 'prepared', NULL, ?, ?, ?, ?)`, input.WorkspaceID, input.AgentSessionID, input.ClientSubmitID, input.NowUnixMS, input.NowUnixMS, input.CanonicalTurnID, input.MetadataJSON)
 	if err != nil {
 		return SubmitClaim{}, false, fmt.Errorf("prepare submit claim: %w", err)
 	}
@@ -284,7 +307,7 @@ func (s *Store) FindSubmitClaimByCanonicalTurn(
 	}
 	rows, err := s.db.QueryContext(ctx, `
 SELECT workspace_id, agent_session_id, client_submit_id, status,
-       canonical_turn_id, turn_id, created_at_unix_ms, updated_at_unix_ms
+	       canonical_turn_id, turn_id, metadata_json, created_at_unix_ms, updated_at_unix_ms
 FROM workspace_agent_submit_claims
 WHERE workspace_id = ? AND agent_session_id = ? AND canonical_turn_id = ?
   AND status IN ('prepared', 'accepted')
@@ -323,7 +346,7 @@ LIMIT 2
 func (s *Store) getSubmitClaim(ctx context.Context, workspaceID, agentSessionID, clientSubmitID string) (SubmitClaim, bool, error) {
 	return scanSubmitClaim(s.db.QueryRowContext(
 		ctx,
-		`SELECT workspace_id, agent_session_id, client_submit_id, status, canonical_turn_id, turn_id, created_at_unix_ms, updated_at_unix_ms
+		`SELECT workspace_id, agent_session_id, client_submit_id, status, canonical_turn_id, turn_id, metadata_json, created_at_unix_ms, updated_at_unix_ms
 		FROM workspace_agent_submit_claims WHERE workspace_id=? AND agent_session_id=? AND client_submit_id=?`,
 		workspaceID,
 		agentSessionID,
@@ -338,7 +361,7 @@ func getSubmitClaimTx(
 ) (SubmitClaim, bool, error) {
 	return scanSubmitClaim(tx.QueryRowContext(
 		ctx,
-		`SELECT workspace_id, agent_session_id, client_submit_id, status, canonical_turn_id, turn_id, created_at_unix_ms, updated_at_unix_ms
+		`SELECT workspace_id, agent_session_id, client_submit_id, status, canonical_turn_id, turn_id, metadata_json, created_at_unix_ms, updated_at_unix_ms
 		FROM workspace_agent_submit_claims WHERE workspace_id=? AND agent_session_id=? AND client_submit_id=?`,
 		workspaceID,
 		agentSessionID,
@@ -357,6 +380,7 @@ func scanSubmitClaim(row rowScanner) (SubmitClaim, bool, error) {
 		&claim.Status,
 		&canonicalTurnID,
 		&turnID,
+		&claim.MetadataJSON,
 		&claim.CreatedAtUnixMS,
 		&claim.UpdatedAtUnixMS,
 	)

--- a/packages/agent/store-sqlite/submit_claims_test.go
+++ b/packages/agent/store-sqlite/submit_claims_test.go
@@ -2,6 +2,7 @@ package storesqlite
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"sync"
 	"testing"
@@ -12,16 +13,17 @@ func TestSubmitClaimIsDurableAndIdempotent(t *testing.T) {
 	store := openTestStore(t, testOptions(&staticProjectPaths{}))
 	input := SubmitClaimPrepare{
 		WorkspaceID: "ws-1", AgentSessionID: "session-1", ClientSubmitID: "submit-1",
-		CanonicalTurnID: "turn-1", NowUnixMS: 10,
+		CanonicalTurnID: "turn-1", MetadataJSON: `{"uiMode":"agent","trace":"private"}`, NowUnixMS: 10,
 	}
 	first, created, err := store.PrepareSubmitClaim(context.Background(), input)
-	if err != nil || !created || first.Status != "prepared" || first.CanonicalTurnID != "turn-1" || first.TurnID != "" {
+	if err != nil || !created || first.Status != "prepared" || first.CanonicalTurnID != "turn-1" || first.TurnID != "" || first.MetadataJSON != `{"uiMode":"agent"}` {
 		t.Fatalf("first = %#v created=%v err=%v", first, created, err)
 	}
 	input.CanonicalTurnID = "turn-retry-must-be-ignored"
+	input.MetadataJSON = `{"uiMode":"os"}`
 	input.NowUnixMS = 99
 	duplicate, created, err := store.PrepareSubmitClaim(context.Background(), input)
-	if err != nil || created || duplicate.Status != "prepared" || duplicate.CanonicalTurnID != "turn-1" || duplicate.CreatedAtUnixMS != 10 {
+	if err != nil || created || duplicate.Status != "prepared" || duplicate.CanonicalTurnID != "turn-1" || duplicate.MetadataJSON != `{"uiMode":"agent"}` || duplicate.CreatedAtUnixMS != 10 {
 		t.Fatalf("duplicate = %#v created=%v err=%v", duplicate, created, err)
 	}
 	accepted, updated, err := store.AcceptSubmitClaim(context.Background(), "ws-1", "session-1", "submit-1", "turn-1", 20)
@@ -117,15 +119,27 @@ VALUES
 	if err := store.applyWorkspaceAgentSubmitClaimsV2(ctx); err != nil {
 		t.Fatal(err)
 	}
-	accepted, ok, err := store.getSubmitClaim(ctx, "ws-1", "session-1", "accepted-legacy")
-	if err != nil || !ok || accepted.CanonicalTurnID != "turn-accepted" {
-		t.Fatalf("accepted legacy claim=%#v ok=%v err=%v", accepted, ok, err)
+	var acceptedCanonical sql.NullString
+	if err := store.db.QueryRowContext(ctx, `
+SELECT canonical_turn_id FROM workspace_agent_submit_claims
+WHERE workspace_id = 'ws-1' AND agent_session_id = 'session-1'
+  AND client_submit_id = 'accepted-legacy'
+`).Scan(&acceptedCanonical); err != nil || !acceptedCanonical.Valid || acceptedCanonical.String != "turn-accepted" {
+		t.Fatalf("accepted legacy canonical=%#v err=%v", acceptedCanonical, err)
 	}
-	prepared, ok, err := store.getSubmitClaim(ctx, "ws-1", "session-1", "prepared-legacy")
-	if err != nil || !ok || prepared.CanonicalTurnID != "" || prepared.Status != "prepared" {
-		t.Fatalf("prepared legacy claim=%#v ok=%v err=%v", prepared, ok, err)
+	var preparedCanonical sql.NullString
+	var preparedStatus string
+	if err := store.db.QueryRowContext(ctx, `
+SELECT canonical_turn_id, status FROM workspace_agent_submit_claims
+WHERE workspace_id = 'ws-1' AND agent_session_id = 'session-1'
+  AND client_submit_id = 'prepared-legacy'
+`).Scan(&preparedCanonical, &preparedStatus); err != nil || preparedCanonical.Valid || preparedStatus != "prepared" {
+		t.Fatalf("prepared legacy canonical=%#v status=%q err=%v", preparedCanonical, preparedStatus, err)
 	}
 	if err := store.applyWorkspaceAgentSubmitClaimsV3(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.applyWorkspaceAgentSubmitClaimsV4(ctx); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := store.db.ExecContext(ctx, `
@@ -138,6 +152,49 @@ VALUES ('ws-1', 'session-1', 'rejected-v3', 'rejected', 'turn-rejected', 3, 4, '
 	rejected, ok, err := store.getSubmitClaim(ctx, "ws-1", "session-1", "rejected-v3")
 	if err != nil || !ok || rejected.Status != "rejected" || rejected.TurnID != "turn-rejected" {
 		t.Fatalf("rejected v3 claim=%#v ok=%v err=%v", rejected, ok, err)
+	}
+}
+
+func TestSubmitClaimV4RepairsMissingMigrationMarkerWhenColumnAlreadyExists(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := New(openTestDB(t), testOptions(&staticProjectPaths{}))
+	if _, err := store.db.ExecContext(ctx, `
+CREATE TABLE agent_store_schema_migrations (
+  id TEXT PRIMARY KEY,
+  applied_at_unix_ms INTEGER NOT NULL
+);`); err != nil {
+		t.Fatal(err)
+	}
+	for _, migrate := range []func(context.Context) error{
+		store.applyWorkspaceAgentSubmitClaimsV1,
+		store.applyWorkspaceAgentSubmitClaimsV2,
+		store.applyWorkspaceAgentSubmitClaimsV3,
+	} {
+		if err := migrate(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Simulate a process that committed the old non-transactional ALTER but
+	// crashed before recording the migration marker.
+	if _, err := store.db.ExecContext(ctx, `
+ALTER TABLE workspace_agent_submit_claims
+  ADD COLUMN metadata_json TEXT NOT NULL DEFAULT '{}'
+  CHECK (json_valid(metadata_json) AND json_type(metadata_json) = 'object');
+`); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.applyWorkspaceAgentSubmitClaimsV4(ctx); err != nil {
+		t.Fatalf("first V4 repair: %v", err)
+	}
+	if err := store.applyWorkspaceAgentSubmitClaimsV4(ctx); err != nil {
+		t.Fatalf("idempotent V4 rerun: %v", err)
+	}
+	var migrationCount int
+	if err := store.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM agent_store_schema_migrations WHERE id = ?
+`, schemaMigrationWorkspaceAgentSubmitClaimsV4).Scan(&migrationCount); err != nil || migrationCount != 1 {
+		t.Fatalf("V4 migration count=%d err=%v", migrationCount, err)
 	}
 }
 

--- a/packages/agent/store-sqlite/transaction_participant.go
+++ b/packages/agent/store-sqlite/transaction_participant.go
@@ -39,15 +39,17 @@ type TransactionParticipant interface {
 }
 
 type TransactionMutation struct {
-	MutationID         string `json:"mutationId"`
-	WorkspaceID        string `json:"workspaceId"`
-	AgentSessionID     string `json:"agentSessionId"`
-	RootAgentSessionID string `json:"rootAgentSessionId,omitempty"`
-	RootTurnID         string `json:"rootTurnId,omitempty"`
-	EntityKind         string `json:"entityKind"`
-	EntityID           string `json:"entityId"`
-	Operation          string `json:"operation"`
-	Version            int64  `json:"version"`
+	MutationID             string `json:"mutationId"`
+	WorkspaceID            string `json:"workspaceId"`
+	AgentSessionID         string `json:"agentSessionId"`
+	RootAgentSessionID     string `json:"rootAgentSessionId,omitempty"`
+	RootTurnID             string `json:"rootTurnId,omitempty"`
+	EntityKind             string `json:"entityKind"`
+	EntityID               string `json:"entityId"`
+	Operation              string `json:"operation"`
+	Version                int64  `json:"version"`
+	TurnTerminalTransition bool   `json:"turnTerminalTransition,omitempty"`
+	StartupReconciled      bool   `json:"startupReconciled,omitempty"`
 }
 
 type TransactionDelta struct {
@@ -62,6 +64,19 @@ func transactionMutation(workspaceID, agentSessionID, entityKind, entityID, oper
 		EntityKind: strings.TrimSpace(entityKind), EntityID: strings.TrimSpace(entityID),
 		Operation: strings.TrimSpace(operation), Version: version,
 	}
+}
+
+func terminalTurnMutation(
+	workspaceID, agentSessionID, turnID, operation string,
+	version int64,
+	startupReconciled bool,
+) TransactionMutation {
+	mutation := transactionMutation(
+		workspaceID, agentSessionID, MutationEntityTurn, turnID, operation, version,
+	)
+	mutation.TurnTerminalTransition = true
+	mutation.StartupReconciled = startupReconciled
+	return mutation
 }
 
 func interactionMutationEntityID(turnID, requestID string) string {

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -3506,6 +3506,7 @@ export type AgentSubmitDiagnostics = {
   promptLength?: number;
   queued?: boolean;
   source?: string;
+  uiMode?: "os" | "agent";
 };
 
 export type AgentPromptContentBlock = {

--- a/services/tuttid/api/daemon_agent_submit_handlers.go
+++ b/services/tuttid/api/daemon_agent_submit_handlers.go
@@ -54,6 +54,11 @@ func (api DaemonAPI) CreateWorkspaceAgentSession(ctx context.Context, request tu
 	}
 	initialGoalControl := initialGoalControlFromGenerated(request.Body.InitialGoalControl)
 	clientSubmitID := strings.TrimSpace(request.Body.ClientSubmitId)
+	if diagnosticsErr := validateAgentSubmitDiagnostics(request.Body.SubmitDiagnostics); diagnosticsErr != nil {
+		return tuttigenerated.CreateWorkspaceAgentSession400JSONResponse{
+			InvalidRequestErrorJSONResponse: invalidRequestError(diagnosticsErr),
+		}, nil
+	}
 	metadata := agentSubmitMetadata(request.Body.SubmitDiagnostics)
 	isolation := ""
 	if request.Body.Isolation != nil {
@@ -245,6 +250,11 @@ func (api DaemonAPI) SendWorkspaceAgentSessionInput(ctx context.Context, request
 		}, nil
 	}
 	clientSubmitID := strings.TrimSpace(request.Body.ClientSubmitId)
+	if diagnosticsErr := validateAgentSubmitDiagnostics(request.Body.SubmitDiagnostics); diagnosticsErr != nil {
+		return tuttigenerated.SendWorkspaceAgentSessionInput400JSONResponse{
+			InvalidRequestErrorJSONResponse: invalidRequestError(diagnosticsErr),
+		}, nil
+	}
 	metadata := agentSubmitMetadata(request.Body.SubmitDiagnostics)
 	guidance := request.Body.Guidance != nil && *request.Body.Guidance
 	targetTurnID := ""
@@ -397,5 +407,17 @@ func agentSubmitMetadata(diagnostics *tuttigenerated.AgentSubmitDiagnostics) map
 	if diagnostics.Source != nil {
 		metadata["source"] = strings.TrimSpace(*diagnostics.Source)
 	}
+	if diagnostics.UiMode != nil {
+		metadata["uiMode"] = strings.TrimSpace(string(*diagnostics.UiMode))
+	}
 	return metadata
+}
+
+func validateAgentSubmitDiagnostics(diagnostics *tuttigenerated.AgentSubmitDiagnostics) *apierrors.ProtocolError {
+	if diagnostics != nil && diagnostics.UiMode != nil && !diagnostics.UiMode.Valid() {
+		return apierrors.MalformedRequest(
+			apierrors.WithDeveloperMessage("submitDiagnostics.uiMode is invalid"),
+		)
+	}
+	return nil
 }

--- a/services/tuttid/api/daemon_agent_submit_handlers_test.go
+++ b/services/tuttid/api/daemon_agent_submit_handlers_test.go
@@ -16,6 +16,7 @@ func TestAgentSubmitMetadataProjectsAllDiagnosticsFields(t *testing.T) {
 	promptLength := 42
 	queued := false
 	source := "  agent-gui  "
+	uiMode := tuttigenerated.AgentSubmitDiagnosticsUiModeAgent
 
 	got := agentSubmitMetadata(&tuttigenerated.AgentSubmitDiagnostics{
 		SubmittedAtUnixMs: &submittedAtUnixMs,
@@ -24,6 +25,7 @@ func TestAgentSubmitMetadataProjectsAllDiagnosticsFields(t *testing.T) {
 		PromptLength:      &promptLength,
 		Queued:            &queued,
 		Source:            &source,
+		UiMode:            &uiMode,
 	})
 	want := map[string]any{
 		"blockCount":              2,
@@ -32,6 +34,7 @@ func TestAgentSubmitMetadataProjectsAllDiagnosticsFields(t *testing.T) {
 		"promptLength":            42,
 		"queued":                  false,
 		"source":                  "agent-gui",
+		"uiMode":                  "agent",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("agentSubmitMetadata() = %#v, want %#v", got, want)
@@ -83,6 +86,21 @@ func TestApplyEffectiveCreateSessionLaunchPinsReplayInputs(t *testing.T) {
 func TestAgentSubmitMetadataWithoutDiagnosticsIsEmpty(t *testing.T) {
 	if got := agentSubmitMetadata(nil); got != nil {
 		t.Fatalf("agentSubmitMetadata() = %#v, want nil", got)
+	}
+}
+
+func TestValidateAgentSubmitDiagnosticsRejectsUnknownUiMode(t *testing.T) {
+	invalid := tuttigenerated.AgentSubmitDiagnosticsUiMode("unknown")
+	if err := validateAgentSubmitDiagnostics(&tuttigenerated.AgentSubmitDiagnostics{UiMode: &invalid}); err == nil {
+		t.Fatal("unknown uiMode accepted")
+	}
+	for _, mode := range []tuttigenerated.AgentSubmitDiagnosticsUiMode{
+		tuttigenerated.AgentSubmitDiagnosticsUiModeOs,
+		tuttigenerated.AgentSubmitDiagnosticsUiModeAgent,
+	} {
+		if err := validateAgentSubmitDiagnostics(&tuttigenerated.AgentSubmitDiagnostics{UiMode: &mode}); err != nil {
+			t.Fatalf("valid uiMode %q rejected: %v", mode, err)
+		}
 	}
 }
 

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -754,6 +754,24 @@ func (e AgentSlashCommandEffect) Valid() bool {
 	}
 }
 
+// Defines values for AgentSubmitDiagnosticsUiMode.
+const (
+	AgentSubmitDiagnosticsUiModeAgent AgentSubmitDiagnosticsUiMode = "agent"
+	AgentSubmitDiagnosticsUiModeOs    AgentSubmitDiagnosticsUiMode = "os"
+)
+
+// Valid indicates whether the value is a known member of the AgentSubmitDiagnosticsUiMode enum.
+func (e AgentSubmitDiagnosticsUiMode) Valid() bool {
+	switch e {
+	case AgentSubmitDiagnosticsUiModeAgent:
+		return true
+	case AgentSubmitDiagnosticsUiModeOs:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for AgentTargetBuiltinLocalLaunchRefType.
 const (
 	AgentTargetBuiltinLocalLaunchRefTypeBuiltinLocal AgentTargetBuiltinLocalLaunchRefType = "builtin_local"
@@ -3834,16 +3852,16 @@ func (e WorkspaceAgentSessionWorktreeSupportErrorCode) Valid() bool {
 
 // Defines values for WorkspaceAgentSource.
 const (
-	LegacyBinding WorkspaceAgentSource = "legacy_binding"
-	User          WorkspaceAgentSource = "user"
+	WorkspaceAgentSourceLegacyBinding WorkspaceAgentSource = "legacy_binding"
+	WorkspaceAgentSourceUser          WorkspaceAgentSource = "user"
 )
 
 // Valid indicates whether the value is a known member of the WorkspaceAgentSource enum.
 func (e WorkspaceAgentSource) Valid() bool {
 	switch e {
-	case LegacyBinding:
+	case WorkspaceAgentSourceLegacyBinding:
 		return true
-	case User:
+	case WorkspaceAgentSourceUser:
 		return true
 	default:
 		return false
@@ -5622,13 +5640,17 @@ type AgentSlashCommandPolicy struct {
 
 // AgentSubmitDiagnostics defines model for AgentSubmitDiagnostics.
 type AgentSubmitDiagnostics struct {
-	BlockCount        *int    `json:"blockCount,omitempty"`
-	HasImage          *bool   `json:"hasImage,omitempty"`
-	PromptLength      *int    `json:"promptLength,omitempty"`
-	Queued            *bool   `json:"queued,omitempty"`
-	Source            *string `json:"source,omitempty"`
-	SubmittedAtUnixMs *int64  `json:"submittedAtUnixMs,omitempty"`
+	BlockCount        *int                          `json:"blockCount,omitempty"`
+	HasImage          *bool                         `json:"hasImage,omitempty"`
+	PromptLength      *int                          `json:"promptLength,omitempty"`
+	Queued            *bool                         `json:"queued,omitempty"`
+	Source            *string                       `json:"source,omitempty"`
+	SubmittedAtUnixMs *int64                        `json:"submittedAtUnixMs,omitempty"`
+	UiMode            *AgentSubmitDiagnosticsUiMode `json:"uiMode,omitempty"`
 }
+
+// AgentSubmitDiagnosticsUiMode defines model for AgentSubmitDiagnostics.UiMode.
+type AgentSubmitDiagnosticsUiMode string
 
 // AgentTarget defines model for AgentTarget.
 type AgentTarget struct {

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -15168,6 +15168,11 @@ components:
           type: boolean
         source:
           type: string
+        uiMode:
+          type: string
+          enum:
+            - os
+            - agent
     AgentPromptContentBlock:
       type: object
       additionalProperties: false

--- a/services/tuttid/biz/agentturnanalytics/ledger.go
+++ b/services/tuttid/biz/agentturnanalytics/ledger.go
@@ -1,0 +1,37 @@
+package agentturnanalytics
+
+import (
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// terminalEventNamespace keeps a canonical Turn's analytics event identity
+// stable across observer replays, daemon restarts, and outbox lease recovery.
+var terminalEventNamespace = uuid.MustParse("7d9d3297-f7ca-5b83-a8f4-44c579b86f13")
+
+type Settlement struct {
+	WorkspaceID       string
+	AgentSessionID    string
+	TurnID            string
+	EventID           string
+	Provider          string
+	Origin            string
+	Outcome           string
+	ErrorCode         string
+	StartupReconciled bool
+	StartedAtUnixMS   int64
+	SettledAtUnixMS   int64
+}
+
+type Delivery struct {
+	Settlement
+	ClientSubmitID string
+	MetadataJSON   string
+}
+
+func StableEventID(workspaceID, agentSessionID, turnID string) string {
+	identity := strings.TrimSpace(workspaceID) + "\x00" +
+		strings.TrimSpace(agentSessionID) + "\x00" + strings.TrimSpace(turnID)
+	return uuid.NewSHA1(terminalEventNamespace, []byte(identity)).String()
+}

--- a/services/tuttid/biz/agentturnanalytics/ledger_test.go
+++ b/services/tuttid/biz/agentturnanalytics/ledger_test.go
@@ -1,0 +1,13 @@
+package agentturnanalytics
+
+import "testing"
+
+func TestStableEventIDIsTurnScopedAndDeterministic(t *testing.T) {
+	first := StableEventID("workspace-1", "session-1", "turn-1")
+	if first == "" || first != StableEventID("workspace-1", "session-1", "turn-1") {
+		t.Fatalf("stable event id = %q", first)
+	}
+	if first == StableEventID("workspace-1", "session-1", "turn-2") {
+		t.Fatal("different Turns received the same event id")
+	}
+}

--- a/services/tuttid/data/workspace/agent_store.go
+++ b/services/tuttid/data/workspace/agent_store.go
@@ -39,7 +39,10 @@ func newAgentStore(db *sql.DB) *agentactivitybiz.Store {
 			legacyIDLocalClaudeCode: agenttargetbiz.IDLocalClaudeCode,
 		},
 		TargetIDBackfillByProvider: defaultTargetIDBackfillByProvider(),
-		TransactionParticipant:     tuttiModeSourceActivityParticipant{},
+		TransactionParticipant: agentTransactionParticipants{
+			tuttiModeSourceActivityParticipant{},
+			agentTurnTerminalAnalyticsParticipant{},
+		},
 	})
 }
 

--- a/services/tuttid/data/workspace/agent_store.go
+++ b/services/tuttid/data/workspace/agent_store.go
@@ -368,6 +368,10 @@ func (s *SQLiteStore) GetTurn(ctx context.Context, workspaceID string, agentSess
 	return s.agentReadStore().GetTurn(ctx, workspaceID, agentSessionID, turnID)
 }
 
+func (s *SQLiteStore) GetTurnSubmission(ctx context.Context, workspaceID string, agentSessionID string, turnID string) (agentactivitybiz.TurnSubmission, bool, error) {
+	return s.agentReadStore().GetTurnSubmission(ctx, workspaceID, agentSessionID, turnID)
+}
+
 func (s *SQLiteStore) GetLatestTurn(ctx context.Context, workspaceID string, agentSessionID string) (agentactivitybiz.Turn, bool, error) {
 	return s.agentReadStore().GetLatestTurn(ctx, workspaceID, agentSessionID)
 }

--- a/services/tuttid/data/workspace/migrations.go
+++ b/services/tuttid/data/workspace/migrations.go
@@ -96,6 +96,7 @@ const schemaMigrationAgentSessionReplayV2 = "agent_session_replay_v2"
 const schemaMigrationAgentProviderRuntimeSelectionsV1 = "agent_provider_runtime_selections_v1"
 const schemaMigrationAgentSessionReplayV3 = "agent_session_replay_v3"
 const schemaMigrationAgentSessionReplayV4 = "agent_session_replay_v4"
+const schemaMigrationAgentTurnTerminalAnalyticsV1 = "agent_turn_terminal_analytics_v1"
 
 func (s *SQLiteStore) Migrate(ctx context.Context) error {
 	if s == nil || s.writeDB == nil {
@@ -210,6 +211,9 @@ INSERT OR IGNORE INTO tuttid_schema_migrations (id, applied_at_unix_ms)
 	// store. They must run after user_projects_v1: the rail section backfill
 	// reads project paths through userProjectPathsQuerier.
 	if err := s.agentStore().Migrate(ctx); err != nil {
+		return err
+	}
+	if err := s.applyAgentTurnTerminalAnalyticsV1(ctx); err != nil {
 		return err
 	}
 	if err := s.applyAgentDataMaintenanceV3(ctx); err != nil {

--- a/services/tuttid/data/workspace/migrations_agent_turn_terminal_analytics.go
+++ b/services/tuttid/data/workspace/migrations_agent_turn_terminal_analytics.go
@@ -1,0 +1,61 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+func (s *SQLiteStore) applyAgentTurnTerminalAnalyticsV1(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationAgentTurnTerminalAnalyticsV1)
+	if err != nil || applied {
+		return err
+	}
+	tx, err := s.writeDB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin Agent Turn terminal analytics v1 migration: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err = tx.ExecContext(ctx, `
+CREATE TABLE IF NOT EXISTS agent_turn_terminal_analytics (
+  workspace_id TEXT NOT NULL,
+  agent_session_id TEXT NOT NULL,
+  turn_id TEXT NOT NULL,
+  event_id TEXT NOT NULL UNIQUE,
+  provider TEXT NOT NULL DEFAULT '',
+  turn_origin TEXT NOT NULL,
+  turn_outcome TEXT NOT NULL,
+  error_code TEXT NOT NULL DEFAULT '',
+  startup_reconciled INTEGER NOT NULL DEFAULT 0 CHECK (startup_reconciled IN (0, 1)),
+  started_at_unix_ms INTEGER NOT NULL DEFAULT 0,
+  settled_at_unix_ms INTEGER NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'leased', 'delivered', 'ignored')),
+  lease_owner TEXT NOT NULL DEFAULT '',
+  lease_expires_at_unix_ms INTEGER NOT NULL DEFAULT 0,
+  ignored_reason TEXT NOT NULL DEFAULT '',
+  created_at_unix_ms INTEGER NOT NULL,
+  updated_at_unix_ms INTEGER NOT NULL,
+  delivered_at_unix_ms INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (workspace_id, agent_session_id, turn_id),
+  FOREIGN KEY (workspace_id, agent_session_id, turn_id)
+    REFERENCES workspace_agent_turns(workspace_id, agent_session_id, turn_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_turn_terminal_analytics_delivery
+  ON agent_turn_terminal_analytics(status, lease_expires_at_unix_ms, created_at_unix_ms);
+`); err != nil {
+		return fmt.Errorf("migrate Agent Turn terminal analytics v1: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
+VALUES (?, ?)
+`, schemaMigrationAgentTurnTerminalAnalyticsV1, unixMs(time.Now().UTC())); err != nil {
+		return fmt.Errorf("record Agent Turn terminal analytics v1 migration: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit Agent Turn terminal analytics v1 migration: %w", err)
+	}
+	return nil
+}

--- a/services/tuttid/data/workspace/sqlite_agent_transaction_participants.go
+++ b/services/tuttid/data/workspace/sqlite_agent_transaction_participants.go
@@ -1,0 +1,83 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	agentstore "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+	agentturnanalyticsbiz "github.com/tutti-os/tutti/services/tuttid/biz/agentturnanalytics"
+)
+
+type agentTransactionParticipants []agentstore.TransactionParticipant
+
+func (participants agentTransactionParticipants) Participate(
+	ctx context.Context,
+	writer agentstore.TransactionWriter,
+	delta agentstore.TransactionDelta,
+) error {
+	for _, participant := range participants {
+		if participant == nil {
+			continue
+		}
+		if err := participant.Participate(ctx, writer, delta); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// agentTurnTerminalAnalyticsParticipant joins the product-owned delivery
+// ledger to the canonical settlement transaction. CommitObserver is only a
+// wake hint; a crash before observer fanout cannot erase this marker.
+type agentTurnTerminalAnalyticsParticipant struct{}
+
+func (agentTurnTerminalAnalyticsParticipant) Participate(
+	ctx context.Context,
+	writer agentstore.TransactionWriter,
+	delta agentstore.TransactionDelta,
+) error {
+	for _, mutation := range delta.Mutations {
+		if strings.TrimSpace(mutation.EntityKind) != agentstore.MutationEntityTurn ||
+			!mutation.TurnTerminalTransition {
+			continue
+		}
+		workspaceID := strings.TrimSpace(mutation.WorkspaceID)
+		agentSessionID := strings.TrimSpace(mutation.AgentSessionID)
+		turnID := strings.TrimSpace(mutation.EntityID)
+		if workspaceID == "" || agentSessionID == "" || turnID == "" {
+			continue
+		}
+		eventID := agentturnanalyticsbiz.StableEventID(workspaceID, agentSessionID, turnID)
+		startupReconciled := mutation.StartupReconciled
+		if _, err := writer.ExecContext(ctx, `
+INSERT INTO agent_turn_terminal_analytics (
+  workspace_id, agent_session_id, turn_id, event_id, provider,
+  turn_origin, turn_outcome, error_code, startup_reconciled,
+  started_at_unix_ms, settled_at_unix_ms, status,
+  created_at_unix_ms, updated_at_unix_ms
+)
+SELECT turn.workspace_id, turn.agent_session_id, turn.turn_id, ?,
+       COALESCE(session.provider, ''), turn.turn_origin, turn.outcome,
+       COALESCE(json_extract(turn.error_json, '$.code'), ''), ?,
+       turn.started_at_unix_ms, turn.settled_at_unix_ms, 'pending',
+       turn.updated_at_unix_ms, turn.updated_at_unix_ms
+FROM workspace_agent_turns AS turn
+JOIN workspace_agent_sessions AS session
+  ON session.workspace_id = turn.workspace_id
+ AND session.agent_session_id = turn.agent_session_id
+WHERE turn.workspace_id = ?
+  AND turn.agent_session_id = ?
+  AND turn.turn_id = ?
+  AND turn.phase = 'settled'
+  AND turn.outcome IN ('completed', 'failed', 'canceled', 'interrupted')
+  AND turn.backfilled = 0
+  AND turn.turn_origin = 'user_prompt'
+  AND session.session_kind = 'root'
+ON CONFLICT(workspace_id, agent_session_id, turn_id) DO NOTHING
+`, eventID, boolInt(startupReconciled), workspaceID, agentSessionID, turnID); err != nil {
+			return fmt.Errorf("append Agent Turn terminal analytics marker: %w", err)
+		}
+	}
+	return nil
+}

--- a/services/tuttid/data/workspace/sqlite_agent_turn_terminal_analytics.go
+++ b/services/tuttid/data/workspace/sqlite_agent_turn_terminal_analytics.go
@@ -1,0 +1,358 @@
+package workspace
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	agentturnanalyticsbiz "github.com/tutti-os/tutti/services/tuttid/biz/agentturnanalytics"
+)
+
+const terminalAnalyticsClaimScanLimit = 64
+
+func (s *SQLiteStore) PutAgentTurnTerminalAnalytics(
+	ctx context.Context,
+	input agentturnanalyticsbiz.Settlement,
+	nowUnixMS int64,
+) (bool, error) {
+	if s == nil || s.writeDB == nil {
+		return false, errors.New("workspace database is not initialized")
+	}
+	input = normalizeTerminalAnalyticsSettlement(input)
+	if err := validateTerminalAnalyticsSettlement(input, nowUnixMS); err != nil {
+		return false, err
+	}
+	result, err := s.writeDB.ExecContext(ctx, `
+INSERT INTO agent_turn_terminal_analytics (
+  workspace_id, agent_session_id, turn_id, event_id, provider,
+  turn_origin, turn_outcome, error_code, startup_reconciled,
+  started_at_unix_ms, settled_at_unix_ms, status,
+  created_at_unix_ms, updated_at_unix_ms
+)
+SELECT turn.workspace_id, turn.agent_session_id, turn.turn_id, ?,
+       COALESCE(session.provider, ''), turn.turn_origin, turn.outcome,
+       COALESCE(json_extract(turn.error_json, '$.code'), ''), ?,
+       turn.started_at_unix_ms, turn.settled_at_unix_ms, 'pending', ?, ?
+FROM workspace_agent_turns AS turn
+JOIN workspace_agent_sessions AS session
+  ON session.workspace_id = turn.workspace_id
+ AND session.agent_session_id = turn.agent_session_id
+WHERE turn.workspace_id = ?
+  AND turn.agent_session_id = ?
+  AND turn.turn_id = ?
+  AND turn.phase = 'settled'
+  AND turn.outcome IN ('completed', 'failed', 'canceled', 'interrupted')
+  AND turn.backfilled = 0
+  AND turn.turn_origin = 'user_prompt'
+  AND session.session_kind = 'root'
+ON CONFLICT(workspace_id, agent_session_id, turn_id) DO NOTHING
+`, input.EventID, boolInt(input.StartupReconciled), nowUnixMS, nowUnixMS,
+		input.WorkspaceID, input.AgentSessionID, input.TurnID)
+	if err != nil {
+		return false, fmt.Errorf("put Agent Turn terminal analytics: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("put Agent Turn terminal analytics rows affected: %w", err)
+	}
+	return rows == 1, nil
+}
+
+func (s *SQLiteStore) ClaimAgentTurnTerminalAnalytics(
+	ctx context.Context,
+	owner string,
+	nowUnixMS int64,
+	leaseExpiresAtUnixMS int64,
+) (agentturnanalyticsbiz.Delivery, bool, error) {
+	if s == nil || s.writeDB == nil {
+		return agentturnanalyticsbiz.Delivery{}, false, errors.New("workspace database is not initialized")
+	}
+	owner = strings.TrimSpace(owner)
+	if owner == "" || nowUnixMS <= 0 || leaseExpiresAtUnixMS <= nowUnixMS {
+		return agentturnanalyticsbiz.Delivery{}, false, errors.New("invalid Agent Turn terminal analytics lease")
+	}
+	tx, err := s.writeDB.BeginTx(ctx, nil)
+	if err != nil {
+		return agentturnanalyticsbiz.Delivery{}, false, fmt.Errorf("begin claim Agent Turn terminal analytics: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	rows, err := tx.QueryContext(ctx, `
+SELECT ledger.workspace_id, ledger.agent_session_id, ledger.turn_id,
+       ledger.event_id, ledger.provider, ledger.turn_origin,
+       ledger.turn_outcome, ledger.error_code, ledger.startup_reconciled,
+       ledger.started_at_unix_ms, ledger.settled_at_unix_ms,
+       (
+         SELECT submission.metadata_json
+         FROM workspace_agent_turn_submissions AS submission
+         WHERE submission.workspace_id = ledger.workspace_id
+           AND submission.agent_session_id = ledger.agent_session_id
+           AND submission.turn_id = ledger.turn_id
+         LIMIT 1
+       ),
+       (
+         SELECT submission.client_submit_id
+         FROM workspace_agent_turn_submissions AS submission
+         WHERE submission.workspace_id = ledger.workspace_id
+           AND submission.agent_session_id = ledger.agent_session_id
+           AND submission.turn_id = ledger.turn_id
+         LIMIT 1
+       ),
+       (
+         SELECT claim.metadata_json
+         FROM workspace_agent_submit_claims AS claim
+         WHERE claim.workspace_id = ledger.workspace_id
+           AND claim.agent_session_id = ledger.agent_session_id
+           AND claim.canonical_turn_id = ledger.turn_id
+         ORDER BY claim.created_at_unix_ms, claim.client_submit_id
+         LIMIT 1
+       ),
+       (
+         SELECT claim.client_submit_id
+         FROM workspace_agent_submit_claims AS claim
+         WHERE claim.workspace_id = ledger.workspace_id
+           AND claim.agent_session_id = ledger.agent_session_id
+           AND claim.canonical_turn_id = ledger.turn_id
+         ORDER BY claim.created_at_unix_ms, claim.client_submit_id
+         LIMIT 1
+       ),
+       (
+         SELECT COUNT(*)
+         FROM workspace_agent_submit_claims AS claim
+         WHERE claim.workspace_id = ledger.workspace_id
+           AND claim.agent_session_id = ledger.agent_session_id
+           AND claim.canonical_turn_id = ledger.turn_id
+       )
+FROM agent_turn_terminal_analytics AS ledger
+WHERE (
+    ledger.status = 'pending'
+    OR (ledger.status = 'leased' AND ledger.lease_expires_at_unix_ms <= ?)
+  )
+  AND (
+    EXISTS (
+      SELECT 1
+      FROM workspace_agent_turn_submissions AS submission
+      WHERE submission.workspace_id = ledger.workspace_id
+        AND submission.agent_session_id = ledger.agent_session_id
+        AND submission.turn_id = ledger.turn_id
+    )
+    OR (
+      (
+        SELECT COUNT(*)
+        FROM workspace_agent_submit_claims AS claim
+        WHERE claim.workspace_id = ledger.workspace_id
+          AND claim.agent_session_id = ledger.agent_session_id
+          AND claim.canonical_turn_id = ledger.turn_id
+      ) = 1
+      AND EXISTS (
+        SELECT 1
+        FROM workspace_agent_submit_claims AS claim
+        WHERE claim.workspace_id = ledger.workspace_id
+          AND claim.agent_session_id = ledger.agent_session_id
+          AND claim.canonical_turn_id = ledger.turn_id
+          AND json_extract(claim.metadata_json, '$.uiMode') IN ('os', 'agent')
+      )
+    )
+  )
+ORDER BY ledger.created_at_unix_ms, ledger.workspace_id,
+         ledger.agent_session_id, ledger.turn_id
+LIMIT ?
+`, nowUnixMS, terminalAnalyticsClaimScanLimit)
+	if err != nil {
+		return agentturnanalyticsbiz.Delivery{}, false, fmt.Errorf("list claimable Agent Turn terminal analytics: %w", err)
+	}
+	type candidate struct {
+		delivery                 agentturnanalyticsbiz.Delivery
+		submissionMetadata       sql.NullString
+		submissionClientSubmitID sql.NullString
+		claimMetadata            sql.NullString
+		claimClientSubmitID      sql.NullString
+		claimCount               int64
+	}
+	candidates := make([]candidate, 0, terminalAnalyticsClaimScanLimit)
+	for rows.Next() {
+		var item candidate
+		var startupReconciled int
+		if err := rows.Scan(
+			&item.delivery.WorkspaceID,
+			&item.delivery.AgentSessionID,
+			&item.delivery.TurnID,
+			&item.delivery.EventID,
+			&item.delivery.Provider,
+			&item.delivery.Origin,
+			&item.delivery.Outcome,
+			&item.delivery.ErrorCode,
+			&startupReconciled,
+			&item.delivery.StartedAtUnixMS,
+			&item.delivery.SettledAtUnixMS,
+			&item.submissionMetadata,
+			&item.submissionClientSubmitID,
+			&item.claimMetadata,
+			&item.claimClientSubmitID,
+			&item.claimCount,
+		); err != nil {
+			rows.Close()
+			return agentturnanalyticsbiz.Delivery{}, false, fmt.Errorf("scan claimable Agent Turn terminal analytics: %w", err)
+		}
+		item.delivery.StartupReconciled = startupReconciled != 0
+		candidates = append(candidates, item)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return agentturnanalyticsbiz.Delivery{}, false, fmt.Errorf("iterate claimable Agent Turn terminal analytics: %w", err)
+	}
+	rows.Close()
+
+	for _, item := range candidates {
+		delivery := item.delivery
+		switch {
+		case item.submissionMetadata.Valid:
+			delivery.MetadataJSON = item.submissionMetadata.String
+			delivery.ClientSubmitID = item.submissionClientSubmitID.String
+		case item.claimCount == 1 && item.claimMetadata.Valid:
+			delivery.MetadataJSON = item.claimMetadata.String
+			delivery.ClientSubmitID = item.claimClientSubmitID.String
+		default:
+			continue
+		}
+		result, err := tx.ExecContext(ctx, `
+UPDATE agent_turn_terminal_analytics
+SET status = 'leased', lease_owner = ?, lease_expires_at_unix_ms = ?,
+    updated_at_unix_ms = ?
+WHERE workspace_id = ? AND agent_session_id = ? AND turn_id = ?
+  AND (status = 'pending' OR (status = 'leased' AND lease_expires_at_unix_ms <= ?))
+`, owner, leaseExpiresAtUnixMS, nowUnixMS, delivery.WorkspaceID,
+			delivery.AgentSessionID, delivery.TurnID, nowUnixMS)
+		if err != nil {
+			return agentturnanalyticsbiz.Delivery{}, false, fmt.Errorf("claim Agent Turn terminal analytics: %w", err)
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return agentturnanalyticsbiz.Delivery{}, false, fmt.Errorf("claim Agent Turn terminal analytics rows affected: %w", err)
+		}
+		if affected != 1 {
+			continue
+		}
+		if err := tx.Commit(); err != nil {
+			return agentturnanalyticsbiz.Delivery{}, false, fmt.Errorf("commit claim Agent Turn terminal analytics: %w", err)
+		}
+		return delivery, true, nil
+	}
+	if err := tx.Commit(); err != nil {
+		return agentturnanalyticsbiz.Delivery{}, false, fmt.Errorf("commit empty Agent Turn terminal analytics claim: %w", err)
+	}
+	return agentturnanalyticsbiz.Delivery{}, false, nil
+}
+
+func (s *SQLiteStore) RequeueAgentTurnTerminalAnalytics(
+	ctx context.Context,
+	nowUnixMS int64,
+) (int64, error) {
+	if s == nil || s.writeDB == nil {
+		return 0, errors.New("workspace database is not initialized")
+	}
+	if nowUnixMS <= 0 {
+		return 0, errors.New("invalid Agent Turn terminal analytics recovery time")
+	}
+	result, err := s.writeDB.ExecContext(ctx, `
+UPDATE agent_turn_terminal_analytics
+SET status = 'pending', lease_owner = '', lease_expires_at_unix_ms = 0,
+    updated_at_unix_ms = ?
+WHERE status = 'leased'
+`, nowUnixMS)
+	if err != nil {
+		return 0, fmt.Errorf("requeue Agent Turn terminal analytics: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("requeue Agent Turn terminal analytics rows affected: %w", err)
+	}
+	return rows, nil
+}
+
+func (s *SQLiteStore) CompleteAgentTurnTerminalAnalytics(
+	ctx context.Context,
+	workspaceID, agentSessionID, turnID, owner string,
+	nowUnixMS int64,
+) (bool, error) {
+	return s.finishAgentTurnTerminalAnalytics(
+		ctx, workspaceID, agentSessionID, turnID, owner, "delivered", "", nowUnixMS,
+	)
+}
+
+func (s *SQLiteStore) IgnoreAgentTurnTerminalAnalytics(
+	ctx context.Context,
+	workspaceID, agentSessionID, turnID, owner, reason string,
+	nowUnixMS int64,
+) (bool, error) {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "invalid_event"
+	}
+	return s.finishAgentTurnTerminalAnalytics(
+		ctx, workspaceID, agentSessionID, turnID, owner, "ignored", reason, nowUnixMS,
+	)
+}
+
+func (s *SQLiteStore) finishAgentTurnTerminalAnalytics(
+	ctx context.Context,
+	workspaceID, agentSessionID, turnID, owner, status, ignoredReason string,
+	nowUnixMS int64,
+) (bool, error) {
+	if s == nil || s.writeDB == nil {
+		return false, errors.New("workspace database is not initialized")
+	}
+	workspaceID = strings.TrimSpace(workspaceID)
+	agentSessionID = strings.TrimSpace(agentSessionID)
+	turnID = strings.TrimSpace(turnID)
+	owner = strings.TrimSpace(owner)
+	if workspaceID == "" || agentSessionID == "" || turnID == "" || owner == "" || nowUnixMS <= 0 {
+		return false, errors.New("invalid Agent Turn terminal analytics completion")
+	}
+	deliveredAtUnixMS := int64(0)
+	if status == "delivered" {
+		deliveredAtUnixMS = nowUnixMS
+	}
+	result, err := s.writeDB.ExecContext(ctx, `
+UPDATE agent_turn_terminal_analytics
+SET status = ?, ignored_reason = ?, lease_owner = '',
+    lease_expires_at_unix_ms = 0, delivered_at_unix_ms = ?,
+    updated_at_unix_ms = ?
+WHERE workspace_id = ? AND agent_session_id = ? AND turn_id = ?
+  AND status = 'leased' AND lease_owner = ?
+`, status, ignoredReason, deliveredAtUnixMS, nowUnixMS,
+		workspaceID, agentSessionID, turnID, owner)
+	if err != nil {
+		return false, fmt.Errorf("finish Agent Turn terminal analytics: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("finish Agent Turn terminal analytics rows affected: %w", err)
+	}
+	return rows == 1, nil
+}
+
+func normalizeTerminalAnalyticsSettlement(input agentturnanalyticsbiz.Settlement) agentturnanalyticsbiz.Settlement {
+	input.WorkspaceID = strings.TrimSpace(input.WorkspaceID)
+	input.AgentSessionID = strings.TrimSpace(input.AgentSessionID)
+	input.TurnID = strings.TrimSpace(input.TurnID)
+	input.EventID = strings.TrimSpace(input.EventID)
+	input.Provider = strings.TrimSpace(input.Provider)
+	input.Origin = strings.TrimSpace(input.Origin)
+	input.Outcome = strings.TrimSpace(input.Outcome)
+	input.ErrorCode = strings.TrimSpace(input.ErrorCode)
+	if input.WorkspaceID != "" && input.AgentSessionID != "" && input.TurnID != "" {
+		input.EventID = agentturnanalyticsbiz.StableEventID(input.WorkspaceID, input.AgentSessionID, input.TurnID)
+	}
+	return input
+}
+
+func validateTerminalAnalyticsSettlement(input agentturnanalyticsbiz.Settlement, nowUnixMS int64) error {
+	if input.WorkspaceID == "" || input.AgentSessionID == "" || input.TurnID == "" ||
+		input.EventID == "" || nowUnixMS <= 0 {
+		return errors.New("invalid Agent Turn terminal analytics settlement")
+	}
+	return nil
+}

--- a/services/tuttid/data/workspace/sqlite_agent_turn_terminal_analytics_test.go
+++ b/services/tuttid/data/workspace/sqlite_agent_turn_terminal_analytics_test.go
@@ -1,0 +1,436 @@
+package workspace
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	agentactivitybiz "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+	agentturnanalyticsbiz "github.com/tutti-os/tutti/services/tuttid/biz/agentturnanalytics"
+	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
+)
+
+func TestTerminalAnalyticsMarkerIsAtomicWithCanonicalSettlement(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openTestSQLiteStore(t)
+	seedTerminalAnalyticsWorkspace(t, store, "ws-atomic")
+	seedTerminalAnalyticsSession(t, store, "ws-atomic", "root", agentactivitybiz.SessionKindRoot, "", "")
+	seedTerminalAnalyticsTurn(t, store, "ws-atomic", "root", "turn-1", agentactivitybiz.TurnOriginUserPrompt, 100)
+
+	if _, err := store.writeDB.ExecContext(ctx, `DROP TABLE agent_turn_terminal_analytics`); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.AgentCanonicalStore().RecordTurnTransition(ctx, agentactivitybiz.TurnTransition{
+		WorkspaceID: "ws-atomic", AgentSessionID: "root", TurnID: "turn-1",
+		Phase: agentactivitybiz.TurnPhaseSettled, Outcome: agentactivitybiz.TurnOutcomeCompleted,
+		OccurredAtUnixMS: 200, SettledAtUnixMS: 200,
+	}); err == nil {
+		t.Fatal("terminal transition succeeded without its durable analytics participant table")
+	}
+	turn, found, err := store.GetTurn(ctx, "ws-atomic", "root", "turn-1")
+	if err != nil || !found || turn.Phase != agentactivitybiz.TurnPhaseSubmitted {
+		t.Fatalf("canonical turn after participant rollback=%#v found=%v err=%v", turn, found, err)
+	}
+}
+
+func TestTerminalAnalyticsPutCannotBypassCanonicalChildEligibility(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openTestSQLiteStore(t)
+	seedTerminalAnalyticsWorkspace(t, store, "ws-put-child")
+	seedTerminalAnalyticsSession(t, store, "ws-put-child", "root", agentactivitybiz.SessionKindRoot, "", "")
+	seedTerminalAnalyticsTurn(t, store, "ws-put-child", "root", "root-turn", agentactivitybiz.TurnOriginUserPrompt, 100)
+	seedTerminalAnalyticsSession(t, store, "ws-put-child", "child", agentactivitybiz.SessionKindChild, "root", "root-turn")
+	seedTerminalAnalyticsTurn(t, store, "ws-put-child", "child", "child-turn", agentactivitybiz.TurnOriginUserPrompt, 110)
+	settleTerminalAnalyticsTurn(t, store, "ws-put-child", "child", "child-turn", 120)
+	assertTerminalAnalyticsRows(t, store, "ws-put-child", "child", 0)
+
+	inserted, err := store.PutAgentTurnTerminalAnalytics(ctx, agentturnanalyticsbiz.Settlement{
+		WorkspaceID: "ws-put-child", AgentSessionID: "child", TurnID: "child-turn",
+		// Simulate a sparse observer that misclassified the child as a root and
+		// supplied otherwise eligible fields. Put must re-check canonical rows.
+		Origin: agentactivitybiz.TurnOriginUserPrompt, Outcome: agentactivitybiz.TurnOutcomeCompleted,
+		SettledAtUnixMS: 120,
+	}, 130)
+	if err != nil || inserted {
+		t.Fatalf("misclassified child Put inserted=%v err=%v", inserted, err)
+	}
+	assertTerminalAnalyticsRows(t, store, "ws-put-child", "child", 0)
+}
+
+func TestTerminalAnalyticsClaimUsesRejectedClaimAndRecoversLease(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openTestSQLiteStore(t)
+	seedTerminalAnalyticsWorkspace(t, store, "ws-rejected")
+	seedTerminalAnalyticsSession(t, store, "ws-rejected", "root", agentactivitybiz.SessionKindRoot, "", "")
+	seedTerminalAnalyticsTurn(t, store, "ws-rejected", "root", "turn-1", agentactivitybiz.TurnOriginUserPrompt, 100)
+	prepareTerminalAnalyticsClaim(t, store, "ws-rejected", "root", "turn-1", "submit-rejected", `{"uiMode":"agent"}`, 110)
+	if _, changed, err := store.RejectSubmitClaim(ctx, "ws-rejected", "root", "submit-rejected", "turn-1", 120); err != nil || !changed {
+		t.Fatalf("RejectSubmitClaim() changed=%v err=%v", changed, err)
+	}
+	settleTerminalAnalyticsTurn(t, store, "ws-rejected", "root", "turn-1", 200)
+
+	first, found, err := store.ClaimAgentTurnTerminalAnalytics(ctx, "owner-1", 300, 400)
+	if err != nil || !found || first.ClientSubmitID != "submit-rejected" || first.MetadataJSON != `{"uiMode":"agent"}` {
+		t.Fatalf("first claim=%#v found=%v err=%v", first, found, err)
+	}
+	if first.EventID != agentturnanalyticsbiz.StableEventID("ws-rejected", "root", "turn-1") {
+		t.Fatalf("event id=%q", first.EventID)
+	}
+	if _, found, err := store.ClaimAgentTurnTerminalAnalytics(ctx, "owner-2", 350, 450); err != nil || found {
+		t.Fatalf("live lease second claim found=%v err=%v", found, err)
+	}
+	if requeued, err := store.RequeueAgentTurnTerminalAnalytics(ctx, 360); err != nil || requeued != 1 {
+		t.Fatalf("RequeueAgentTurnTerminalAnalytics()=%d err=%v", requeued, err)
+	}
+	second, found, err := store.ClaimAgentTurnTerminalAnalytics(ctx, "owner-2", 370, 470)
+	if err != nil || !found || second.EventID != first.EventID {
+		t.Fatalf("recovered claim=%#v found=%v err=%v", second, found, err)
+	}
+	if finished, err := store.CompleteAgentTurnTerminalAnalytics(ctx, "ws-rejected", "root", "turn-1", "owner-1", 380); err != nil || finished {
+		t.Fatalf("stale owner completion finished=%v err=%v", finished, err)
+	}
+	if finished, err := store.CompleteAgentTurnTerminalAnalytics(ctx, "ws-rejected", "root", "turn-1", "owner-2", 390); err != nil || !finished {
+		t.Fatalf("current owner completion finished=%v err=%v", finished, err)
+	}
+}
+
+func TestTerminalAnalyticsClaimDoesNotGuessAmbiguousOrIncompleteProvenance(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openTestSQLiteStore(t)
+	seedTerminalAnalyticsWorkspace(t, store, "ws-provenance")
+	seedTerminalAnalyticsSession(t, store, "ws-provenance", "root", agentactivitybiz.SessionKindRoot, "", "")
+
+	// Two claims can legitimately target one canonical turn (initial submit and
+	// guidance). Claim provenance must fail closed until the lossless envelope
+	// arrives instead of silently selecting one.
+	seedTerminalAnalyticsTurn(t, store, "ws-provenance", "root", "ambiguous", agentactivitybiz.TurnOriginUserPrompt, 100)
+	prepareTerminalAnalyticsClaim(t, store, "ws-provenance", "root", "ambiguous", "submit-a", `{"uiMode":"agent"}`, 101)
+	prepareTerminalAnalyticsClaim(t, store, "ws-provenance", "root", "ambiguous", "submit-b", `{"uiMode":"os"}`, 102)
+	settleTerminalAnalyticsTurn(t, store, "ws-provenance", "root", "ambiguous", 110)
+
+	// A claim without validated uiMode is also not definitive. A later full
+	// submission may contain valid provenance and must still be deliverable.
+	seedTerminalAnalyticsTurn(t, store, "ws-provenance", "root", "incomplete", agentactivitybiz.TurnOriginUserPrompt, 120)
+	prepareTerminalAnalyticsClaim(t, store, "ws-provenance", "root", "incomplete", "submit-empty", `{}`, 121)
+	settleTerminalAnalyticsTurn(t, store, "ws-provenance", "root", "incomplete", 130)
+
+	if _, found, err := store.ClaimAgentTurnTerminalAnalytics(ctx, "owner", 200, 300); err != nil || found {
+		t.Fatalf("claim before envelopes found=%v err=%v", found, err)
+	}
+	recordTerminalAnalyticsSubmission(t, store, "ws-provenance", "root", "ambiguous", "envelope-a", `{"uiMode":"os"}`, 210)
+	delivery, found, err := store.ClaimAgentTurnTerminalAnalytics(ctx, "owner", 220, 320)
+	if err != nil || !found || delivery.TurnID != "ambiguous" || delivery.ClientSubmitID != "envelope-a" || delivery.MetadataJSON != `{"uiMode":"os"}` {
+		t.Fatalf("submission-preferred delivery=%#v found=%v err=%v", delivery, found, err)
+	}
+	if finished, err := store.CompleteAgentTurnTerminalAnalytics(ctx, delivery.WorkspaceID, delivery.AgentSessionID, delivery.TurnID, "owner", 230); err != nil || !finished {
+		t.Fatalf("complete ambiguous delivery=%v err=%v", finished, err)
+	}
+	recordTerminalAnalyticsSubmission(t, store, "ws-provenance", "root", "incomplete", "envelope-empty", `{"uiMode":"agent"}`, 240)
+	delivery, found, err = store.ClaimAgentTurnTerminalAnalytics(ctx, "owner", 250, 350)
+	if err != nil || !found || delivery.TurnID != "incomplete" || delivery.ClientSubmitID != "envelope-empty" || delivery.MetadataJSON != `{"uiMode":"agent"}` {
+		t.Fatalf("late-envelope delivery=%#v found=%v err=%v", delivery, found, err)
+	}
+}
+
+func TestTerminalAnalyticsClaimAvoidsHeadOfLineStarvation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openTestSQLiteStore(t)
+	seedTerminalAnalyticsWorkspace(t, store, "ws-hol")
+	seedTerminalAnalyticsSession(t, store, "ws-hol", "root", agentactivitybiz.SessionKindRoot, "", "")
+	for index := 0; index < terminalAnalyticsClaimScanLimit; index++ {
+		turnID := "blocked-" + twoDigit(index)
+		seedTerminalAnalyticsTurn(t, store, "ws-hol", "root", turnID, agentactivitybiz.TurnOriginUserPrompt, int64(100+index*10))
+		prepareTerminalAnalyticsClaim(t, store, "ws-hol", "root", turnID, "submit-"+turnID, `{}`, int64(101+index*10))
+		settleTerminalAnalyticsTurn(t, store, "ws-hol", "root", turnID, int64(102+index*10))
+	}
+	seedTerminalAnalyticsTurn(t, store, "ws-hol", "root", "ready", agentactivitybiz.TurnOriginUserPrompt, 10_000)
+	prepareTerminalAnalyticsClaim(t, store, "ws-hol", "root", "ready", "submit-ready", `{"uiMode":"agent"}`, 10_001)
+	settleTerminalAnalyticsTurn(t, store, "ws-hol", "root", "ready", 10_002)
+
+	delivery, found, err := store.ClaimAgentTurnTerminalAnalytics(ctx, "owner", 20_000, 21_000)
+	if err != nil || !found || delivery.TurnID != "ready" {
+		t.Fatalf("claim behind %d unresolved rows=%#v found=%v err=%v", terminalAnalyticsClaimScanLimit, delivery, found, err)
+	}
+}
+
+func TestTerminalAnalyticsMarkerRequiresExplicitTerminalTransition(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openTestSQLiteStore(t)
+	seedTerminalAnalyticsWorkspace(t, store, "ws-marker")
+	seedTerminalAnalyticsSession(t, store, "ws-marker", "root", agentactivitybiz.SessionKindRoot, "", "")
+	seedTerminalAnalyticsTurn(t, store, "ws-marker", "root", "turn-1", agentactivitybiz.TurnOriginUserPrompt, 100)
+	settleTerminalAnalyticsTurn(t, store, "ws-marker", "root", "turn-1", 200)
+	if _, err := store.writeDB.ExecContext(ctx, `DELETE FROM agent_turn_terminal_analytics`); err != nil {
+		t.Fatal(err)
+	}
+	turn, accepted, err := store.AgentCanonicalStore().RecordTurnTransition(ctx, agentactivitybiz.TurnTransition{
+		WorkspaceID: "ws-marker", AgentSessionID: "root", TurnID: "turn-1",
+		CapabilityRefs:   []agentactivitybiz.CapabilityReference{{Capability: "mcp", Source: "late"}},
+		OccurredAtUnixMS: 300,
+	})
+	if err != nil || !accepted || turn.Phase != agentactivitybiz.TurnPhaseSettled {
+		t.Fatalf("late capability merge turn=%#v accepted=%v err=%v", turn, accepted, err)
+	}
+	assertTerminalAnalyticsRows(t, store, "ws-marker", "root", 0)
+}
+
+func TestLateProviderBindingDoesNotRecreateTerminalMarker(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openTestSQLiteStore(t)
+	seedTerminalAnalyticsWorkspace(t, store, "ws-binding")
+	seedTerminalAnalyticsSession(t, store, "ws-binding", "root", agentactivitybiz.SessionKindRoot, "", "")
+	seedTerminalAnalyticsTurn(t, store, "ws-binding", "root", "turn-1", agentactivitybiz.TurnOriginUserPrompt, 100)
+	completed, err := store.ReportActivityState(ctx, agentactivitybiz.ActivityStateReport{
+		Session: agentactivitybiz.SessionStateReport{
+			WorkspaceID: "ws-binding", AgentSessionID: "root", OccurredAtUnixMS: 110,
+		},
+		RootProviderTurn: &agentactivitybiz.RootProviderTurnTransition{
+			WorkspaceID: "ws-binding", RootAgentSessionID: "root", RootTurnID: "turn-1",
+			ProviderTurnID: "provider-turn", Phase: agentactivitybiz.RootProviderTurnPhaseCompleted,
+			Outcome: agentactivitybiz.TurnOutcomeCompleted, OccurredAtUnixMS: 110,
+		},
+	})
+	if err != nil || !completed.RootTurnAccepted || completed.RootTurn.Phase != agentactivitybiz.TurnPhaseSettled {
+		t.Fatalf("provider completion=%#v err=%v", completed, err)
+	}
+	if _, err := store.writeDB.ExecContext(ctx, `DELETE FROM agent_turn_terminal_analytics`); err != nil {
+		t.Fatal(err)
+	}
+	late, err := store.ReportActivityState(ctx, agentactivitybiz.ActivityStateReport{
+		Session: agentactivitybiz.SessionStateReport{
+			WorkspaceID: "ws-binding", AgentSessionID: "root", OccurredAtUnixMS: 120,
+		},
+		RootProviderTurn: &agentactivitybiz.RootProviderTurnTransition{
+			WorkspaceID: "ws-binding", RootAgentSessionID: "root", RootTurnID: "turn-1",
+			ProviderTurnID:          "provider-turn",
+			ProviderTurnBindingJSON: json.RawMessage(`{"checkpointMessageId":"late"}`),
+			OccurredAtUnixMS:        120,
+		},
+	})
+	if err != nil || late.RootTurnAccepted || !late.RootProviderTurnAccepted {
+		t.Fatalf("late provider binding=%#v err=%v", late, err)
+	}
+	assertTerminalAnalyticsRows(t, store, "ws-binding", "root", 0)
+}
+
+func TestTerminalAnalyticsMarkerCascadesOnPurgeAndClear(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openTestSQLiteStore(t)
+	seedTerminalAnalyticsWorkspace(t, store, "ws-cleanup")
+	for _, sessionID := range []string{"purge", "clear"} {
+		seedTerminalAnalyticsSession(t, store, "ws-cleanup", sessionID, agentactivitybiz.SessionKindRoot, "", "")
+		seedTerminalAnalyticsTurn(t, store, "ws-cleanup", sessionID, "turn-1", agentactivitybiz.TurnOriginUserPrompt, 100)
+		settleTerminalAnalyticsTurn(t, store, "ws-cleanup", sessionID, "turn-1", 200)
+	}
+	if removed, err := store.DeleteSession(ctx, "ws-cleanup", "purge"); err != nil || !removed {
+		t.Fatalf("DeleteSession() removed=%v err=%v", removed, err)
+	}
+	if _, err := store.PurgeDeletedSessions(ctx, agentactivitybiz.PurgeDeletedSessionsInput{
+		CutoffUnixMS: time.Now().Add(time.Hour).UnixMilli(),
+	}); err != nil {
+		t.Fatalf("PurgeDeletedSessions() err=%v", err)
+	}
+	assertTerminalAnalyticsRows(t, store, "ws-cleanup", "purge", 0)
+	assertTerminalAnalyticsRows(t, store, "ws-cleanup", "clear", 1)
+	if _, err := store.ClearSessions(ctx, "ws-cleanup"); err != nil {
+		t.Fatalf("ClearSessions() err=%v", err)
+	}
+	assertTerminalAnalyticsRows(t, store, "ws-cleanup", "clear", 0)
+}
+
+func TestSoftDeleteEmitsOnlyActualRootTurnTerminalTransition(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openTestSQLiteStore(t)
+	seedTerminalAnalyticsWorkspace(t, store, "ws-delete")
+	seedTerminalAnalyticsSession(t, store, "ws-delete", "root", agentactivitybiz.SessionKindRoot, "", "")
+
+	// Remove the ordinary marker for an already-settled historical Turn. If
+	// soft deletion inferred transitions from final row shape, it would recreate
+	// this event even though deletion did not settle it.
+	seedTerminalAnalyticsTurn(t, store, "ws-delete", "root", "old-settled", agentactivitybiz.TurnOriginUserPrompt, 100)
+	settleTerminalAnalyticsTurn(t, store, "ws-delete", "root", "old-settled", 110)
+	if _, err := store.writeDB.ExecContext(ctx, `
+DELETE FROM agent_turn_terminal_analytics
+WHERE workspace_id = 'ws-delete' AND agent_session_id = 'root' AND turn_id = 'old-settled'
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	seedTerminalAnalyticsTurn(t, store, "ws-delete", "root", "live-root", agentactivitybiz.TurnOriginUserPrompt, 200)
+	prepareTerminalAnalyticsClaim(t, store, "ws-delete", "root", "live-root", "submit-root", `{"uiMode":"agent"}`, 201)
+	seedTerminalAnalyticsSession(t, store, "ws-delete", "child", agentactivitybiz.SessionKindChild, "root", "live-root")
+	seedTerminalAnalyticsTurn(t, store, "ws-delete", "child", "live-child", agentactivitybiz.TurnOriginUserPrompt, 210)
+	prepareTerminalAnalyticsClaim(t, store, "ws-delete", "child", "live-child", "submit-child", `{"uiMode":"agent"}`, 211)
+
+	if removed, err := store.DeleteSession(ctx, "ws-delete", "root"); err != nil || !removed {
+		t.Fatalf("DeleteSession() removed=%v err=%v", removed, err)
+	}
+	var total int
+	if err := store.writeDB.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM agent_turn_terminal_analytics WHERE workspace_id = 'ws-delete'
+`).Scan(&total); err != nil || total != 1 {
+		t.Fatalf("soft-delete analytics count=%d err=%v, want only live root", total, err)
+	}
+	delivery, found, err := store.ClaimAgentTurnTerminalAnalytics(ctx, "owner", time.Now().UnixMilli(), time.Now().Add(time.Minute).UnixMilli())
+	if err != nil || !found || delivery.TurnID != "live-root" || delivery.Outcome != agentactivitybiz.TurnOutcomeInterrupted {
+		t.Fatalf("soft-delete delivery=%#v found=%v err=%v", delivery, found, err)
+	}
+}
+
+func TestChildTerminalSettlesAndMarksCanonicalRootOnlyOnce(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openTestSQLiteStore(t)
+	seedTerminalAnalyticsWorkspace(t, store, "ws-child")
+	seedTerminalAnalyticsSession(t, store, "ws-child", "root", agentactivitybiz.SessionKindRoot, "", "")
+	seedTerminalAnalyticsTurn(t, store, "ws-child", "root", "root-turn", agentactivitybiz.TurnOriginUserPrompt, 100)
+	prepareTerminalAnalyticsClaim(t, store, "ws-child", "root", "root-turn", "submit-root", `{"uiMode":"agent"}`, 101)
+	seedTerminalAnalyticsSession(t, store, "ws-child", "child", agentactivitybiz.SessionKindChild, "root", "root-turn")
+	seedTerminalAnalyticsTurn(t, store, "ws-child", "child", "child-turn", agentactivitybiz.TurnOriginProviderInitiated, 110)
+
+	providerCompleted, err := store.ReportActivityState(ctx, agentactivitybiz.ActivityStateReport{
+		Session: agentactivitybiz.SessionStateReport{
+			WorkspaceID: "ws-child", AgentSessionID: "root", OccurredAtUnixMS: 120,
+		},
+		RootProviderTurn: &agentactivitybiz.RootProviderTurnTransition{
+			WorkspaceID: "ws-child", RootAgentSessionID: "root", RootTurnID: "root-turn",
+			ProviderTurnID: "provider-turn", Phase: agentactivitybiz.RootProviderTurnPhaseCompleted,
+			Outcome: agentactivitybiz.TurnOutcomeCompleted, OccurredAtUnixMS: 120,
+		},
+	})
+	if err != nil || !providerCompleted.RootTurnAccepted || providerCompleted.RootTurn.Phase != agentactivitybiz.TurnPhaseWaiting {
+		t.Fatalf("provider completion=%#v err=%v", providerCompleted, err)
+	}
+	terminalInput := agentactivitybiz.ActivityStateReport{
+		Session: agentactivitybiz.SessionStateReport{
+			WorkspaceID: "ws-child", AgentSessionID: "child", OccurredAtUnixMS: 130,
+		},
+		Turn: &agentactivitybiz.TurnTransition{
+			WorkspaceID: "ws-child", AgentSessionID: "child", TurnID: "child-turn",
+			Phase: agentactivitybiz.TurnPhaseSettled, Outcome: agentactivitybiz.TurnOutcomeCompleted,
+			SettledAtUnixMS: 130, OccurredAtUnixMS: 130,
+		},
+	}
+	terminal, err := store.ReportActivityState(ctx, terminalInput)
+	if err != nil || !terminal.RootTurnAccepted || terminal.RootTurn.Phase != agentactivitybiz.TurnPhaseSettled {
+		t.Fatalf("child terminal=%#v err=%v", terminal, err)
+	}
+	var rootRows, childRows int
+	if err := store.writeDB.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM agent_turn_terminal_analytics
+WHERE workspace_id = 'ws-child' AND agent_session_id = 'root' AND turn_id = 'root-turn'
+`).Scan(&rootRows); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.writeDB.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM agent_turn_terminal_analytics
+WHERE workspace_id = 'ws-child' AND agent_session_id = 'child'
+`).Scan(&childRows); err != nil {
+		t.Fatal(err)
+	}
+	if rootRows != 1 || childRows != 0 {
+		t.Fatalf("terminal marker rows root=%d child=%d", rootRows, childRows)
+	}
+	if _, err := store.ReportActivityState(ctx, terminalInput); err != nil {
+		t.Fatalf("terminal replay err=%v", err)
+	}
+	assertTerminalAnalyticsRows(t, store, "ws-child", "root", 1)
+	delivery, found, err := store.ClaimAgentTurnTerminalAnalytics(ctx, "owner", 200, 300)
+	if err != nil || !found || delivery.AgentSessionID != "root" || delivery.TurnID != "root-turn" {
+		t.Fatalf("root delivery=%#v found=%v err=%v", delivery, found, err)
+	}
+}
+
+func seedTerminalAnalyticsWorkspace(t *testing.T, store *SQLiteStore, workspaceID string) {
+	t.Helper()
+	if err := store.Create(context.Background(), workspacebiz.Summary{ID: workspaceID, Name: workspaceID}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func seedTerminalAnalyticsSession(t *testing.T, store *SQLiteStore, workspaceID, sessionID, kind, rootSessionID, rootTurnID string) {
+	t.Helper()
+	input := agentactivitybiz.SessionStateReport{
+		WorkspaceID: workspaceID, AgentSessionID: sessionID, Kind: kind,
+		RootAgentSessionID: rootSessionID, RootTurnID: rootTurnID,
+		Origin: "runtime", Provider: "codex", Status: "active", CurrentPhase: "working",
+		OccurredAtUnixMS: 10,
+	}
+	if kind == agentactivitybiz.SessionKindChild {
+		input.ParentAgentSessionID = rootSessionID
+		input.ParentTurnID = rootTurnID
+		input.ParentToolCallID = "tool-" + sessionID
+	}
+	if _, err := store.ReportSessionState(context.Background(), input); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func seedTerminalAnalyticsTurn(t *testing.T, store *SQLiteStore, workspaceID, sessionID, turnID, origin string, occurred int64) {
+	t.Helper()
+	if _, accepted, err := store.AgentCanonicalStore().RecordTurnTransition(context.Background(), agentactivitybiz.TurnTransition{
+		WorkspaceID: workspaceID, AgentSessionID: sessionID, TurnID: turnID,
+		Phase: agentactivitybiz.TurnPhaseSubmitted, Origin: origin,
+		StartedAtUnixMS: occurred, OccurredAtUnixMS: occurred,
+	}); err != nil || !accepted {
+		t.Fatalf("seed turn %q accepted=%v err=%v", turnID, accepted, err)
+	}
+}
+
+func settleTerminalAnalyticsTurn(t *testing.T, store *SQLiteStore, workspaceID, sessionID, turnID string, occurred int64) {
+	t.Helper()
+	if _, accepted, err := store.AgentCanonicalStore().RecordTurnTransition(context.Background(), agentactivitybiz.TurnTransition{
+		WorkspaceID: workspaceID, AgentSessionID: sessionID, TurnID: turnID,
+		Phase: agentactivitybiz.TurnPhaseSettled, Outcome: agentactivitybiz.TurnOutcomeCompleted,
+		SettledAtUnixMS: occurred, OccurredAtUnixMS: occurred,
+	}); err != nil || !accepted {
+		t.Fatalf("settle turn %q accepted=%v err=%v", turnID, accepted, err)
+	}
+}
+
+func prepareTerminalAnalyticsClaim(t *testing.T, store *SQLiteStore, workspaceID, sessionID, turnID, clientSubmitID, metadataJSON string, occurred int64) {
+	t.Helper()
+	if _, created, err := store.PrepareSubmitClaim(context.Background(), agentactivitybiz.SubmitClaimPrepare{
+		WorkspaceID: workspaceID, AgentSessionID: sessionID, CanonicalTurnID: turnID,
+		ClientSubmitID: clientSubmitID, MetadataJSON: metadataJSON, NowUnixMS: occurred,
+	}); err != nil || !created {
+		t.Fatalf("prepare claim %q created=%v err=%v", clientSubmitID, created, err)
+	}
+}
+
+func recordTerminalAnalyticsSubmission(t *testing.T, store *SQLiteStore, workspaceID, sessionID, turnID, clientSubmitID, metadataJSON string, occurred int64) {
+	t.Helper()
+	if _, created, err := store.AgentCanonicalStore().RecordTurnSubmission(context.Background(), agentactivitybiz.TurnSubmission{
+		WorkspaceID: workspaceID, AgentSessionID: sessionID, TurnID: turnID,
+		ContentJSON: `[]`, CapabilityRefsJSON: `[]`, TuttiModeSnapshotJSON: `{}`,
+		MetadataJSON: metadataJSON, ClientSubmitID: clientSubmitID,
+		CreatedAtUnixMS: occurred, UpdatedAtUnixMS: occurred,
+	}); err != nil || !created {
+		t.Fatalf("record submission %q created=%v err=%v", turnID, created, err)
+	}
+}
+
+func assertTerminalAnalyticsRows(t *testing.T, store *SQLiteStore, workspaceID, sessionID string, want int) {
+	t.Helper()
+	var got int
+	if err := store.writeDB.QueryRowContext(context.Background(), `
+SELECT COUNT(*) FROM agent_turn_terminal_analytics
+WHERE workspace_id = ? AND agent_session_id = ?
+`, workspaceID, sessionID).Scan(&got); err != nil || got != want {
+		t.Fatalf("terminal analytics rows workspace=%q session=%q got=%d want=%d err=%v", workspaceID, sessionID, got, want, err)
+	}
+}
+
+func twoDigit(value int) string {
+	return string(rune('0'+value/10)) + string(rune('0'+value%10))
+}

--- a/services/tuttid/data/workspace/store.go
+++ b/services/tuttid/data/workspace/store.go
@@ -58,6 +58,7 @@ type AgentActivityStore interface {
 	agentactivitybiz.Repository
 	agentactivitybiz.SessionTurnSummaryReader
 	agentactivitybiz.EffectiveSessionTurnReader
+	agentactivitybiz.TurnSubmissionReader
 	CheckpointRuntimeOperation(context.Context, agentactivitybiz.CheckpointRuntimeOperationInput) (agentactivitybiz.RuntimeOperation, bool, error)
 	CompletePlanDecisionRuntimeOperation(context.Context, agentactivitybiz.CompletePlanDecisionRuntimeOperationInput) (agentactivitybiz.RuntimeOperationCompletion, bool, error)
 	FindTurnByClientSubmitID(context.Context, string, string, string) (string, bool, error)

--- a/services/tuttid/service/agent/activity_projection.go
+++ b/services/tuttid/service/agent/activity_projection.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	replay "github.com/tutti-os/tutti/packages/agent/session-replay"
@@ -30,6 +32,9 @@ type ActivityProjection struct {
 	turnForkabilityResolver      TurnForkabilityResolver
 	replayCommitObserver         ReplayCommitObserver
 	terminalFailureObserver      agenthost.TerminalFailureObserver
+	terminalAnalyticsOwner       string
+	terminalAnalyticsWake        chan struct{}
+	terminalAnalyticsDrainMu     sync.Mutex
 	// rootTurnSettleStateObserver is the dedicated, opt-in consumer list for
 	// synthesized canonical root-turn settlement states. It is deliberately
 	// separate from sessionStateObserver: the general observers historically
@@ -46,7 +51,11 @@ var (
 )
 
 func NewActivityProjection(repo agentactivitybiz.Repository) *ActivityProjection {
-	return &ActivityProjection{repo: repo}
+	return &ActivityProjection{
+		repo:                   repo,
+		terminalAnalyticsOwner: uuid.NewString(),
+		terminalAnalyticsWake:  make(chan struct{}, 1),
+	}
 }
 
 type ActivityUpdatePublisher interface {

--- a/services/tuttid/service/agent/activity_projection_commits.go
+++ b/services/tuttid/service/agent/activity_projection_commits.go
@@ -50,6 +50,7 @@ func (p *ActivityProjection) ObserveCommitted(ctx context.Context, delta agentho
 		p.observeSessionMessages(ctx, committed.Input, committed.Reply)
 	}
 	for _, settled := range delta.RootTurnsSettled {
+		p.reportRootTurnTerminalEvent(ctx, settled)
 		if settled.StartupReconciled {
 			// Startup reconciliation force-settles every turn left on disk.
 			// Waking the Tutti-mode and automation observers for those would

--- a/services/tuttid/service/agent/activity_projection_turn_terminal.go
+++ b/services/tuttid/service/agent/activity_projection_turn_terminal.go
@@ -1,0 +1,85 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+	agentactivitybiz "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+	agentturnterminal "github.com/tutti-os/tutti/services/tuttid/service/reporter/events/agent/turn_terminal"
+)
+
+func (p *ActivityProjection) reportRootTurnTerminalEvent(ctx context.Context, settled agenthost.RootTurnSettled) {
+	if p == nil || p.analyticsReporter == nil || settled.IsChildSession {
+		return
+	}
+	turn := settled.Turn
+	if turn.Backfilled || strings.TrimSpace(turn.Origin) != agentactivitybiz.TurnOriginUserPrompt {
+		return
+	}
+	reader, ok := p.repo.(agentactivitybiz.TurnSubmissionReader)
+	if !ok {
+		logSkippedTurnTerminalEvent(ctx, settled, "submission_reader_unavailable")
+		return
+	}
+	submission, found, err := reader.GetTurnSubmission(
+		ctx,
+		settled.WorkspaceID,
+		settled.AgentSessionID,
+		turn.TurnID,
+	)
+	if err != nil {
+		logSkippedTurnTerminalEvent(ctx, settled, "submission_read_failed")
+		return
+	}
+	if !found {
+		logSkippedTurnTerminalEvent(ctx, settled, "submission_missing")
+		return
+	}
+	mode, ok := terminalSubmissionMode(submission.MetadataJSON)
+	if !ok {
+		logSkippedTurnTerminalEvent(ctx, settled, "submission_mode_invalid")
+		return
+	}
+	eventName, params, ok := agentturnterminal.Build(agentturnterminal.Input{
+		AgentSessionID:    settled.AgentSessionID,
+		ClientSubmitID:    submission.ClientSubmitID,
+		ErrorCode:         turn.ErrorCode,
+		Mode:              mode,
+		Origin:            turn.Origin,
+		Outcome:           turn.Outcome,
+		Provider:          settled.Provider,
+		SettledAtUnixMS:   turn.SettledAtUnixMS,
+		StartedAtUnixMS:   turn.StartedAtUnixMS,
+		StartupReconciled: settled.StartupReconciled,
+		TurnID:            turn.TurnID,
+	})
+	if !ok {
+		return
+	}
+	agentturnterminal.Track(ctx, p.analyticsReporter, eventName, params)
+}
+
+func terminalSubmissionMode(metadataJSON string) (string, bool) {
+	var metadata map[string]any
+	if err := json.Unmarshal([]byte(metadataJSON), &metadata); err != nil || metadata == nil {
+		return "", false
+	}
+	mode, ok := metadata["uiMode"].(string)
+	if !ok || (mode != "os" && mode != "agent") {
+		return "", false
+	}
+	return mode, true
+}
+
+func logSkippedTurnTerminalEvent(ctx context.Context, settled agenthost.RootTurnSettled, reason string) {
+	slog.DebugContext(
+		ctx,
+		"agent turn terminal analytics skipped",
+		"reason", reason,
+		"agent_session_id", strings.TrimSpace(settled.AgentSessionID),
+		"turn_id", strings.TrimSpace(settled.Turn.TurnID),
+	)
+}

--- a/services/tuttid/service/agent/activity_projection_turn_terminal.go
+++ b/services/tuttid/service/agent/activity_projection_turn_terminal.go
@@ -5,18 +5,79 @@ import (
 	"encoding/json"
 	"log/slog"
 	"strings"
+	"time"
 
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	agentactivitybiz "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+	agentturnanalyticsbiz "github.com/tutti-os/tutti/services/tuttid/biz/agentturnanalytics"
 	agentturnterminal "github.com/tutti-os/tutti/services/tuttid/service/reporter/events/agent/turn_terminal"
 )
 
+const (
+	terminalAnalyticsPollInterval = time.Second
+	terminalAnalyticsLease        = 30 * time.Second
+	terminalAnalyticsDrainLimit   = 128
+	terminalAnalyticsStoreTimeout = 5 * time.Second
+)
+
+type turnTerminalAnalyticsStore interface {
+	PutAgentTurnTerminalAnalytics(context.Context, agentturnanalyticsbiz.Settlement, int64) (bool, error)
+	ClaimAgentTurnTerminalAnalytics(context.Context, string, int64, int64) (agentturnanalyticsbiz.Delivery, bool, error)
+	CompleteAgentTurnTerminalAnalytics(context.Context, string, string, string, string, int64) (bool, error)
+	IgnoreAgentTurnTerminalAnalytics(context.Context, string, string, string, string, string, int64) (bool, error)
+	RequeueAgentTurnTerminalAnalytics(context.Context, int64) (int64, error)
+}
+
 func (p *ActivityProjection) reportRootTurnTerminalEvent(ctx context.Context, settled agenthost.RootTurnSettled) {
-	if p == nil || p.analyticsReporter == nil || settled.IsChildSession {
+	if p == nil || settled.IsChildSession {
 		return
 	}
 	turn := settled.Turn
 	if turn.Backfilled || strings.TrimSpace(turn.Origin) != agentactivitybiz.TurnOriginUserPrompt {
+		return
+	}
+	if store, ok := p.repo.(turnTerminalAnalyticsStore); ok {
+		persistCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), terminalAnalyticsStoreTimeout)
+		_, err := store.PutAgentTurnTerminalAnalytics(persistCtx, terminalAnalyticsSettlement(settled), time.Now().UnixMilli())
+		cancel()
+		if err != nil {
+			// Canonical production writes already inserted this marker through the
+			// transaction participant. This post-commit put supports adapter tests
+			// and old callers and is never the durability boundary.
+			slog.WarnContext(ctx, "agent turn terminal analytics wake failed",
+				"event", "agent.turn_terminal_analytics.marker_unavailable",
+				"agent_session_id", strings.TrimSpace(settled.AgentSessionID),
+				"turn_id", strings.TrimSpace(turn.TurnID),
+				"error", err,
+			)
+			return
+		}
+		p.wakeTurnTerminalAnalytics()
+		p.drainTurnTerminalAnalytics(ctx, store)
+		return
+	}
+	p.reportRootTurnTerminalEventDirect(ctx, settled)
+}
+
+func terminalAnalyticsSettlement(settled agenthost.RootTurnSettled) agentturnanalyticsbiz.Settlement {
+	turn := settled.Turn
+	return agentturnanalyticsbiz.Settlement{
+		WorkspaceID:       strings.TrimSpace(settled.WorkspaceID),
+		AgentSessionID:    strings.TrimSpace(settled.AgentSessionID),
+		TurnID:            strings.TrimSpace(turn.TurnID),
+		EventID:           agentturnanalyticsbiz.StableEventID(settled.WorkspaceID, settled.AgentSessionID, turn.TurnID),
+		Provider:          strings.TrimSpace(settled.Provider),
+		Origin:            strings.TrimSpace(turn.Origin),
+		Outcome:           strings.TrimSpace(turn.Outcome),
+		ErrorCode:         strings.TrimSpace(turn.ErrorCode),
+		StartupReconciled: settled.StartupReconciled,
+		StartedAtUnixMS:   turn.StartedAtUnixMS,
+		SettledAtUnixMS:   turn.SettledAtUnixMS,
+	}
+}
+
+func (p *ActivityProjection) reportRootTurnTerminalEventDirect(ctx context.Context, settled agenthost.RootTurnSettled) {
+	if p.analyticsReporter == nil {
 		return
 	}
 	reader, ok := p.repo.(agentactivitybiz.TurnSubmissionReader)
@@ -24,12 +85,7 @@ func (p *ActivityProjection) reportRootTurnTerminalEvent(ctx context.Context, se
 		logSkippedTurnTerminalEvent(ctx, settled, "submission_reader_unavailable")
 		return
 	}
-	submission, found, err := reader.GetTurnSubmission(
-		ctx,
-		settled.WorkspaceID,
-		settled.AgentSessionID,
-		turn.TurnID,
-	)
+	submission, found, err := reader.GetTurnSubmission(ctx, settled.WorkspaceID, settled.AgentSessionID, settled.Turn.TurnID)
 	if err != nil {
 		logSkippedTurnTerminalEvent(ctx, settled, "submission_read_failed")
 		return
@@ -38,28 +94,153 @@ func (p *ActivityProjection) reportRootTurnTerminalEvent(ctx context.Context, se
 		logSkippedTurnTerminalEvent(ctx, settled, "submission_missing")
 		return
 	}
-	mode, ok := terminalSubmissionMode(submission.MetadataJSON)
-	if !ok {
-		logSkippedTurnTerminalEvent(ctx, settled, "submission_mode_invalid")
+	tracked, reason := p.trackTurnTerminalAnalytics(ctx, agentturnanalyticsbiz.Delivery{
+		Settlement:     terminalAnalyticsSettlement(settled),
+		ClientSubmitID: submission.ClientSubmitID,
+		MetadataJSON:   submission.MetadataJSON,
+	})
+	if !tracked {
+		logSkippedTurnTerminalEvent(ctx, settled, reason)
+	}
+}
+
+// RunTurnTerminalAnalytics drains the durable ledger on startup, wake hints,
+// and a bounded polling interval. Startup requeues abandoned leases because
+// tuttid has a single process owner for this database.
+func (p *ActivityProjection) RunTurnTerminalAnalytics(ctx context.Context) {
+	if p == nil {
 		return
+	}
+	store, ok := p.repo.(turnTerminalAnalyticsStore)
+	if !ok {
+		return
+	}
+	now := time.Now().UnixMilli()
+	// Requeue shares the drain critical section. Otherwise startup can reset a
+	// lease held by a synchronous observer drain whose Track call is in flight,
+	// making the same local owner deliver the event twice.
+	p.terminalAnalyticsDrainMu.Lock()
+	if _, err := store.RequeueAgentTurnTerminalAnalytics(ctx, now); err != nil && ctx.Err() == nil {
+		slog.WarnContext(ctx, "agent turn terminal analytics lease recovery failed",
+			"event", "agent.turn_terminal_analytics.lease_recovery_failed", "error", err)
+	}
+	p.terminalAnalyticsDrainMu.Unlock()
+	p.drainTurnTerminalAnalytics(ctx, store)
+
+	ticker := time.NewTicker(terminalAnalyticsPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-p.terminalAnalyticsWake:
+			p.drainTurnTerminalAnalytics(ctx, store)
+		case <-ticker.C:
+			p.drainTurnTerminalAnalytics(ctx, store)
+		}
+	}
+}
+
+func (p *ActivityProjection) wakeTurnTerminalAnalytics() {
+	if p == nil || p.terminalAnalyticsWake == nil {
+		return
+	}
+	select {
+	case p.terminalAnalyticsWake <- struct{}{}:
+	default:
+	}
+}
+
+func (p *ActivityProjection) drainTurnTerminalAnalytics(ctx context.Context, store turnTerminalAnalyticsStore) {
+	if p == nil || p.analyticsReporter == nil || store == nil {
+		return
+	}
+	// Observer wakeups and the periodic worker may race. Serializing drains
+	// prevents one owner from reclaiming an expired lease while an earlier
+	// Track call is still in flight and then completing the newer claim.
+	p.terminalAnalyticsDrainMu.Lock()
+	defer p.terminalAnalyticsDrainMu.Unlock()
+	for index := 0; index < terminalAnalyticsDrainLimit && ctx.Err() == nil; index++ {
+		now := time.Now().UnixMilli()
+		delivery, found, err := store.ClaimAgentTurnTerminalAnalytics(
+			ctx, p.terminalAnalyticsOwner, now, now+terminalAnalyticsLease.Milliseconds(),
+		)
+		if err != nil {
+			if ctx.Err() == nil {
+				slog.WarnContext(ctx, "agent turn terminal analytics claim failed",
+					"event", "agent.turn_terminal_analytics.claim_failed", "error", err)
+			}
+			return
+		}
+		if !found {
+			return
+		}
+		tracked, reason := p.trackTurnTerminalAnalytics(ctx, delivery)
+		finishNow := time.Now().UnixMilli()
+		var finished bool
+		if !tracked {
+			finished, err = store.IgnoreAgentTurnTerminalAnalytics(
+				ctx, delivery.WorkspaceID, delivery.AgentSessionID, delivery.TurnID,
+				p.terminalAnalyticsOwner, reason, finishNow,
+			)
+		} else {
+			finished, err = store.CompleteAgentTurnTerminalAnalytics(
+				ctx, delivery.WorkspaceID, delivery.AgentSessionID, delivery.TurnID,
+				p.terminalAnalyticsOwner, finishNow,
+			)
+		}
+		if err != nil {
+			if ctx.Err() == nil {
+				slog.WarnContext(ctx, "agent turn terminal analytics completion failed",
+					"event", "agent.turn_terminal_analytics.completion_failed",
+					"agent_session_id", delivery.AgentSessionID,
+					"turn_id", delivery.TurnID,
+					"error", err,
+				)
+			}
+			return
+		}
+		if !finished {
+			if ctx.Err() == nil {
+				slog.WarnContext(ctx, "agent turn terminal analytics lease lost before completion",
+					"event", "agent.turn_terminal_analytics.lease_lost",
+					"agent_session_id", delivery.AgentSessionID,
+					"turn_id", delivery.TurnID,
+				)
+			}
+			return
+		}
+	}
+	p.wakeTurnTerminalAnalytics()
+}
+
+func (p *ActivityProjection) trackTurnTerminalAnalytics(
+	ctx context.Context,
+	delivery agentturnanalyticsbiz.Delivery,
+) (bool, string) {
+	mode, ok := terminalSubmissionMode(delivery.MetadataJSON)
+	if !ok {
+		return false, "submission_mode_invalid"
 	}
 	eventName, params, ok := agentturnterminal.Build(agentturnterminal.Input{
-		AgentSessionID:    settled.AgentSessionID,
-		ClientSubmitID:    submission.ClientSubmitID,
-		ErrorCode:         turn.ErrorCode,
+		AgentSessionID:    delivery.AgentSessionID,
+		ClientSubmitID:    delivery.ClientSubmitID,
+		ErrorCode:         delivery.ErrorCode,
 		Mode:              mode,
-		Origin:            turn.Origin,
-		Outcome:           turn.Outcome,
-		Provider:          settled.Provider,
-		SettledAtUnixMS:   turn.SettledAtUnixMS,
-		StartedAtUnixMS:   turn.StartedAtUnixMS,
-		StartupReconciled: settled.StartupReconciled,
-		TurnID:            turn.TurnID,
+		Origin:            delivery.Origin,
+		Outcome:           delivery.Outcome,
+		Provider:          delivery.Provider,
+		SettledAtUnixMS:   delivery.SettledAtUnixMS,
+		StartedAtUnixMS:   delivery.StartedAtUnixMS,
+		StartupReconciled: delivery.StartupReconciled,
+		TurnID:            delivery.TurnID,
 	})
 	if !ok {
-		return
+		return false, "terminal_event_invalid"
 	}
+	params["event_id"] = delivery.EventID
 	agentturnterminal.Track(ctx, p.analyticsReporter, eventName, params)
+	return true, ""
 }
 
 func terminalSubmissionMode(metadataJSON string) (string, bool) {

--- a/services/tuttid/service/agent/activity_projection_turn_terminal_integration_test.go
+++ b/services/tuttid/service/agent/activity_projection_turn_terminal_integration_test.go
@@ -1,0 +1,334 @@
+package agent
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+	agentactivitybiz "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+	agentturnanalyticsbiz "github.com/tutti-os/tutti/services/tuttid/biz/agentturnanalytics"
+	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
+	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
+	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
+)
+
+func TestSettleStaleTurnsOnStartupDeliversDurableTerminalAnalyticsOnce(t *testing.T) {
+	ctx := context.Background()
+	store := openTerminalAnalyticsIntegrationStore(t, "ws-startup")
+	seedTerminalAnalyticsIntegrationSession(t, store, "ws-startup", "root")
+	seedTerminalAnalyticsIntegrationTurn(t, store, "ws-startup", "root", "turn-startup", 100)
+	if _, created, err := store.PrepareSubmitClaim(ctx, agentactivitybiz.SubmitClaimPrepare{
+		WorkspaceID: "ws-startup", AgentSessionID: "root", CanonicalTurnID: "turn-startup",
+		ClientSubmitID: "submit-startup", MetadataJSON: `{"uiMode":"agent"}`, NowUnixMS: 110,
+	}); err != nil || !created {
+		t.Fatalf("PrepareSubmitClaim() created=%v err=%v", created, err)
+	}
+	reporter := newConcurrentTerminalAnalyticsReporter()
+	projection := NewActivityProjection(store)
+	projection.SetAnalyticsReporter(reporter)
+
+	if err := projection.SettleStaleTurnsOnStartup(ctx); err != nil {
+		t.Fatal(err)
+	}
+	events := reporter.snapshot()
+	if len(events) != 1 || events[0].Name != "agent.turn_cancelled" {
+		t.Fatalf("startup events=%#v", events)
+	}
+	params := events[0].Params
+	if params["startup_reconciled"] != true || params["client_submit_id"] != "submit-startup" ||
+		params["event_id"] != agentturnanalyticsbiz.StableEventID("ws-startup", "root", "turn-startup") {
+		t.Fatalf("startup params=%#v", params)
+	}
+	if err := projection.SettleStaleTurnsOnStartup(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(reporter.snapshot()); got != 1 {
+		t.Fatalf("startup replay event count=%d, want 1", got)
+	}
+}
+
+func TestTerminalAnalyticsWorkerJoinsSettlementBeforeClaimAndStopsWithContext(t *testing.T) {
+	ctx := context.Background()
+	store := openTerminalAnalyticsIntegrationStore(t, "ws-late-claim")
+	seedTerminalAnalyticsIntegrationSession(t, store, "ws-late-claim", "root")
+	seedTerminalAnalyticsIntegrationTurn(t, store, "ws-late-claim", "root", "turn-late", 100)
+	turn, accepted, err := store.AgentCanonicalStore().RecordTurnTransition(ctx, agentactivitybiz.TurnTransition{
+		WorkspaceID: "ws-late-claim", AgentSessionID: "root", TurnID: "turn-late",
+		Phase: agentactivitybiz.TurnPhaseSettled, Outcome: agentactivitybiz.TurnOutcomeCompleted,
+		SettledAtUnixMS: 200, OccurredAtUnixMS: 200,
+	})
+	if err != nil || !accepted {
+		t.Fatalf("terminal transition accepted=%v err=%v", accepted, err)
+	}
+
+	reporter := newConcurrentTerminalAnalyticsReporter()
+	projection := NewActivityProjection(store)
+	projection.SetAnalyticsReporter(reporter)
+	workerCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		projection.RunTurnTerminalAnalytics(workerCtx)
+		close(done)
+	}()
+	if reporter.waitForCount(1, 150*time.Millisecond) {
+		t.Fatal("terminal analytics delivered before durable submission provenance existed")
+	}
+	if _, created, err := store.PrepareSubmitClaim(ctx, agentactivitybiz.SubmitClaimPrepare{
+		WorkspaceID: "ws-late-claim", AgentSessionID: "root", CanonicalTurnID: "turn-late",
+		ClientSubmitID: "submit-late", MetadataJSON: `{"uiMode":"os"}`, NowUnixMS: 300,
+	}); err != nil || !created {
+		t.Fatalf("late PrepareSubmitClaim() created=%v err=%v", created, err)
+	}
+	// Do not send a wake hint: the periodic drain is the recovery path for a
+	// crash between the durable claim commit and post-commit notification.
+	if !reporter.waitForCount(1, 3*time.Second) {
+		t.Fatal("periodic terminal analytics drain did not join the late claim")
+	}
+	events := reporter.snapshot()
+	if len(events) != 1 || events[0].Params["event_id"] != agentturnanalyticsbiz.StableEventID("ws-late-claim", "root", "turn-late") {
+		t.Fatalf("late-claim events=%#v", events)
+	}
+	if err := projection.ObserveCommitted(ctx, agenthost.CommittedDelta{
+		RootTurnsSettled: []agenthost.RootTurnSettled{{
+			WorkspaceID: "ws-late-claim", AgentSessionID: "root", Provider: "codex", Turn: turn,
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(reporter.snapshot()); got != 1 {
+		t.Fatalf("duplicate ObserveCommitted event count=%d, want 1", got)
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("terminal analytics worker did not stop with context")
+	}
+}
+
+func TestTerminalAnalyticsStartupRequeueWaitsForInFlightObserverDrain(t *testing.T) {
+	store := &blockingTerminalAnalyticsStore{
+		activityProjectionRepoStub: &activityProjectionRepoStub{},
+		state:                      "pending",
+		requeueCalled:              make(chan struct{}, 1),
+		delivery: agentturnanalyticsbiz.Delivery{
+			Settlement: agentturnanalyticsbiz.Settlement{
+				WorkspaceID: "ws-race", AgentSessionID: "root", TurnID: "turn-1",
+				EventID: agentturnanalyticsbiz.StableEventID("ws-race", "root", "turn-1"),
+				Origin:  agentactivitybiz.TurnOriginUserPrompt, Outcome: agentactivitybiz.TurnOutcomeCompleted,
+				StartedAtUnixMS: 100, SettledAtUnixMS: 200,
+			},
+			ClientSubmitID: "submit-1", MetadataJSON: `{"uiMode":"agent"}`,
+		},
+	}
+	reporter := &blockingTerminalAnalyticsReporter{
+		started: make(chan struct{}), release: make(chan struct{}),
+	}
+	projection := NewActivityProjection(store)
+	projection.SetAnalyticsReporter(reporter)
+
+	drainDone := make(chan struct{})
+	go func() {
+		projection.drainTurnTerminalAnalytics(context.Background(), store)
+		close(drainDone)
+	}()
+	select {
+	case <-reporter.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("observer drain did not enter Track")
+	}
+	workerCtx, cancel := context.WithCancel(context.Background())
+	workerDone := make(chan struct{})
+	go func() {
+		projection.RunTurnTerminalAnalytics(workerCtx)
+		close(workerDone)
+	}()
+	select {
+	case <-store.requeueCalled:
+		t.Fatal("startup requeue reset an in-flight observer lease")
+	case <-time.After(150 * time.Millisecond):
+	}
+	close(reporter.release)
+	select {
+	case <-drainDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("observer drain did not finish")
+	}
+	select {
+	case <-store.requeueCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("startup requeue did not resume after observer drain")
+	}
+	cancel()
+	select {
+	case <-workerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not stop")
+	}
+	if reporter.count() != 1 {
+		t.Fatalf("Track count=%d, want 1", reporter.count())
+	}
+}
+
+type concurrentTerminalAnalyticsReporter struct {
+	mu     sync.Mutex
+	events []reporterservice.Event
+	wake   chan struct{}
+}
+
+type blockingTerminalAnalyticsReporter struct {
+	mu      sync.Mutex
+	tracked int
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (r *blockingTerminalAnalyticsReporter) Track(context.Context, ...reporterservice.Event) {
+	r.mu.Lock()
+	r.tracked++
+	r.mu.Unlock()
+	r.once.Do(func() { close(r.started) })
+	<-r.release
+}
+
+func (*blockingTerminalAnalyticsReporter) Close() error { return nil }
+
+func (r *blockingTerminalAnalyticsReporter) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.tracked
+}
+
+type blockingTerminalAnalyticsStore struct {
+	*activityProjectionRepoStub
+	mu            sync.Mutex
+	state         string
+	owner         string
+	delivery      agentturnanalyticsbiz.Delivery
+	requeueCalled chan struct{}
+}
+
+func (*blockingTerminalAnalyticsStore) PutAgentTurnTerminalAnalytics(context.Context, agentturnanalyticsbiz.Settlement, int64) (bool, error) {
+	return false, nil
+}
+
+func (s *blockingTerminalAnalyticsStore) ClaimAgentTurnTerminalAnalytics(_ context.Context, owner string, _, _ int64) (agentturnanalyticsbiz.Delivery, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.state != "pending" {
+		return agentturnanalyticsbiz.Delivery{}, false, nil
+	}
+	s.state = "leased"
+	s.owner = owner
+	return s.delivery, true, nil
+}
+
+func (s *blockingTerminalAnalyticsStore) CompleteAgentTurnTerminalAnalytics(_ context.Context, _, _, _, owner string, _ int64) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.state != "leased" || s.owner != owner {
+		return false, nil
+	}
+	s.state = "delivered"
+	s.owner = ""
+	return true, nil
+}
+
+func (s *blockingTerminalAnalyticsStore) IgnoreAgentTurnTerminalAnalytics(_ context.Context, _, _, _, owner, _ string, _ int64) (bool, error) {
+	return s.CompleteAgentTurnTerminalAnalytics(context.Background(), "", "", "", owner, 0)
+}
+
+func (s *blockingTerminalAnalyticsStore) RequeueAgentTurnTerminalAnalytics(context.Context, int64) (int64, error) {
+	s.mu.Lock()
+	var changed int64
+	if s.state == "leased" {
+		s.state = "pending"
+		s.owner = ""
+		changed = 1
+	}
+	s.mu.Unlock()
+	select {
+	case s.requeueCalled <- struct{}{}:
+	default:
+	}
+	return changed, nil
+}
+
+func newConcurrentTerminalAnalyticsReporter() *concurrentTerminalAnalyticsReporter {
+	return &concurrentTerminalAnalyticsReporter{wake: make(chan struct{}, 1)}
+}
+
+func (r *concurrentTerminalAnalyticsReporter) Track(_ context.Context, events ...reporterservice.Event) {
+	r.mu.Lock()
+	r.events = append(r.events, events...)
+	r.mu.Unlock()
+	select {
+	case r.wake <- struct{}{}:
+	default:
+	}
+}
+
+func (*concurrentTerminalAnalyticsReporter) Close() error { return nil }
+
+func (r *concurrentTerminalAnalyticsReporter) snapshot() []reporterservice.Event {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]reporterservice.Event(nil), r.events...)
+}
+
+func (r *concurrentTerminalAnalyticsReporter) waitForCount(want int, timeout time.Duration) bool {
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	for {
+		if len(r.snapshot()) >= want {
+			return true
+		}
+		select {
+		case <-r.wake:
+		case <-deadline.C:
+			return len(r.snapshot()) >= want
+		}
+	}
+}
+
+func openTerminalAnalyticsIntegrationStore(t *testing.T, workspaceID string) *workspacedata.SQLiteStore {
+	t.Helper()
+	store, err := workspacedata.OpenSQLiteStore(filepath.Join(t.TempDir(), "tuttid.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Create(context.Background(), workspacebiz.Summary{ID: workspaceID, Name: workspaceID}); err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+func seedTerminalAnalyticsIntegrationSession(t *testing.T, store *workspacedata.SQLiteStore, workspaceID, sessionID string) {
+	t.Helper()
+	if _, err := store.ReportSessionState(context.Background(), agentactivitybiz.SessionStateReport{
+		WorkspaceID: workspaceID, AgentSessionID: sessionID, Kind: agentactivitybiz.SessionKindRoot,
+		Origin: "runtime", Provider: "codex", Status: "active", CurrentPhase: "working",
+		OccurredAtUnixMS: 10,
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func seedTerminalAnalyticsIntegrationTurn(t *testing.T, store *workspacedata.SQLiteStore, workspaceID, sessionID, turnID string, occurred int64) {
+	t.Helper()
+	if _, accepted, err := store.AgentCanonicalStore().RecordTurnTransition(context.Background(), agentactivitybiz.TurnTransition{
+		WorkspaceID: workspaceID, AgentSessionID: sessionID, TurnID: turnID,
+		Phase: agentactivitybiz.TurnPhaseSubmitted, Origin: agentactivitybiz.TurnOriginUserPrompt,
+		StartedAtUnixMS: occurred, OccurredAtUnixMS: occurred,
+	}); err != nil || !accepted {
+		t.Fatalf("RecordTurnTransition() accepted=%v err=%v", accepted, err)
+	}
+}

--- a/services/tuttid/service/agent/activity_projection_turn_terminal_test.go
+++ b/services/tuttid/service/agent/activity_projection_turn_terminal_test.go
@@ -1,0 +1,137 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+	agentactivitybiz "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+func TestActivityProjectionReportsCanonicalUserTurnOutcomes(t *testing.T) {
+	tests := []struct {
+		name              string
+		outcome           string
+		wantEvent         string
+		startupReconciled bool
+	}{
+		{name: "completed", outcome: agentactivitybiz.TurnOutcomeCompleted, wantEvent: "agent.turn_completed"},
+		{name: "failed", outcome: agentactivitybiz.TurnOutcomeFailed, wantEvent: "agent.turn_failed"},
+		{name: "canceled", outcome: agentactivitybiz.TurnOutcomeCanceled, wantEvent: "agent.turn_cancelled"},
+		{name: "startup interrupted", outcome: agentactivitybiz.TurnOutcomeInterrupted, wantEvent: "agent.turn_cancelled", startupReconciled: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &activityProjectionRepoStub{
+				submission: agentactivitybiz.TurnSubmission{
+					ClientSubmitID: "submit-1",
+					MetadataJSON:   `{"uiMode":"agent"}`,
+				},
+				submissionFound: true,
+			}
+			reporter := &recordingAgentAnalyticsReporter{}
+			projection := NewActivityProjection(repo)
+			projection.SetAnalyticsReporter(reporter)
+
+			err := projection.ObserveCommitted(context.Background(), agenthost.CommittedDelta{
+				RootTurnsSettled: []agenthost.RootTurnSettled{{
+					WorkspaceID: "ws-1", AgentSessionID: "session-1", Provider: "codex",
+					StartupReconciled: tt.startupReconciled,
+					Turn: agentactivitybiz.Turn{
+						TurnID: "turn-1", Origin: agentactivitybiz.TurnOriginUserPrompt,
+						Outcome: tt.outcome, ErrorCode: "runtime_failed",
+						StartedAtUnixMS: 1_000, SettledAtUnixMS: 11_000,
+					},
+				}},
+			})
+			if err != nil {
+				t.Fatalf("ObserveCommitted() error=%v", err)
+			}
+			if len(reporter.events) != 1 || reporter.events[0].Name != tt.wantEvent {
+				t.Fatalf("events=%#v, want one %s", reporter.events, tt.wantEvent)
+			}
+			params := reporter.events[0].Params
+			for key, want := range map[string]any{
+				"agent_session_id": "session-1",
+				"client_submit_id": "submit-1",
+				"mode":             "agent",
+				"provider":         "codex",
+				"turn_id":          "turn-1",
+				"turn_origin":      agentactivitybiz.TurnOriginUserPrompt,
+				"turn_outcome":     tt.outcome,
+			} {
+				if got := params[key]; got != want {
+					t.Fatalf("params[%q]=%#v, want %#v in %#v", key, got, want, params)
+				}
+			}
+			if _, exists := params["error_message"]; exists {
+				t.Fatalf("params contain raw error message: %#v", params)
+			}
+			if _, exists := params["workspace_id"]; exists {
+				t.Fatalf("params contain workspace identity: %#v", params)
+			}
+		})
+	}
+}
+
+func TestActivityProjectionSkipsIneligibleTerminalTurns(t *testing.T) {
+	tests := []struct {
+		name       string
+		metadata   string
+		origin     string
+		backfilled bool
+		child      bool
+		found      bool
+	}{
+		{name: "child session", metadata: `{"uiMode":"agent"}`, origin: agentactivitybiz.TurnOriginUserPrompt, child: true, found: true},
+		{name: "goal turn", metadata: `{"uiMode":"agent"}`, origin: agentactivitybiz.TurnOriginGoalArm, found: true},
+		{name: "provider initiated", metadata: `{"uiMode":"agent"}`, origin: agentactivitybiz.TurnOriginProviderInitiated, found: true},
+		{name: "backfilled", metadata: `{"uiMode":"agent"}`, origin: agentactivitybiz.TurnOriginUserPrompt, backfilled: true, found: true},
+		{name: "legacy missing submission", origin: agentactivitybiz.TurnOriginUserPrompt},
+		{name: "missing mode", metadata: `{}`, origin: agentactivitybiz.TurnOriginUserPrompt, found: true},
+		{name: "invalid mode", metadata: `{"uiMode":"unknown"}`, origin: agentactivitybiz.TurnOriginUserPrompt, found: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &activityProjectionRepoStub{
+				submission:      agentactivitybiz.TurnSubmission{MetadataJSON: tt.metadata},
+				submissionFound: tt.found,
+			}
+			reporter := &recordingAgentAnalyticsReporter{}
+			projection := NewActivityProjection(repo)
+			projection.SetAnalyticsReporter(reporter)
+			_ = projection.ObserveCommitted(context.Background(), agenthost.CommittedDelta{
+				RootTurnsSettled: []agenthost.RootTurnSettled{{
+					WorkspaceID: "ws-1", AgentSessionID: "session-1", Provider: "codex", IsChildSession: tt.child,
+					Turn: agentactivitybiz.Turn{
+						TurnID: "turn-1", Origin: tt.origin, Backfilled: tt.backfilled,
+						Outcome: agentactivitybiz.TurnOutcomeCompleted,
+					},
+				}},
+			})
+			if len(reporter.events) != 0 {
+				t.Fatalf("events=%#v, want none", reporter.events)
+			}
+		})
+	}
+}
+
+func TestTerminalSubmissionModeRequiresClosedEnum(t *testing.T) {
+	for _, tt := range []struct {
+		metadata string
+		mode     string
+		ok       bool
+	}{
+		{metadata: `{"uiMode":"os"}`, mode: "os", ok: true},
+		{metadata: `{"uiMode":"agent"}`, mode: "agent", ok: true},
+		{metadata: `{"uiMode":" agent "}`},
+		{metadata: `{"uiMode":null}`},
+		{metadata: `{}`},
+		{metadata: `not-json`},
+	} {
+		mode, ok := terminalSubmissionMode(tt.metadata)
+		if mode != tt.mode || ok != tt.ok {
+			t.Fatalf("terminalSubmissionMode(%q)=(%q,%v), want (%q,%v)", tt.metadata, mode, ok, tt.mode, tt.ok)
+		}
+	}
+}

--- a/services/tuttid/service/agent/activity_projection_turn_terminal_test.go
+++ b/services/tuttid/service/agent/activity_projection_turn_terminal_test.go
@@ -6,6 +6,7 @@ import (
 
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	agentactivitybiz "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+	agentturnanalyticsbiz "github.com/tutti-os/tutti/services/tuttid/biz/agentturnanalytics"
 )
 
 func TestActivityProjectionReportsCanonicalUserTurnOutcomes(t *testing.T) {
@@ -54,6 +55,7 @@ func TestActivityProjectionReportsCanonicalUserTurnOutcomes(t *testing.T) {
 			for key, want := range map[string]any{
 				"agent_session_id": "session-1",
 				"client_submit_id": "submit-1",
+				"event_id":         agentturnanalyticsbiz.StableEventID("ws-1", "session-1", "turn-1"),
 				"mode":             "agent",
 				"provider":         "codex",
 				"turn_id":          "turn-1",

--- a/services/tuttid/service/agent/service_test_support_test.go
+++ b/services/tuttid/service/agent/service_test_support_test.go
@@ -25,23 +25,26 @@ func (f fakeAgentTargetLookup) GetAgentTarget(_ context.Context, id string) (age
 }
 
 type activityProjectionRepoStub struct {
-	clearResult    agentactivitybiz.ClearSessionsResult
-	settleStaleErr error
-	settlements    []agentactivitybiz.StaleTurnSettlement
-	stateResult    agentactivitybiz.StateReportResult
-	stateInput     agentactivitybiz.SessionStateReport
-	messageInput   agentactivitybiz.SessionMessageReport
-	messageResult  agentactivitybiz.MessageReportResult
-	messagePage    agentactivitybiz.MessagePage
-	messagePageOK  bool
-	messagePageErr error
-	turnResult     agentactivitybiz.Turn
-	turnResults    map[string]agentactivitybiz.Turn
-	turnFound      bool
-	turnErr        error
-	sectionsPage   agentactivitybiz.SessionSectionsPage
-	sectionsOK     bool
-	sectionsErr    error
+	clearResult     agentactivitybiz.ClearSessionsResult
+	settleStaleErr  error
+	settlements     []agentactivitybiz.StaleTurnSettlement
+	stateResult     agentactivitybiz.StateReportResult
+	stateInput      agentactivitybiz.SessionStateReport
+	messageInput    agentactivitybiz.SessionMessageReport
+	messageResult   agentactivitybiz.MessageReportResult
+	messagePage     agentactivitybiz.MessagePage
+	messagePageOK   bool
+	messagePageErr  error
+	turnResult      agentactivitybiz.Turn
+	turnResults     map[string]agentactivitybiz.Turn
+	turnFound       bool
+	turnErr         error
+	sectionsPage    agentactivitybiz.SessionSectionsPage
+	sectionsOK      bool
+	sectionsErr     error
+	submission      agentactivitybiz.TurnSubmission
+	submissionFound bool
+	submissionErr   error
 }
 
 func (r *activityProjectionRepoStub) ClearSessions(context.Context, string) (agentactivitybiz.ClearSessionsResult, error) {
@@ -171,6 +174,10 @@ func (r *activityProjectionRepoStub) GetTurn(_ context.Context, _ string, agentS
 		return turn, ok, r.turnErr
 	}
 	return r.turnResult, r.turnFound, r.turnErr
+}
+
+func (r *activityProjectionRepoStub) GetTurnSubmission(context.Context, string, string, string) (agentactivitybiz.TurnSubmission, bool, error) {
+	return r.submission, r.submissionFound, r.submissionErr
 }
 
 func (*activityProjectionRepoStub) GetLatestTurn(context.Context, string, string) (agentactivitybiz.Turn, bool, error) {

--- a/services/tuttid/service/reporter/events/agent/turn_terminal/event.go
+++ b/services/tuttid/service/reporter/events/agent/turn_terminal/event.go
@@ -1,0 +1,20 @@
+package turn_terminal
+
+import (
+	"context"
+
+	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
+	reporterevents "github.com/tutti-os/tutti/services/tuttid/service/reporter/events"
+)
+
+const (
+	EventCompleted = "agent.turn_completed"
+	EventFailed    = "agent.turn_failed"
+	EventCancelled = "agent.turn_cancelled"
+)
+
+type Params map[string]any
+
+func Track(ctx context.Context, reporter reporterservice.Reporter, eventName string, params Params) {
+	reporterevents.Track(ctx, reporter, eventName, map[string]any(params))
+}

--- a/services/tuttid/service/reporter/events/agent/turn_terminal/params.go
+++ b/services/tuttid/service/reporter/events/agent/turn_terminal/params.go
@@ -1,0 +1,129 @@
+package turn_terminal
+
+import "strings"
+
+const unknownErrorCode = "agent_unknown_error"
+
+type Input struct {
+	AgentSessionID    string
+	ClientSubmitID    string
+	ErrorCode         string
+	Mode              string
+	Outcome           string
+	Origin            string
+	Provider          string
+	StartupReconciled bool
+	StartedAtUnixMS   int64
+	SettledAtUnixMS   int64
+	TurnID            string
+}
+
+func Build(input Input) (string, Params, bool) {
+	mode := strings.TrimSpace(input.Mode)
+	if mode != "os" && mode != "agent" {
+		return "", nil, false
+	}
+	outcome := strings.TrimSpace(input.Outcome)
+	eventName, status := terminalEvent(outcome)
+	if eventName == "" {
+		return "", nil, false
+	}
+	provider := strings.TrimSpace(input.Provider)
+	if provider == "" {
+		provider = "unknown"
+	}
+	turnID := strings.TrimSpace(input.TurnID)
+	params := Params{
+		"agent_kind":          "local-agent",
+		"agent_session_id":    strings.TrimSpace(input.AgentSessionID),
+		"client_submit_id":    strings.TrimSpace(input.ClientSubmitID),
+		"event_source":        "canonical_turn_settled",
+		"interaction_source":  "user",
+		"invocation_id":       turnID,
+		"is_child_session":    false,
+		"mode":                mode,
+		"operation_id":        turnID,
+		"provider":            provider,
+		"startup_reconciled":  input.StartupReconciled,
+		"status":              status,
+		"surface":             "direct_session",
+		"turn_id":             turnID,
+		"turn_origin":         strings.TrimSpace(input.Origin),
+		"turn_outcome":        outcome,
+		"viewer_relationship": "self",
+		"viewer_role":         "owner",
+	}
+	if durationMS, ok := terminalDuration(input.StartedAtUnixMS, input.SettledAtUnixMS); ok {
+		params["duration_ms"] = durationMS
+		params["duration_bucket"] = durationBucket(durationMS)
+	}
+	switch eventName {
+	case EventCompleted:
+		params["value_enum"] = "completed"
+	case EventFailed:
+		params["error_category"] = "runtime"
+		params["error_code"] = safeErrorCode(input.ErrorCode)
+		params["failure_stage"] = "settled"
+	case EventCancelled:
+		if input.StartupReconciled {
+			params["source"] = "startup_reconciliation"
+		} else {
+			params["source"] = "runtime_event"
+		}
+	}
+	return eventName, params, true
+}
+
+func terminalEvent(outcome string) (string, string) {
+	switch outcome {
+	case "completed":
+		return EventCompleted, "completed"
+	case "failed":
+		return EventFailed, "failed"
+	case "canceled", "interrupted":
+		return EventCancelled, "cancelled"
+	default:
+		return "", ""
+	}
+}
+
+func terminalDuration(startedAtUnixMS, settledAtUnixMS int64) (int64, bool) {
+	if startedAtUnixMS <= 0 || settledAtUnixMS < startedAtUnixMS {
+		return 0, false
+	}
+	return settledAtUnixMS - startedAtUnixMS, true
+}
+
+func durationBucket(durationMS int64) string {
+	switch {
+	case durationMS < 1_000:
+		return "lt_1s"
+	case durationMS < 3_000:
+		return "1s_to_3s"
+	case durationMS < 10_000:
+		return "3s_to_10s"
+	case durationMS < 30_000:
+		return "10s_to_30s"
+	case durationMS < 60_000:
+		return "30s_to_60s"
+	default:
+		return "gte_60s"
+	}
+}
+
+func safeErrorCode(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" || len(value) > 128 {
+		return unknownErrorCode
+	}
+	for _, character := range value {
+		if (character >= 'a' && character <= 'z') ||
+			(character >= 'A' && character <= 'Z') ||
+			(character >= '0' && character <= '9') ||
+			character == '_' || character == '-' || character == '.' || character == ':' {
+			continue
+		}
+		return unknownErrorCode
+	}
+	return value
+}

--- a/services/tuttid/service/reporter/events/agent/turn_terminal/params_test.go
+++ b/services/tuttid/service/reporter/events/agent/turn_terminal/params_test.go
@@ -1,0 +1,65 @@
+package turn_terminal
+
+import "testing"
+
+func TestBuildMapsTerminalOutcomes(t *testing.T) {
+	tests := []struct {
+		name       string
+		outcome    string
+		eventName  string
+		status     string
+		extraKey   string
+		extraValue any
+	}{
+		{name: "completed", outcome: "completed", eventName: EventCompleted, status: "completed", extraKey: "value_enum", extraValue: "completed"},
+		{name: "failed", outcome: "failed", eventName: EventFailed, status: "failed", extraKey: "error_code", extraValue: "runtime_failed"},
+		{name: "canceled", outcome: "canceled", eventName: EventCancelled, status: "cancelled", extraKey: "source", extraValue: "runtime_event"},
+		{name: "interrupted", outcome: "interrupted", eventName: EventCancelled, status: "cancelled", extraKey: "source", extraValue: "startup_reconciliation"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eventName, params, ok := Build(Input{
+				AgentSessionID: "session-1", ClientSubmitID: "submit-1", ErrorCode: "runtime_failed",
+				Mode: "agent", Origin: "user_prompt", Outcome: tt.outcome, Provider: "codex",
+				StartupReconciled: tt.outcome == "interrupted", StartedAtUnixMS: 1_000,
+				SettledAtUnixMS: 11_000, TurnID: "turn-1",
+			})
+			if !ok || eventName != tt.eventName {
+				t.Fatalf("Build() event=%q ok=%v, want %q true", eventName, ok, tt.eventName)
+			}
+			for key, want := range map[string]any{
+				"agent_session_id": "session-1", "client_submit_id": "submit-1",
+				"duration_bucket": "10s_to_30s", "duration_ms": int64(10_000),
+				"mode": "agent", "provider": "codex", "status": tt.status,
+				"turn_id": "turn-1", "turn_origin": "user_prompt", "turn_outcome": tt.outcome,
+				tt.extraKey: tt.extraValue,
+			} {
+				if got := params[key]; got != want {
+					t.Fatalf("params[%q]=%#v, want %#v in %#v", key, got, want, params)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildRejectsMissingModeAndUnknownOutcome(t *testing.T) {
+	for _, input := range []Input{
+		{Mode: "", Outcome: "completed"},
+		{Mode: "unknown", Outcome: "completed"},
+		{Mode: "agent", Outcome: "running"},
+	} {
+		if eventName, params, ok := Build(input); ok || eventName != "" || params != nil {
+			t.Fatalf("Build(%#v)=(%q,%#v,%v), want rejected", input, eventName, params, ok)
+		}
+	}
+}
+
+func TestBuildUsesContentFreeErrorFallback(t *testing.T) {
+	_, params, ok := Build(Input{Mode: "os", Outcome: "failed", ErrorCode: "secret path /Users/example"})
+	if !ok || params["error_code"] != unknownErrorCode {
+		t.Fatalf("params=%#v ok=%v, want safe fallback", params, ok)
+	}
+	if _, exists := params["error_message"]; exists {
+		t.Fatalf("params contain raw error message: %#v", params)
+	}
+}

--- a/services/tuttid/wiring_daemon_api.go
+++ b/services/tuttid/wiring_daemon_api.go
@@ -508,6 +508,7 @@ func buildDaemonAPI(
 	if err := agentHost.Recover(ctx); err != nil {
 		return tuttiapi.DaemonAPI{}, nil, nil, nil, fmt.Errorf("recover agent host: %w", err)
 	}
+	go agentActivityProjection.RunTurnTerminalAnalytics(ctx)
 	go func() {
 		if err := agentHost.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
 			slog.ErrorContext(ctx, "agent Host worker lifecycle stopped", "error", err)


### PR DESCRIPTION
## Summary

Terminal turn analytics could be permanently missed when a provider settled a turn before the submission envelope was persisted. The same canonical root turn could also be emitted twice when provider settlement raced with cancel completion. Startup reconciliation, child-to-root settlement, and soft session deletion had additional gaps.

This PR includes the terminal outcome instrumentation from #2428 and makes it durable and idempotent:

- joins exact canonical `live -> settled` transitions to a product-owned SQLite delivery ledger in the same transaction
- persists only validated `uiMode` provenance in submit claims before provider dispatch, then joins late or rejected submissions safely
- delivers with a stable per-turn `event_id`, leased restart recovery, and serialized requeue/drain behavior
- reports only canonical root, direct `user_prompt`, non-backfilled turns
- distinguishes cancel targets settled by the current transaction from targets that were already settled
- carries full startup turn provenance, attributes child-triggered root settlement to the root owner, and covers soft-delete interruption
- cascades ledger cleanup when canonical turns are purged

The canonical turn lifecycle itself is unchanged; the new transaction marker records which accepted mutation actually performed the terminal transition so late metadata merges, replays, imports, forks, and already-settled cancel completion cannot manufacture analytics events.

## Verification

- `TestObservedCancelCompletionDoesNotRepeatAlreadySettledRoot` reproduces the provider/cancel overlap and verifies one settlement.
- `TestTerminalAnalyticsWorkerJoinsSettlementBeforeClaimAndStopsWithContext` commits settlement before provenance and verifies later durable delivery with one stable event ID.
- `TestSettleStaleTurnsOnStartupDeliversDurableTerminalAnalyticsOnce` verifies startup reconciliation is delivered once.
- `TestChildTerminalSettlesAndMarksCanonicalRootOnlyOnce` verifies a child terminal settles and marks only the canonical root.
- `TestSoftDeleteEmitsOnlyActualRootTurnTerminalTransition` verifies deleting an active session produces one interrupted root event without recreating historical events.
- `go test -race ./services/tuttid/service/agent -run '^TestTerminalAnalyticsStartupRequeueWaitsForInFlightObserverDrain$' -count=1`

## Fallback Three Questions

- Source: the one-second drain poll compensates for a settlement or provenance commit whose post-commit wake is lost because the process exits, or for the valid ordering where provider settlement commits before the submission envelope.
- Why can it not be fixed at that source? Provider acceptance and terminal reports may occur before `Runtime.Exec` returns, while submission provenance can only be finalized afterward. A post-commit observer is not a durable join between those independently ordered facts.
- Removal condition: remove the poll when both settlement and submission provenance feed a transactionally durable delivery queue with guaranteed wakeup/startup replay, or when they can be committed atomically at their source.

## Checklist

- [x] This does not change canonical session/turn/goal/runtime-operation lifecycle semantics; it records accepted terminal transitions and adds Host/store regression coverage.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
