### PR TITLE
Add Agent Host runtime admission diagnostics

### DIFF
--- a/packages/agent/host/command_failure.go
+++ b/packages/agent/host/command_failure.go
@@ -64,7 +64,7 @@ func (h *Host) beginCommand(
 	if h != nil {
 		command.startedAt = h.now()
 	}
-	if h == nil || h.terminalFailure == nil {
+	if h == nil {
 		return ctx, command
 	}
 	return context.WithValue(ctx, commandTerminalFailureKey{}, command), command

--- a/packages/agent/host/lifecycle.go
+++ b/packages/agent/host/lifecycle.go
@@ -22,7 +22,10 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 		operationID: operationID, requestID: activationID, clientSubmitID: clientSubmitID, turnID: input.TurnID,
 	})
 	var result CreateSessionResult
-	err := h.withWorkspaceRuntimeOperation(ctx, workspaceID, func(operationCtx context.Context) error {
+	err := h.withWorkspaceRuntimeOperationInfo(ctx, WorkspaceRuntimeOperationInfo{
+		WorkspaceID: workspaceID, OperationID: operationID, Kind: "session_create",
+		AgentSessionID: input.AgentSessionID, Source: "host.CreateSession",
+	}, func(operationCtx context.Context) error {
 		var createErr error
 		result, createErr = h.createSession(operationCtx, workspaceID, input)
 		return createErr
@@ -359,7 +362,10 @@ func (h *Host) EnsureRuntimeSession(ctx context.Context, ref SessionRef) (Provid
 		return ProviderRuntimeSession{}, ErrSessionNotFound
 	}
 	var result ProviderRuntimeSession
-	err := h.withWorkspaceRuntimeOperation(ctx, ref.WorkspaceID, func(operationCtx context.Context) error {
+	err := h.withWorkspaceRuntimeOperationInfo(ctx, WorkspaceRuntimeOperationInfo{
+		WorkspaceID: ref.WorkspaceID, Kind: "ensure_runtime_session",
+		AgentSessionID: ref.AgentSessionID, Source: "host.EnsureRuntimeSession",
+	}, func(operationCtx context.Context) error {
 		var ensureErr error
 		result, ensureErr = h.ensureRuntimeSession(operationCtx, ref)
 		return ensureErr

--- a/packages/agent/host/lifecycle.go
+++ b/packages/agent/host/lifecycle.go
@@ -774,37 +774,6 @@ func (h *Host) UpdateTitle(ctx context.Context, input UpdateTitleInput) (UpdateT
 	return result, nil
 }
 
-func (h *Host) requireSendAllowedByEffectiveHistory(ctx context.Context, ref SessionRef) error {
-	if h == nil || h.effectiveHistory == nil {
-		return nil
-	}
-	history, found, err := h.effectiveHistory.GetSessionHistory(ctx, ref.WorkspaceID, ref.AgentSessionID)
-	if err != nil || !found || history.RecoveryState == storesqlite.SessionHistoryRecoveryReady {
-		return err
-	}
-	if h.editRetryDisabled {
-		// Durable edit-retry is neutralized, so a fence whose owning operation is
-		// no longer in flight can never clear through the saga (recovery only
-		// quarantines claimable operations; a previously failed one is invisible
-		// to it). Heal it here so the session is not send-blocked forever; if the
-		// clear does not apply (operation still in flight), fall through to the
-		// normal fence error.
-		if cleared, clearErr := h.effectiveHistory.ClearAbandonedEditRetryFence(ctx, storesqlite.ClearAbandonedEditRetryFenceInput{
-			WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID, NowUnixMS: h.now().UnixMilli(),
-		}); clearErr == nil && cleared {
-			return nil
-		}
-	}
-	switch history.RecoveryState {
-	case storesqlite.SessionHistoryRecoveryRollbackPending:
-		return ErrEditRetryInProgress
-	case storesqlite.SessionHistoryRecoveryRequired:
-		return ErrEditRetryRecoveryRequired
-	default:
-		return ErrEditRetryResendPending
-	}
-}
-
 func (h *Host) acquireSession(ctx context.Context, ref SessionRef) (func(), error) {
 	if h.locker == nil {
 		return func() {}, nil

--- a/packages/agent/host/lifecycle_submission_helpers.go
+++ b/packages/agent/host/lifecycle_submission_helpers.go
@@ -1,0 +1,82 @@
+package agenthost
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+func (h *Host) recordTurnSubmission(
+	ctx context.Context,
+	ref SessionRef,
+	turnID string,
+	clientSubmitID string,
+	content []PromptContentBlock,
+	displayPrompt string,
+	capabilityRefs []CapabilityReference,
+	tuttiModeSnapshot *TuttiModeTurnSnapshot,
+) error {
+	if h == nil || h.turnSubmissions == nil {
+		return nil
+	}
+	contentJSON, err := json.Marshal(content)
+	if err != nil {
+		return fmt.Errorf("encode turn submission content: %w", err)
+	}
+	capabilityRefsJSON, err := json.Marshal(capabilityRefs)
+	if err != nil {
+		return fmt.Errorf("encode turn submission capability refs: %w", err)
+	}
+	tuttiModeSnapshotJSON, err := json.Marshal(tuttiModeSnapshot)
+	if err != nil {
+		return fmt.Errorf("encode turn submission tutti mode snapshot: %w", err)
+	}
+	now := h.now().UnixMilli()
+	_, _, err = h.turnSubmissions.RecordTurnSubmission(ctx, storesqlite.TurnSubmission{
+		WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
+		TurnID: strings.TrimSpace(turnID), ContentJSON: string(contentJSON),
+		DisplayPrompt:         strings.TrimSpace(displayPrompt),
+		CapabilityRefsJSON:    string(capabilityRefsJSON),
+		TuttiModeSnapshotJSON: string(tuttiModeSnapshotJSON),
+		ClientSubmitID:        strings.TrimSpace(clientSubmitID),
+		CreatedAtUnixMS:       now, UpdatedAtUnixMS: now,
+	})
+	if err != nil {
+		return fmt.Errorf("record turn submission envelope: %w", err)
+	}
+	return nil
+}
+
+func (h *Host) requireSendAllowedByEffectiveHistory(ctx context.Context, ref SessionRef) error {
+	if h == nil || h.effectiveHistory == nil {
+		return nil
+	}
+	history, found, err := h.effectiveHistory.GetSessionHistory(ctx, ref.WorkspaceID, ref.AgentSessionID)
+	if err != nil || !found || history.RecoveryState == storesqlite.SessionHistoryRecoveryReady {
+		return err
+	}
+	if h.editRetryDisabled {
+		// Durable edit-retry is neutralized, so a fence whose owning operation is
+		// no longer in flight can never clear through the saga (recovery only
+		// quarantines claimable operations; a previously failed one is invisible
+		// to it). Heal it here so the session is not send-blocked forever; if the
+		// clear does not apply (operation still in flight), fall through to the
+		// normal fence error.
+		if cleared, clearErr := h.effectiveHistory.ClearAbandonedEditRetryFence(ctx, storesqlite.ClearAbandonedEditRetryFenceInput{
+			WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID, NowUnixMS: h.now().UnixMilli(),
+		}); clearErr == nil && cleared {
+			return nil
+		}
+	}
+	switch history.RecoveryState {
+	case storesqlite.SessionHistoryRecoveryRollbackPending:
+		return ErrEditRetryInProgress
+	case storesqlite.SessionHistoryRecoveryRequired:
+		return ErrEditRetryRecoveryRequired
+	default:
+		return ErrEditRetryResendPending
+	}
+}

--- a/packages/agent/host/lifecycle_submission_helpers.go
+++ b/packages/agent/host/lifecycle_submission_helpers.go
@@ -2,53 +2,9 @@ package agenthost
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"strings"
 
 	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 )
-
-func (h *Host) recordTurnSubmission(
-	ctx context.Context,
-	ref SessionRef,
-	turnID string,
-	clientSubmitID string,
-	content []PromptContentBlock,
-	displayPrompt string,
-	capabilityRefs []CapabilityReference,
-	tuttiModeSnapshot *TuttiModeTurnSnapshot,
-) error {
-	if h == nil || h.turnSubmissions == nil {
-		return nil
-	}
-	contentJSON, err := json.Marshal(content)
-	if err != nil {
-		return fmt.Errorf("encode turn submission content: %w", err)
-	}
-	capabilityRefsJSON, err := json.Marshal(capabilityRefs)
-	if err != nil {
-		return fmt.Errorf("encode turn submission capability refs: %w", err)
-	}
-	tuttiModeSnapshotJSON, err := json.Marshal(tuttiModeSnapshot)
-	if err != nil {
-		return fmt.Errorf("encode turn submission tutti mode snapshot: %w", err)
-	}
-	now := h.now().UnixMilli()
-	_, _, err = h.turnSubmissions.RecordTurnSubmission(ctx, storesqlite.TurnSubmission{
-		WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
-		TurnID: strings.TrimSpace(turnID), ContentJSON: string(contentJSON),
-		DisplayPrompt:         strings.TrimSpace(displayPrompt),
-		CapabilityRefsJSON:    string(capabilityRefsJSON),
-		TuttiModeSnapshotJSON: string(tuttiModeSnapshotJSON),
-		ClientSubmitID:        strings.TrimSpace(clientSubmitID),
-		CreatedAtUnixMS:       now, UpdatedAtUnixMS: now,
-	})
-	if err != nil {
-		return fmt.Errorf("record turn submission envelope: %w", err)
-	}
-	return nil
-}
 
 func (h *Host) requireSendAllowedByEffectiveHistory(ctx context.Context, ref SessionRef) error {
 	if h == nil || h.effectiveHistory == nil {

--- a/packages/agent/host/lifecycle_workspace_disconnect_test.go
+++ b/packages/agent/host/lifecycle_workspace_disconnect_test.go
@@ -154,6 +154,77 @@ func TestDurableWorkspaceRuntimeDisconnectFenceRunsSweepWithExclusiveContext(t *
 	}
 }
 
+func TestWorkspaceRuntimeAdmissionSnapshotReportsOperationAndFenceHolders(t *testing.T) {
+	t.Parallel()
+	host := New(Config{Runtime: &workspaceDisconnectRuntime{disconnected: make(map[string]bool)}})
+	operationEntered := make(chan struct{})
+	releaseOperation := make(chan struct{})
+	operationDone := make(chan error, 1)
+	go func() {
+		operationDone <- host.WithWorkspaceRuntimeOperationInfo(
+			context.Background(),
+			WorkspaceRuntimeOperationInfo{
+				WorkspaceID:    "workspace-1",
+				OperationID:    "operation-1",
+				Kind:           "prompt_turn",
+				AgentSessionID: "session-1",
+				Source:         "test.operation",
+			},
+			func(context.Context) error {
+				close(operationEntered)
+				<-releaseOperation
+				return nil
+			},
+		)
+	}()
+	<-operationEntered
+
+	fence, err := host.AcquireWorkspaceRuntimeDisconnectFence(context.Background(), "workspace-1")
+	if err != nil {
+		t.Fatalf("AcquireWorkspaceRuntimeDisconnectFence: %v", err)
+	}
+
+	snapshot := host.SnapshotWorkspaceRuntimeAdmission("workspace-1")
+	if snapshot.Operations != 1 || snapshot.Disconnectors != 1 || snapshot.Exclusive || !snapshot.Disconnecting {
+		t.Fatalf("initial admission snapshot = %#v", snapshot)
+	}
+	if len(snapshot.OperationHolders) != 1 || snapshot.OperationHolders[0].OperationID != "operation-1" ||
+		snapshot.OperationHolders[0].Kind != "prompt_turn" ||
+		snapshot.OperationHolders[0].AgentSessionID != "session-1" ||
+		snapshot.OperationHolders[0].Source != "test.operation" || snapshot.OperationHolders[0].StartedAt.IsZero() {
+		t.Fatalf("operation holder snapshot = %#v", snapshot.OperationHolders)
+	}
+	if len(snapshot.DisconnectHolders) != 1 || snapshot.DisconnectHolders[0].FenceID == "" ||
+		snapshot.DisconnectHolders[0].Exclusive || snapshot.DisconnectHolders[0].AcquiredAt.IsZero() {
+		t.Fatalf("disconnect holder snapshot = %#v", snapshot.DisconnectHolders)
+	}
+
+	waitCtx, cancelWait := context.WithCancel(context.Background())
+	cancelWait()
+	if _, err := fence.Wait(waitCtx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled fence wait error = %v", err)
+	}
+	if got := host.SnapshotWorkspaceRuntimeAdmission("workspace-1"); got.Operations != 1 || got.Disconnectors != 1 {
+		t.Fatalf("snapshot after canceled wait = %#v", got)
+	}
+
+	close(releaseOperation)
+	if err := <-operationDone; err != nil {
+		t.Fatalf("runtime operation: %v", err)
+	}
+	if _, err := fence.Wait(context.Background()); err != nil {
+		t.Fatalf("retry fence wait: %v", err)
+	}
+	snapshot = host.SnapshotWorkspaceRuntimeAdmission("workspace-1")
+	if !snapshot.Exclusive || len(snapshot.DisconnectHolders) != 1 || !snapshot.DisconnectHolders[0].Exclusive {
+		t.Fatalf("exclusive admission snapshot = %#v", snapshot)
+	}
+	fence.Release()
+	if got := host.SnapshotWorkspaceRuntimeAdmission("workspace-1"); got.Operations != 0 || got.Disconnectors != 0 || got.Exclusive || got.Disconnecting {
+		t.Fatalf("released admission snapshot = %#v", got)
+	}
+}
+
 func TestReentrantAttachmentCleanupDoesNotDisconnectNewConnectionAfterOperationLeaves(t *testing.T) {
 	t.Parallel()
 	runtime := &workspaceDisconnectRuntime{

--- a/packages/agent/host/runtime_operations.go
+++ b/packages/agent/host/runtime_operations.go
@@ -160,7 +160,11 @@ func (h *Host) processRuntimeOperation(ctx context.Context, operation storesqlit
 	if operation.Kind == storesqlite.RuntimeOperationKindPlanDecision {
 		var result storesqlite.RuntimeOperation
 		var processErr error
-		err := h.withWorkspaceRuntimeOperation(ctx, operation.WorkspaceID, func(operationCtx context.Context) error {
+		err := h.withWorkspaceRuntimeOperationInfo(ctx, WorkspaceRuntimeOperationInfo{
+			WorkspaceID: operation.WorkspaceID, OperationID: operation.OperationID,
+			Kind: operation.Kind, AgentSessionID: operation.AgentSessionID,
+			Source: "host.runtime_operation_worker",
+		}, func(operationCtx context.Context) error {
 			result, processErr = h.processRuntimeOperationAdmitted(operationCtx, operation, recovering)
 			return processErr
 		})

--- a/packages/agent/host/session_actor.go
+++ b/packages/agent/host/session_actor.go
@@ -68,7 +68,9 @@ func (h *Host) withSessionMutationActor(ctx context.Context, workspaceID, agentS
 	if h == nil || h.sessionMutationActor == nil {
 		return ErrInvalidArgument
 	}
-	return h.withWorkspaceRuntimeOperation(ctx, workspaceID, func(operationCtx context.Context) error {
+	return h.withWorkspaceRuntimeOperationInfo(ctx, WorkspaceRuntimeOperationInfo{
+		WorkspaceID: workspaceID, AgentSessionID: agentSessionID,
+	}, func(operationCtx context.Context) error {
 		return h.sessionMutationActor.Do(operationCtx, SessionRef{WorkspaceID: workspaceID, AgentSessionID: agentSessionID}, fn)
 	})
 }

--- a/packages/agent/host/session_management.go
+++ b/packages/agent/host/session_management.go
@@ -48,7 +48,10 @@ func (h *Host) GetSession(ctx context.Context, ref SessionRef) (GetSessionResult
 // lock used by resume protects both paths.
 func (h *Host) UpdateSettings(ctx context.Context, input UpdateSettingsInput) (UpdateSettingsResult, error) {
 	var result UpdateSettingsResult
-	err := h.withWorkspaceRuntimeOperation(ctx, input.WorkspaceID, func(operationCtx context.Context) error {
+	err := h.withWorkspaceRuntimeOperationInfo(ctx, WorkspaceRuntimeOperationInfo{
+		WorkspaceID: input.WorkspaceID, Kind: "settings_update",
+		AgentSessionID: input.AgentSessionID, Source: "host.UpdateSettings",
+	}, func(operationCtx context.Context) error {
 		var updateErr error
 		result, updateErr = h.updateSettings(operationCtx, input)
 		return updateErr

--- a/packages/agent/host/workspace_runtime_gate.go
+++ b/packages/agent/host/workspace_runtime_gate.go
@@ -3,12 +3,57 @@ package agenthost
 import (
 	"context"
 	"errors"
+	"log/slog"
+	"sort"
 	"strings"
 	"sync"
+	"time"
+
+	"github.com/google/uuid"
 )
 
 var errWorkspaceRuntimeDisconnectReentrant = errors.New("workspace runtime disconnect requested by an admitted operation")
 var errWorkspaceRuntimeDisconnectFenceReleased = errors.New("workspace runtime disconnect fence is released")
+
+// WorkspaceRuntimeOperationInfo identifies one runtime mutation for admission
+// diagnostics. OperationID is caller-owned when available; Host generates one
+// when the caller does not provide it.
+type WorkspaceRuntimeOperationInfo struct {
+	WorkspaceID    string
+	OperationID    string
+	Kind           string
+	AgentSessionID string
+	Source         string
+}
+
+// WorkspaceRuntimeOperationSnapshot describes one mutation currently admitted
+// by a Workspace runtime gate.
+type WorkspaceRuntimeOperationSnapshot struct {
+	OperationID    string
+	Kind           string
+	AgentSessionID string
+	Source         string
+	StartedAt      time.Time
+}
+
+// WorkspaceRuntimeDisconnectSnapshot describes one acquired disconnect fence.
+type WorkspaceRuntimeDisconnectSnapshot struct {
+	FenceID    string
+	AcquiredAt time.Time
+	Exclusive  bool
+}
+
+// WorkspaceRuntimeAdmissionSnapshot is a point-in-time diagnostic view of one
+// Workspace runtime gate. It is read-only and does not affect admission.
+type WorkspaceRuntimeAdmissionSnapshot struct {
+	WorkspaceID       string
+	Operations        int
+	Disconnectors     int
+	Disconnecting     bool
+	Exclusive         bool
+	OperationHolders  []WorkspaceRuntimeOperationSnapshot
+	DisconnectHolders []WorkspaceRuntimeDisconnectSnapshot
+}
 
 type workspaceRuntimeAdmission struct {
 	mu     sync.Mutex
@@ -16,13 +61,15 @@ type workspaceRuntimeAdmission struct {
 }
 
 type workspaceRuntimeAdmissionState struct {
-	changed       chan struct{}
-	operations    int
-	disconnecting bool
-	disconnectors int
-	exclusive     bool
-	refs          int
-	deferred      []func(context.Context)
+	changed           chan struct{}
+	operations        int
+	disconnecting     bool
+	disconnectors     int
+	exclusive         bool
+	refs              int
+	deferred          []func(context.Context)
+	operationHolders  map[string]WorkspaceRuntimeOperationSnapshot
+	disconnectHolders map[string]WorkspaceRuntimeDisconnectSnapshot
 }
 
 // WorkspaceRuntimeDisconnectFence closes Workspace runtime admission as soon
@@ -33,6 +80,8 @@ type WorkspaceRuntimeDisconnectFence struct {
 	gate        *workspaceRuntimeAdmission
 	workspaceID string
 	state       *workspaceRuntimeAdmissionState
+	holderID    string
+	fenceID     string
 
 	mu        sync.Mutex
 	released  bool
@@ -52,11 +101,45 @@ func newWorkspaceRuntimeAdmission() *workspaceRuntimeAdmission {
 	return &workspaceRuntimeAdmission{states: make(map[string]*workspaceRuntimeAdmissionState)}
 }
 
+func normalizeWorkspaceRuntimeOperationInfo(
+	ctx context.Context,
+	info WorkspaceRuntimeOperationInfo,
+) WorkspaceRuntimeOperationInfo {
+	info.WorkspaceID = strings.TrimSpace(info.WorkspaceID)
+	if command := commandTerminalFailureFrom(ctx); command != nil {
+		command.mu.Lock()
+		if info.OperationID == "" {
+			info.OperationID = strings.TrimSpace(command.operationID)
+		}
+		if info.Kind == "" {
+			info.Kind = strings.TrimSpace(command.flow)
+		}
+		if info.AgentSessionID == "" {
+			info.AgentSessionID = strings.TrimSpace(command.agentSessionID)
+		}
+		if info.Source == "" && command.flow != "" {
+			info.Source = "host.command." + strings.TrimSpace(command.flow)
+		}
+		command.mu.Unlock()
+	}
+	if info.OperationID == "" {
+		info.OperationID = "runtime-operation:" + uuid.NewString()
+	}
+	if info.Kind == "" {
+		info.Kind = "runtime_operation"
+	}
+	if info.Source == "" {
+		info.Source = "host.workspace_runtime_operation"
+	}
+	return info
+}
+
 func (g *workspaceRuntimeAdmission) enterOperation(
 	ctx context.Context,
-	workspaceID string,
+	info WorkspaceRuntimeOperationInfo,
 ) (context.Context, func(), error) {
-	workspaceID = strings.TrimSpace(workspaceID)
+	info = normalizeWorkspaceRuntimeOperationInfo(ctx, info)
+	workspaceID := info.WorkspaceID
 	if g == nil || workspaceID == "" {
 		return ctx, func() {}, ErrInvalidArgument
 	}
@@ -71,6 +154,14 @@ func (g *workspaceRuntimeAdmission) enterOperation(
 		g.mu.Lock()
 		state := g.stateLocked(workspaceID)
 		if !state.disconnecting {
+			holderID := uuid.NewString()
+			state.operationHolders[holderID] = WorkspaceRuntimeOperationSnapshot{
+				OperationID:    info.OperationID,
+				Kind:           info.Kind,
+				AgentSessionID: info.AgentSessionID,
+				Source:         info.Source,
+				StartedAt:      time.Now(),
+			}
 			state.operations++
 			g.mu.Unlock()
 			operationCtx := context.WithValue(ctx, workspaceRuntimeAdmissionContextKey{}, workspaceRuntimeAdmissionContext{
@@ -78,7 +169,7 @@ func (g *workspaceRuntimeAdmission) enterOperation(
 			})
 			var once sync.Once
 			return operationCtx, func() {
-				once.Do(func() { g.leaveOperation(workspaceID, state) })
+				once.Do(func() { g.leaveOperation(workspaceID, state, holderID) })
 			}, nil
 		}
 		changed := state.changed
@@ -137,13 +228,21 @@ func (g *workspaceRuntimeAdmission) acquireDisconnectFence(
 	}
 	g.mu.Lock()
 	state := g.stateLocked(workspaceID)
+	holderID := uuid.NewString()
+	fenceID := uuid.NewString()
 	state.disconnectors++
+	state.disconnectHolders[holderID] = WorkspaceRuntimeDisconnectSnapshot{
+		FenceID: fenceID, AcquiredAt: time.Now(), Exclusive: false,
+	}
 	if !state.disconnecting {
 		state.disconnecting = true
 		g.notifyLocked(state)
 	}
 	g.mu.Unlock()
-	return &WorkspaceRuntimeDisconnectFence{gate: g, workspaceID: workspaceID, state: state}, nil
+	return &WorkspaceRuntimeDisconnectFence{
+		gate: g, workspaceID: workspaceID, state: state,
+		holderID: holderID, fenceID: fenceID,
+	}, nil
 }
 
 // Wait drains already-admitted operations and grants one exclusive disconnect
@@ -154,6 +253,7 @@ func (f *WorkspaceRuntimeDisconnectFence) Wait(ctx context.Context) (context.Con
 		return ctx, ErrInvalidArgument
 	}
 	if err := ctx.Err(); err != nil {
+		f.logWaitFailure(err)
 		return ctx, err
 	}
 	f.mu.Lock()
@@ -179,6 +279,10 @@ func (f *WorkspaceRuntimeDisconnectFence) Wait(ctx context.Context) (context.Con
 			}
 			f.state.exclusive = true
 			f.exclusive = true
+			if holder, ok := f.state.disconnectHolders[f.holderID]; ok {
+				holder.Exclusive = true
+				f.state.disconnectHolders[f.holderID] = holder
+			}
 			f.mu.Unlock()
 			f.gate.mu.Unlock()
 			return context.WithValue(ctx, workspaceRuntimeAdmissionContextKey{}, workspaceRuntimeAdmissionContext{
@@ -189,7 +293,9 @@ func (f *WorkspaceRuntimeDisconnectFence) Wait(ctx context.Context) (context.Con
 		f.gate.mu.Unlock()
 		select {
 		case <-ctx.Done():
-			return ctx, ctx.Err()
+			err := ctx.Err()
+			f.logWaitFailure(err)
+			return ctx, err
 		case <-changed:
 		}
 	}
@@ -213,6 +319,7 @@ func (f *WorkspaceRuntimeDisconnectFence) Release() {
 		f.state.exclusive = false
 		f.exclusive = false
 	}
+	delete(f.state.disconnectHolders, f.holderID)
 	f.state.disconnectors--
 	if f.state.disconnectors == 0 && len(f.state.deferred) == 0 {
 		f.state.disconnecting = false
@@ -226,15 +333,20 @@ func (f *WorkspaceRuntimeDisconnectFence) Release() {
 func (g *workspaceRuntimeAdmission) stateLocked(workspaceID string) *workspaceRuntimeAdmissionState {
 	state := g.states[workspaceID]
 	if state == nil {
-		state = &workspaceRuntimeAdmissionState{changed: make(chan struct{})}
+		state = &workspaceRuntimeAdmissionState{
+			changed:           make(chan struct{}),
+			operationHolders:  make(map[string]WorkspaceRuntimeOperationSnapshot),
+			disconnectHolders: make(map[string]WorkspaceRuntimeDisconnectSnapshot),
+		}
 		g.states[workspaceID] = state
 	}
 	state.refs++
 	return state
 }
 
-func (g *workspaceRuntimeAdmission) leaveOperation(workspaceID string, state *workspaceRuntimeAdmissionState) {
+func (g *workspaceRuntimeAdmission) leaveOperation(workspaceID string, state *workspaceRuntimeAdmissionState, holderID string) {
 	g.mu.Lock()
+	delete(state.operationHolders, holderID)
 	state.operations--
 	g.notifyLocked(state)
 	var deferred []func(context.Context)
@@ -302,6 +414,60 @@ func (g *workspaceRuntimeAdmission) releaseReferenceLocked(workspaceID string, s
 	}
 }
 
+func (g *workspaceRuntimeAdmission) snapshot(workspaceID string) WorkspaceRuntimeAdmissionSnapshot {
+	workspaceID = strings.TrimSpace(workspaceID)
+	snapshot := WorkspaceRuntimeAdmissionSnapshot{WorkspaceID: workspaceID}
+	if g == nil || workspaceID == "" {
+		return snapshot
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	state := g.states[workspaceID]
+	if state == nil {
+		return snapshot
+	}
+	snapshot.Operations = state.operations
+	snapshot.Disconnectors = state.disconnectors
+	snapshot.Disconnecting = state.disconnecting
+	snapshot.Exclusive = state.exclusive
+	for _, holder := range state.operationHolders {
+		snapshot.OperationHolders = append(snapshot.OperationHolders, holder)
+	}
+	for _, holder := range state.disconnectHolders {
+		snapshot.DisconnectHolders = append(snapshot.DisconnectHolders, holder)
+	}
+	sort.Slice(snapshot.OperationHolders, func(i, j int) bool {
+		left, right := snapshot.OperationHolders[i], snapshot.OperationHolders[j]
+		if !left.StartedAt.Equal(right.StartedAt) {
+			return left.StartedAt.Before(right.StartedAt)
+		}
+		return left.OperationID < right.OperationID
+	})
+	sort.Slice(snapshot.DisconnectHolders, func(i, j int) bool {
+		return snapshot.DisconnectHolders[i].FenceID < snapshot.DisconnectHolders[j].FenceID
+	})
+	return snapshot
+}
+
+func (f *WorkspaceRuntimeDisconnectFence) logWaitFailure(err error) {
+	if f == nil || f.gate == nil || err == nil {
+		return
+	}
+	snapshot := f.gate.snapshot(f.workspaceID)
+	slog.Warn("workspace runtime disconnect drain wait failed",
+		"event", "agent.host.workspace_runtime.disconnect.drain_wait_failed",
+		"workspace_id", snapshot.WorkspaceID,
+		"fence_id", f.fenceID,
+		"error", err,
+		"operations", snapshot.Operations,
+		"disconnectors", snapshot.Disconnectors,
+		"disconnecting", snapshot.Disconnecting,
+		"exclusive", snapshot.Exclusive,
+		"operation_holders", snapshot.OperationHolders,
+		"disconnect_holders", snapshot.DisconnectHolders,
+	)
+}
+
 func (*workspaceRuntimeAdmission) notifyLocked(state *workspaceRuntimeAdmissionState) {
 	close(state.changed)
 	state.changed = make(chan struct{})
@@ -312,10 +478,18 @@ func (h *Host) withWorkspaceRuntimeOperation(
 	workspaceID string,
 	fn func(context.Context) error,
 ) error {
+	return h.withWorkspaceRuntimeOperationInfo(ctx, WorkspaceRuntimeOperationInfo{WorkspaceID: workspaceID}, fn)
+}
+
+func (h *Host) withWorkspaceRuntimeOperationInfo(
+	ctx context.Context,
+	info WorkspaceRuntimeOperationInfo,
+	fn func(context.Context) error,
+) error {
 	if h == nil || h.workspaceRuntimeAdmission == nil || fn == nil {
 		return ErrInvalidArgument
 	}
-	operationCtx, release, err := h.workspaceRuntimeAdmission.enterOperation(ctx, workspaceID)
+	operationCtx, release, err := h.workspaceRuntimeAdmission.enterOperation(ctx, info)
 	if err != nil {
 		return err
 	}
@@ -333,6 +507,28 @@ func (h *Host) WithWorkspaceRuntimeOperation(
 	fn func(context.Context) error,
 ) error {
 	return h.withWorkspaceRuntimeOperation(ctx, workspaceID, fn)
+}
+
+// WithWorkspaceRuntimeOperationInfo runs one caller-owned runtime mutation
+// under Host's Workspace admission with diagnostics supplied by the caller.
+// It is an additive variant of WithWorkspaceRuntimeOperation for adapters that
+// can name the concrete runtime operation and session.
+func (h *Host) WithWorkspaceRuntimeOperationInfo(
+	ctx context.Context,
+	info WorkspaceRuntimeOperationInfo,
+	fn func(context.Context) error,
+) error {
+	return h.withWorkspaceRuntimeOperationInfo(ctx, info, fn)
+}
+
+// SnapshotWorkspaceRuntimeAdmission returns the current diagnostic state for
+// one Workspace runtime gate. The snapshot is empty when the Workspace has no
+// live gate state.
+func (h *Host) SnapshotWorkspaceRuntimeAdmission(workspaceID string) WorkspaceRuntimeAdmissionSnapshot {
+	if h == nil || h.workspaceRuntimeAdmission == nil {
+		return WorkspaceRuntimeAdmissionSnapshot{WorkspaceID: strings.TrimSpace(workspaceID)}
+	}
+	return h.workspaceRuntimeAdmission.snapshot(workspaceID)
 }
 
 // AcquireWorkspaceRuntimeDisconnectFence synchronously prevents new runtime


### PR DESCRIPTION
## Summary
- Add per-workspace runtime admission snapshots with operation and disconnect-fence holders.
- Log drain-wait failures with operation counts, fence state, IDs, kinds, session IDs, sources, and start times.
- Identify common Agent Host runtime operations in the admission state.

## Tests
- `go test ./...` (packages/agent/host)
- `golangci-lint run --allow-parallel-runners --config services/tuttid/.golangci.yml packages/agent/host`

## Notes
- The changed-check lanes that require repository `node_modules` could not run in this worktree; CI should provide those dependencies.