### PR TITLE
fix(agent): make Controller own canonical submit admission

### DIFF
--- a/packages/agent/activity-core/src/engine/createAgentSessionEngine.ts
+++ b/packages/agent/activity-core/src/engine/createAgentSessionEngine.ts
@@ -32,6 +32,7 @@ import {
   type SessionMutationCancellation
 } from "./sessionMutationDispatch.ts";
 import { requestSessionActivation } from "./sessionActivation.operation.ts";
+import { createPromptQueueId } from "./promptQueue.identity.ts";
 import {
   createInitialAgentSessionEngineState,
   rootEngineReducer
@@ -589,6 +590,7 @@ export function createAgentSessionEngine({
           }
         : {}),
       clientSubmitId,
+      promptId: createPromptQueueId(),
       content,
       ...(displayPrompt ? { displayPrompt } : {}),
       expiresAtUnixMs:

--- a/packages/agent/activity-core/src/engine/engineIntent.normalization.ts
+++ b/packages/agent/activity-core/src/engine/engineIntent.normalization.ts
@@ -3,6 +3,7 @@ import type {
   EngineClock,
   EngineIntent
 } from "./types.ts";
+import { createPromptQueueId } from "./promptQueue.identity.ts";
 
 export function withEngineObservationTime(
   intent: EngineIntent,
@@ -15,6 +16,13 @@ export function withEngineObservationTime(
     intent.observedAtUnixMs === undefined
   ) {
     return { ...intent, observedAtUnixMs: clock.nowUnixMs() };
+  }
+  if (
+    (intent.type === "submit/requested" ||
+      intent.type === "plan/feedbackRequested") &&
+    !intent.promptId?.trim()
+  ) {
+    return { ...intent, promptId: createPromptQueueId() };
   }
   return intent;
 }

--- a/packages/agent/activity-core/src/engine/engineRuntime.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/engineRuntime.reducer.test.ts
@@ -269,6 +269,10 @@ test("submit during in-flight activation queues and drains once the session appe
       ?.clientSubmitId,
     "submit-1"
   );
+  const promptId =
+    submitted.state.promptQueue.recordsBySessionId["session-1"]?.prompts[0]?.id;
+  assert.ok(promptId);
+  assert.notEqual(promptId, "submit-1");
   assert.equal(
     submitted.commands.some((command) => command.type === "queue/sendPrompt"),
     false
@@ -297,6 +301,10 @@ test("submit during in-flight activation queues and drains once the session appe
   assert.equal(
     send?.type === "queue/sendPrompt" ? send.clientSubmitId : "",
     "submit-1"
+  );
+  assert.equal(
+    send?.type === "queue/sendPrompt" ? send.promptId : "",
+    promptId
   );
 });
 
@@ -350,6 +358,7 @@ test("canceling a queued submit atomically removes queue and pending intent", ()
   state = rootEngineReducer(state, {
     agentSessionId: "session-1",
     clientSubmitId: "submit-1",
+    promptId: "prompt-submit-1",
     content: [{ type: "text", text: "queued" }],
     expiresAtUnixMs: 120_000,
     requestedAtUnixMs: 2,
@@ -646,6 +655,7 @@ test("an uncertain queued submit cannot be half-canceled", () => {
   state = rootEngineReducer(state, {
     agentSessionId: "session-1",
     clientSubmitId: "submit-1",
+    promptId: "prompt-submit-1",
     content: [{ type: "text", text: "queued" }],
     expiresAtUnixMs: 120_000,
     requestedAtUnixMs: 2,
@@ -693,7 +703,7 @@ test("an uncertain queued submit cannot be half-canceled", () => {
   assert.equal(
     canceled.state.promptQueue.recordsBySessionId["session-1"]
       ?.uncertainDelivery?.promptId,
-    "submit-1"
+    "prompt-submit-1"
   );
   assert.deepEqual(canceled.commands, []);
 
@@ -709,7 +719,7 @@ test("an uncertain queued submit cannot be half-canceled", () => {
   assert.equal(
     expired.state.promptQueue.recordsBySessionId["session-1"]?.uncertainDelivery
       ?.promptId,
-    "submit-1"
+    "prompt-submit-1"
   );
 });
 
@@ -963,7 +973,7 @@ test("composer send-now uses exact-turn cancel before a normal ACP prompt", () =
   );
   assert.equal(
     result.state.promptQueue.recordsBySessionId["session-1"]?.sendNextPromptId,
-    "submit-fallback"
+    "prompt-submit-fallback"
   );
 });
 
@@ -1296,7 +1306,7 @@ test("successful queued send waits for its exact canonical turn before FIFO drai
   );
   assert.equal(
     secondSend?.type === "queue/sendPrompt" ? secondSend.promptId : null,
-    "submit-2"
+    "prompt-submit-2"
   );
 });
 
@@ -1378,7 +1388,7 @@ test("timeout message confirmation waits for exact-turn lifecycle reconcile", ()
   );
   assert.equal(
     secondSend?.type === "queue/sendPrompt" ? secondSend.promptId : null,
-    "submit-2"
+    "prompt-submit-2"
   );
 });
 
@@ -1386,6 +1396,7 @@ function queuedSubmit(clientSubmitId: string, requestedAtUnixMs: number) {
   return {
     agentSessionId: "session-1",
     clientSubmitId,
+    promptId: `prompt-${clientSubmitId}`,
     content: [{ type: "text" as const, text: clientSubmitId }],
     expiresAtUnixMs: requestedAtUnixMs + 120_000,
     requestedAtUnixMs,
@@ -1421,6 +1432,7 @@ function sendNowSubmit(clientSubmitId: string) {
   return {
     agentSessionId: "session-1",
     clientSubmitId,
+    promptId: `prompt-${clientSubmitId}`,
     content: [{ type: "text" as const, text: "inserted" }],
     expiresAtUnixMs: 120_000,
     requestedAtUnixMs: 2,

--- a/packages/agent/activity-core/src/engine/pendingIntents.types.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.types.ts
@@ -272,6 +272,8 @@ export interface SubmitRequestedIntent {
   type: "submit/requested";
   agentSessionId: string;
   clientSubmitId: string;
+  /** Queue-owned identity; absent only for older replayed intents. */
+  promptId?: string;
   capabilityRefs?: readonly AgentActivityCapabilityReference[];
   content: readonly AgentPromptContentBlock[];
   displayPrompt?: string;

--- a/packages/agent/activity-core/src/engine/planDecision.types.ts
+++ b/packages/agent/activity-core/src/engine/planDecision.types.ts
@@ -43,6 +43,8 @@ export interface PlanFeedbackRequestedIntent {
   agentSessionId: string;
   capabilityRefs?: readonly import("../types.ts").AgentActivityCapabilityReference[];
   clientSubmitId: string;
+  /** Queue-owned identity; absent only for older replayed intents. */
+  promptId?: string;
   content: readonly import("../types.ts").AgentPromptContentBlock[];
   displayPrompt?: string;
   expiresAtUnixMs: number;

--- a/packages/agent/activity-core/src/engine/promptQueue.identity.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.identity.ts
@@ -1,0 +1,8 @@
+/** Allocates a queue-local identity distinct from clientSubmitId. */
+export function createPromptQueueId(): string {
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return `prompt:${globalThis.crypto.randomUUID()}`;
+  }
+  const fallbackHex = Math.random().toString(16).slice(2).padEnd(12, "0");
+  return `prompt:00000000-0000-4000-8000-${fallbackHex.slice(0, 12)}`;
+}

--- a/packages/agent/activity-core/src/engine/promptQueue.lookup.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.lookup.ts
@@ -12,6 +12,48 @@ export function promptQueuePromptIdForClientSubmit(
   );
 }
 
+export function promptQueueHasClientSubmitInFlight(
+  state: PromptQueueState,
+  agentSessionId: string,
+  clientSubmitId: string
+): boolean {
+  const sessionId = agentSessionId.trim();
+  const submitId = clientSubmitId.trim();
+  const record = state.recordsBySessionId[sessionId];
+  if (!record || !submitId) return false;
+  const promptId = promptQueuePromptIdForClientSubmit(
+    state,
+    sessionId,
+    submitId
+  );
+  return Boolean(
+    record.inFlight &&
+    (record.inFlight.clientSubmitId === submitId ||
+      record.inFlight.promptId === promptId)
+  );
+}
+
+export function promptQueueHasClientSubmitUncertainDelivery(
+  state: PromptQueueState,
+  agentSessionId: string,
+  clientSubmitId: string
+): boolean {
+  const sessionId = agentSessionId.trim();
+  const submitId = clientSubmitId.trim();
+  const record = state.recordsBySessionId[sessionId];
+  if (!record || !submitId) return false;
+  const promptId = promptQueuePromptIdForClientSubmit(
+    state,
+    sessionId,
+    submitId
+  );
+  return Boolean(
+    record.uncertainDelivery &&
+    (record.uncertainDelivery.clientSubmitId === submitId ||
+      record.uncertainDelivery.promptId === promptId)
+  );
+}
+
 export function canCancelQueuedSubmit(
   state: PromptQueueState,
   agentSessionId: string,

--- a/packages/agent/activity-core/src/engine/promptQueue.pendingSendNow.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.pendingSendNow.ts
@@ -23,7 +23,7 @@ export function pendingSendNowFromSubmit(
         awaitingTurnExpiresAtUnixMs:
           intent.requestedAtUnixMs + TURN_CANCEL_TIMEOUT_MS,
         cancelCommandId: `submit:cancel:${intent.clientSubmitId}`,
-        promptId: intent.clientSubmitId,
+        promptId: intent.promptId?.trim() || intent.clientSubmitId,
         targetTurnId: target,
         timeoutMs: TURN_CANCEL_TIMEOUT_MS
       }

--- a/packages/agent/activity-core/src/engine/promptQueue.prompt.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.prompt.ts
@@ -19,10 +19,11 @@ export function normalizeQueuedPrompt(
 ): EngineQueuedPrompt | null {
   const id = prompt.id.trim();
   if (!id || prompt.content.length === 0) return null;
+  // This is the raw queue-record boundary. Older persisted records predate
+  // clientSubmitId, so the compatibility mapping is deliberately kept here.
+  const clientSubmitId = prompt.clientSubmitId?.trim() || id;
   return {
-    ...(prompt.clientSubmitId?.trim()
-      ? { clientSubmitId: prompt.clientSubmitId.trim() }
-      : {}),
+    clientSubmitId,
     ...clonePromptCapabilityReferences(prompt.capabilityRefs),
     content: prompt.content.map((block) => ({ ...block })),
     createdAtUnixMs: prompt.createdAtUnixMs,

--- a/packages/agent/activity-core/src/engine/promptQueue.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.reducer.test.ts
@@ -58,6 +58,91 @@ test("available canonical lifecycle sends an enqueued prompt immediately", () =>
   );
 });
 
+test("queue identity stays separate across delivery retry and explicit retry", () => {
+  const lifecycle = canonicalLifecycle("running", 1);
+  const first = reduce(
+    createInitialPromptQueueState(),
+    submit("submit-1", ""),
+    lifecycle
+  );
+  const firstPrompt = first.state.recordsBySessionId["session-1"]?.prompts[0];
+  assert.ok(firstPrompt);
+  assert.equal(firstPrompt.clientSubmitId, "submit-1");
+  assert.notEqual(firstPrompt.id, firstPrompt.clientSubmitId);
+
+  const explicitRetry = reduce(first.state, submit("submit-2", ""), lifecycle);
+  const retryPrompt =
+    explicitRetry.state.recordsBySessionId["session-1"]?.prompts[1];
+  assert.ok(retryPrompt);
+  assert.equal(retryPrompt.clientSubmitId, "submit-2");
+  assert.notEqual(retryPrompt.id, firstPrompt.id);
+
+  const sent = reduce(
+    first.state,
+    turnUpserted(settledTurn("turn-1", 2)),
+    canonicalLifecycle("settled", 2)
+  );
+  const firstCommand = send(sent.commands[0]);
+  assert.equal(firstCommand.promptId, firstPrompt.id);
+  assert.equal(firstCommand.clientSubmitId, "submit-1");
+
+  const failed = reduce(
+    sent.state,
+    commandResult(commandId(sent.commands[0]), "queue/sendPrompt", "failed"),
+    canonicalLifecycle("settled", 2)
+  );
+  const retried = reduce(
+    failed.state,
+    sendNow(firstPrompt.id),
+    canonicalLifecycle("settled", 2)
+  );
+  const retryCommand = send(retried.commands[0]);
+  assert.equal(retryCommand.promptId, firstPrompt.id);
+  assert.equal(retryCommand.clientSubmitId, "submit-1");
+});
+
+test("queue removal uses prompt.id rather than clientSubmitId", () => {
+  const queued = reduce(
+    createInitialPromptQueueState(),
+    {
+      agentSessionId: "session-1",
+      prompt: {
+        clientSubmitId: "submit-1",
+        content: [{ type: "text", text: "prompt" }],
+        createdAtUnixMs: 1,
+        id: "prompt-1"
+      },
+      type: "queue/enqueued",
+      workspaceId: "workspace-1"
+    },
+    canonicalLifecycle("running", 1)
+  );
+  const unchanged = reduce(
+    queued.state,
+    {
+      agentSessionId: "session-1",
+      promptId: "submit-1",
+      type: "queue/removed"
+    },
+    canonicalLifecycle("running", 1)
+  );
+  assert.equal(
+    unchanged.state.recordsBySessionId["session-1"]?.prompts[0]?.id,
+    "prompt-1"
+  );
+
+  const removed = reduce(
+    queued.state,
+    {
+      agentSessionId: "session-1",
+      promptId: "prompt-1",
+      type: "queue/removed"
+    },
+    canonicalLifecycle("running", 1)
+  );
+  assert.equal(removed.state.recordsBySessionId["session-1"], undefined);
+});
+
 test("user settings inFlight blocks drain until settings settle to idle", () => {
   let lifecycle = canonicalLifecycle("settled", 1);
   lifecycle = sessionLifecycleReducer(lifecycle, {
@@ -1304,11 +1389,12 @@ function enqueueGuidance(promptId: string) {
   };
 }
 
-function submit(clientSubmitId: string) {
+function submit(clientSubmitId: string, promptId = clientSubmitId) {
   return {
     type: "submit/requested" as const,
     agentSessionId: "session-1",
     clientSubmitId,
+    ...(promptId ? { promptId } : {}),
     content: [{ type: "text" as const, text: clientSubmitId }],
     expiresAtUnixMs: 60_000,
     requestedAtUnixMs: 1,

--- a/packages/agent/activity-core/src/engine/promptQueue.reducer.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.reducer.ts
@@ -35,6 +35,7 @@ import {
   isSettingsUpdateBlockingDrain,
   resolveQueueDrainDecision
 } from "./promptQueue.drainDecision.ts";
+import { createPromptQueueId } from "./promptQueue.identity.ts";
 import {
   deriveCanonicalSubmitAvailability,
   type CanonicalSessionLifecycleView
@@ -125,7 +126,7 @@ function reduceQueueOwnedState(
         return requestQueuedPromptSendNow(
           enqueueSubmit(state, intent, context.lifecycle).state,
           intent.agentSessionId,
-          intent.clientSubmitId,
+          intent.promptId ?? "",
           context.sendNowStrategy,
           targetTurnId,
           pendingSendNowFromSubmit(
@@ -231,7 +232,13 @@ function enqueuePrompt(
   const current =
     state.recordsBySessionId[agentSessionId] ??
     emptyQueueRecord(workspaceId, agentSessionId);
-  if (current.prompts.some((candidate) => candidate.id === prompt.id)) {
+  if (
+    current.prompts.some(
+      (candidate) =>
+        candidate.id === prompt.id ||
+        candidate.clientSubmitId === prompt.clientSubmitId
+    )
+  ) {
     return unchanged(state);
   }
   return result(
@@ -300,7 +307,7 @@ function sendCommandFromImmediateSubmit(
     ...(intent.targetTurnId?.trim()
       ? { targetTurnId: intent.targetTurnId.trim() }
       : {}),
-    promptId: intent.clientSubmitId,
+    promptId: intent.promptId?.trim() || createPromptQueueId(),
     ...clonePromptRequiredSettingsPatch(intent.requiredSettingsPatch),
     timeoutMs: QUEUE_SEND_TIMEOUT_MS,
     type: "queue/sendPrompt",
@@ -613,6 +620,9 @@ function drainSession(
     commandId,
     decision.guidance
   );
+  if (!command) {
+    return state === originalState ? unchanged(state) : result(state);
+  }
   const nextState = replaceRecord(
     { ...state, nextCommandSequence: sequence + 1 },
     record.agentSessionId,
@@ -620,6 +630,7 @@ function drainSession(
       ...record,
       inFlight: {
         commandId,
+        clientSubmitId: head.clientSubmitId,
         ...(decision.guidance ? { guidance: true as const } : {}),
         kind: "send",
         promptId: head.id,
@@ -641,13 +652,15 @@ function sendCommandFromQueuedPrompt(
   head: PromptQueueRecord["prompts"][number],
   commandId: string,
   guidance: boolean
-): Extract<EngineCommand, { type: "queue/sendPrompt" }> {
+): Extract<EngineCommand, { type: "queue/sendPrompt" }> | null {
+  const clientSubmitId = head.clientSubmitId?.trim();
+  if (!clientSubmitId) return null;
   return {
     agentSessionId: record.agentSessionId,
     ...clonePromptCapabilityReferences(head.capabilityRefs),
     commandId,
-    ...(head.clientSubmitId ? { correlationId: head.clientSubmitId } : {}),
-    clientSubmitId: head.clientSubmitId ?? head.id,
+    correlationId: clientSubmitId,
+    clientSubmitId,
     content: head.runtimeContent ?? head.content,
     ...(head.displayPrompt ? { displayPrompt: head.displayPrompt } : {}),
     ...(guidance ? { guidance: true } : {}),

--- a/packages/agent/activity-core/src/engine/promptQueue.submit.test.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.submit.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { SubmitRequestedIntent } from "./pendingIntents.types.ts";
+import { normalizeQueuedPrompt } from "./promptQueue.prompt.ts";
+import { queuedPromptFromSubmitIntent } from "./promptQueue.submit.ts";
+
+function submit(
+  clientSubmitId: string,
+  promptId?: string
+): SubmitRequestedIntent {
+  return {
+    agentSessionId: "session-1",
+    clientSubmitId,
+    ...(promptId ? { promptId } : {}),
+    content: [{ type: "text", text: clientSubmitId }],
+    expiresAtUnixMs: 10_000,
+    requestedAtUnixMs: 1,
+    type: "submit/requested",
+    workspaceId: "workspace-1"
+  };
+}
+
+test("new queued prompts have independent queue and delivery identities", () => {
+  const first = queuedPromptFromSubmitIntent(submit("submit-1"), true);
+  const second = queuedPromptFromSubmitIntent(submit("submit-2"), true);
+
+  assert.equal(first.clientSubmitId, "submit-1");
+  assert.equal(second.clientSubmitId, "submit-2");
+  assert.notEqual(first.id, first.clientSubmitId);
+  assert.notEqual(second.id, second.clientSubmitId);
+  assert.notEqual(first.id, second.id);
+});
+
+test("an explicitly supplied queue identity survives replay", () => {
+  const prompt = queuedPromptFromSubmitIntent(
+    submit("submit-1", "prompt-1"),
+    true
+  );
+
+  assert.equal(prompt.id, "prompt-1");
+  assert.equal(prompt.clientSubmitId, "submit-1");
+});
+
+test("legacy clientSubmitId migration is confined to queue prompt decoding", () => {
+  const prompt = normalizeQueuedPrompt({
+    content: [{ type: "text", text: "legacy" }],
+    createdAtUnixMs: 1,
+    id: "legacy-prompt"
+  });
+
+  assert.equal(prompt?.id, "legacy-prompt");
+  assert.equal(prompt?.clientSubmitId, "legacy-prompt");
+});

--- a/packages/agent/activity-core/src/engine/promptQueue.submit.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.submit.ts
@@ -3,6 +3,7 @@ import {
   clonePromptCapabilityReferences,
   clonePromptRequiredSettingsPatch
 } from "./promptQueue.prompt.ts";
+import { createPromptQueueId } from "./promptQueue.identity.ts";
 import type { EngineQueuedPrompt } from "./promptQueue.types.ts";
 
 export function queuedPromptFromSubmitIntent(
@@ -15,7 +16,7 @@ export function queuedPromptFromSubmitIntent(
     content: intent.content,
     createdAtUnixMs: intent.requestedAtUnixMs,
     ...(intent.displayPrompt ? { displayPrompt: intent.displayPrompt } : {}),
-    id: intent.clientSubmitId,
+    id: intent.promptId?.trim() || createPromptQueueId(),
     ...clonePromptRequiredSettingsPatch(intent.requiredSettingsPatch),
     submitDiagnostics: {
       ...(intent.submitDiagnostics ?? {}),

--- a/packages/agent/activity-core/src/engine/promptQueue.types.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.types.ts
@@ -7,6 +7,7 @@ import type {
 
 export interface EngineQueuedPrompt {
   capabilityRefs?: readonly AgentActivityCapabilityReference[];
+  /** Required for new records; absent only in legacy queue snapshots. */
   clientSubmitId?: string;
   content: readonly AgentPromptContentBlock[];
   createdAtUnixMs: number;
@@ -25,6 +26,8 @@ export type PromptQueueSuspendReason = "user_stop";
 
 export interface PromptQueueInFlightCommand {
   commandId: string;
+  /** Required for new records; absent only in legacy queue snapshots. */
+  clientSubmitId?: string;
   /** Set when the command was dispatched as an active-turn steer. */
   guidance?: true;
   kind: "send";

--- a/packages/agent/activity-core/src/engine/rootReducer.ts
+++ b/packages/agent/activity-core/src/engine/rootReducer.ts
@@ -16,6 +16,9 @@ import {
   resolveQueuedPromptSendNowStrategy
 } from "./promptQueue.sendNow.ts";
 import {
+  promptQueueHasClientSubmitInFlight,
+  promptQueueHasClientSubmitUncertainDelivery,
+  promptQueuePromptIdForClientSubmit,
   canCancelQueuedSubmit,
   isQueuedSubmitDeliveryPending
 } from "./promptQueue.lookup.ts";
@@ -80,6 +83,7 @@ import {
   createInitialSessionGoalControlState,
   sessionGoalControlReducer
 } from "./sessionGoalControl.reducer.ts";
+import { createPromptQueueId } from "./promptQueue.identity.ts";
 
 // Root reducer: static composition of domain reducers, zero business logic.
 // Cross-domain read-only context is passed explicitly; domains still own all
@@ -109,6 +113,13 @@ export function rootEngineReducer(
   state: RootAgentSessionEngineState,
   intent: RootEngineIntent
 ): RootEngineReducerResult<RootAgentSessionEngineState> {
+  if (
+    (intent.type === "submit/requested" ||
+      intent.type === "plan/feedbackRequested") &&
+    !intent.promptId?.trim()
+  ) {
+    intent = { ...intent, promptId: createPromptQueueId() };
+  }
   if (intent.type === "prompt/executionRequested") {
     const promptExecutions = promptExecutionReducer(
       state.promptExecutions,
@@ -266,9 +277,6 @@ export function rootEngineReducer(
           submitSession?.capabilities
         )
       : null;
-  const queueRecord = submitIntent
-    ? state.promptQueue.recordsBySessionId[submitSessionId]
-    : undefined;
   // A session whose activation is still in flight is not in sessionsById yet.
   // Plain submits for it are accepted into the queue (they drain once the
   // session upserts) instead of being silently dropped; routings that dispatch
@@ -290,11 +298,21 @@ export function rootEngineReducer(
       submitSendNowStrategy !== null) &&
     !state.sessionLifecycle.deletedSessionIds[submitSessionId] &&
     !state.pendingIntents.submitsByClientSubmitId[submitId] &&
-    !queueRecord?.prompts.some(
-      (prompt) => prompt.id === submitId || prompt.clientSubmitId === submitId
+    !promptQueuePromptIdForClientSubmit(
+      state.promptQueue,
+      submitSessionId,
+      submitId
     ) &&
-    queueRecord?.inFlight?.promptId !== submitId &&
-    queueRecord?.uncertainDelivery?.promptId !== submitId
+    !promptQueueHasClientSubmitInFlight(
+      state.promptQueue,
+      submitSessionId,
+      submitId
+    ) &&
+    !promptQueueHasClientSubmitUncertainDelivery(
+      state.promptQueue,
+      submitSessionId,
+      submitId
+    )
   );
   const feedbackAccepted = Boolean(
     intent.type === "plan/feedbackRequested" &&

--- a/packages/agent/activity-core/src/engine/sessionPrompt.semantic.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionPrompt.semantic.test.ts
@@ -63,7 +63,16 @@ test("semantic prompt submission owns scope, confirmation window, and send proje
   });
 
   assert.deepEqual(result, { accepted: true, queued: false });
-  assert.deepEqual(harness.observedIntents.at(-1), {
+  const observed = harness.observedIntents.at(-1);
+  if (!observed || observed.type !== "submit/requested") {
+    throw new Error("submit intent was not observed");
+  }
+  const { promptId: observedPromptId, ...observedWithoutQueueId } = observed;
+  if (!observedPromptId) {
+    throw new Error("submit intent did not allocate a queue prompt id");
+  }
+  assert.match(observedPromptId, /^prompt:/);
+  assert.deepEqual(observedWithoutQueueId, {
     agentSessionId: "session-1",
     capabilityRefs: [{ capability: "tutti", source: "slash_command" }],
     clientSubmitId: "submit-1",
@@ -86,7 +95,7 @@ test("semantic prompt submission owns scope, confirmation window, and send proje
       content: [{ text: "runtime text", type: "text" }],
       correlationId: "submit-1",
       displayPrompt: "Display text",
-      promptId: "submit-1",
+      promptId: observedPromptId,
       submitDiagnostics: {
         blockCount: 1,
         queued: false,
@@ -142,6 +151,10 @@ test("send-now retains the prompt until authoritative guidance capabilities arri
 
   assert.deepEqual(result, { accepted: true, queued: true });
   assert.equal(harness.commands.length, 0);
+  const promptId =
+    harness.engine.getSnapshot().promptQueue.recordsBySessionId["session-1"]
+      ?.prompts[0]?.id;
+  assert.ok(promptId);
 
   const capabilitySnapshot = {
     sessions: [
@@ -163,7 +176,7 @@ test("send-now retains the prompt until authoritative guidance capabilities arri
       content: [{ text: "steer when ready", type: "text" }],
       correlationId: "submit-guidance",
       guidance: true,
-      promptId: "submit-guidance",
+      promptId,
       submitDiagnostics: {
         blockCount: 1,
         queued: true,
@@ -189,6 +202,10 @@ test("send-now retains the prompt until authoritative interrupt capability arriv
 
   assert.deepEqual(result, { accepted: true, queued: true });
   assert.equal(harness.commands.length, 0);
+  const promptId =
+    harness.engine.getSnapshot().promptQueue.recordsBySessionId["session-1"]
+      ?.prompts[0]?.id;
+  assert.ok(promptId);
 
   harness.engine.dispatch({
     sessions: [
@@ -210,7 +227,7 @@ test("send-now retains the prompt until authoritative interrupt capability arriv
   assert.equal(
     harness.engine.getSnapshot().promptQueue.recordsBySessionId["session-1"]
       ?.sendNextPromptId,
-    "submit-interrupt"
+    promptId
   );
 });
 
@@ -272,6 +289,10 @@ test("deferred send-now survives a temporary interaction blocker for the same tu
     content: [{ text: "steer after approval", type: "text" }],
     routing: "send_now"
   });
+  const promptId =
+    harness.engine.getSnapshot().promptQueue.recordsBySessionId["session-1"]
+      ?.prompts[0]?.id;
+  assert.ok(promptId);
   const pendingInteraction: AgentActivityInteraction = {
     agentSessionId: "session-1",
     createdAtUnixMs: 3,
@@ -298,7 +319,7 @@ test("deferred send-now survives a temporary interaction blocker for the same tu
   assert.equal(harness.commands.length, 0);
   assert.ok(
     harness.engine.getSnapshot().promptQueue.recordsBySessionId["session-1"]
-      ?.pendingSendNowByPromptId?.["submit-after-approval"]
+      ?.pendingSendNowByPromptId?.[promptId]
   );
 
   harness.engine.dispatch({
@@ -344,7 +365,7 @@ test("unsupported deferred send-now restores ordinary FIFO order", () => {
   const queued =
     harness.engine.getSnapshot().promptQueue.recordsBySessionId["session-1"];
   assert.deepEqual(
-    queued?.prompts.map((prompt) => prompt.id),
+    queued?.prompts.map((prompt) => prompt.clientSubmitId),
     ["ordinary-first", "send-now-second"]
   );
   assert.deepEqual(queued?.pendingSendNowByPromptId, undefined);
@@ -489,10 +510,10 @@ test("consecutive deferred send-now prompts retain independent decisions", () =>
       harness.engine.getSnapshot().promptQueue.recordsBySessionId["session-1"];
     assert.deepEqual(
       Object.keys(before?.pendingSendNowByPromptId ?? {}).sort(),
-      [`${scenario.name}-first`, `${scenario.name}-second`]
+      before?.prompts.map((prompt) => prompt.id).sort()
     );
     assert.deepEqual(
-      before?.prompts.map((prompt) => prompt.id),
+      before?.prompts.map((prompt) => prompt.clientSubmitId),
       [`${scenario.name}-first`, `${scenario.name}-second`]
     );
 
@@ -504,8 +525,11 @@ test("consecutive deferred send-now prompts retain independent decisions", () =>
     assert.equal(harness.commands[0]?.type ?? null, scenario.commandType);
     const after =
       harness.engine.getSnapshot().promptQueue.recordsBySessionId["session-1"];
+    const remainingPromptId = after?.prompts.find(
+      (prompt) => prompt.clientSubmitId === `${scenario.name}-second`
+    )?.id;
     assert.deepEqual(Object.keys(after?.pendingSendNowByPromptId ?? {}), [
-      `${scenario.name}-second`
+      ...(remainingPromptId ? [remainingPromptId] : [])
     ]);
     const command = harness.commands[0];
     if (command?.type === "queue/sendPrompt") {

--- a/packages/agent/daemon/README.md
+++ b/packages/agent/daemon/README.md
@@ -258,25 +258,25 @@ and must not introduce a second mapping in between.
 `ActivityReporter` and `SessionActivityReporterAdapter` are compatibility
 projection contracts; they are not sufficient to host a runtime controller
 because their state and message writes may use separate transactions.
-`agentdaemon.Config.Reporter` requires `DurableActivityReporter`, whose
-`ReportSubmitProvenance` method must atomically persist the canonical
-client-submit message and the submitted Turn admission before provider
-dispatch, and return only after that message can be queried by
-`clientSubmitId`. A host decorator embeds or otherwise preserves this required
+`agentdaemon.Config.Reporter` requires `DurableActivityReporter`, which exposes
+two separate durable operations. `AdmitSubmitIntent` is the Controller's
+pre-dispatch barrier and the sole operation that creates the canonical user
+message and the submitted Turn. It must complete before the Controller
+dispatches to the provider and is keyed by the stable `ClientSubmitID`.
+`UpdateSubmitProvenance` records only submit identity, provider, and delivery
+facts; it carries no canonical message payload. Provider and Host retries are
+therefore idempotent provenance updates and must never rewrite the canonical
+message. A host decorator embeds or otherwise preserves this required
 interface; there is no optional capability probe to forward manually.
 
 The daemon service passes `ClientSubmitID` through typed create/send and runtime
-inputs. `Exec` uses `ReportSubmitProvenance` as the pre-dispatch admission
-barrier. After `Exec` returns, the service explicitly calls the required
-`RuntimeController.DurablyReportSubmitProvenance` method as an idempotent
-reconciliation barrier before it accepts any submit claim; this second call
-does not represent a second provider admission. The runtime adapter delegates
-that call to the controller after `Exec` has released the session lifecycle
-lock; the controller places the uncoalesced barrier behind earlier reports in
-the same FIFO. A barrier failure is delivery-unknown, and provider work is
-never blindly replayed. Host-owned user submissions, including follow-up
-submissions, carry a stable `ClientSubmitID`; standalone internal runtime
-calls may retain their generated prompt-message identity.
+inputs. The Controller calls `AdmitSubmitIntent` before provider dispatch, then
+uses `UpdateSubmitProvenance` to record acceptance, failure, or
+delivery-unknown outcomes after execution. The runtime adapter and Host use
+the same provenance operation for reconciliation; they do not replay the
+canonical payload or create another user message. Host-owned user submissions,
+including follow-up submissions, carry a stable `ClientSubmitID`; standalone
+internal runtime calls may retain their generated prompt-message identity.
 
 ```go
 client := agentsessionstore.NewClient(agentsessionstore.Config{

--- a/packages/agent/daemon/activity/reporter.go
+++ b/packages/agent/daemon/activity/reporter.go
@@ -10,6 +10,14 @@ type ActivityReporter interface {
 	Report(ctx context.Context, input ReportActivityInput) error
 }
 
+// SubmitIntentReporter is the explicit durable submit boundary. It is kept
+// separate from SessionActivityReporter so ordinary activity implementations
+// cannot accidentally manufacture canonical user messages.
+type SubmitIntentReporter interface {
+	AdmitSubmitIntent(context.Context, SubmitIntentInput) (SubmitIntentReply, error)
+	UpdateSubmitProvenance(context.Context, SubmitProvenanceInput) (SubmitProvenanceReply, error)
+}
+
 type SessionActivityReporter interface {
 	ReportSessionState(context.Context, ReportSessionStateInput) (ReportSessionStateReply, error)
 	ReportSessionMessages(context.Context, ReportSessionMessagesInput) (ReportSessionMessagesReply, error)

--- a/packages/agent/daemon/activity/reporter_adapter.go
+++ b/packages/agent/daemon/activity/reporter_adapter.go
@@ -40,6 +40,30 @@ type SessionActivityReporterAdapter struct {
 
 var _ ActivityReporter = (*SessionActivityReporterAdapter)(nil)
 
+var _ SubmitIntentReporter = (*SessionActivityReporterAdapter)(nil)
+
+func (a *SessionActivityReporterAdapter) AdmitSubmitIntent(ctx context.Context, input SubmitIntentInput) (SubmitIntentReply, error) {
+	if a == nil || a.reporter == nil {
+		return SubmitIntentReply{}, errors.New("agent activity reporter is unavailable")
+	}
+	reporter, ok := a.reporter.(SubmitIntentReporter)
+	if !ok {
+		return SubmitIntentReply{}, errors.New("agent activity reporter does not support submit intent admission")
+	}
+	return reporter.AdmitSubmitIntent(ctx, input)
+}
+
+func (a *SessionActivityReporterAdapter) UpdateSubmitProvenance(ctx context.Context, input SubmitProvenanceInput) (SubmitProvenanceReply, error) {
+	if a == nil || a.reporter == nil {
+		return SubmitProvenanceReply{}, errors.New("agent activity reporter is unavailable")
+	}
+	reporter, ok := a.reporter.(SubmitIntentReporter)
+	if !ok {
+		return SubmitProvenanceReply{}, errors.New("agent activity reporter does not support submit provenance")
+	}
+	return reporter.UpdateSubmitProvenance(ctx, input)
+}
+
 func (a *SessionActivityReporterAdapter) BindGoalProvenance(ctx context.Context, input BindGoalProvenanceInput) (GoalProvenanceBinding, error) {
 	if a == nil {
 		return GoalProvenanceBinding{}, errors.New("agent activity reporter does not support goal provenance")

--- a/packages/agent/daemon/activity/types.go
+++ b/packages/agent/daemon/activity/types.go
@@ -55,6 +55,50 @@ type ReportActivityReply struct {
 	RequestBodyBytes                  int `json:"-"`
 }
 
+// SubmitIntentInput is the only activity input that may carry the canonical
+// user message. The state and message are committed together by the
+// admission endpoint; subsequent provenance updates must use
+// SubmitProvenanceInput instead.
+type SubmitIntentInput struct {
+	WorkspaceID                     string                     `json:"workspaceId"`
+	AgentSessionID                  string                     `json:"agentSessionId"`
+	ClientSubmitID                  string                     `json:"clientSubmitId"`
+	CanonicalTurnID                 string                     `json:"canonicalTurnId"`
+	CanonicalMessageID              string                     `json:"canonicalMessageId"`
+	CanonicalSubmitOccurredAtUnixMS int64                      `json:"canonicalSubmitOccurredAtUnixMs,omitempty"`
+	State                           ReportSessionStateInput    `json:"state"`
+	Messages                        ReportSessionMessagesInput `json:"messages"`
+}
+
+type SubmitIntentReply struct {
+	Accepted             bool `json:"accepted"`
+	AcceptedMessageCount int  `json:"acceptedMessageCount"`
+	RequestBodyBytes     int  `json:"-"`
+}
+
+// SubmitProvenanceInput deliberately contains no canonical message payload.
+// It is safe for Provider and Host retries because it can only advance the
+// submit's identity and delivery state.
+type SubmitProvenanceInput struct {
+	WorkspaceID        string `json:"workspaceId"`
+	AgentSessionID     string `json:"agentSessionId"`
+	ClientSubmitID     string `json:"clientSubmitId"`
+	CanonicalTurnID    string `json:"canonicalTurnId"`
+	CanonicalMessageID string `json:"canonicalMessageId,omitempty"`
+	ProviderSessionID  string `json:"providerSessionId,omitempty"`
+	ProviderTurnID     string `json:"providerTurnId,omitempty"`
+	DispatchStatus     string `json:"dispatchStatus,omitempty"`
+	DeliveryStatus     string `json:"deliveryStatus,omitempty"`
+	FailureReason      string `json:"failureReason,omitempty"`
+	OccurredAtUnixMS   int64  `json:"occurredAtUnixMs,omitempty"`
+	Guidance           bool   `json:"guidance,omitempty"`
+}
+
+type SubmitProvenanceReply struct {
+	Accepted         bool `json:"accepted"`
+	RequestBodyBytes int  `json:"-"`
+}
+
 type WorkspaceAgentGoalReconcileRequest struct {
 	RequestID           string `json:"requestId"`
 	Phase               string `json:"phase"`

--- a/packages/agent/daemon/hostadapter/runtime.go
+++ b/packages/agent/daemon/hostadapter/runtime.go
@@ -25,7 +25,7 @@ type RuntimeBackend interface {
 	State(string, string) (agentruntime.SessionStateSnapshot, error)
 	CanResume(agentruntime.ResumeInput) bool
 	Exec(context.Context, agentruntime.ExecInput) (agentruntime.ExecResult, error)
-	DurablyReportSubmitProvenance(context.Context, agentruntime.SubmitProvenanceInput) error
+	UpdateSubmitProvenance(context.Context, agentruntime.SubmitProvenanceInput) error
 	ValidatePromptContent(context.Context, agentruntime.ExecInput) error
 	Cancel(context.Context, agentruntime.CancelInput) (agentruntime.CancelResult, error)
 	SubmitInteractive(context.Context, agentruntime.SubmitInteractiveInput) (agentruntime.SubmitInteractiveResult, error)
@@ -65,7 +65,7 @@ var (
 	_ host.RuntimeWorkspaceDisconnector            = (*RuntimeController)(nil)
 	_ host.RuntimeWorkspaceDisconnectTargeter      = (*RuntimeController)(nil)
 	_ host.RuntimeRetainedSettingsUpdater          = (*RuntimeController)(nil)
-	_ host.RuntimeSubmitProvenanceReporter         = (*RuntimeController)(nil)
+	_ host.RuntimeSubmitProvenanceUpdater          = (*RuntimeController)(nil)
 	_ host.SessionForkRuntime                      = (*RuntimeController)(nil)
 	_ host.SessionForkTurnBindingRecoveryRuntime   = (*RuntimeController)(nil)
 	_ host.SideConversationRuntime                 = (*RuntimeController)(nil)
@@ -277,11 +277,11 @@ func (a *RuntimeController) Exec(ctx context.Context, input host.RuntimeExecInpu
 	return projected, mapRuntimeError(err)
 }
 
-func (a *RuntimeController) DurablyReportSubmitProvenance(ctx context.Context, input host.RuntimeSubmitProvenanceInput) error {
+func (a *RuntimeController) UpdateSubmitProvenance(ctx context.Context, input host.RuntimeSubmitProvenanceInput) error {
 	if err := a.requireBackend(); err != nil {
 		return err
 	}
-	return mapRuntimeError(a.Backend.DurablyReportSubmitProvenance(ctx, runtimeSubmitProvenanceInput(input)))
+	return mapRuntimeError(a.Backend.UpdateSubmitProvenance(ctx, runtimeSubmitProvenanceInput(input)))
 }
 
 func (a *RuntimeController) ReconcileProviderTurnAcceptance(
@@ -827,9 +827,10 @@ func runtimeSubmitProvenanceInput(input host.RuntimeSubmitProvenanceInput) agent
 	return agentruntime.SubmitProvenanceInput{
 		RoomID: input.WorkspaceID, AgentSessionID: input.AgentSessionID,
 		TurnID: input.TurnID, ClientSubmitID: input.ClientSubmitID,
-		CanonicalSubmitOccurredAtUnixMS: input.CanonicalSubmitOccurredAtUnixMS,
-		Content:                         runtimePromptContent(input.Content), DisplayPrompt: input.DisplayPrompt,
-		Guidance: input.Guidance,
+		CanonicalMessageID: input.CanonicalMessageID, ProviderSessionID: input.ProviderSessionID,
+		ProviderTurnID: input.ProviderTurnID, DispatchStatus: input.DispatchStatus,
+		DeliveryStatus: input.DeliveryStatus, FailureReason: input.FailureReason,
+		OccurredAtUnixMS: input.CanonicalSubmitOccurredAtUnixMS, Guidance: input.Guidance,
 	}
 }
 

--- a/packages/agent/daemon/hostadapter/runtime_test.go
+++ b/packages/agent/daemon/hostadapter/runtime_test.go
@@ -210,7 +210,7 @@ func TestRuntimeControllerBridgesGoalLifecycleToHostSink(t *testing.T) {
 	}
 }
 
-func (b *provenanceRuntimeBackend) DurablyReportSubmitProvenance(_ context.Context, input agentruntime.SubmitProvenanceInput) error {
+func (b *provenanceRuntimeBackend) UpdateSubmitProvenance(_ context.Context, input agentruntime.SubmitProvenanceInput) error {
 	b.input = input
 	return b.err
 }
@@ -476,27 +476,29 @@ func TestRuntimeControllerFailsClosedWithoutBackend(t *testing.T) {
 	}
 }
 
-func TestRuntimeControllerDelegatesDurableSubmitProvenance(t *testing.T) {
+func TestRuntimeControllerDelegatesSubmitProvenance(t *testing.T) {
 	backend := &provenanceRuntimeBackend{}
 	controller := &RuntimeController{Backend: backend}
 	input := host.RuntimeSubmitProvenanceInput{
 		WorkspaceID: " workspace-1 ", AgentSessionID: "session-1", TurnID: "turn-1",
-		ClientSubmitID: "submit-1", DisplayPrompt: "display", Guidance: true,
+		ClientSubmitID: "submit-1", CanonicalMessageID: "message-1", Guidance: true,
+		ProviderSessionID: "provider-session-1", ProviderTurnID: "provider-turn-1",
+		DispatchStatus: "accepted", DeliveryStatus: "accepted", FailureReason: "",
 		CanonicalSubmitOccurredAtUnixMS: 1_234,
-		Content:                         []host.PromptContentBlock{{Type: "text", Text: "hello"}},
 	}
 
-	if err := controller.DurablyReportSubmitProvenance(t.Context(), input); err != nil {
+	if err := controller.UpdateSubmitProvenance(t.Context(), input); err != nil {
 		t.Fatal(err)
 	}
 	if backend.input.RoomID != input.WorkspaceID || backend.input.AgentSessionID != input.AgentSessionID ||
 		backend.input.TurnID != input.TurnID || backend.input.ClientSubmitID != input.ClientSubmitID ||
-		backend.input.CanonicalSubmitOccurredAtUnixMS != input.CanonicalSubmitOccurredAtUnixMS ||
-		backend.input.DisplayPrompt != input.DisplayPrompt || !backend.input.Guidance {
+		backend.input.CanonicalMessageID != input.CanonicalMessageID ||
+		backend.input.ProviderSessionID != input.ProviderSessionID ||
+		backend.input.ProviderTurnID != input.ProviderTurnID ||
+		backend.input.DispatchStatus != input.DispatchStatus ||
+		backend.input.DeliveryStatus != input.DeliveryStatus ||
+		backend.input.OccurredAtUnixMS != input.CanonicalSubmitOccurredAtUnixMS || !backend.input.Guidance {
 		t.Fatalf("delegated provenance = %#v", backend.input)
-	}
-	if len(backend.input.Content) != 1 || backend.input.Content[0].Text != "hello" {
-		t.Fatalf("delegated content = %#v", backend.input.Content)
 	}
 }
 

--- a/packages/agent/daemon/runtime/activity_projection.go
+++ b/packages/agent/daemon/runtime/activity_projection.go
@@ -53,7 +53,7 @@ func ProjectActivityEventsToStreamEvents(session Session, events []activityshare
 		if isPrecommitTerminalTextMessage(event) {
 			continue
 		}
-		if update, ok := messageUpdateFromSessionEvent(source, event, sessionID, timestamp); ok {
+		if update, ok := messageUpdateFromSessionEvent(messageProjectionRealtime, source, event, sessionID, timestamp); ok {
 			out = append(out, StreamEvent{
 				EventType: StreamEventMessageUpdate,
 				Data:      update,

--- a/packages/agent/daemon/runtime/claude_sdk_execution.go
+++ b/packages/agent/daemon/runtime/claude_sdk_execution.go
@@ -83,7 +83,8 @@ func (a *ClaudeCodeSDKAdapter) exec(
 	}
 	startEvents := []activityshared.Event{
 		newUserPromptActivityEvent(ctx, session, content, explicitDisplayPrompt, visibleText, turnID, map[string]any{
-			"adapter": claudeSDKSidecarAdapterName,
+			"adapter":                claudeSDKSidecarAdapterName,
+			messageOriginMetadataKey: string(messageOriginProviderEcho),
 		}),
 		newTurnActivityEvent(session, EventTurnStarted, turnID, SessionStatusWorking, "", "", map[string]any{
 			"adapter": claudeSDKSidecarAdapterName,
@@ -552,9 +553,10 @@ func (a *ClaudeCodeSDKAdapter) GuideActiveTurnWithProviderDispatch(
 	}
 	events := []activityshared.Event{
 		newUserPromptActivityEvent(ctx, session, content, explicitDisplayPrompt, visibleText, turnID, map[string]any{
-			"adapter":  claudeSDKSidecarAdapterName,
-			"guidance": true,
-			"steered":  true,
+			"adapter":                claudeSDKSidecarAdapterName,
+			messageOriginMetadataKey: string(messageOriginGuidance),
+			"guidance":               true,
+			"steered":                true,
 		}),
 	}
 	if err := a.startClaudeSDKReader(session.AgentSessionID, adapterSession); err != nil {

--- a/packages/agent/daemon/runtime/claude_sdk_goal_lifecycle_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_goal_lifecycle_test.go
@@ -67,8 +67,12 @@ func (r *blockingFirstClaudeGoalReporter) Report(ctx context.Context, report age
 	return nil
 }
 
-func (r *blockingFirstClaudeGoalReporter) ReportSubmitProvenance(ctx context.Context, report agentsessionstore.ReportActivityInput) error {
-	return r.Report(ctx, report)
+func (r *blockingFirstClaudeGoalReporter) AdmitSubmitIntent(ctx context.Context, input agentsessionstore.SubmitIntentInput) error {
+	return r.Report(ctx, reportFromSubmitIntentInput(input))
+}
+
+func (*blockingFirstClaudeGoalReporter) UpdateSubmitProvenance(context.Context, agentsessionstore.SubmitProvenanceInput) error {
+	return nil
 }
 
 func (r *blockingFirstClaudeGoalReporter) snapshot() []agentsessionstore.ReportActivityInput {

--- a/packages/agent/daemon/runtime/claude_sdk_transport_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_transport_test.go
@@ -744,10 +744,12 @@ func TestClaudeCodeSDKAdapterControllerPublishesUIActivityWithSidecarTestDriver(
 	defer unsubscribe()
 
 	execResult, err := controller.Exec(ctx, ExecInput{
-		RoomID:         started.Session.RoomID,
-		AgentSessionID: started.Session.AgentSessionID,
-		Content:        textPrompt("say hello"),
-		DisplayPrompt:  "say hello",
+		RoomID:                          started.Session.RoomID,
+		AgentSessionID:                  started.Session.AgentSessionID,
+		ClientSubmitID:                  "claude-sdk-sidecar:say-hello",
+		CanonicalSubmitOccurredAtUnixMS: time.Now().UnixMilli(),
+		Content:                         textPrompt("say hello"),
+		DisplayPrompt:                   "say hello",
 	})
 	if err != nil {
 		t.Fatalf("Exec: %v", err)

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_goal_control_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_goal_control_test.go
@@ -194,9 +194,11 @@ func TestControllerGoalControl(t *testing.T) {
 	}
 	// Resume and edit the objective while a turn is running.
 	if _, err := controller.Exec(context.Background(), ExecInput{
-		RoomID:         "room-1",
-		AgentSessionID: agentSessionID,
-		Content:        textPrompt("long task"),
+		RoomID:                          "room-1",
+		AgentSessionID:                  agentSessionID,
+		ClientSubmitID:                  "goal-long-task-submit",
+		CanonicalSubmitOccurredAtUnixMS: 1_001,
+		Content:                         textPrompt("long task"),
 	}); err != nil {
 		t.Fatalf("Exec long task: %v", err)
 	}

--- a/packages/agent/daemon/runtime/codex_appserver_goal.go
+++ b/packages/agent/daemon/runtime/codex_appserver_goal.go
@@ -37,8 +37,9 @@ func (a *CodexAppServerAdapter) steerActiveTurn(
 	}
 	events := []activityshared.Event{
 		newUserPromptActivityEvent(ctx, session, content, explicitDisplayPrompt, displayPrompt, turnID, map[string]any{
-			"guidance": true,
-			"steered":  true,
+			messageOriginMetadataKey: string(messageOriginGuidance),
+			"guidance":               true,
+			"steered":                true,
 		}),
 	}
 	if emit != nil {

--- a/packages/agent/daemon/runtime/codex_appserver_image_generation_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_image_generation_test.go
@@ -74,6 +74,7 @@ func TestAppServerImageGenerationPublishesFileBackedContentWithoutBase64(t *test
 	}
 
 	messageUpdate, ok := messageUpdateFromSessionEvent(
+		messageProjectionDurable,
 		canonical.EventSource{Provider: string(ProviderCodex)},
 		event,
 		session.AgentSessionID,

--- a/packages/agent/daemon/runtime/codex_appserver_turn.go
+++ b/packages/agent/daemon/runtime/codex_appserver_turn.go
@@ -499,7 +499,9 @@ func (a *CodexAppServerAdapter) execBlocking(
 		return append([]activityshared.Event(nil), events...)
 	}
 	startEvents := []activityshared.Event{
-		newUserPromptActivityEvent(ctx, session, content, explicitDisplayPrompt, visibleText, turnID, nil),
+		newUserPromptActivityEvent(ctx, session, content, explicitDisplayPrompt, visibleText, turnID, map[string]any{
+			messageOriginMetadataKey: string(messageOriginProviderEcho),
+		}),
 		newTurnActivityEvent(session, EventTurnStarted, turnID, SessionStatusWorking, "", "", nil),
 	}
 

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -161,6 +161,7 @@ type reportRequest struct {
 	ctx              context.Context
 	report           agentsessionstore.ReportActivityInput
 	submitProvenance bool
+	provenance       *SubmitProvenanceInput
 	barrier          bool
 	done             chan error
 }

--- a/packages/agent/daemon/runtime/controller_exec_async_test.go
+++ b/packages/agent/daemon/runtime/controller_exec_async_test.go
@@ -279,9 +279,11 @@ func TestControllerExecPublishesTerminalEventAfterPartialEmitError(t *testing.T)
 	}
 	defer unsubscribe()
 	if _, err := controller.Exec(context.Background(), ExecInput{
-		RoomID:         "room-1",
-		AgentSessionID: started.Session.AgentSessionID,
-		Content:        textPrompt("run"),
+		RoomID:                          "room-1",
+		AgentSessionID:                  started.Session.AgentSessionID,
+		ClientSubmitID:                  "terminal-settled-submit",
+		CanonicalSubmitOccurredAtUnixMS: 1_001,
+		Content:                         textPrompt("run"),
 	}); err != nil {
 		t.Fatalf("Exec: %v", err)
 	}
@@ -304,9 +306,11 @@ func TestControllerExecReconcilesWorkingStatusAfterTurnFinishesWithoutTerminalEv
 		t.Fatalf("Start: %v", err)
 	}
 	if _, err := controller.Exec(context.Background(), ExecInput{
-		RoomID:         "room-1",
-		AgentSessionID: started.Session.AgentSessionID,
-		Content:        textPrompt("run"),
+		RoomID:                          "room-1",
+		AgentSessionID:                  started.Session.AgentSessionID,
+		ClientSubmitID:                  "terminal-settled-submit",
+		CanonicalSubmitOccurredAtUnixMS: 1_001,
+		Content:                         textPrompt("run"),
 	}); err != nil {
 		t.Fatalf("Exec: %v", err)
 	}
@@ -345,9 +349,11 @@ func TestControllerExecReportsTerminalTurnAsSettledAndAvailable(t *testing.T) {
 		t.Fatalf("Start: %v", err)
 	}
 	if _, err := controller.Exec(context.Background(), ExecInput{
-		RoomID:         "room-1",
-		AgentSessionID: started.Session.AgentSessionID,
-		Content:        textPrompt("run"),
+		RoomID:                          "room-1",
+		AgentSessionID:                  started.Session.AgentSessionID,
+		ClientSubmitID:                  "terminal-availability-submit",
+		CanonicalSubmitOccurredAtUnixMS: 1_002,
+		Content:                         textPrompt("run"),
 	}); err != nil {
 		t.Fatalf("Exec: %v", err)
 	}

--- a/packages/agent/daemon/runtime/controller_exec_test.go
+++ b/packages/agent/daemon/runtime/controller_exec_test.go
@@ -3,7 +3,6 @@ package agentruntime
 import (
 	"context"
 	"errors"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -130,11 +129,13 @@ func TestControllerHiddenSessionPublishesLiveEventsAndReportsActivity(t *testing
 	}
 
 	execResult, err := controller.Exec(ctx, ExecInput{
-		RoomID:           "room-1",
-		AgentSessionID:   started.Session.AgentSessionID,
-		Content:          textPrompt("hello"),
-		InitialTitle:     "hello",
-		InitialTitleBase: started.Session.Title,
+		RoomID:                          "room-1",
+		AgentSessionID:                  started.Session.AgentSessionID,
+		ClientSubmitID:                  "hidden-session-submit",
+		CanonicalSubmitOccurredAtUnixMS: 1_001,
+		Content:                         textPrompt("hello"),
+		InitialTitle:                    "hello",
+		InitialTitleBase:                started.Session.Title,
 	})
 	if err != nil {
 		t.Fatalf("Exec: %v", err)
@@ -179,11 +180,13 @@ func TestControllerStartExecPublishesAndReports(t *testing.T) {
 	defer unsubscribe()
 
 	execResult, err := controller.Exec(ctx, ExecInput{
-		RoomID:           "room-1",
-		AgentSessionID:   started.Session.AgentSessionID,
-		Content:          textPrompt("hello"),
-		InitialTitle:     "hello",
-		InitialTitleBase: started.Session.Title,
+		RoomID:                          "room-1",
+		AgentSessionID:                  started.Session.AgentSessionID,
+		ClientSubmitID:                  "start-exec-submit",
+		CanonicalSubmitOccurredAtUnixMS: 1_002,
+		Content:                         textPrompt("hello"),
+		InitialTitle:                    "hello",
+		InitialTitleBase:                started.Session.Title,
 	})
 	if err != nil {
 		t.Fatalf("Exec: %v", err)
@@ -268,8 +271,9 @@ userMessagePublished:
 	if len(userMessageIDs) == 0 {
 		t.Fatalf("report calls = %#v, want user message update for turn", reportCalls)
 	}
-	if userMessageIDs[0] == "" || !strings.HasPrefix(userMessageIDs[0], turnUserMessageIDPrefix) {
-		t.Fatalf("user message IDs = %#v, want a generated turn-user message ID", userMessageIDs)
+	wantMessageID := userPromptActivityMessageIDFromClientSubmitID("start-exec-submit")
+	if userMessageIDs[0] != wantMessageID {
+		t.Fatalf("user message IDs = %#v, want client-submit message ID %q", userMessageIDs, wantMessageID)
 	}
 	for _, messageID := range userMessageIDs[1:] {
 		if messageID != userMessageIDs[0] {
@@ -311,9 +315,11 @@ func TestControllerReportsMessageUpdateOnlyRuntimeBatch(t *testing.T) {
 	}
 
 	execResult, err := controller.Exec(context.Background(), ExecInput{
-		RoomID:         started.Session.RoomID,
-		AgentSessionID: started.Session.AgentSessionID,
-		Content:        textPrompt("stream"),
+		RoomID:                          started.Session.RoomID,
+		AgentSessionID:                  started.Session.AgentSessionID,
+		ClientSubmitID:                  "stream-message-submit",
+		CanonicalSubmitOccurredAtUnixMS: 1_003,
+		Content:                         textPrompt("stream"),
 	})
 	if err != nil {
 		t.Fatalf("Exec: %v", err)
@@ -373,9 +379,11 @@ func TestControllerExecRunsOutsideRequestContext(t *testing.T) {
 
 	requestCtx, cancelRequest := context.WithCancel(context.Background())
 	execResult, err := controller.Exec(requestCtx, ExecInput{
-		RoomID:         "room-1",
-		AgentSessionID: started.Session.AgentSessionID,
-		Content:        textPrompt("run tests"),
+		RoomID:                          "room-1",
+		AgentSessionID:                  started.Session.AgentSessionID,
+		ClientSubmitID:                  "request-context-submit",
+		CanonicalSubmitOccurredAtUnixMS: 1_004,
+		Content:                         textPrompt("run tests"),
 	})
 	if err != nil {
 		t.Fatalf("Exec: %v", err)
@@ -492,9 +500,11 @@ func TestControllerExecRejectsPromptDuringActiveTurn(t *testing.T) {
 	}
 
 	first, err := controller.Exec(ctx, ExecInput{
-		RoomID:         started.Session.RoomID,
-		AgentSessionID: started.Session.AgentSessionID,
-		Content:        textPrompt("first prompt"),
+		RoomID:                          started.Session.RoomID,
+		AgentSessionID:                  started.Session.AgentSessionID,
+		ClientSubmitID:                  "first-prompt-submit",
+		CanonicalSubmitOccurredAtUnixMS: 1_005,
+		Content:                         textPrompt("first prompt"),
 	})
 	if err != nil {
 		t.Fatalf("first Exec: %v", err)
@@ -538,9 +548,11 @@ func TestControllerExecGuidanceDuringActiveTurn(t *testing.T) {
 		t.Fatalf("Start: %v", err)
 	}
 	first, err := controller.Exec(ctx, ExecInput{
-		RoomID:         started.Session.RoomID,
-		AgentSessionID: started.Session.AgentSessionID,
-		Content:        textPrompt("first prompt"),
+		RoomID:                          started.Session.RoomID,
+		AgentSessionID:                  started.Session.AgentSessionID,
+		ClientSubmitID:                  "guidance-base-submit",
+		CanonicalSubmitOccurredAtUnixMS: 1_001,
+		Content:                         textPrompt("first prompt"),
 	})
 	if err != nil {
 		t.Fatalf("first Exec: %v", err)
@@ -963,9 +975,11 @@ func TestControllerExecReportsReturnedEventsNotAlreadyEmitted(t *testing.T) {
 		t.Fatalf("Start: %v", err)
 	}
 	execResult, err := controller.Exec(context.Background(), ExecInput{
-		RoomID:         "room-1",
-		AgentSessionID: started.Session.AgentSessionID,
-		Content:        textPrompt("run"),
+		RoomID:                          "room-1",
+		AgentSessionID:                  started.Session.AgentSessionID,
+		ClientSubmitID:                  "returned-events-submit",
+		CanonicalSubmitOccurredAtUnixMS: 1_006,
+		Content:                         textPrompt("run"),
 	})
 	if err != nil {
 		t.Fatalf("Exec: %v", err)

--- a/packages/agent/daemon/runtime/controller_goal_test_support_test.go
+++ b/packages/agent/daemon/runtime/controller_goal_test_support_test.go
@@ -22,8 +22,12 @@ func (blockingGoalReconcileReporter) Report(ctx context.Context, _ agentsessions
 	return ctx.Err()
 }
 
-func (r blockingGoalReconcileReporter) ReportSubmitProvenance(ctx context.Context, report agentsessionstore.ReportActivityInput) error {
-	return r.Report(ctx, report)
+func (blockingGoalReconcileReporter) AdmitSubmitIntent(_ context.Context, _ agentsessionstore.SubmitIntentInput) error {
+	return nil
+}
+
+func (blockingGoalReconcileReporter) UpdateSubmitProvenance(context.Context, agentsessionstore.SubmitProvenanceInput) error {
+	return nil
 }
 
 func (r *goalPrepareBarrierReporter) Report(ctx context.Context, report agentsessionstore.ReportActivityInput) error {
@@ -43,8 +47,12 @@ func (r *goalPrepareBarrierReporter) Report(ctx context.Context, report agentses
 	return nil
 }
 
-func (r *goalPrepareBarrierReporter) ReportSubmitProvenance(ctx context.Context, report agentsessionstore.ReportActivityInput) error {
-	return r.Report(ctx, report)
+func (*goalPrepareBarrierReporter) AdmitSubmitIntent(_ context.Context, _ agentsessionstore.SubmitIntentInput) error {
+	return nil
+}
+
+func (*goalPrepareBarrierReporter) UpdateSubmitProvenance(context.Context, agentsessionstore.SubmitProvenanceInput) error {
+	return nil
 }
 
 func (r *goalPrepareBarrierReporter) phaseSnapshot() []string {

--- a/packages/agent/daemon/runtime/controller_provisional_acceptance_test.go
+++ b/packages/agent/daemon/runtime/controller_provisional_acceptance_test.go
@@ -166,9 +166,13 @@ func TestControllerProvisionalSessionPublishesPromptAndSettlesRejectedFirstTurn(
 	}
 
 	result, err := controller.Exec(t.Context(), ExecInput{
-		RoomID: "room-1", AgentSessionID: "session-rejected",
-		TurnID: "turn-rejected", Content: textPrompt("hello"),
-		RequireProviderAcceptance: true,
+		RoomID:                          "room-1",
+		AgentSessionID:                  "session-rejected",
+		TurnID:                          "turn-rejected",
+		ClientSubmitID:                  "submit-rejected",
+		CanonicalSubmitOccurredAtUnixMS: 1_001,
+		Content:                         textPrompt("hello"),
+		RequireProviderAcceptance:       true,
 	})
 	var appErr *AppError
 	if !errors.As(err, &appErr) || appErr.Code != "auth_required" {
@@ -228,9 +232,13 @@ func TestControllerProviderlessCanonicalTerminalSettlesRootTurn(t *testing.T) {
 	}
 
 	result, err := controller.Exec(t.Context(), ExecInput{
-		RoomID: "room-1", AgentSessionID: "session-providerless-terminal",
-		TurnID: "turn-providerless-terminal", Content: textPrompt("hello"),
-		RequireProviderAcceptance: true,
+		RoomID:                          "room-1",
+		AgentSessionID:                  "session-providerless-terminal",
+		TurnID:                          "turn-providerless-terminal",
+		ClientSubmitID:                  "submit-providerless-terminal",
+		CanonicalSubmitOccurredAtUnixMS: 1_002,
+		Content:                         textPrompt("hello"),
+		RequireProviderAcceptance:       true,
 	})
 	if err != nil {
 		t.Fatalf("Exec() error = %v, want canonical submit retained", err)
@@ -308,9 +316,13 @@ func TestControllerProviderlessCanonicalTerminalCommitRetryConverges(t *testing.
 			}
 
 			result, err := controller.Exec(t.Context(), ExecInput{
-				RoomID: "room-1", AgentSessionID: sessionID,
-				TurnID: turnID, Content: textPrompt("hello"),
-				RequireProviderAcceptance: true,
+				RoomID:                          "room-1",
+				AgentSessionID:                  sessionID,
+				TurnID:                          turnID,
+				ClientSubmitID:                  "submit-providerless-terminal-retry",
+				CanonicalSubmitOccurredAtUnixMS: 1_003,
+				Content:                         textPrompt("hello"),
+				RequireProviderAcceptance:       true,
 			})
 			if err != nil {
 				t.Fatalf("Exec() error = %v, want canonical submit retained", err)

--- a/packages/agent/daemon/runtime/controller_report_test_support_test.go
+++ b/packages/agent/daemon/runtime/controller_report_test_support_test.go
@@ -2,6 +2,7 @@ package agentruntime
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"testing"
@@ -12,13 +13,48 @@ import (
 )
 
 type recordingReporter struct {
-	mu      sync.Mutex
-	calls   []reportCall
-	updates chan struct{}
+	mu         sync.Mutex
+	calls      []reportCall
+	provenance []agentsessionstore.SubmitProvenanceInput
+	updates    chan struct{}
 }
 
 type reportCall struct {
 	report agentsessionstore.ReportActivityInput
+}
+
+func reportFromSubmitIntentInput(input agentsessionstore.SubmitIntentInput) agentsessionstore.ReportActivityInput {
+	report := agentsessionstore.ReportActivityInput{
+		WorkspaceID: input.WorkspaceID,
+		Connector:   input.State.Connector,
+		Source:      input.State.Source,
+	}
+	var statePatch agentsessionstore.WorkspaceAgentStatePatch
+	if raw, err := json.Marshal(input.State.State); err == nil {
+		_ = json.Unmarshal(raw, &statePatch)
+	}
+	statePatch.AgentSessionID = input.AgentSessionID
+	report.StatePatches = []agentsessionstore.WorkspaceAgentStatePatch{statePatch}
+	for _, message := range input.Messages.Updates {
+		messageUpdate := agentsessionstore.WorkspaceAgentMessageUpdate{
+			AgentSessionID:    input.AgentSessionID,
+			MessageID:         message.MessageID,
+			TurnID:            message.TurnID,
+			Role:              message.Role,
+			Kind:              message.Kind,
+			Status:            message.Status,
+			Semantics:         message.Semantics,
+			Payload:           message.Payload,
+			OccurredAtUnixMS:  message.OccurredAtUnixMS,
+			StartedAtUnixMS:   message.StartedAtUnixMS,
+			CompletedAtUnixMS: message.CompletedAtUnixMS,
+		}
+		if seq, ok := message.Payload["seq"].(uint64); ok {
+			messageUpdate.Seq = seq
+		}
+		report.MessageUpdates = append(report.MessageUpdates, messageUpdate)
+	}
+	return report
 }
 
 func (r *recordingReporter) Report(_ context.Context, report agentsessionstore.ReportActivityInput) error {
@@ -34,8 +70,27 @@ func (r *recordingReporter) Report(_ context.Context, report agentsessionstore.R
 	return nil
 }
 
-func (r *recordingReporter) ReportSubmitProvenance(ctx context.Context, report agentsessionstore.ReportActivityInput) error {
-	return r.Report(ctx, report)
+func (r *recordingReporter) AdmitSubmitIntent(ctx context.Context, input agentsessionstore.SubmitIntentInput) error {
+	return r.Report(ctx, reportFromSubmitIntentInput(input))
+}
+
+func (r *recordingReporter) UpdateSubmitProvenance(_ context.Context, input agentsessionstore.SubmitProvenanceInput) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.provenance = append(r.provenance, input)
+	if r.updates != nil {
+		select {
+		case r.updates <- struct{}{}:
+		default:
+		}
+	}
+	return nil
+}
+
+func (r *recordingReporter) provenanceSnapshot() []agentsessionstore.SubmitProvenanceInput {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]agentsessionstore.SubmitProvenanceInput(nil), r.provenance...)
 }
 
 func (r *recordingReporter) snapshot() []reportCall {

--- a/packages/agent/daemon/runtime/controller_report_worker.go
+++ b/packages/agent/daemon/runtime/controller_report_worker.go
@@ -3,6 +3,7 @@ package agentruntime
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"time"
@@ -232,9 +233,8 @@ func (c *Controller) observeProviderObservations(
 }
 
 // reportSubmittedTurnDurable is the acceptance barrier for a user submission.
-// The durable reporter commits the submitted Turn and canonical user message
-// together before Exec may publish the transition, start provider work, or
-// return success.
+// Admission is the only runtime path that may create the canonical user
+// message. Provider activity and Host provenance use separate contracts.
 func (c *Controller) reportSubmittedTurnDurable(
 	ctx context.Context,
 	session Session,
@@ -257,7 +257,92 @@ func (c *Controller) reportSubmittedTurnDurable(
 	if keepProvisional {
 		hideProvisionalSessionReport(&report)
 	}
-	return c.reporter.ReportSubmitProvenance(ctx, report)
+	activityInput, err := submitIntentActivityInput(SubmitIntentInput{
+		RoomID:                          session.RoomID,
+		AgentSessionID:                  session.AgentSessionID,
+		TurnID:                          firstSubmitTurnID(report),
+		ClientSubmitID:                  firstSubmitClientSubmitID(report),
+		CanonicalMessageID:              firstSubmitMessageID(report),
+		CanonicalSubmitOccurredAtUnixMS: firstSubmitOccurredAt(report),
+		Report:                          report,
+	})
+	if err != nil {
+		return err
+	}
+	return c.reporter.AdmitSubmitIntent(ctx, activityInput)
+}
+
+func submitIntentActivityInput(input SubmitIntentInput) (agentsessionstore.SubmitIntentInput, error) {
+	stateInputs := agentsessionstore.SessionStateInputsFromActivity(input.Report)
+	messageInputs, err := agentsessionstore.SessionMessageInputsFromActivity(input.Report)
+	if err != nil {
+		return agentsessionstore.SubmitIntentInput{}, err
+	}
+	if len(stateInputs) != 1 || len(messageInputs) != 1 || len(messageInputs[0].Updates) != 1 {
+		return agentsessionstore.SubmitIntentInput{}, fmt.Errorf(
+			"submit intent admission requires one state and one canonical message, got %d state inputs and %d message inputs",
+			len(stateInputs), len(messageInputs),
+		)
+	}
+	message := messageInputs[0].Updates[0]
+	if strings.TrimSpace(message.MessageID) == "" || strings.TrimSpace(message.TurnID) == "" {
+		return agentsessionstore.SubmitIntentInput{}, errors.New("submit intent admission requires canonical message identity")
+	}
+	if strings.TrimSpace(input.RoomID) == "" || strings.TrimSpace(input.AgentSessionID) == "" ||
+		strings.TrimSpace(input.TurnID) == "" || strings.TrimSpace(input.ClientSubmitID) == "" {
+		return agentsessionstore.SubmitIntentInput{}, errors.New("submit intent admission requires complete scope and identity")
+	}
+	if message.TurnID != input.TurnID || payloadString(message.Payload, "clientSubmitId") != input.ClientSubmitID {
+		return agentsessionstore.SubmitIntentInput{}, errors.New("submit intent admission identity does not match canonical message")
+	}
+	return agentsessionstore.SubmitIntentInput{
+		WorkspaceID: input.RoomID, AgentSessionID: input.AgentSessionID,
+		ClientSubmitID: input.ClientSubmitID, CanonicalTurnID: input.TurnID,
+		CanonicalMessageID:              firstNonEmptyString(input.CanonicalMessageID, message.MessageID),
+		CanonicalSubmitOccurredAtUnixMS: input.CanonicalSubmitOccurredAtUnixMS,
+		State:                           stateInputs[0], Messages: messageInputs[0],
+	}, nil
+}
+
+func firstSubmitTurnID(report agentsessionstore.ReportActivityInput) string {
+	for _, update := range report.MessageUpdates {
+		if strings.TrimSpace(update.Role) == RoleUser {
+			return strings.TrimSpace(update.TurnID)
+		}
+	}
+	for _, patch := range report.StatePatches {
+		if patch.Turn != nil {
+			return strings.TrimSpace(patch.Turn.TurnID)
+		}
+	}
+	return ""
+}
+
+func firstSubmitClientSubmitID(report agentsessionstore.ReportActivityInput) string {
+	for _, update := range report.MessageUpdates {
+		if clientSubmitID := payloadString(update.Payload, "clientSubmitId"); clientSubmitID != "" {
+			return clientSubmitID
+		}
+	}
+	return ""
+}
+
+func firstSubmitMessageID(report agentsessionstore.ReportActivityInput) string {
+	for _, update := range report.MessageUpdates {
+		if strings.TrimSpace(update.Role) == RoleUser {
+			return strings.TrimSpace(update.MessageID)
+		}
+	}
+	return ""
+}
+
+func firstSubmitOccurredAt(report agentsessionstore.ReportActivityInput) int64 {
+	for _, update := range report.MessageUpdates {
+		if strings.TrimSpace(update.Role) == RoleUser && update.OccurredAtUnixMS > 0 {
+			return update.OccurredAtUnixMS
+		}
+	}
+	return 0
 }
 
 func hideProvisionalSessionReport(report *agentsessionstore.ReportActivityInput) {
@@ -635,8 +720,8 @@ func (c *Controller) report(ctx context.Context, request reportRequest) (reportE
 	if c.reporter == nil {
 		return errors.New("agent session activity reporter is unavailable")
 	}
-	if request.submitProvenance {
-		reportErr = c.reporter.ReportSubmitProvenance(ctx, request.report)
+	if request.provenance != nil {
+		reportErr = c.reporter.UpdateSubmitProvenance(ctx, submitProvenanceActivityInput(*request.provenance))
 	} else {
 		reportErr = c.reporter.Report(ctx, request.report)
 	}
@@ -660,6 +745,23 @@ func (c *Controller) report(ctx context.Context, request reportRequest) (reportE
 		)
 	}
 	return reportErr
+}
+
+func submitProvenanceActivityInput(input SubmitProvenanceInput) agentsessionstore.SubmitProvenanceInput {
+	return agentsessionstore.SubmitProvenanceInput{
+		WorkspaceID:        input.RoomID,
+		AgentSessionID:     input.AgentSessionID,
+		ClientSubmitID:     input.ClientSubmitID,
+		CanonicalTurnID:    input.TurnID,
+		CanonicalMessageID: input.CanonicalMessageID,
+		ProviderSessionID:  input.ProviderSessionID,
+		ProviderTurnID:     input.ProviderTurnID,
+		DispatchStatus:     input.DispatchStatus,
+		DeliveryStatus:     input.DeliveryStatus,
+		FailureReason:      input.FailureReason,
+		OccurredAtUnixMS:   input.OccurredAtUnixMS,
+		Guidance:           input.Guidance,
+	}
 }
 
 func sessionKey(roomID, agentSessionID string) string {

--- a/packages/agent/daemon/runtime/controller_report_worker_test.go
+++ b/packages/agent/daemon/runtime/controller_report_worker_test.go
@@ -36,8 +36,12 @@ func (r *reentrantQueueReporter) Report(_ context.Context, report agentsessionst
 	return nil
 }
 
-func (r *reentrantQueueReporter) ReportSubmitProvenance(ctx context.Context, report agentsessionstore.ReportActivityInput) error {
-	return r.Report(ctx, report)
+func (r *reentrantQueueReporter) AdmitSubmitIntent(ctx context.Context, input agentsessionstore.SubmitIntentInput) error {
+	return r.Report(ctx, reportFromSubmitIntentInput(input))
+}
+
+func (*reentrantQueueReporter) UpdateSubmitProvenance(context.Context, agentsessionstore.SubmitProvenanceInput) error {
+	return nil
 }
 
 func (r *reentrantQueueReporter) snapshot() []string {

--- a/packages/agent/daemon/runtime/controller_root_turn_test.go
+++ b/packages/agent/daemon/runtime/controller_root_turn_test.go
@@ -34,9 +34,11 @@ func TestReconcileRootTurnSettlementPublishesFailureDetail(t *testing.T) {
 	defer unsubscribe()
 
 	execResult, err := controller.Exec(ctx, ExecInput{
-		RoomID:         "room-1",
-		AgentSessionID: started.Session.AgentSessionID,
-		Content:        textPrompt("hello"),
+		RoomID:                          "room-1",
+		AgentSessionID:                  started.Session.AgentSessionID,
+		ClientSubmitID:                  "root-turn-submit",
+		CanonicalSubmitOccurredAtUnixMS: 1_001,
+		Content:                         textPrompt("hello"),
 	})
 	if err != nil {
 		t.Fatalf("Exec: %v", err)

--- a/packages/agent/daemon/runtime/controller_session_rename_race_test.go
+++ b/packages/agent/daemon/runtime/controller_session_rename_race_test.go
@@ -193,9 +193,11 @@ func TestControllerSetTitleDuringActiveTurnSurvivesCompletion(t *testing.T) {
 		t.Fatalf("Start: %v", err)
 	}
 	execResult, err := controller.Exec(context.Background(), ExecInput{
-		RoomID:         "room-1",
-		AgentSessionID: started.Session.AgentSessionID,
-		Content:        textPrompt("hello"),
+		RoomID:                          "room-1",
+		AgentSessionID:                  started.Session.AgentSessionID,
+		ClientSubmitID:                  "rename-active-submit",
+		CanonicalSubmitOccurredAtUnixMS: 1_001,
+		Content:                         textPrompt("hello"),
 	})
 	if err != nil {
 		t.Fatalf("Exec: %v", err)
@@ -257,9 +259,11 @@ func TestControllerLateProviderTitleCannotOverwriteUserRename(t *testing.T) {
 		t.Fatalf("Start: %v", err)
 	}
 	execResult, err := controller.Exec(context.Background(), ExecInput{
-		RoomID:         "room-1",
-		AgentSessionID: started.Session.AgentSessionID,
-		Content:        textPrompt("hello"),
+		RoomID:                          "room-1",
+		AgentSessionID:                  started.Session.AgentSessionID,
+		ClientSubmitID:                  "rename-provider-title-submit",
+		CanonicalSubmitOccurredAtUnixMS: 1_002,
+		Content:                         textPrompt("hello"),
 	})
 	if err != nil {
 		t.Fatalf("Exec: %v", err)
@@ -320,9 +324,11 @@ func TestControllerSetTitleDuringActiveAsyncTurnSurvivesCompletion(t *testing.T)
 		t.Fatalf("Start: %v", err)
 	}
 	if _, err := controller.Exec(context.Background(), ExecInput{
-		RoomID:         "room-1",
-		AgentSessionID: started.Session.AgentSessionID,
-		Content:        textPrompt("hello"),
+		RoomID:                          "room-1",
+		AgentSessionID:                  started.Session.AgentSessionID,
+		ClientSubmitID:                  "rename-async-submit",
+		CanonicalSubmitOccurredAtUnixMS: 1_003,
+		Content:                         textPrompt("hello"),
 	}); err != nil {
 		t.Fatalf("Exec: %v", err)
 	}

--- a/packages/agent/daemon/runtime/controller_session_resume_test.go
+++ b/packages/agent/daemon/runtime/controller_session_resume_test.go
@@ -141,9 +141,11 @@ func TestControllerResumeReattachesExistingProviderSession(t *testing.T) {
 	defer unsubscribe()
 
 	execResult, err := controller.Exec(context.Background(), ExecInput{
-		RoomID:         "room-1",
-		AgentSessionID: "agent-session-1",
-		Content:        textPrompt("continue"),
+		RoomID:                          "room-1",
+		AgentSessionID:                  "agent-session-1",
+		ClientSubmitID:                  "resume-continue-submit",
+		CanonicalSubmitOccurredAtUnixMS: 1_001,
+		Content:                         textPrompt("continue"),
 	})
 	if err != nil {
 		t.Fatalf("Exec after Resume: %v", err)
@@ -229,9 +231,11 @@ func TestControllerResumeRecreatesMissingProviderSessionWhenOptedIn(t *testing.T
 		}
 		// The recreated session must be live so a turn can run on it.
 		result, err := controller.Exec(context.Background(), ExecInput{
-			RoomID:         "room-1",
-			AgentSessionID: "imported-1",
-			Content:        textPrompt("continue"),
+			RoomID:                          "room-1",
+			AgentSessionID:                  "imported-1",
+			ClientSubmitID:                  "resume-recreated-submit",
+			CanonicalSubmitOccurredAtUnixMS: 1_002,
+			Content:                         textPrompt("continue"),
 		})
 		if err != nil {
 			t.Fatalf("Exec after recreate: %v", err)

--- a/packages/agent/daemon/runtime/controller_side_conversation_test.go
+++ b/packages/agent/daemon/runtime/controller_side_conversation_test.go
@@ -284,6 +284,7 @@ func TestSideConversationOpensDuringActiveParentWithoutDurableWrites(t *testing.
 	}
 	if _, err := controller.Exec(t.Context(), ExecInput{
 		RoomID: "workspace-side", AgentSessionID: "parent", TurnID: "parent-turn",
+		ClientSubmitID: "parent-submit", CanonicalSubmitOccurredAtUnixMS: 1,
 		Content: []PromptContentBlock{{Type: "text", Text: "keep working"}},
 	}); err != nil {
 		t.Fatal(err)
@@ -311,12 +312,11 @@ func TestSideConversationOpensDuringActiveParentWithoutDurableWrites(t *testing.
 	if !controller.HasActiveTurn("workspace-side", "parent") {
 		t.Fatal("opening Side disturbed the active parent turn")
 	}
-	if err := controller.DurablyReportSubmitProvenance(
+	if err := controller.UpdateSubmitProvenance(
 		t.Context(),
 		SubmitProvenanceInput{
 			RoomID: "workspace-side", AgentSessionID: "side-1",
 			TurnID: "side-turn", ClientSubmitID: "side-submit",
-			Content: []PromptContentBlock{{Type: "text", Text: "side question"}},
 		},
 	); !errors.Is(err, ErrSideConversationUnsupported) {
 		t.Fatalf("Side submit provenance error = %v, want unsupported", err)

--- a/packages/agent/daemon/runtime/controller_start_test.go
+++ b/packages/agent/daemon/runtime/controller_start_test.go
@@ -499,8 +499,11 @@ func TestControllerProvisionalStartCommitsWithFirstTurn(t *testing.T) {
 		t.Fatalf("Sessions() before first turn acceptance = %#v, want provisional session hidden", sessions)
 	}
 	result, err := controller.Exec(context.Background(), ExecInput{
-		RoomID: "room-1", AgentSessionID: "agent-session-1",
-		Content: []PromptContentBlock{{Type: "text", Text: "hello"}},
+		RoomID:                          "room-1",
+		AgentSessionID:                  "agent-session-1",
+		ClientSubmitID:                  "provisional-first-turn",
+		CanonicalSubmitOccurredAtUnixMS: 1_001,
+		Content:                         []PromptContentBlock{{Type: "text", Text: "hello"}},
 	})
 	if err != nil || result.TurnID == "" {
 		t.Fatalf("Exec() = %#v, %v", result, err)

--- a/packages/agent/daemon/runtime/controller_submit_provenance.go
+++ b/packages/agent/daemon/runtime/controller_submit_provenance.go
@@ -3,19 +3,13 @@ package agentruntime
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
-
-	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+	"time"
 )
 
-// DurablyReportSubmitProvenance waits until the exact client submit can be
-// queried from durable storage. Callers must invoke it only after Exec has
-// returned, because Exec owns the per-session lifecycle lock while dispatching
-// to the provider. The report remains queued when the caller context is
-// canceled: provider work may already be running, so losing provenance would
-// make a safe retry impossible.
-func (c *Controller) DurablyReportSubmitProvenance(ctx context.Context, input SubmitProvenanceInput) error {
+// UpdateSubmitProvenance records provider and delivery facts after Exec. It
+// never reconstructs or submits a canonical user message.
+func (c *Controller) UpdateSubmitProvenance(ctx context.Context, input SubmitProvenanceInput) error {
 	if c == nil || c.reporter == nil {
 		return errors.New("agent session activity reporter is unavailable")
 	}
@@ -30,79 +24,31 @@ func (c *Controller) DurablyReportSubmitProvenance(ctx context.Context, input Su
 	if !ok {
 		return ErrSessionNotFound
 	}
-	key := sessionKey(input.RoomID, input.AgentSessionID)
-	c.mu.Lock()
-	publicationPending := c.sessionPublicationPendingLocked(key)
-	c.mu.Unlock()
-	if publicationPending {
-		// A nonstandard caller may still be inside the provisional window when
-		// this late provenance arrives. Keep it hidden until the submitted-intent
-		// barrier publishes the canonical prompt; normal initial-content creates
-		// have already crossed that barrier before Exec returns.
-		session.Visible = false
-	}
 	if session.IsSideConversation() {
 		return ErrSideConversationUnsupported
 	}
-	canonicalSubmit, err := newCanonicalSubmitFact(
-		input.ClientSubmitID,
-		input.CanonicalSubmitOccurredAtUnixMS,
-	)
-	if err != nil {
-		return err
+	if input.OccurredAtUnixMS <= 0 {
+		input.OccurredAtUnixMS = time.Now().UnixMilli()
 	}
-	content := normalizeRuntimePromptContent(input.Content)
-	if len(content) == 0 {
-		return errors.New("submit provenance prompt is required")
-	}
-
-	messageID := userPromptActivityMessageIDFromClientSubmitID(input.ClientSubmitID)
-	explicitDisplayPrompt, visibleText := explicitAndVisiblePromptText(content, input.DisplayPrompt)
-	message := newUserPromptActivityEventWithFact(
-		session,
-		content,
-		explicitDisplayPrompt,
-		visibleText,
-		input.TurnID,
-		canonicalSubmit,
-		nil,
-	)
-	// Do not replay a submitted lifecycle patch here. Exec durably committed
-	// that patch before provider dispatch. The adapter's user-message report may
-	// race this barrier, so both paths reconstruct it from the same canonical
-	// submit occurrence. This atomic write requires the exact turn to exist
-	// without regressing a fast provider that already moved it onward.
-	report := reportActivityInput(session, []activityshared.Event{message})
-	c.enrichReportWithSessionSnapshot(session, &report)
-	if publicationPending {
-		hideProvisionalSessionReport(&report)
-	}
-	if len(report.StatePatches) != 1 || len(report.MessageUpdates) != 1 {
-		return fmt.Errorf(
-			"build atomic submit provenance: got %d state patches and %d message updates",
-			len(report.StatePatches),
-			len(report.MessageUpdates),
-		)
-	}
-	if update := report.MessageUpdates[0]; strings.TrimSpace(update.MessageID) != messageID ||
-		strings.TrimSpace(update.TurnID) != input.TurnID ||
-		strings.TrimSpace(payloadString(update.Payload, "clientSubmitId")) != input.ClientSubmitID {
-		return errors.New("build atomic submit provenance: canonical message identity was not preserved")
-	}
-
-	done := make(chan error, 1)
 	request := reportRequest{
 		ctx:              context.WithoutCancel(ctx),
-		report:           report,
 		submitProvenance: true,
-		done:             done,
+		provenance: &SubmitProvenanceInput{
+			RoomID: input.RoomID, AgentSessionID: input.AgentSessionID,
+			ClientSubmitID: input.ClientSubmitID, TurnID: input.TurnID,
+			CanonicalMessageID: input.CanonicalMessageID, ProviderSessionID: input.ProviderSessionID,
+			ProviderTurnID: input.ProviderTurnID, DispatchStatus: input.DispatchStatus,
+			DeliveryStatus: input.DeliveryStatus, FailureReason: input.FailureReason,
+			OccurredAtUnixMS: input.OccurredAtUnixMS, Guidance: input.Guidance,
+		},
+		done: make(chan error, 1),
 	}
 	if c.reportQueue == nil {
 		return c.report(request.ctx, request)
 	}
 	c.reportQueue.enqueue(request)
 	select {
-	case err := <-done:
+	case err := <-request.done:
 		return err
 	case <-ctx.Done():
 		return ctx.Err()

--- a/packages/agent/daemon/runtime/controller_submit_provenance_test.go
+++ b/packages/agent/daemon/runtime/controller_submit_provenance_test.go
@@ -3,7 +3,6 @@ package agentruntime
 import (
 	"context"
 	"errors"
-	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -61,7 +60,7 @@ func (a *canonicalSubmitSequenceAdapter) ExecAsync(
 				explicitDisplayPrompt,
 				visibleText,
 				turnID,
-				nil,
+				map[string]any{messageOriginMetadataKey: string(messageOriginProviderEcho)},
 			),
 		})
 	}
@@ -113,13 +112,15 @@ func TestCanonicalSubmitSequenceIsStableAcrossRuntimeAndProvenanceOrder(t *testi
 				waitForCanonicalSubmitEmission(t, adapter.emitted)
 				waitForCanonicalSubmitMessageReports(t, reporter, clientSubmitID, 1)
 			}
-			if err := controller.DurablyReportSubmitProvenance(t.Context(), SubmitProvenanceInput{
-				RoomID:                          started.Session.RoomID,
-				AgentSessionID:                  started.Session.AgentSessionID,
-				TurnID:                          execResult.TurnID,
-				ClientSubmitID:                  clientSubmitID,
-				CanonicalSubmitOccurredAtUnixMS: occurredAtUnixMS,
-				Content:                         content,
+			if err := controller.UpdateSubmitProvenance(t.Context(), SubmitProvenanceInput{
+				RoomID:             started.Session.RoomID,
+				AgentSessionID:     started.Session.AgentSessionID,
+				TurnID:             execResult.TurnID,
+				ClientSubmitID:     clientSubmitID,
+				CanonicalMessageID: userPromptActivityMessageIDFromClientSubmitID(clientSubmitID),
+				OccurredAtUnixMS:   occurredAtUnixMS,
+				DispatchStatus:     "accepted",
+				DeliveryStatus:     "accepted",
 			}); err != nil {
 				t.Fatal(err)
 			}
@@ -128,16 +129,38 @@ func TestCanonicalSubmitSequenceIsStableAcrossRuntimeAndProvenanceOrder(t *testi
 				waitForCanonicalSubmitEmission(t, adapter.emitted)
 			}
 
-			updates := waitForCanonicalSubmitMessageReports(t, reporter, clientSubmitID, 2)
-			if !reflect.DeepEqual(updates[0], updates[1]) {
-				t.Fatalf("canonical submit updates differ:\nfirst=%#v\nsecond=%#v", updates[0], updates[1])
+			updates := waitForCanonicalSubmitMessageReports(t, reporter, clientSubmitID, 1)
+			if updates[0].MessageID != userPromptActivityMessageIDFromClientSubmitID(clientSubmitID) ||
+				updates[0].TurnID != execResult.TurnID {
+				t.Fatalf("canonical submit identity = %#v", updates[0])
 			}
 			if updates[0].Seq != uint64(occurredAtUnixMS) || updates[0].OccurredAtUnixMS != occurredAtUnixMS {
-				t.Fatalf("canonical submit sequence = %d occurredAt=%d", updates[0].Seq, updates[0].OccurredAtUnixMS)
+				t.Fatalf("canonical submit sequence/occurrence = seq:%d occurred:%d", updates[0].Seq, updates[0].OccurredAtUnixMS)
 			}
 			projected := agentsessionstore.SessionMessageUpdateFromActivityUpdate(updates[0])
 			if projected.Payload["seq"] != uint64(occurredAtUnixMS) {
 				t.Fatalf("canonical payload seq = %#v", projected.Payload["seq"])
+			}
+			reporter.waitForReports(t, "provider echo activity", func(calls []reportCall) bool {
+				count := 0
+				for _, call := range calls {
+					for _, item := range call.report.TimelineItems {
+						if item.ItemType == "provider.echo" && item.EventID == "provider-echo:"+userPromptActivityMessageIDFromClientSubmitID(clientSubmitID) {
+							count++
+						}
+					}
+				}
+				return count == 1
+			})
+			provenance := reporter.provenanceSnapshot()
+			if len(provenance) != 1 {
+				t.Fatalf("submit provenance updates = %#v, want one status-only update", provenance)
+			}
+			if provenance[0].ClientSubmitID != clientSubmitID ||
+				provenance[0].CanonicalMessageID != userPromptActivityMessageIDFromClientSubmitID(clientSubmitID) ||
+				provenance[0].DispatchStatus != "accepted" ||
+				provenance[0].DeliveryStatus != "accepted" {
+				t.Fatalf("submit provenance update = %#v, want identity and status only", provenance[0])
 			}
 		})
 	}
@@ -195,9 +218,13 @@ func (r *submittedTurnBarrierReporter) Report(ctx context.Context, input agentse
 	}
 }
 
-func (r *submittedTurnBarrierReporter) ReportSubmitProvenance(ctx context.Context, report agentsessionstore.ReportActivityInput) error {
+func (r *submittedTurnBarrierReporter) AdmitSubmitIntent(ctx context.Context, input agentsessionstore.SubmitIntentInput) error {
 	r.provenanceCalls++
-	return r.Report(ctx, report)
+	return r.Report(ctx, reportFromSubmitIntentInput(input))
+}
+
+func (*submittedTurnBarrierReporter) UpdateSubmitProvenance(context.Context, agentsessionstore.SubmitProvenanceInput) error {
+	return nil
 }
 
 type executionSignalAdapter struct {

--- a/packages/agent/daemon/runtime/controller_turn_lifecycle_test.go
+++ b/packages/agent/daemon/runtime/controller_turn_lifecycle_test.go
@@ -232,11 +232,15 @@ func (r *sessionEventTerminalBarrierReporter) Report(
 	}
 }
 
-func (r *sessionEventTerminalBarrierReporter) ReportSubmitProvenance(
+func (r *sessionEventTerminalBarrierReporter) AdmitSubmitIntent(
 	ctx context.Context,
-	report agentsessionstore.ReportActivityInput,
+	input agentsessionstore.SubmitIntentInput,
 ) error {
-	return r.Report(ctx, report)
+	return r.Report(ctx, reportFromSubmitIntentInput(input))
+}
+
+func (*sessionEventTerminalBarrierReporter) UpdateSubmitProvenance(context.Context, agentsessionstore.SubmitProvenanceInput) error {
+	return nil
 }
 
 func lateChildCompletionEvent(root Session) activityshared.Event {

--- a/packages/agent/daemon/runtime/controller_turn_state.go
+++ b/packages/agent/daemon/runtime/controller_turn_state.go
@@ -30,7 +30,7 @@ func submittedTurnActivityEvents(
 		explicitDisplayPrompt,
 		visibleText,
 		turnID,
-		nil,
+		map[string]any{messageOriginMetadataKey: string(messageOriginCanonicalSubmit)},
 	)
 	event := activityshared.NewTurnUpdated(eventContext, turnID, activityshared.TurnPhaseSubmitted)
 	event.Payload.Title = strings.TrimSpace(submittedTitle)

--- a/packages/agent/daemon/runtime/edit_retry_provider_test.go
+++ b/packages/agent/daemon/runtime/edit_retry_provider_test.go
@@ -60,11 +60,15 @@ func (reporter *providerAcceptanceBarrierReporter) Report(
 	return nil
 }
 
-func (reporter *providerAcceptanceBarrierReporter) ReportSubmitProvenance(
+func (reporter *providerAcceptanceBarrierReporter) AdmitSubmitIntent(
 	ctx context.Context,
-	report agentsessionstore.ReportActivityInput,
+	input agentsessionstore.SubmitIntentInput,
 ) error {
-	return reporter.Report(ctx, report)
+	return reporter.Report(ctx, reportFromSubmitIntentInput(input))
+}
+
+func (*providerAcceptanceBarrierReporter) UpdateSubmitProvenance(context.Context, agentsessionstore.SubmitProvenanceInput) error {
+	return nil
 }
 
 func TestCodexEffectiveHistoryUsesNoHandlerTypedCommands(t *testing.T) {
@@ -329,9 +333,13 @@ func TestControllerHistoryReplacementExplicitRejectionIsTyped(t *testing.T) {
 	})
 
 	result, err := controller.Exec(t.Context(), ExecInput{
-		RoomID: "room-edit-retry", AgentSessionID: sessionID,
-		TurnID: "replacement-turn-rejected", Content: textPrompt("replacement"),
-		HistoryReplacement: true,
+		RoomID:                          "room-edit-retry",
+		AgentSessionID:                  sessionID,
+		TurnID:                          "replacement-turn-rejected",
+		ClientSubmitID:                  "history-replacement-rejected",
+		CanonicalSubmitOccurredAtUnixMS: 1_001,
+		Content:                         textPrompt("replacement"),
+		HistoryReplacement:              true,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -641,8 +649,12 @@ func TestControllerHistoryReplacementNeverSteersActiveTurn(t *testing.T) {
 	})
 
 	if _, err := controller.Exec(t.Context(), ExecInput{
-		RoomID: "room-edit-retry", AgentSessionID: sessionID,
-		TurnID: "ordinary-active-turn", Content: textPrompt("keep working"),
+		RoomID:                          "room-edit-retry",
+		AgentSessionID:                  sessionID,
+		TurnID:                          "ordinary-active-turn",
+		ClientSubmitID:                  "ordinary-active-submit",
+		CanonicalSubmitOccurredAtUnixMS: 1_002,
+		Content:                         textPrompt("keep working"),
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -652,9 +664,13 @@ func TestControllerHistoryReplacementNeverSteersActiveTurn(t *testing.T) {
 	})
 
 	result, err := controller.Exec(t.Context(), ExecInput{
-		RoomID: "room-edit-retry", AgentSessionID: sessionID,
-		TurnID: "replacement-must-not-steer", Content: textPrompt("replacement"),
-		HistoryReplacement: true,
+		RoomID:                          "room-edit-retry",
+		AgentSessionID:                  sessionID,
+		TurnID:                          "replacement-must-not-steer",
+		ClientSubmitID:                  "history-replacement-active",
+		CanonicalSubmitOccurredAtUnixMS: 1_003,
+		Content:                         textPrompt("replacement"),
+		HistoryReplacement:              true,
 	})
 	if !errors.Is(err, ErrSessionActiveTurn) {
 		t.Fatalf("replacement error = %v, want ErrSessionActiveTurn", err)

--- a/packages/agent/daemon/runtime/message_origin.go
+++ b/packages/agent/daemon/runtime/message_origin.go
@@ -1,0 +1,105 @@
+package agentruntime
+
+import (
+	"strings"
+
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+)
+
+const messageOriginMetadataKey = "messageOrigin"
+
+type messageOrigin string
+
+const (
+	messageOriginCanonicalSubmit   messageOrigin = "canonical_submit"
+	messageOriginProviderEcho      messageOrigin = "provider_echo"
+	messageOriginHistoricalReplay  messageOrigin = "historical_replay"
+	messageOriginGuidance          messageOrigin = "guidance"
+	messageOriginProviderInitiated messageOrigin = "provider_initiated"
+	messageOriginProviderActivity  messageOrigin = "provider_activity"
+)
+
+// messageOriginForSessionEvent is deliberately driven by an explicit producer
+// marker. Role=user is not enough to identify a canonical submit: historical
+// replay, guidance, and provider-initiated messages are all valid user events.
+func messageOriginForSessionEvent(event activityshared.Event) messageOrigin {
+	metadata := event.Payload.Metadata
+	switch strings.TrimSpace(stringFromPayload(metadata, messageOriginMetadataKey)) {
+	case string(messageOriginCanonicalSubmit):
+		return messageOriginCanonicalSubmit
+	case string(messageOriginProviderEcho):
+		return messageOriginProviderEcho
+	case string(messageOriginHistoricalReplay):
+		return messageOriginHistoricalReplay
+	case string(messageOriginGuidance):
+		return messageOriginGuidance
+	case string(messageOriginProviderInitiated):
+		return messageOriginProviderInitiated
+	}
+	if metadata["guidance"] == true || metadata["steered"] == true {
+		return messageOriginGuidance
+	}
+	if metadata["historicalReplay"] == true || metadata["replayed"] == true {
+		return messageOriginHistoricalReplay
+	}
+	if metadata["providerInitiated"] == true {
+		return messageOriginProviderInitiated
+	}
+	if event.Payload.Role == activityshared.MessageRoleUser {
+		// Unknown user events remain activity instead of being treated as a
+		// canonical submit. This preserves historical/provider-initiated input
+		// while failing closed for canonical ownership.
+		return messageOriginProviderInitiated
+	}
+	return messageOriginProviderActivity
+}
+
+func isProviderEchoMessageEvent(event activityshared.Event) bool {
+	return event.Payload.Role == activityshared.MessageRoleUser &&
+		messageOriginForSessionEvent(event) == messageOriginProviderEcho
+}
+
+// providerEchoTimelineItem keeps a provider echo observable without sending it
+// through the canonical message writer. Its stable identity makes duplicate
+// echoes idempotent at the activity layer.
+func providerEchoTimelineItem(
+	event activityshared.Event,
+	sessionID string,
+	timestamp int64,
+) (agentsessionstore.WorkspaceAgentTimelineItem, bool) {
+	if !isProviderEchoMessageEvent(event) || strings.TrimSpace(sessionID) == "" || timestamp <= 0 {
+		return agentsessionstore.WorkspaceAgentTimelineItem{}, false
+	}
+	messageID := firstNonEmptyString(stringFromPayload(event.Payload.Metadata, "messageId"), event.EventID)
+	if messageID == "" {
+		return agentsessionstore.WorkspaceAgentTimelineItem{}, false
+	}
+	payload := clonePayload(event.Payload.Metadata)
+	if payload == nil {
+		payload = map[string]any{}
+	}
+	payload[messageOriginMetadataKey] = string(messageOriginProviderEcho)
+	if event.Payload.Content != "" {
+		if _, exists := payload["content"]; !exists {
+			payload["content"] = event.Payload.Content
+		}
+		if _, exists := payload["text"]; !exists {
+			payload["text"] = event.Payload.Content
+		}
+	}
+	return agentsessionstore.WorkspaceAgentTimelineItem{
+		AgentSessionID:   strings.TrimSpace(sessionID),
+		TurnID:           strings.TrimSpace(event.Payload.TurnID),
+		EventSource:      "runtime",
+		EventID:          "provider-echo:" + messageID,
+		ActorType:        "provider",
+		ActorID:          strings.TrimSpace(string(event.Provider)),
+		OccurredAtUnixMS: timestamp,
+		CreatedAtUnixMS:  timestamp,
+		ItemType:         "provider.echo",
+		Role:             string(activityshared.MessageRoleUser),
+		Status:           firstNonEmptyString(stringFromPayload(event.Payload.Metadata, "streamState"), event.Payload.Status),
+		Payload:          payload,
+	}, true
+}

--- a/packages/agent/daemon/runtime/queued_reporter.go
+++ b/packages/agent/daemon/runtime/queued_reporter.go
@@ -13,6 +13,42 @@ type QueuedReporter struct {
 	ClientProvider func() ActivityClient
 }
 
+func (r QueuedReporter) AdmitSubmitIntent(ctx context.Context, input agentsessionstore.SubmitIntentInput) error {
+	if r.ClientProvider == nil {
+		return errors.New("agent session activity client provider is nil")
+	}
+	client, ok := r.ClientProvider().(submitIntentActivityClient)
+	if !ok || client == nil {
+		return errors.New("agent session activity client does not support submit intent admission")
+	}
+	reply, err := client.AdmitSubmitIntent(ctx, input)
+	if err != nil {
+		return err
+	}
+	if !reply.Accepted || reply.AcceptedMessageCount < 1 {
+		return errors.New("submit intent admission was not accepted")
+	}
+	return nil
+}
+
+func (r QueuedReporter) UpdateSubmitProvenance(ctx context.Context, input agentsessionstore.SubmitProvenanceInput) error {
+	if r.ClientProvider == nil {
+		return errors.New("agent session activity client provider is nil")
+	}
+	client, ok := r.ClientProvider().(submitIntentActivityClient)
+	if !ok || client == nil {
+		return errors.New("agent session activity client does not support submit provenance")
+	}
+	reply, err := client.UpdateSubmitProvenance(ctx, input)
+	if err != nil {
+		return err
+	}
+	if !reply.Accepted {
+		return errors.New("submit provenance update was not accepted")
+	}
+	return nil
+}
+
 func (r QueuedReporter) BindGoalProvenance(ctx context.Context, input agentsessionstore.BindGoalProvenanceInput) (agentsessionstore.GoalProvenanceBinding, error) {
 	if r.ClientProvider == nil {
 		return agentsessionstore.GoalProvenanceBinding{}, errors.New("agent session activity client provider is nil")

--- a/packages/agent/daemon/runtime/reporter.go
+++ b/packages/agent/daemon/runtime/reporter.go
@@ -23,18 +23,58 @@ type ActivityReporter interface {
 }
 
 // DurableActivityReporter is the required host boundary for runtime
-// controllers. ReportSubmitProvenance must atomically persist the report's
-// session/turn patch and canonical client-submit message before returning.
-// Compatibility ActivityReporter implementations that split state and message
-// persistence do not satisfy this contract and cannot host a controller.
+// controllers. AdmitSubmitIntent is the only operation that may persist the
+// canonical client-submit message. UpdateSubmitProvenance carries only
+// identity and delivery facts and must not rewrite that message.
 type DurableActivityReporter interface {
 	ActivityReporter
-	ReportSubmitProvenance(context.Context, agentsessionstore.ReportActivityInput) error
+	AdmitSubmitIntent(context.Context, agentsessionstore.SubmitIntentInput) error
+	UpdateSubmitProvenance(context.Context, agentsessionstore.SubmitProvenanceInput) error
 }
 
 type ActivityClient interface {
 	ReportSessionState(context.Context, canonical.ReportSessionStateInput) (canonical.ReportSessionStateReply, error)
 	ReportSessionMessages(context.Context, canonical.ReportSessionMessagesInput) (canonical.ReportSessionMessagesReply, error)
+}
+
+type submitIntentActivityClient interface {
+	agentsessionstore.SubmitIntentReporter
+}
+
+func (r Reporter) AdmitSubmitIntent(ctx context.Context, input agentsessionstore.SubmitIntentInput) error {
+	if r.ClientProvider == nil {
+		return errors.New("agent session activity client provider is nil")
+	}
+	client, ok := r.ClientProvider().(submitIntentActivityClient)
+	if !ok || client == nil {
+		return errors.New("agent session activity client does not support submit intent admission")
+	}
+	reply, err := client.AdmitSubmitIntent(ctx, input)
+	if err != nil {
+		return err
+	}
+	if !reply.Accepted || reply.AcceptedMessageCount < 1 {
+		return errors.New("submit intent admission was not accepted")
+	}
+	return nil
+}
+
+func (r Reporter) UpdateSubmitProvenance(ctx context.Context, input agentsessionstore.SubmitProvenanceInput) error {
+	if r.ClientProvider == nil {
+		return errors.New("agent session activity client provider is nil")
+	}
+	client, ok := r.ClientProvider().(submitIntentActivityClient)
+	if !ok || client == nil {
+		return errors.New("agent session activity client does not support submit provenance")
+	}
+	reply, err := client.UpdateSubmitProvenance(ctx, input)
+	if err != nil {
+		return err
+	}
+	if !reply.Accepted {
+		return errors.New("submit provenance update was not accepted")
+	}
+	return nil
 }
 
 type goalProvenanceActivityClient interface {
@@ -226,6 +266,7 @@ func reportActivityInput(session Session, events []activityshared.Event) agentse
 		},
 		Source: source,
 	}
+	providerEchoIDs := make(map[string]struct{})
 	now := time.Now().UnixMilli()
 	for _, event := range events {
 		appendProviderObservation(&input, event)
@@ -237,7 +278,14 @@ func reportActivityInput(session Session, events []activityshared.Event) agentse
 		if timestamp <= 0 {
 			timestamp = now
 		}
-		if update, ok := messageUpdateFromSessionEvent(source, event, sessionID, timestamp); ok {
+		if echo, ok := providerEchoTimelineItem(event, sessionID, timestamp); ok {
+			if _, seen := providerEchoIDs[echo.EventID]; !seen {
+				input.TimelineItems = append(input.TimelineItems, echo)
+				providerEchoIDs[echo.EventID] = struct{}{}
+			}
+			continue
+		}
+		if update, ok := messageUpdateFromSessionEvent(messageProjectionDurable, source, event, sessionID, timestamp); ok {
 			input.MessageUpdates = append(input.MessageUpdates, update)
 		}
 		if audit, ok := sessionAuditUpdateFromSessionEvent(event, sessionID, timestamp); ok {

--- a/packages/agent/daemon/runtime/reporter_message.go
+++ b/packages/agent/daemon/runtime/reporter_message.go
@@ -9,7 +9,22 @@ import (
 	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
 )
 
+type messageProjectionTarget uint8
+
+const (
+	// messageProjectionDurable is the projection sent to the durable activity
+	// writer. Provider echoes are represented separately as timeline activity
+	// and must never become canonical message updates here.
+	messageProjectionDurable messageProjectionTarget = iota
+	// messageProjectionRealtime is the live stream projection. It keeps
+	// provider echoes observable, with their explicit origin and submit
+	// association, so filtering the durable projection cannot reorder the live
+	// stream.
+	messageProjectionRealtime
+)
+
 func messageUpdateFromSessionEvent(
+	target messageProjectionTarget,
 	source canonical.EventSource,
 	event activityshared.Event,
 	sessionID string,
@@ -17,7 +32,7 @@ func messageUpdateFromSessionEvent(
 ) (agentsessionstore.WorkspaceAgentMessageUpdate, bool) {
 	switch event.Type {
 	case activityshared.EventMessageAppended, activityshared.EventMessageCreated:
-		return textMessageUpdateFromSessionEvent(event, sessionID, timestamp)
+		return textMessageUpdateFromSessionEvent(target, event, sessionID, timestamp)
 	case activityshared.EventCallStarted, activityshared.EventCallCompleted, activityshared.EventCallFailed:
 		return callMessageUpdateFromSessionEvent(source, event, sessionID, timestamp)
 	default:
@@ -26,10 +41,14 @@ func messageUpdateFromSessionEvent(
 }
 
 func textMessageUpdateFromSessionEvent(
+	target messageProjectionTarget,
 	event activityshared.Event,
 	sessionID string,
 	timestamp int64,
 ) (agentsessionstore.WorkspaceAgentMessageUpdate, bool) {
+	if target == messageProjectionDurable && isProviderEchoMessageEvent(event) {
+		return agentsessionstore.WorkspaceAgentMessageUpdate{}, false
+	}
 	messageID := firstNonEmptyString(stringFromPayload(event.Payload.Metadata, "messageId"), event.EventID)
 	if strings.TrimSpace(sessionID) == "" || messageID == "" || timestamp <= 0 {
 		return agentsessionstore.WorkspaceAgentMessageUpdate{}, false
@@ -45,6 +64,9 @@ func textMessageUpdateFromSessionEvent(
 	}
 	payload := map[string]any{
 		"source": "runtime",
+	}
+	if role == RoleUser {
+		payload[messageOriginMetadataKey] = string(messageOriginForSessionEvent(event))
 	}
 	if event.Payload.Content != "" {
 		payload["content"] = event.Payload.Content

--- a/packages/agent/daemon/runtime/reporter_message_origin_test.go
+++ b/packages/agent/daemon/runtime/reporter_message_origin_test.go
@@ -1,0 +1,169 @@
+package agentruntime
+
+import (
+	"testing"
+
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+)
+
+func TestReportActivityInputRoutesProviderEchoAwayFromCanonicalMessage(t *testing.T) {
+	t.Parallel()
+
+	session := reportTestSession()
+	canonical := originTestMessageEvent(
+		session,
+		"canonical-submit-event",
+		messageOriginCanonicalSubmit,
+		"client-submit:user:submit-1",
+		"submit-1",
+		"canonical content",
+	)
+	echo := originTestMessageEvent(
+		session,
+		"provider-echo-event",
+		messageOriginProviderEcho,
+		"client-submit:user:submit-1",
+		"submit-1",
+		"conflicting provider content",
+	)
+
+	for _, events := range [][]activityshared.Event{
+		{canonical, echo, echo},
+		{echo, canonical, echo},
+	} {
+		report := reportActivityInput(session, events)
+		if len(report.MessageUpdates) != 1 {
+			t.Fatalf("message updates = %#v, want one canonical message", report.MessageUpdates)
+		}
+		message := report.MessageUpdates[0]
+		if message.MessageID != "client-submit:user:submit-1" || message.Payload["content"] != "canonical content" ||
+			message.Payload[messageOriginMetadataKey] != string(messageOriginCanonicalSubmit) {
+			t.Fatalf("canonical message = %#v", message)
+		}
+		if len(report.TimelineItems) != 1 || report.TimelineItems[0].ItemType != "provider.echo" ||
+			report.TimelineItems[0].EventID != "provider-echo:client-submit:user:submit-1" {
+			t.Fatalf("provider echo activity = %#v", report.TimelineItems)
+		}
+		if report.TimelineItems[0].Payload["content"] != "conflicting provider content" {
+			t.Fatalf("provider echo payload = %#v, want conflicting activity content", report.TimelineItems[0].Payload)
+		}
+	}
+}
+
+func TestRealtimeProjectionKeepsProviderEchoBeforeToolCall(t *testing.T) {
+	t.Parallel()
+
+	session := reportTestSession()
+	echo := originTestMessageEvent(
+		session,
+		"provider-echo-event",
+		messageOriginProviderEcho,
+		"client-submit:user:submit-1",
+		"submit-1",
+		"provider echo",
+	)
+	tool := newTurnActivityEvent(session, EventCallStarted, "turn-1", messageStreamStateStreaming, "", "Read files", map[string]any{
+		"callId":   "tool-1",
+		"callType": "tool",
+		"name":     "Read files",
+	})
+
+	stream := ProjectActivityEventsToStreamEvents(session, []activityshared.Event{echo, tool})
+	if len(stream) < 2 {
+		t.Fatalf("stream = %#v, want provider echo followed by tool call", stream)
+	}
+	echoUpdate, ok := stream[0].Data.(agentsessionstore.WorkspaceAgentMessageUpdate)
+	if !ok || stream[0].EventType != StreamEventMessageUpdate {
+		t.Fatalf("first stream event = %#v, want realtime provider echo message update", stream[0])
+	}
+	if echoUpdate.Role != RoleUser || echoUpdate.Payload[messageOriginMetadataKey] != string(messageOriginProviderEcho) ||
+		echoUpdate.Payload["clientSubmitId"] != "submit-1" || echoUpdate.Payload["content"] != "provider echo" {
+		t.Fatalf("provider echo stream update = %#v", echoUpdate)
+	}
+	toolUpdate, ok := stream[1].Data.(agentsessionstore.WorkspaceAgentMessageUpdate)
+	if !ok || stream[1].EventType != StreamEventMessageUpdate || toolUpdate.Kind != "tool_call" {
+		t.Fatalf("second stream event = %#v, want tool call after provider echo", stream[1])
+	}
+}
+
+func TestReportActivityInputPreservesNonCanonicalUserOrigins(t *testing.T) {
+	t.Parallel()
+
+	session := reportTestSession()
+	events := []activityshared.Event{
+		originTestMessageEvent(session, "history-1", messageOriginHistoricalReplay, "history-1", "", "historical user message"),
+		originTestMessageEvent(session, "guidance-1", messageOriginGuidance, "guidance-1", "guidance-submit", "guidance message"),
+		originTestMessageEvent(session, "provider-1", messageOriginProviderInitiated, "provider-1", "", "provider initiated message"),
+	}
+
+	report := reportActivityInput(session, events)
+	if len(report.MessageUpdates) != len(events) {
+		t.Fatalf("message updates = %#v, want all non-echo user messages", report.MessageUpdates)
+	}
+	for index, wantOrigin := range []messageOrigin{
+		messageOriginHistoricalReplay,
+		messageOriginGuidance,
+		messageOriginProviderInitiated,
+	} {
+		if got := report.MessageUpdates[index].Payload[messageOriginMetadataKey]; got != string(wantOrigin) {
+			t.Fatalf("message %d origin = %#v, want %q", index, got, wantOrigin)
+		}
+	}
+}
+
+func TestRealtimeProjectionPreservesNonCanonicalUserOrigins(t *testing.T) {
+	t.Parallel()
+
+	session := reportTestSession()
+	events := []activityshared.Event{
+		originTestMessageEvent(session, "history-1", messageOriginHistoricalReplay, "history-1", "", "historical user message"),
+		originTestMessageEvent(session, "guidance-1", messageOriginGuidance, "guidance-1", "guidance-submit", "guidance message"),
+		originTestMessageEvent(session, "provider-1", messageOriginProviderInitiated, "provider-1", "", "provider initiated message"),
+	}
+
+	stream := ProjectActivityEventsToStreamEvents(session, events)
+	if len(stream) != len(events) {
+		t.Fatalf("stream = %#v, want one message update per non-echo origin", stream)
+	}
+	for index, wantOrigin := range []messageOrigin{
+		messageOriginHistoricalReplay,
+		messageOriginGuidance,
+		messageOriginProviderInitiated,
+	} {
+		update, ok := stream[index].Data.(agentsessionstore.WorkspaceAgentMessageUpdate)
+		if !ok || stream[index].EventType != StreamEventMessageUpdate {
+			t.Fatalf("stream event %d = %#v, want message update", index, stream[index])
+		}
+		if got := update.Payload[messageOriginMetadataKey]; got != string(wantOrigin) {
+			t.Fatalf("stream message %d origin = %#v, want %q", index, got, wantOrigin)
+		}
+	}
+}
+
+func originTestMessageEvent(
+	session Session,
+	eventID string,
+	origin messageOrigin,
+	messageID string,
+	clientSubmitID string,
+	content string,
+) activityshared.Event {
+	metadata := map[string]any{
+		messageOriginMetadataKey: string(origin),
+		"messageId":              messageID,
+	}
+	if clientSubmitID != "" {
+		metadata["clientSubmitId"] = clientSubmitID
+	}
+	return newTurnActivityEventWithID(
+		session,
+		eventID,
+		EventMessage,
+		"turn-1",
+		messageStreamStateCompleted,
+		RoleUser,
+		content,
+		metadata,
+	)
+}

--- a/packages/agent/daemon/runtime/standard_acp_turn.go
+++ b/packages/agent/daemon/runtime/standard_acp_turn.go
@@ -56,7 +56,9 @@ func (a *standardACPAdapter) Exec(
 	}
 
 	startEvents := []activityshared.Event{
-		newUserPromptActivityEvent(ctx, session, content, explicitDisplayPrompt, visibleText, turnID, nil),
+		newUserPromptActivityEvent(ctx, session, content, explicitDisplayPrompt, visibleText, turnID, map[string]any{
+			messageOriginMetadataKey: string(messageOriginProviderEcho),
+		}),
 		newTurnActivityEvent(session, EventTurnStarted, turnID, SessionStatusWorking, "", "", nil),
 		standardACPRootProviderTurnStartedEvent(session, turnID),
 	}

--- a/packages/agent/daemon/runtime/turn_lifecycle_authority_test.go
+++ b/packages/agent/daemon/runtime/turn_lifecycle_authority_test.go
@@ -248,7 +248,7 @@ func TestApplyLifecycleSnapshotToPatchProviderAgnostic(t *testing.T) {
 	if patch.SubmitAvailability == nil || patch.SubmitAvailability.State != "blocked" {
 		t.Fatalf("patch submit availability not derived: %#v", patch.SubmitAvailability)
 	}
-	if _, isMessage := messageUpdateFromSessionEvent(canonical.EventSource{}, event, "agent-1", 1); isMessage {
+	if _, isMessage := messageUpdateFromSessionEvent(messageProjectionDurable, canonical.EventSource{}, event, "agent-1", 1); isMessage {
 		t.Fatal("stamped turn event must never become a message update")
 	}
 }

--- a/packages/agent/daemon/runtime/types.go
+++ b/packages/agent/daemon/runtime/types.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
 	canonical "github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
@@ -237,19 +238,34 @@ type ExecInput struct {
 	RequireProviderAcceptance bool
 }
 
-// SubmitProvenanceInput describes the canonical user submit that an adapter
-// has already accepted. It is reported separately from Exec so waiting for
-// durable provenance never happens while Exec holds the session lifecycle
-// lock.
-type SubmitProvenanceInput struct {
+// SubmitIntentInput is the Controller-owned admission request. Report carries
+// exactly one canonical user message and its matching submitted turn.
+type SubmitIntentInput struct {
 	RoomID                          string
 	AgentSessionID                  string
 	TurnID                          string
 	ClientSubmitID                  string
+	CanonicalMessageID              string
 	CanonicalSubmitOccurredAtUnixMS int64
-	Content                         []PromptContentBlock
-	DisplayPrompt                   string
-	Guidance                        bool
+	Report                          agentsessionstore.ReportActivityInput
+}
+
+// SubmitProvenanceInput contains only submit identity and delivery facts. It
+// intentionally has no prompt content or display text: Host and Provider can
+// retry it without rewriting the canonical user message.
+type SubmitProvenanceInput struct {
+	RoomID             string
+	AgentSessionID     string
+	TurnID             string
+	ClientSubmitID     string
+	CanonicalMessageID string
+	ProviderSessionID  string
+	ProviderTurnID     string
+	DispatchStatus     string
+	DeliveryStatus     string
+	FailureReason      string
+	OccurredAtUnixMS   int64
+	Guidance           bool
 }
 
 type CapabilityReference = activityshared.CapabilityReference

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerDraftAttachmentEpochs.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerDraftAttachmentEpochs.ts
@@ -1,0 +1,92 @@
+import { useCallback, useRef, type RefObject } from "react";
+import type { AgentComposerDraft } from "../model/agentGuiNodeTypes";
+
+export function useStableEventCallback<Args extends unknown[], Result>(
+  callback: (...args: Args) => Result
+): (...args: Args) => Result {
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+  return useCallback((...args: Args) => callbackRef.current(...args), []);
+}
+
+interface UseComposerDraftAttachmentEpochsInput {
+  draftScopeKey: string;
+  draftByScopeKeyRef: RefObject<Record<string, AgentComposerDraft>>;
+}
+
+export function useComposerDraftAttachmentEpochs({
+  draftScopeKey,
+  draftByScopeKeyRef
+}: UseComposerDraftAttachmentEpochsInput) {
+  const activeDraftScopeKeyRef = useRef(draftScopeKey);
+  activeDraftScopeKeyRef.current = draftScopeKey;
+  const attachmentEpochByScopeKeyRef = useRef<
+    Record<string, Record<string, symbol>>
+  >({});
+  const registerAttachmentEpoch = useStableEventCallback(
+    (sourceScopeKey: string, attachmentKey: string): symbol => {
+      const scopeEpochs =
+        attachmentEpochByScopeKeyRef.current[sourceScopeKey] ?? {};
+      const epoch = Symbol(attachmentKey);
+      scopeEpochs[attachmentKey] = epoch;
+      attachmentEpochByScopeKeyRef.current[sourceScopeKey] = scopeEpochs;
+      return epoch;
+    }
+  );
+  const invalidateAttachmentEpoch = useStableEventCallback(
+    (sourceScopeKey: string, attachmentKey: string): void => {
+      delete attachmentEpochByScopeKeyRef.current[sourceScopeKey]?.[
+        attachmentKey
+      ];
+    }
+  );
+  const isCurrentAttachmentEpoch = useStableEventCallback(
+    (sourceScopeKey: string, attachmentKey: string, epoch: symbol): boolean => {
+      if (activeDraftScopeKeyRef.current !== sourceScopeKey) return false;
+      const currentDraft = draftByScopeKeyRef.current[sourceScopeKey];
+      return Boolean(
+        currentDraft?.some(
+          (block) =>
+            (block.type === "image" || block.type === "file") &&
+            block.id === attachmentKey
+        ) &&
+        attachmentEpochByScopeKeyRef.current[sourceScopeKey]?.[
+          attachmentKey
+        ] === epoch
+      );
+    }
+  );
+  const isActiveDraftScope = useStableEventCallback(
+    (sourceScopeKey: string): boolean =>
+      activeDraftScopeKeyRef.current === sourceScopeKey
+  );
+  const invalidateRemovedAttachmentEpochs = useStableEventCallback(
+    (
+      sourceScopeKey: string,
+      currentDraft: AgentComposerDraft | undefined,
+      nextDraft: AgentComposerDraft
+    ): void => {
+      if (!currentDraft) return;
+      const nextAttachmentKeys = new Set(
+        nextDraft
+          .filter((block) => block.type === "image" || block.type === "file")
+          .map((block) => block.id)
+      );
+      for (const block of currentDraft) {
+        if (
+          (block.type === "image" || block.type === "file") &&
+          !nextAttachmentKeys.has(block.id)
+        ) {
+          invalidateAttachmentEpoch(sourceScopeKey, block.id);
+        }
+      }
+    }
+  );
+  return {
+    invalidateAttachmentEpoch,
+    invalidateRemovedAttachmentEpochs,
+    isActiveDraftScope,
+    isCurrentAttachmentEpoch,
+    registerAttachmentEpoch
+  };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerDraftAttachments.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerDraftAttachments.ts
@@ -1,4 +1,3 @@
-import { flushSync } from "react-dom";
 import {
   startTransition,
   useCallback,
@@ -7,7 +6,6 @@ import {
   type RefObject,
   type SetStateAction
 } from "react";
-import type { WorkspaceFileReference } from "@tutti-os/workspace-file-reference/contracts";
 import { useOptionalAgentHostApi } from "../../../agentActivityHost";
 import { useOptionalAgentGUIRuntime } from "../../../agentActivityRuntime";
 import { translate } from "../../../i18n/index";
@@ -52,19 +50,17 @@ import {
 } from "./composerDraftUtils";
 import { reportAgentComposerDiagnostic } from "./agentComposerDiagnostics";
 import type { AgentGUIComposerContentType } from "../engagement/agentGUIEngagement.types";
+import {
+  useComposerDraftReferencePicker,
+  type WorkspaceReferencePickResult
+} from "./useComposerDraftReferencePicker";
+import {
+  useComposerDraftAttachmentEpochs,
+  useStableEventCallback
+} from "./useComposerDraftAttachmentEpochs";
 
-export interface WorkspaceReferencePickResult {
-  files: readonly WorkspaceFileReference[];
-  mentionItems: readonly AgentContextMentionItem[];
-}
+export type { WorkspaceReferencePickResult } from "./useComposerDraftReferencePicker";
 
-function useStableEventCallback<Args extends unknown[], Result>(
-  callback: (...args: Args) => Result
-): (...args: Args) => Result {
-  const callbackRef = useRef(callback);
-  callbackRef.current = callback;
-  return useCallback((...args: Args) => callbackRef.current(...args), []);
-}
 export interface UseComposerDraftAttachmentsInput {
   workspaceId: string;
   workspacePath?: string | null;
@@ -128,8 +124,13 @@ export function useComposerDraftAttachments({
 }: UseComposerDraftAttachmentsInput) {
   const agentHostApi = useOptionalAgentHostApi();
   const agentActivityRuntime = useOptionalAgentGUIRuntime();
-  const activeDraftScopeKeyRef = useRef(draftScopeKey);
-  activeDraftScopeKeyRef.current = draftScopeKey;
+  const {
+    invalidateAttachmentEpoch,
+    invalidateRemovedAttachmentEpochs,
+    isActiveDraftScope,
+    isCurrentAttachmentEpoch,
+    registerAttachmentEpoch
+  } = useComposerDraftAttachmentEpochs({ draftScopeKey, draftByScopeKeyRef });
   const reportContentEntered = useStableEventCallback(
     (contentType: AgentGUIComposerContentType): void => {
       onContentEntered?.(contentType);
@@ -143,6 +144,11 @@ export function useComposerDraftAttachments({
   });
   const publishScopedDraft = useStableEventCallback(
     (sourceScopeKey: string, nextDraft: AgentComposerDraft): void => {
+      invalidateRemovedAttachmentEpochs(
+        sourceScopeKey,
+        draftByScopeKeyRef.current[sourceScopeKey],
+        nextDraft
+      );
       draftByScopeKeyRef.current[sourceScopeKey] = nextDraft;
       if (sourceScopeKey === draftScopeKey) {
         draftPromptRef.current = agentComposerDraftPrompt(nextDraft);
@@ -170,6 +176,12 @@ export function useComposerDraftAttachments({
   const openReferencesForEntityRef = useRef<
     ((entity: AgentContextMentionItem) => void) | null
   >(null);
+  const { handleOpenReferencesForEntity, handleWorkspaceReferencePicker } =
+    useComposerDraftReferencePicker({
+      clearActiveFileMentionTrigger,
+      editorHandleRef,
+      onRequestWorkspaceReferences
+    });
   const handleDraftChange = useStableEventCallback(
     (nextDraft: string): void => {
       if (isGoalModeActive) {
@@ -272,6 +284,12 @@ export function useComposerDraftAttachments({
         previewUrl: `data:${image.mimeType};base64,${image.data}`,
         uploading: Boolean(uploadPromptContent)
       }));
+      const uploadEpochByImageId = new Map(
+        nextImages.map((image) => [
+          image.id,
+          registerAttachmentEpoch(draftScopeKey, image.id)
+        ])
+      );
       const nextDraftImages = [...currentDraftImages, ...nextImages];
       draftImagesRef.current = nextDraftImages;
       reportContentEntered("image");
@@ -294,6 +312,17 @@ export function useComposerDraftAttachments({
           ]
         })
           .then((result) => {
+            const uploadEpoch = uploadEpochByImageId.get(draftImage.id);
+            if (
+              !uploadEpoch ||
+              !isCurrentAttachmentEpoch(
+                draftScopeKey,
+                draftImage.id,
+                uploadEpoch
+              )
+            ) {
+              return;
+            }
             const uploadedImage = result.content.find(
               (block) => block.type === "image"
             );
@@ -351,6 +380,17 @@ export function useComposerDraftAttachments({
             );
           })
           .catch((error: unknown) => {
+            const uploadEpoch = uploadEpochByImageId.get(draftImage.id);
+            if (
+              !uploadEpoch ||
+              !isCurrentAttachmentEpoch(
+                draftScopeKey,
+                draftImage.id,
+                uploadEpoch
+              )
+            ) {
+              return;
+            }
             const message =
               error instanceof Error ? error.message : String(error);
             reportAgentComposerDiagnostic(agentActivityRuntime, {
@@ -386,6 +426,8 @@ export function useComposerDraftAttachments({
       promptImagesSupported,
       promptAssetLimit,
       reportContentEntered,
+      isCurrentAttachmentEpoch,
+      registerAttachmentEpoch,
       updateScopedDraft,
       workspaceId
     ]
@@ -393,6 +435,7 @@ export function useComposerDraftAttachments({
 
   const removeDraftImage = useCallback(
     (id: string): void => {
+      invalidateAttachmentEpoch(draftScopeKey, id);
       const nextDraftImages = draftImagesRef.current.filter(
         (image) => image.id !== id
       );
@@ -401,7 +444,7 @@ export function useComposerDraftAttachments({
         updateAgentComposerDraft(currentDraft, { images: nextDraftImages })
       );
     },
-    [draftScopeKey, updateScopedDraft]
+    [draftScopeKey, invalidateAttachmentEpoch, publishScopedDraft]
   );
 
   const addDraftFiles = useCallback(
@@ -467,7 +510,7 @@ export function useComposerDraftAttachments({
           referencedIds.has(file.id)
         );
         const editorUpdated =
-          activeDraftScopeKeyRef.current === sourceScopeKey &&
+          isActiveDraftScope(sourceScopeKey) &&
           editorHandleRef.current?.updateComposerFiles(
             visibleSettled.map((file) => ({
               errorCode: file.uploadErrorCode,
@@ -531,6 +574,7 @@ export function useComposerDraftAttachments({
     [
       agentActivityRuntime,
       draftScopeKey,
+      isActiveDraftScope,
       prepareExternalPromptFiles,
       promptAssetLimit,
       promptFilesSupported,
@@ -555,10 +599,7 @@ export function useComposerDraftAttachments({
     [draftScopeKey, updateScopedDraft]
   );
 
-  // "Show in text field": dissolve a pasted-text chip back into the composer as
-  // inline prompt text and drop the attachment. Only possible while the full
-  // body is still in memory (a fresh paste); a chip restored from a queued
-  // message carries only the landed path, so expansion is unavailable there.
+  // Dissolve a fresh pasted-text chip back into inline prompt text.
   const expandDraftLargeTextToPrompt = useCallback(
     (id: string): void => {
       const item = draftLargeTextsRef.current.find((entry) => entry.id === id);
@@ -679,46 +720,6 @@ export function useComposerDraftAttachments({
     ]
   );
 
-  const applyReferencePickResult = useCallback(
-    async (result: WorkspaceReferencePickResult) => {
-      if (result.files.length > 0) {
-        editorHandleRef.current?.insertWorkspaceReferences(result.files);
-      }
-      if (result.mentionItems.length > 0) {
-        editorHandleRef.current?.insertMentionItems(result.mentionItems);
-      }
-    },
-    []
-  );
-
-  const handleWorkspaceReferencePicker = useCallback(async () => {
-    if (!onRequestWorkspaceReferences) {
-      return;
-    }
-    await applyReferencePickResult(await onRequestWorkspaceReferences());
-  }, [applyReferencePickResult, onRequestWorkspaceReferences]);
-
-  // @ 面板里点任务/应用行的「查看产物」入口:保留面板,打开引用 picker 并定位到该实体;
-  // 选中的文件仍按常规插入,但不会把该任务/应用本身作为 mention 插入。
-  const handleOpenReferencesForEntity = useCallback(
-    (entity: AgentContextMentionItem): void => {
-      if (!onRequestWorkspaceReferences) {
-        return;
-      }
-      void onRequestWorkspaceReferences(entity).then((result) => {
-        if (result.files.length > 0 || result.mentionItems.length > 0) {
-          flushSync(clearActiveFileMentionTrigger);
-        }
-        return applyReferencePickResult(result);
-      });
-    },
-    [
-      clearActiveFileMentionTrigger,
-      applyReferencePickResult,
-      onRequestWorkspaceReferences
-    ]
-  );
-  // 让 handleLinkClick(定义在前)能转发到此处:点击 workspace-reference chip 即定位打开 picker。
   openReferencesForEntityRef.current = handleOpenReferencesForEntity;
 
   const handleLinkClick = useCallback(

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerDraftReferencePicker.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerDraftReferencePicker.ts
@@ -1,0 +1,65 @@
+import { flushSync } from "react-dom";
+import { useCallback, type RefObject } from "react";
+import type { AgentRichTextEditorHandle } from "../agentRichText/AgentRichTextEditor";
+import type { AgentContextMentionItem } from "../agentRichText/agentFileMentionExtension";
+
+export interface WorkspaceReferencePickResult {
+  files: readonly import("@tutti-os/workspace-file-reference/contracts").WorkspaceFileReference[];
+  mentionItems: readonly AgentContextMentionItem[];
+}
+
+interface UseComposerDraftReferencePickerInput {
+  editorHandleRef: RefObject<AgentRichTextEditorHandle | null>;
+  clearActiveFileMentionTrigger: () => void;
+  onRequestWorkspaceReferences?:
+    | ((
+        entity?: AgentContextMentionItem | null
+      ) => Promise<WorkspaceReferencePickResult>)
+    | null;
+}
+
+export function useComposerDraftReferencePicker({
+  editorHandleRef,
+  clearActiveFileMentionTrigger,
+  onRequestWorkspaceReferences
+}: UseComposerDraftReferencePickerInput) {
+  const applyReferencePickResult = useCallback(
+    async (result: WorkspaceReferencePickResult) => {
+      if (result.files.length > 0) {
+        editorHandleRef.current?.insertWorkspaceReferences(result.files);
+      }
+      if (result.mentionItems.length > 0) {
+        editorHandleRef.current?.insertMentionItems(result.mentionItems);
+      }
+    },
+    [editorHandleRef]
+  );
+
+  const handleWorkspaceReferencePicker = useCallback(async () => {
+    if (!onRequestWorkspaceReferences) return;
+    await applyReferencePickResult(await onRequestWorkspaceReferences());
+  }, [applyReferencePickResult, onRequestWorkspaceReferences]);
+
+  const handleOpenReferencesForEntity = useCallback(
+    (entity: AgentContextMentionItem): void => {
+      if (!onRequestWorkspaceReferences) return;
+      void onRequestWorkspaceReferences(entity).then((result) => {
+        if (result.files.length > 0 || result.mentionItems.length > 0) {
+          flushSync(clearActiveFileMentionTrigger);
+        }
+        return applyReferencePickResult(result);
+      });
+    },
+    [
+      clearActiveFileMentionTrigger,
+      applyReferencePickResult,
+      onRequestWorkspaceReferences
+    ]
+  );
+
+  return {
+    applyReferencePickResult,
+    handleOpenReferencesForEntity,
+    handleWorkspaceReferencePicker
+  };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.draftMessageHelpers.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.draftMessageHelpers.spec.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../shared/agentCustomMentionKinds";
 import {
   buildAgentComposerDraft,
+  updateAgentComposerDraft,
   snapshotAgentComposerDraft
 } from "../model/agentComposerDraft";
 import type { SubmittedDraftSnapshot } from "../model/agentGuiNodeTypes";
@@ -179,8 +180,7 @@ describe("submitted composer draft cleanup", () => {
         }
       ]
     });
-    const currentDraft = buildAgentComposerDraft({
-      prompt: "Review this",
+    const currentDraft = updateAgentComposerDraft(submittedDraft, {
       images: [
         {
           id: "image-1",
@@ -207,22 +207,26 @@ describe("submitted composer draft cleanup", () => {
     expect(result[sourceScopeKey]).toEqual([{ type: "text", text: "" }]);
   });
 
-  it("retains an image when its upload reports an error", () => {
+  it("clears when an upload reports an error without changing intent", () => {
     const current = snapshotAgentComposerDraft(submittedDraft);
     const image = current.find((block) => block.type === "image");
     if (image) image.uploadError = "upload failed";
     const drafts = { [sourceScopeKey]: current };
 
-    expect(clearSubmittedDraftIfUnchanged({ drafts, snapshot })).toBe(drafts);
+    expect(
+      clearSubmittedDraftIfUnchanged({ drafts, snapshot })[sourceScopeKey]
+    ).toEqual([{ type: "text", text: "" }]);
   });
 
-  it("keeps detecting unknown image metadata as a draft change", () => {
+  it("clears when unknown image metadata changes without changing intent", () => {
     const current = snapshotAgentComposerDraft(submittedDraft);
     const image = current.find((block) => block.type === "image");
     Object.assign(image ?? {}, { futureMetadata: "edited" });
     const drafts = { [sourceScopeKey]: current };
 
-    expect(clearSubmittedDraftIfUnchanged({ drafts, snapshot })).toBe(drafts);
+    expect(
+      clearSubmittedDraftIfUnchanged({ drafts, snapshot })[sourceScopeKey]
+    ).toEqual([{ type: "text", text: "" }]);
   });
 
   it("compares newly-added block metadata without maintaining a field list", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.draftMessageHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.draftMessageHelpers.ts
@@ -18,7 +18,10 @@ import type {
 import {
   agentComposerDraftPreservingConnectors,
   emptyAgentComposerDraft,
-  materializePastedTextInstructions
+  agentComposerDraftIntentEqual,
+  agentComposerDraftRevision,
+  materializePastedTextInstructions,
+  withAgentComposerDraftRevision
 } from "../model/agentComposerDraft";
 import { materializeAgentCustomMentionPromptText } from "../agentRichText/agentMentionMarkdown";
 import { type AgentGUIConversationSummary } from "../model/agentGuiConversationModel";
@@ -258,49 +261,6 @@ function areDraftValuesStructurallyEqual(
   );
 }
 
-// Upload completion replaces the local image bytes with a provider locator and
-// updates presentation state. Those transitions do not mean the user edited
-// the submitted image. Keep uploadError and unknown fields comparable so a
-// failed upload or a future user-owned field still prevents clearing.
-const IMAGE_SUBMISSION_TRANSIENT_FIELDS = new Set([
-  "attachmentId",
-  "data",
-  "path",
-  "previewUrl",
-  "uploading",
-  "url"
-]);
-
-function submissionComparableDraftBlock(
-  block: AgentComposerDraft[number]
-): unknown {
-  if (block.type !== "image") {
-    return block;
-  }
-  return Object.fromEntries(
-    Object.entries(block).filter(
-      ([key]) => !IMAGE_SUBMISSION_TRANSIENT_FIELDS.has(key)
-    )
-  );
-}
-
-function areAgentComposerDraftsEquivalentForSubmission(
-  left: AgentComposerDraft,
-  right: AgentComposerDraft
-): boolean {
-  return (
-    left.length === right.length &&
-    left.every((block, index) => {
-      const other = right[index];
-      if (!other || block.type !== other.type) return false;
-      return areDraftValuesStructurallyEqual(
-        submissionComparableDraftBlock(block),
-        submissionComparableDraftBlock(other)
-      );
-    })
-  );
-}
-
 export function deleteSubmittedDraftSnapshotsForScopes(input: {
   snapshots: Record<string, SubmittedDraftSnapshot>;
   scopeKeys: ReadonlySet<string>;
@@ -450,12 +410,15 @@ export function shouldClearSubmittedDraft(input: {
   currentDraft: AgentComposerDraft | undefined;
   submittedDraft: AgentComposerDraft;
 }): boolean {
-  return Boolean(
-    input.currentDraft &&
-    areAgentComposerDraftsEquivalentForSubmission(
-      input.currentDraft,
-      input.submittedDraft
-    )
+  if (!input.currentDraft) return false;
+  const currentRevision = agentComposerDraftRevision(input.currentDraft);
+  const submittedRevision = agentComposerDraftRevision(input.submittedDraft);
+  if (currentRevision !== null && submittedRevision !== null) {
+    return currentRevision === submittedRevision;
+  }
+  return agentComposerDraftIntentEqual(
+    input.currentDraft,
+    input.submittedDraft
   );
 }
 
@@ -463,22 +426,37 @@ export function clearSubmittedDraftIfUnchanged(input: {
   drafts: Record<string, AgentComposerDraft>;
   snapshot: SubmittedDraftSnapshot;
 }): Record<string, AgentComposerDraft> {
-  if (
-    !shouldClearSubmittedDraft({
-      currentDraft: input.drafts[input.snapshot.sourceScopeKey],
-      submittedDraft: input.snapshot.content
-    })
-  ) {
+  const currentDraft = input.drafts[input.snapshot.sourceScopeKey];
+  if (!currentDraft) return input.drafts;
+  const currentRevision = agentComposerDraftRevision(currentDraft);
+  const submittedRevision =
+    input.snapshot.revision ??
+    agentComposerDraftRevision(input.snapshot.content);
+  const canClear =
+    currentRevision !== null && submittedRevision !== null
+      ? currentRevision === submittedRevision
+      : shouldClearSubmittedDraft({
+          currentDraft,
+          submittedDraft: input.snapshot.content
+        });
+  if (!canClear) {
     return input.drafts;
   }
+  const clearedDraft = withAgentComposerDraftRevision(
+    emptyAgentComposerDraft(),
+    Math.max(currentRevision ?? 0, submittedRevision ?? 0) + 1
+  );
+  const nextDraft = isAgentComposerSessionDraftScope(
+    input.snapshot.sourceScopeKey
+  )
+    ? agentComposerDraftPreservingConnectors(currentDraft)
+    : clearedDraft;
+  withAgentComposerDraftRevision(
+    nextDraft,
+    Math.max(currentRevision ?? 0, submittedRevision ?? 0) + 1
+  );
   return {
     ...input.drafts,
-    [input.snapshot.sourceScopeKey]: isAgentComposerSessionDraftScope(
-      input.snapshot.sourceScopeKey
-    )
-      ? agentComposerDraftPreservingConnectors(
-          input.drafts[input.snapshot.sourceScopeKey]
-        )
-      : emptyAgentComposerDraft()
+    [input.snapshot.sourceScopeKey]: nextDraft
   };
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.ts
@@ -20,12 +20,14 @@ import type {
 import {
   agentPromptContentDisplayText,
   agentPromptContentHasImage,
+  agentComposerDraftRevision,
   emptyAgentComposerDraft,
   normalizeAgentPromptContentBlocks,
   snapshotAgentComposerDraft
 } from "../model/agentComposerDraft";
 import type {
   AgentComposerDraft,
+  AgentComposerSubmissionToken,
   SubmittedDraftSnapshot
 } from "../model/agentGuiNodeTypes";
 import { resolveAgentComposerDraftScopeKey } from "../model/agentComposerDraftScope";
@@ -266,9 +268,17 @@ export function useAgentGUISubmitInteractionActions(
           options?.submittedDraft ??
           draftByScopeKeyRef.current[sourceScopeKey] ??
           emptyAgentComposerDraft();
+        const content = snapshotAgentComposerDraft(submittedDraft);
+        const submissionToken: AgentComposerSubmissionToken = {
+          scopeKey: sourceScopeKey,
+          revision: agentComposerDraftRevision(content) ?? 0,
+          clientSubmitId: submitTrace.clientSubmitId
+        };
         submittedDraftSnapshotsRef.current[submitTrace.clientSubmitId] = {
-          sourceScopeKey,
-          content: snapshotAgentComposerDraft(submittedDraft),
+          clientSubmitId: submissionToken.clientSubmitId,
+          content,
+          revision: submissionToken.revision,
+          sourceScopeKey: submissionToken.scopeKey,
           targetAgentSessionId: agentSessionId
         };
       }

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.ts
@@ -162,18 +162,43 @@ export function applyPastedTextStagingResult(
     uploading: false
   };
 }
+import {
+  agentComposerDraftIntentEqual,
+  agentComposerDraftRevision,
+  createAgentComposerDraftRevision,
+  withAgentComposerDraftRevision
+} from "./agentComposerDraftIntent";
+
+export {
+  agentComposerDraftIntentEqual,
+  agentComposerDraftRevision,
+  createAgentComposerDraftRevision,
+  projectAgentComposerDraftIntent,
+  withAgentComposerDraftRevision
+} from "./agentComposerDraftIntent";
 
 export const MAX_AGENT_COMPOSER_DRAFT_IMAGES = 8;
 
 export function emptyAgentComposerDraft(): AgentComposerDraft {
-  return [{ type: "text", text: "" }];
+  const draft: AgentComposerDraft = [{ type: "text", text: "" }];
+  return withAgentComposerDraftRevision(
+    draft,
+    createAgentComposerDraftRevision()
+  );
 }
 
 export function snapshotAgentComposerDraft(
   draft: AgentComposerDraft
 ): AgentComposerDraft {
   const [textBlock, ...attachmentBlocks] = draft;
-  return [{ ...textBlock }, ...attachmentBlocks.map((block) => ({ ...block }))];
+  const snapshot = [
+    { ...textBlock },
+    ...attachmentBlocks.map((block) => ({ ...block }))
+  ] as AgentComposerDraft;
+  return withAgentComposerDraftRevision(
+    snapshot,
+    agentComposerDraftRevision(draft) ?? createAgentComposerDraftRevision()
+  );
 }
 
 export function agentComposerDraftPrompt(
@@ -235,7 +260,7 @@ export function buildAgentComposerDraft(input: {
   quotes?: readonly AgentComposerQuoteBlock[];
   connectors?: readonly AgentComposerDraftConnector[];
 }): AgentComposerDraft {
-  return [
+  const draft = [
     { type: "text", text: input.prompt },
     ...(input.images ?? []).map((image) => ({
       type: "image" as const,
@@ -255,7 +280,11 @@ export function buildAgentComposerDraft(input: {
     ),
     ...(input.quotes ?? []).map((quote) => ({ ...quote })),
     ...agentComposerDraftConnectorBlocks(input.connectors ?? [])
-  ];
+  ] as AgentComposerDraft;
+  return withAgentComposerDraftRevision(
+    draft,
+    createAgentComposerDraftRevision()
+  );
 }
 
 export function updateAgentComposerDraft(
@@ -269,7 +298,7 @@ export function updateAgentComposerDraft(
     connectors: readonly AgentComposerDraftConnector[];
   }>
 ): AgentComposerDraft {
-  return buildAgentComposerDraft({
+  const nextDraft = buildAgentComposerDraft({
     prompt: update.prompt ?? agentComposerDraftPrompt(draft),
     images: update.images ?? agentComposerDraftImages(draft),
     files: update.files ?? agentComposerDraftFiles(draft),
@@ -277,6 +306,16 @@ export function updateAgentComposerDraft(
     quotes: update.quotes ?? agentComposerDraftQuotes(draft),
     connectors: update.connectors ?? agentComposerDraftConnectors(draft)
   });
+  const currentRevision = agentComposerDraftRevision(draft);
+  if (currentRevision !== null) {
+    withAgentComposerDraftRevision(
+      nextDraft,
+      agentComposerDraftIntentEqual(draft, nextDraft)
+        ? currentRevision
+        : currentRevision + 1
+    );
+  }
+  return nextDraft;
 }
 
 export function agentComposerDraftHasContent(

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraftIntent.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraftIntent.ts
@@ -1,0 +1,177 @@
+import {
+  AGENT_PASTED_TEXT_BLOCK_KIND,
+  type AgentComposerDraft,
+  type AgentComposerDraftContent,
+  type AgentComposerDraftImage
+} from "./agentGuiNodeTypes";
+
+const draftRevisionByIdentity = new WeakMap<AgentComposerDraft, number>();
+
+export function createAgentComposerDraftRevision(): number {
+  const random = new Uint32Array(1);
+  if (typeof globalThis.crypto?.getRandomValues === "function") {
+    globalThis.crypto.getRandomValues(random);
+    return random[0] || 1;
+  }
+  return Math.floor(Math.random() * 0xffffffff) + 1;
+}
+
+export function emptyAgentComposerDraft(): AgentComposerDraft {
+  const draft: AgentComposerDraft = [{ type: "text", text: "" }];
+  draftRevisionByIdentity.set(draft, createAgentComposerDraftRevision());
+  return draft;
+}
+
+export function agentComposerDraftRevision(
+  draft: AgentComposerDraft | undefined
+): number | null {
+  if (!draft) return null;
+  return draftRevisionByIdentity.get(draft) ?? null;
+}
+
+export function withAgentComposerDraftRevision(
+  draft: AgentComposerDraft,
+  revision: number
+): AgentComposerDraft {
+  draftRevisionByIdentity.set(draft, revision);
+  return draft;
+}
+
+type AgentComposerDraftIntentBlock =
+  | { type: "text"; text: string }
+  | { type: "quote"; id: string; text: string }
+  | { type: "connector"; connectorKey: string }
+  | {
+      type: "image";
+      id: string;
+      name: string;
+      mimeType: AgentComposerDraftImage["mimeType"];
+    }
+  | {
+      type: "file";
+      kind: "file";
+      id: string;
+      name: string;
+      mimeType?: string;
+    }
+  | {
+      type: "file";
+      kind: typeof AGENT_PASTED_TEXT_BLOCK_KIND;
+      id: string;
+      name: string;
+      mimeType?: string;
+      text: string;
+    };
+
+type AgentComposerDraftPastedTextIntent = Extract<
+  AgentComposerDraftIntentBlock,
+  { type: "file"; kind: typeof AGENT_PASTED_TEXT_BLOCK_KIND }
+>;
+
+/** Projects only user-owned draft intent, excluding preparation metadata. */
+export function projectAgentComposerDraftIntent(
+  draft: AgentComposerDraft
+): AgentComposerDraftIntentBlock[] {
+  return draft.map((block) => {
+    if (block.type === "text") {
+      return { type: "text", text: block.text };
+    }
+    if (block.type === "image") {
+      return {
+        type: "image",
+        id: block.id,
+        name: block.name,
+        mimeType: block.mimeType
+      };
+    }
+    if (block.type === "quote") {
+      return { type: "quote", id: block.id, text: block.text };
+    }
+    if (block.type === "connector") {
+      return { type: "connector", connectorKey: block.connectorKey };
+    }
+    if (block.type === "file" && block.kind === AGENT_PASTED_TEXT_BLOCK_KIND) {
+      const pastedTextBlock = block as Extract<
+        AgentComposerDraftContent[number],
+        { type: "file"; kind: typeof AGENT_PASTED_TEXT_BLOCK_KIND }
+      >;
+      return {
+        type: "file",
+        kind: AGENT_PASTED_TEXT_BLOCK_KIND,
+        id: pastedTextBlock.id,
+        name: pastedTextBlock.name,
+        ...(pastedTextBlock.mimeType
+          ? { mimeType: pastedTextBlock.mimeType }
+          : {}),
+        text: pastedTextBlock.text
+      };
+    }
+    return {
+      type: "file",
+      kind: "file",
+      id: block.id,
+      name: block.name,
+      ...(block.mimeType ? { mimeType: block.mimeType } : {})
+    };
+  });
+}
+
+export function agentComposerDraftIntentEqual(
+  left: AgentComposerDraft,
+  right: AgentComposerDraft
+): boolean {
+  const leftIntent = projectAgentComposerDraftIntent(left);
+  const rightIntent = projectAgentComposerDraftIntent(right);
+  if (leftIntent.length !== rightIntent.length) return false;
+  return leftIntent.every((block, index) => {
+    const other = rightIntent[index];
+    if (!other || block.type !== other.type) return false;
+    if (block.type === "text" && other.type === "text") {
+      return block.text === other.text;
+    }
+    if (block.type === "image" && other.type === "image") {
+      return (
+        block.id === other.id &&
+        block.name === other.name &&
+        block.mimeType === other.mimeType
+      );
+    }
+    if (block.type === "quote" && other.type === "quote") {
+      return block.id === other.id && block.text === other.text;
+    }
+    if (block.type === "connector" && other.type === "connector") {
+      return block.connectorKey === other.connectorKey;
+    }
+    if (block.type !== "file" || other.type !== "file") return false;
+    const sameFileIntent =
+      block.kind === other.kind &&
+      block.id === other.id &&
+      block.name === other.name &&
+      block.mimeType === other.mimeType;
+    if (!sameFileIntent) return false;
+    if (
+      block.kind !== AGENT_PASTED_TEXT_BLOCK_KIND ||
+      other.kind !== AGENT_PASTED_TEXT_BLOCK_KIND
+    ) {
+      return true;
+    }
+    return (
+      (block as AgentComposerDraftPastedTextIntent).text ===
+      (other as AgentComposerDraftPastedTextIntent).text
+    );
+  });
+}
+
+export function snapshotAgentComposerDraft(
+  draft: AgentComposerDraft
+): AgentComposerDraft {
+  const [textBlock, ...attachmentBlocks] = draft;
+  const snapshot = [
+    { ...textBlock },
+    ...attachmentBlocks.map((block) => ({ ...block }))
+  ] as AgentComposerDraft;
+  return withAgentComposerDraftRevision(
+    snapshot,
+    agentComposerDraftRevision(draft) ?? createAgentComposerDraftRevision()
+  );
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
@@ -245,8 +245,27 @@ export type AgentComposerDraftContent = [
 /** One atomic, unsent composer message. */
 export type AgentComposerDraft = AgentComposerDraftContent;
 
+/**
+ * Immutable identity captured for one composer submission attempt.
+ *
+ * The draft content is kept separately as the payload snapshot needed by the
+ * current submission adapter. It must not participate in the clear decision.
+ */
+export interface AgentComposerSubmissionToken {
+  scopeKey: string;
+  revision: number;
+  clientSubmitId: string;
+}
+
 export interface SubmittedDraftSnapshot {
   sourceScopeKey: string;
+  /**
+   * Revision captured at admission. Optional for snapshots created by older
+   * activation paths; those fall back to the revision carried by `content`.
+   */
+  revision?: number;
+  /** External correlation id for the submission attempt. */
+  clientSubmitId?: string;
   content: AgentComposerDraftContent;
   /** Existing-session destination; may differ from source after recovery. */
   targetAgentSessionId?: string;

--- a/packages/agent/host/edit_retry_replacement.go
+++ b/packages/agent/host/edit_retry_replacement.go
@@ -62,7 +62,6 @@ func (h *Host) reconcileEditRetryReplacement(
 			ProviderTurnID:    replacement.ID,
 			Source:            RuntimeAcceptanceSourceHistoryRead,
 		},
-		nil,
 	)
 	if err != nil {
 		failed, failErr := h.failEditRetryRecovery(
@@ -227,7 +226,7 @@ func (h *Host) dispatchEditRetryReplacement(
 	if receipt := execResult.ProviderDispatch.Acceptance; receipt != nil &&
 		execResult.ProviderDispatch.Disposition == RuntimeDispatchDispositionApplied {
 		completed, completeErr := h.completeEditRetryAcceptance(
-			ctx, operation, owner, input, *receipt, hydrated,
+			ctx, operation, owner, input, *receipt,
 		)
 		if completeErr == nil {
 			return completed, nil
@@ -237,7 +236,7 @@ func (h *Host) dispatchEditRetryReplacement(
 		)
 	}
 	if strings.TrimSpace(execResult.TurnID) == payload.ReplacementTurnID {
-		if err := h.recordEditRetryReplacementSubmission(ctx, operation, input, hydrated); err != nil {
+		if err := h.recordEditRetryReplacementSubmission(ctx, operation, input); err != nil {
 			return h.failEditRetryRecovery(
 				ctx, operation, owner, storesqlite.EditRetryReasonRecoveryRequired, err,
 			)
@@ -265,7 +264,6 @@ func (h *Host) completeEditRetryAcceptance(
 	owner string,
 	input SendInput,
 	receipt RuntimeProviderAcceptanceReceipt,
-	hydrated []PromptContentBlock,
 ) (storesqlite.RuntimeOperation, error) {
 	payload, err := storesqlite.DecodeEditRetryOperationPayload(operation.Payload)
 	if err != nil {
@@ -275,7 +273,7 @@ func (h *Host) completeEditRetryAcceptance(
 		strings.TrimSpace(receipt.ProviderTurnID) == "" {
 		return operation, editRetryInvariant("provider acceptance receipt identity mismatch")
 	}
-	if err := h.recordEditRetryReplacementSubmission(ctx, operation, input, hydrated); err != nil {
+	if err := h.recordEditRetryReplacementSubmission(ctx, operation, input); err != nil {
 		return operation, err
 	}
 	replacement, found, err := h.store.GetTurn(
@@ -338,28 +336,17 @@ func (h *Host) recordEditRetryReplacementSubmission(
 	ctx context.Context,
 	operation storesqlite.RuntimeOperation,
 	input SendInput,
-	hydrated []PromptContentBlock,
 ) error {
 	payload, err := storesqlite.DecodeEditRetryOperationPayload(operation.Payload)
 	if err != nil {
 		return err
 	}
-	if reporter, ok := h.runtime.(RuntimeSubmitProvenanceReporter); ok {
-		if hydrated == nil {
-			hydrated = append([]PromptContentBlock(nil), input.Content...)
-			if h.attachments != nil {
-				hydrated, err = h.attachments.HydrateRuntimeContent(
-					operation.WorkspaceID, operation.AgentSessionID, input.Content,
-				)
-				if err != nil {
-					return err
-				}
-			}
-		}
-		if err := reporter.DurablyReportSubmitProvenance(ctx, RuntimeSubmitProvenanceInput{
+	if reporter, ok := h.runtime.(RuntimeSubmitProvenanceUpdater); ok {
+		if err := reporter.UpdateSubmitProvenance(ctx, RuntimeSubmitProvenanceInput{
 			WorkspaceID: operation.WorkspaceID, AgentSessionID: operation.AgentSessionID,
 			TurnID: payload.ReplacementTurnID, ClientSubmitID: payload.ClientSubmitID,
-			Content: hydrated, DisplayPrompt: input.DisplayPrompt,
+			DispatchStatus: "accepted", DeliveryStatus: "accepted",
+			CanonicalSubmitOccurredAtUnixMS: h.now().UnixMilli(),
 		}); err != nil {
 			return err
 		}

--- a/packages/agent/host/lifecycle.go
+++ b/packages/agent/host/lifecycle.go
@@ -287,6 +287,7 @@ func (h *Host) createSession(ctx context.Context, workspaceID string, input Crea
 			if persistErr := h.persistRuntimeSubmitOutcome(
 				ctx, SessionRef{WorkspaceID: workspaceID, AgentSessionID: session.ID}, execResult,
 				firstNonEmpty(claim.ClientSubmitID, input.ClientSubmitID, legacyClientSubmitID(metadata)),
+				err.Error(),
 				claim.CreatedAtUnixMS, preparedContent, displayPrompt, input.CapabilityRefs,
 				metadata, input.TuttiModeSnapshot,
 			); persistErr != nil {
@@ -321,12 +322,11 @@ func (h *Host) createSession(ctx context.Context, workspaceID string, input Crea
 		claimPending = false
 		return createSessionCreatedErrorResult(input, session, canonicalSession, ErrSubmitDeliveryUnknown)
 	}
-	if reporter, ok := h.runtime.(RuntimeSubmitProvenanceReporter); ok {
-		if err := reporter.DurablyReportSubmitProvenance(ctx, RuntimeSubmitProvenanceInput{
-			WorkspaceID: workspaceID, AgentSessionID: session.ID, TurnID: turnID,
-			ClientSubmitID: claim.ClientSubmitID, CanonicalSubmitOccurredAtUnixMS: claim.CreatedAtUnixMS,
-			Content: preparedContent.Hydrated, DisplayPrompt: displayPrompt,
-		}); err != nil {
+	if reporter, ok := h.runtime.(RuntimeSubmitProvenanceUpdater); ok {
+		if err := reporter.UpdateSubmitProvenance(ctx, runtimeSubmitProvenanceInput(
+			workspaceID, session.ID, turnID, claim.ClientSubmitID, claim.CreatedAtUnixMS,
+			session.ProviderSessionID, execResult, "", false,
+		)); err != nil {
 			// Provider acceptance is already possible. Keep the runtime, canonical
 			// session, and prepared claim intact so a retry cannot dispatch twice.
 			claimPending = false
@@ -655,6 +655,7 @@ func (h *Host) sendInputSerialized(
 			if persistErr := h.persistRuntimeSubmitOutcome(
 				ctx, ref, execResult,
 				firstNonEmpty(claim.ClientSubmitID, input.ClientSubmitID, legacyClientSubmitID(metadata)),
+				err.Error(),
 				claim.CreatedAtUnixMS, preparedContent, displayPrompt, input.CapabilityRefs,
 				metadata, input.TuttiModeSnapshot,
 			); persistErr != nil {
@@ -700,12 +701,11 @@ func (h *Host) sendInputSerialized(
 		claimPending = false
 		return SendInputResult{}, ErrSubmitDeliveryUnknown
 	}
-	if reporter, ok := h.runtime.(RuntimeSubmitProvenanceReporter); ok {
-		if err := reporter.DurablyReportSubmitProvenance(ctx, RuntimeSubmitProvenanceInput{
-			WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID, TurnID: turnID,
-			ClientSubmitID: claim.ClientSubmitID, CanonicalSubmitOccurredAtUnixMS: claim.CreatedAtUnixMS,
-			Content: preparedContent.Hydrated, DisplayPrompt: displayPrompt, Guidance: input.Guidance,
-		}); err != nil {
+	if reporter, ok := h.runtime.(RuntimeSubmitProvenanceUpdater); ok {
+		if err := reporter.UpdateSubmitProvenance(ctx, runtimeSubmitProvenanceInput(
+			ref.WorkspaceID, ref.AgentSessionID, turnID, claim.ClientSubmitID, claim.CreatedAtUnixMS,
+			session.ProviderSessionID, execResult, "", input.Guidance,
+		)); err != nil {
 			claimPending = false
 			return SendInputResult{}, errors.Join(ErrSubmitDeliveryUnknown, err)
 		}

--- a/packages/agent/host/ports.go
+++ b/packages/agent/host/ports.go
@@ -344,8 +344,8 @@ type RuntimeProviderTurnAcceptanceReconciler interface {
 	ReconcileProviderTurnAcceptance(context.Context, RuntimeProviderTurnAcceptanceInput) error
 }
 
-type RuntimeSubmitProvenanceReporter interface {
-	DurablyReportSubmitProvenance(context.Context, RuntimeSubmitProvenanceInput) error
+type RuntimeSubmitProvenanceUpdater interface {
+	UpdateSubmitProvenance(context.Context, RuntimeSubmitProvenanceInput) error
 }
 
 // RuntimeOperationStore is the complete durable coordinator boundary. Keeping

--- a/packages/agent/host/submit_provenance.go
+++ b/packages/agent/host/submit_provenance.go
@@ -1,0 +1,66 @@
+package agenthost
+
+import "strings"
+
+type RuntimeSubmitProvenanceInput struct {
+	WorkspaceID                     string
+	AgentSessionID                  string
+	TurnID                          string
+	ClientSubmitID                  string
+	CanonicalMessageID              string
+	ProviderSessionID               string
+	ProviderTurnID                  string
+	DispatchStatus                  string
+	DeliveryStatus                  string
+	FailureReason                   string
+	CanonicalSubmitOccurredAtUnixMS int64
+	Guidance                        bool
+}
+
+func runtimeSubmitProvenanceInput(
+	workspaceID string,
+	agentSessionID string,
+	turnID string,
+	clientSubmitID string,
+	occurredAtUnixMS int64,
+	providerSessionID string,
+	execResult RuntimeExecResult,
+	failureReason string,
+	guidance bool,
+) RuntimeSubmitProvenanceInput {
+	dispatch := execResult.ProviderDispatch
+	if dispatch.Acceptance != nil {
+		providerSessionID = firstNonEmpty(providerSessionID, dispatch.Acceptance.ProviderSessionID)
+	}
+	providerTurnID := ""
+	if dispatch.Acceptance != nil {
+		providerTurnID = strings.TrimSpace(dispatch.Acceptance.ProviderTurnID)
+	}
+	dispatchStatus, deliveryStatus := submitStatuses(dispatch.Disposition, failureReason)
+	return RuntimeSubmitProvenanceInput{
+		WorkspaceID: workspaceID, AgentSessionID: agentSessionID, TurnID: turnID,
+		ClientSubmitID: clientSubmitID, CanonicalMessageID: "client-submit:user:" + clientSubmitID,
+		ProviderSessionID: providerSessionID,
+		ProviderTurnID:    providerTurnID, DispatchStatus: dispatchStatus,
+		DeliveryStatus: deliveryStatus, FailureReason: failureReason,
+		CanonicalSubmitOccurredAtUnixMS: occurredAtUnixMS, Guidance: guidance,
+	}
+}
+
+func submitStatuses(disposition RuntimeDispatchDisposition, failureReason string) (string, string) {
+	switch disposition {
+	case RuntimeDispatchDispositionApplied, RuntimeDispatchDispositionAppliedWithoutProviderTurn:
+		return "accepted", "accepted"
+	case RuntimeDispatchDispositionRejected:
+		return "failed", "failed"
+	case RuntimeDispatchDispositionNotDispatched:
+		return "not_started", "not_started"
+	case RuntimeDispatchDispositionOutcomeUnknown:
+		return "unknown", "unknown"
+	default:
+		if strings.TrimSpace(failureReason) != "" {
+			return "unknown", "unknown"
+		}
+		return "not_started", "pending"
+	}
+}

--- a/packages/agent/host/submit_provenance_recovery.go
+++ b/packages/agent/host/submit_provenance_recovery.go
@@ -52,6 +52,7 @@ func (h *Host) persistRuntimeSubmitOutcome(
 	ref SessionRef,
 	result RuntimeExecResult,
 	clientSubmitID string,
+	failureReason string,
 	occurredAtUnixMS int64,
 	prepared preparedPromptContent,
 	displayPrompt string,
@@ -63,10 +64,11 @@ func (h *Host) persistRuntimeSubmitOutcome(
 		ctx,
 		ref.WorkspaceID,
 		ref.AgentSessionID,
+		result,
 		result.TurnID,
 		clientSubmitID,
+		failureReason,
 		occurredAtUnixMS,
-		prepared.Hydrated,
 		prepared.Persisted,
 		displayPrompt,
 		false,
@@ -84,10 +86,11 @@ func (h *Host) persistSubmitAfterRuntimeOutcome(
 	ctx context.Context,
 	workspaceID string,
 	agentSessionID string,
+	execResult RuntimeExecResult,
 	turnID string,
 	clientSubmitID string,
+	failureReason string,
 	occurredAtUnixMS int64,
-	hydratedContent []PromptContentBlock,
 	persistedContent []PromptContentBlock,
 	displayPrompt string,
 	guidance bool,
@@ -107,17 +110,11 @@ func (h *Host) persistSubmitAfterRuntimeOutcome(
 	)
 	defer cancel()
 
-	if reporter, ok := h.runtime.(RuntimeSubmitProvenanceReporter); ok {
-		if err := reporter.DurablyReportSubmitProvenance(persistCtx, RuntimeSubmitProvenanceInput{
-			WorkspaceID:                     workspaceID,
-			AgentSessionID:                  agentSessionID,
-			TurnID:                          turnID,
-			ClientSubmitID:                  clientSubmitID,
-			CanonicalSubmitOccurredAtUnixMS: occurredAtUnixMS,
-			Content:                         hydratedContent,
-			DisplayPrompt:                   displayPrompt,
-			Guidance:                        guidance,
-		}); err != nil {
+	if reporter, ok := h.runtime.(RuntimeSubmitProvenanceUpdater); ok {
+		if err := reporter.UpdateSubmitProvenance(persistCtx, runtimeSubmitProvenanceInput(
+			workspaceID, agentSessionID, turnID, clientSubmitID, occurredAtUnixMS,
+			"", execResult, failureReason, guidance,
+		)); err != nil {
 			return err
 		}
 	}

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -498,17 +498,6 @@ type RuntimeProviderTurnAcceptanceInput struct {
 	ClientUserMessageID string
 }
 
-type RuntimeSubmitProvenanceInput struct {
-	WorkspaceID                     string
-	AgentSessionID                  string
-	TurnID                          string
-	ClientSubmitID                  string
-	CanonicalSubmitOccurredAtUnixMS int64
-	Content                         []PromptContentBlock
-	DisplayPrompt                   string
-	Guidance                        bool
-}
-
 type CompletedCommand struct {
 	Kind   string
 	Status string

--- a/packages/agent/store-sqlite/migrations.go
+++ b/packages/agent/store-sqlite/migrations.go
@@ -51,6 +51,7 @@ const schemaMigrationWorkspaceAgentSubmitClaimsV1 = "workspace_agent_submit_clai
 const schemaMigrationWorkspaceAgentSubmitClaimsV2 = "workspace_agent_submit_claims_v2"
 const schemaMigrationWorkspaceAgentSubmitClaimsV3 = "workspace_agent_submit_claims_v3"
 const schemaMigrationWorkspaceAgentSubmitClaimsV4 = "workspace_agent_submit_claims_v4_submission_metadata"
+const schemaMigrationWorkspaceAgentSubmitClaimsV5 = "workspace_agent_submit_claims_v5_provenance_ledger"
 const schemaMigrationAgentTargetsV1 = "agent_targets_v1"
 const schemaMigrationAgentTargetsV2 = "agent_targets_v2"
 const schemaMigrationAgentTargetsV3 = "agent_targets_v3"
@@ -227,6 +228,9 @@ CREATE TABLE IF NOT EXISTS `+schemaMigrationsTable+` (
 		return err
 	}
 	if err := s.applyWorkspaceAgentSubmitClaimsV4(ctx); err != nil {
+		return err
+	}
+	if err := s.applyWorkspaceAgentSubmitClaimsV5(ctx); err != nil {
 		return err
 	}
 	if err := s.applyWorkspaceAgentSessionTitlesV1(ctx); err != nil {

--- a/packages/agent/store-sqlite/migrations_submit_claims.go
+++ b/packages/agent/store-sqlite/migrations_submit_claims.go
@@ -150,3 +150,49 @@ ALTER TABLE workspace_agent_submit_claims
 	}
 	return nil
 }
+
+// V5 makes the submit claim the durable provenance ledger. The existing
+// prepared/accepted/rejected claim status remains the submit lifecycle
+// outcome; dispatch and delivery are deliberately separate monotonic
+// projections so an ambiguous delivery can be reconciled without allocating
+// another canonical message or turn.
+func (s *Store) applyWorkspaceAgentSubmitClaimsV5(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentSubmitClaimsV5)
+	if err != nil || applied {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin workspace agent submit claims v5: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `
+ALTER TABLE workspace_agent_submit_claims
+  ADD COLUMN canonical_message_id TEXT;
+ALTER TABLE workspace_agent_submit_claims
+  ADD COLUMN canonical_content_hash TEXT;
+ALTER TABLE workspace_agent_submit_claims
+  ADD COLUMN provider_session_id TEXT;
+ALTER TABLE workspace_agent_submit_claims
+  ADD COLUMN provider_turn_id TEXT;
+ALTER TABLE workspace_agent_submit_claims
+  ADD COLUMN dispatch_status TEXT NOT NULL DEFAULT 'not_started'
+    CHECK (dispatch_status IN ('not_started','dispatched','accepted','failed','unknown'));
+ALTER TABLE workspace_agent_submit_claims
+  ADD COLUMN delivery_status TEXT NOT NULL DEFAULT 'not_started'
+    CHECK (delivery_status IN ('not_started','pending','accepted','failed','unknown'));
+ALTER TABLE workspace_agent_submit_claims
+  ADD COLUMN failure_reason TEXT;
+CREATE INDEX IF NOT EXISTS idx_workspace_agent_submit_claims_provider_turn
+  ON workspace_agent_submit_claims(workspace_id, agent_session_id, provider_turn_id);
+`); err != nil {
+		return fmt.Errorf("migrate workspace agent submit claims v5: %w", err)
+	}
+	if err := recordMigrationTx(ctx, tx, schemaMigrationWorkspaceAgentSubmitClaimsV5); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit workspace agent submit claims v5: %w", err)
+	}
+	return nil
+}

--- a/packages/agent/store-sqlite/submit_claims.go
+++ b/packages/agent/store-sqlite/submit_claims.go
@@ -2,7 +2,9 @@ package storesqlite
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,26 +12,171 @@ import (
 )
 
 var ErrSubmitClaimTurnConflict = errors.New("workspace agent submit claim canonical turn conflict")
+var ErrSubmitClaimIdentityConflict = errors.New("workspace agent submit claim immutable identity conflict")
+
+const (
+	SubmitDispatchStatusNotStarted = "not_started"
+	SubmitDispatchStatusDispatched = "dispatched"
+	SubmitDispatchStatusAccepted   = "accepted"
+	SubmitDispatchStatusFailed     = "failed"
+	SubmitDispatchStatusUnknown    = "unknown"
+
+	SubmitDeliveryStatusNotStarted = "not_started"
+	SubmitDeliveryStatusPending    = "pending"
+	SubmitDeliveryStatusAccepted   = "accepted"
+	SubmitDeliveryStatusFailed     = "failed"
+	SubmitDeliveryStatusUnknown    = "unknown"
+)
 
 type SubmitClaim struct {
-	WorkspaceID     string
-	AgentSessionID  string
-	ClientSubmitID  string
-	Status          string
-	CanonicalTurnID string
-	TurnID          string
-	MetadataJSON    string
-	CreatedAtUnixMS int64
-	UpdatedAtUnixMS int64
+	WorkspaceID          string
+	AgentSessionID       string
+	ClientSubmitID       string
+	Status               string
+	CanonicalTurnID      string
+	CanonicalMessageID   string
+	CanonicalContentHash string
+	ProviderSessionID    string
+	ProviderTurnID       string
+	DispatchStatus       string
+	DeliveryStatus       string
+	FailureReason        string
+	TurnID               string
+	MetadataJSON         string
+	CreatedAtUnixMS      int64
+	UpdatedAtUnixMS      int64
 }
 
 type SubmitClaimPrepare struct {
-	WorkspaceID     string
-	AgentSessionID  string
-	ClientSubmitID  string
-	CanonicalTurnID string
-	MetadataJSON    string
-	NowUnixMS       int64
+	WorkspaceID          string
+	AgentSessionID       string
+	ClientSubmitID       string
+	CanonicalTurnID      string
+	CanonicalMessageID   string
+	CanonicalContentHash string
+	MetadataJSON         string
+	NowUnixMS            int64
+}
+
+// SubmitProvenanceUpdate changes only durable provenance. It never carries a
+// canonical message payload, so Provider and Host retries cannot rewrite the
+// user message admitted by the Controller.
+type SubmitProvenanceUpdate struct {
+	WorkspaceID          string
+	AgentSessionID       string
+	ClientSubmitID       string
+	CanonicalTurnID      string
+	CanonicalMessageID   string
+	CanonicalContentHash string
+	ProviderSessionID    string
+	ProviderTurnID       string
+	DispatchStatus       string
+	DeliveryStatus       string
+	FailureReason        string
+	NowUnixMS            int64
+}
+
+func canonicalSubmitContentHash(message MessageUpdate) (string, error) {
+	content := map[string]any{
+		"role":          strings.TrimSpace(message.Role),
+		"kind":          strings.TrimSpace(message.Kind),
+		"content":       message.Payload["content"],
+		"contentMode":   message.Payload["contentMode"],
+		"displayPrompt": message.Payload["displayPrompt"],
+		"text":          message.Payload["text"],
+	}
+	encoded, err := json.Marshal(content)
+	if err != nil {
+		return "", fmt.Errorf("encode canonical submit content: %w", err)
+	}
+	digest := sha256.Sum256(encoded)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func validateSubmitStatus(status string, delivery bool) error {
+	if status == "" {
+		return nil
+	}
+	allowed := map[string]struct{}{
+		SubmitDispatchStatusNotStarted: {}, SubmitDispatchStatusDispatched: {},
+		SubmitDispatchStatusAccepted: {}, SubmitDispatchStatusFailed: {},
+		SubmitDispatchStatusUnknown: {},
+	}
+	if delivery {
+		allowed = map[string]struct{}{
+			SubmitDeliveryStatusNotStarted: {}, SubmitDeliveryStatusPending: {},
+			SubmitDeliveryStatusAccepted: {}, SubmitDeliveryStatusFailed: {},
+			SubmitDeliveryStatusUnknown: {},
+		}
+	}
+	if _, ok := allowed[status]; !ok {
+		return fmt.Errorf("invalid submit %s status %q", map[bool]string{true: "delivery", false: "dispatch"}[delivery], status)
+	}
+	return nil
+}
+
+// advanceSubmitStatus applies the intentionally small monotonic state
+// machine. Unknown is recoverable because it represents an ambiguous write;
+// accepted and failed are terminal. A late lower-priority report is ignored,
+// never used to regress the durable state.
+func advanceSubmitStatus(current, incoming string, delivery bool) (string, bool, error) {
+	if current == "" {
+		if delivery {
+			current = SubmitDeliveryStatusNotStarted
+		} else {
+			current = SubmitDispatchStatusNotStarted
+		}
+	}
+	if incoming == "" || incoming == current {
+		return current, false, nil
+	}
+	if err := validateSubmitStatus(incoming, delivery); err != nil {
+		return current, false, err
+	}
+	accepted := SubmitDispatchStatusAccepted
+	failed := SubmitDispatchStatusFailed
+	unknown := SubmitDispatchStatusUnknown
+	if delivery {
+		accepted = SubmitDeliveryStatusAccepted
+		failed = SubmitDeliveryStatusFailed
+		unknown = SubmitDeliveryStatusUnknown
+	}
+	if current == accepted || current == failed {
+		return current, false, nil
+	}
+	if current == unknown && incoming != accepted && incoming != failed {
+		return current, false, nil
+	}
+	if incoming == SubmitDispatchStatusNotStarted || incoming == SubmitDeliveryStatusNotStarted {
+		return current, false, nil
+	}
+	if current == SubmitDispatchStatusDispatched || current == SubmitDeliveryStatusPending {
+		return incoming, true, nil
+	}
+	if current == SubmitDispatchStatusNotStarted || current == SubmitDeliveryStatusNotStarted || current == unknown {
+		return incoming, true, nil
+	}
+	return current, false, nil
+}
+
+func validateSubmitClaimMetadata(claim SubmitClaim, canonicalMessageID, canonicalContentHash string) error {
+	canonicalMessageID = strings.TrimSpace(canonicalMessageID)
+	canonicalContentHash = strings.TrimSpace(canonicalContentHash)
+	if canonicalMessageID != "" && claim.CanonicalMessageID != "" && claim.CanonicalMessageID != canonicalMessageID {
+		return fmt.Errorf("%w: canonical message stored=%q incoming=%q", ErrSubmitClaimIdentityConflict, claim.CanonicalMessageID, canonicalMessageID)
+	}
+	if canonicalContentHash != "" && claim.CanonicalContentHash != "" && claim.CanonicalContentHash != canonicalContentHash {
+		return fmt.Errorf("%w: canonical content hash does not match", ErrSubmitClaimIdentityConflict)
+	}
+	return nil
+}
+
+func validateSubmitClaimIdentity(claim SubmitClaim, canonicalTurnID, canonicalMessageID, canonicalContentHash string) error {
+	canonicalTurnID = strings.TrimSpace(canonicalTurnID)
+	if claim.CanonicalTurnID != "" && claim.CanonicalTurnID != canonicalTurnID {
+		return fmt.Errorf("%w: canonical turn stored=%q incoming=%q", ErrSubmitClaimTurnConflict, claim.CanonicalTurnID, canonicalTurnID)
+	}
+	return validateSubmitClaimMetadata(claim, canonicalMessageID, canonicalContentHash)
 }
 
 func (s *Store) PrepareSubmitClaim(ctx context.Context, input SubmitClaimPrepare) (SubmitClaim, bool, error) {
@@ -37,6 +184,8 @@ func (s *Store) PrepareSubmitClaim(ctx context.Context, input SubmitClaimPrepare
 	input.AgentSessionID = strings.TrimSpace(input.AgentSessionID)
 	input.ClientSubmitID = strings.TrimSpace(input.ClientSubmitID)
 	input.CanonicalTurnID = strings.TrimSpace(input.CanonicalTurnID)
+	input.CanonicalMessageID = strings.TrimSpace(input.CanonicalMessageID)
+	input.CanonicalContentHash = strings.TrimSpace(input.CanonicalContentHash)
 	if strings.TrimSpace(input.MetadataJSON) == "" {
 		input.MetadataJSON = "{}"
 	}
@@ -74,6 +223,12 @@ func (s *Store) PrepareSubmitClaim(ctx context.Context, input SubmitClaimPrepare
 	); err != nil {
 		return SubmitClaim{}, false, err
 	} else if found {
+		// Preserve the legacy retry contract: PrepareSubmitClaim returns the
+		// existing claim even if a caller rebuilt a provisional turn. The strict
+		// identity fence belongs to AdmitSubmitIntent and UpdateSubmitProvenance.
+		if err := validateSubmitClaimMetadata(claim, input.CanonicalMessageID, input.CanonicalContentHash); err != nil {
+			return SubmitClaim{}, false, err
+		}
 		if err := tx.Commit(); err != nil {
 			return SubmitClaim{}, false, fmt.Errorf("commit duplicate submit claim read: %w", err)
 		}
@@ -88,8 +243,10 @@ func (s *Store) PrepareSubmitClaim(ctx context.Context, input SubmitClaimPrepare
 		return SubmitClaim{}, false, err
 	}
 	result, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO workspace_agent_submit_claims
-		(workspace_id, agent_session_id, client_submit_id, status, turn_id, created_at_unix_ms, updated_at_unix_ms, canonical_turn_id, metadata_json)
-		VALUES (?, ?, ?, 'prepared', NULL, ?, ?, ?, ?)`, input.WorkspaceID, input.AgentSessionID, input.ClientSubmitID, input.NowUnixMS, input.NowUnixMS, input.CanonicalTurnID, input.MetadataJSON)
+		(workspace_id, agent_session_id, client_submit_id, status, turn_id, created_at_unix_ms, updated_at_unix_ms,
+		 canonical_turn_id, canonical_message_id, canonical_content_hash, metadata_json)
+		VALUES (?, ?, ?, 'prepared', NULL, ?, ?, ?, ?, ?, ?)`, input.WorkspaceID, input.AgentSessionID, input.ClientSubmitID,
+		input.NowUnixMS, input.NowUnixMS, input.CanonicalTurnID, nullString(input.CanonicalMessageID), nullString(input.CanonicalContentHash), input.MetadataJSON)
 	if err != nil {
 		return SubmitClaim{}, false, fmt.Errorf("prepare submit claim: %w", err)
 	}
@@ -114,6 +271,122 @@ func (s *Store) PrepareSubmitClaim(ctx context.Context, input SubmitClaimPrepare
 		return SubmitClaim{}, false, fmt.Errorf("commit prepare submit claim: %w", err)
 	}
 	return claim, created, nil
+}
+
+// UpdateSubmitProvenance records provider and delivery facts without
+// accepting a message payload. Immutable identities may be filled exactly
+// once, but never replaced. Statuses advance monotonically and terminal
+// accepted/failed states ignore late lower-priority reports.
+func (s *Store) UpdateSubmitProvenance(ctx context.Context, input SubmitProvenanceUpdate) (SubmitClaim, bool, error) {
+	input.WorkspaceID = strings.TrimSpace(input.WorkspaceID)
+	input.AgentSessionID = strings.TrimSpace(input.AgentSessionID)
+	input.ClientSubmitID = strings.TrimSpace(input.ClientSubmitID)
+	input.CanonicalTurnID = strings.TrimSpace(input.CanonicalTurnID)
+	input.CanonicalMessageID = strings.TrimSpace(input.CanonicalMessageID)
+	input.CanonicalContentHash = strings.TrimSpace(input.CanonicalContentHash)
+	input.ProviderSessionID = strings.TrimSpace(input.ProviderSessionID)
+	input.ProviderTurnID = strings.TrimSpace(input.ProviderTurnID)
+	input.DispatchStatus = strings.TrimSpace(input.DispatchStatus)
+	input.DeliveryStatus = strings.TrimSpace(input.DeliveryStatus)
+	input.FailureReason = strings.TrimSpace(input.FailureReason)
+	if input.WorkspaceID == "" || input.AgentSessionID == "" || input.ClientSubmitID == "" ||
+		input.CanonicalTurnID == "" || input.NowUnixMS <= 0 {
+		return SubmitClaim{}, false, fmt.Errorf("invalid workspace agent submit provenance update")
+	}
+	if err := validateSubmitStatus(input.DispatchStatus, false); err != nil {
+		return SubmitClaim{}, false, err
+	}
+	if err := validateSubmitStatus(input.DeliveryStatus, true); err != nil {
+		return SubmitClaim{}, false, err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return SubmitClaim{}, false, fmt.Errorf("begin update submit provenance: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	claim, found, err := getSubmitClaimTx(ctx, tx, input.WorkspaceID, input.AgentSessionID, input.ClientSubmitID)
+	if err != nil {
+		return SubmitClaim{}, false, err
+	}
+	if !found {
+		return SubmitClaim{}, false, fmt.Errorf("submit provenance claim does not exist")
+	}
+	if err := validateSubmitClaimIdentity(claim, input.CanonicalTurnID, input.CanonicalMessageID, input.CanonicalContentHash); err != nil {
+		return claim, false, err
+	}
+	if claim.ProviderSessionID != "" && input.ProviderSessionID != "" && claim.ProviderSessionID != input.ProviderSessionID {
+		return claim, false, fmt.Errorf("%w: provider session stored=%q incoming=%q", ErrSubmitClaimIdentityConflict, claim.ProviderSessionID, input.ProviderSessionID)
+	}
+	if claim.ProviderTurnID != "" && input.ProviderTurnID != "" && claim.ProviderTurnID != input.ProviderTurnID {
+		return claim, false, fmt.Errorf("%w: provider turn stored=%q incoming=%q", ErrSubmitClaimIdentityConflict, claim.ProviderTurnID, input.ProviderTurnID)
+	}
+	if err := requireSessionForkSourceWritableTx(ctx, tx, input.WorkspaceID, input.AgentSessionID); err != nil {
+		return SubmitClaim{}, false, err
+	}
+
+	nextDispatch, dispatchChanged, err := advanceSubmitStatus(claim.DispatchStatus, input.DispatchStatus, false)
+	if err != nil {
+		return claim, false, err
+	}
+	nextDelivery, deliveryChanged, err := advanceSubmitStatus(claim.DeliveryStatus, input.DeliveryStatus, true)
+	if err != nil {
+		return claim, false, err
+	}
+	nextCanonicalMessageID := claim.CanonicalMessageID
+	if nextCanonicalMessageID == "" {
+		nextCanonicalMessageID = input.CanonicalMessageID
+	}
+	nextCanonicalContentHash := claim.CanonicalContentHash
+	if nextCanonicalContentHash == "" {
+		nextCanonicalContentHash = input.CanonicalContentHash
+	}
+	nextProviderSessionID := claim.ProviderSessionID
+	if nextProviderSessionID == "" {
+		nextProviderSessionID = input.ProviderSessionID
+	}
+	nextProviderTurnID := claim.ProviderTurnID
+	if nextProviderTurnID == "" {
+		nextProviderTurnID = input.ProviderTurnID
+	}
+	nextFailureReason := claim.FailureReason
+	if nextFailureReason == "" && input.FailureReason != "" &&
+		(nextDispatch == SubmitDispatchStatusFailed || nextDispatch == SubmitDispatchStatusUnknown ||
+			nextDelivery == SubmitDeliveryStatusFailed || nextDelivery == SubmitDeliveryStatusUnknown) {
+		nextFailureReason = input.FailureReason
+	}
+	changed := dispatchChanged || deliveryChanged ||
+		nextCanonicalMessageID != claim.CanonicalMessageID ||
+		nextCanonicalContentHash != claim.CanonicalContentHash ||
+		nextProviderSessionID != claim.ProviderSessionID ||
+		nextProviderTurnID != claim.ProviderTurnID ||
+		nextFailureReason != claim.FailureReason
+	if !changed {
+		if err := tx.Commit(); err != nil {
+			return SubmitClaim{}, false, fmt.Errorf("commit submit provenance replay: %w", err)
+		}
+		return claim, false, nil
+	}
+	if _, err := tx.ExecContext(ctx, `
+UPDATE workspace_agent_submit_claims
+SET canonical_message_id = ?, canonical_content_hash = ?, provider_session_id = ?, provider_turn_id = ?,
+    dispatch_status = ?, delivery_status = ?, failure_reason = ?, updated_at_unix_ms = ?
+WHERE workspace_id = ? AND agent_session_id = ? AND client_submit_id = ?
+`, nullString(nextCanonicalMessageID), nullString(nextCanonicalContentHash), nullString(nextProviderSessionID),
+		nullString(nextProviderTurnID), nextDispatch, nextDelivery, nullString(nextFailureReason), input.NowUnixMS,
+		input.WorkspaceID, input.AgentSessionID, input.ClientSubmitID); err != nil {
+		return SubmitClaim{}, false, fmt.Errorf("update submit provenance: %w", err)
+	}
+	claim, found, err = getSubmitClaimTx(ctx, tx, input.WorkspaceID, input.AgentSessionID, input.ClientSubmitID)
+	if err != nil {
+		return SubmitClaim{}, false, err
+	}
+	if !found {
+		return SubmitClaim{}, false, fmt.Errorf("updated submit provenance claim disappeared before it could be read")
+	}
+	if err := tx.Commit(); err != nil {
+		return SubmitClaim{}, false, fmt.Errorf("commit submit provenance: %w", err)
+	}
+	return claim, true, nil
 }
 
 func (s *Store) AcceptSubmitClaim(ctx context.Context, workspaceID, agentSessionID, clientSubmitID, turnID string, nowUnixMS int64) (SubmitClaim, bool, error) {
@@ -307,7 +580,9 @@ func (s *Store) FindSubmitClaimByCanonicalTurn(
 	}
 	rows, err := s.db.QueryContext(ctx, `
 SELECT workspace_id, agent_session_id, client_submit_id, status,
-	       canonical_turn_id, turn_id, metadata_json, created_at_unix_ms, updated_at_unix_ms
+       canonical_turn_id, turn_id, metadata_json, created_at_unix_ms, updated_at_unix_ms,
+       canonical_message_id, canonical_content_hash, provider_session_id,
+       provider_turn_id, dispatch_status, delivery_status, failure_reason
 FROM workspace_agent_submit_claims
 WHERE workspace_id = ? AND agent_session_id = ? AND canonical_turn_id = ?
   AND status IN ('prepared', 'accepted')
@@ -346,7 +621,9 @@ LIMIT 2
 func (s *Store) getSubmitClaim(ctx context.Context, workspaceID, agentSessionID, clientSubmitID string) (SubmitClaim, bool, error) {
 	return scanSubmitClaim(s.db.QueryRowContext(
 		ctx,
-		`SELECT workspace_id, agent_session_id, client_submit_id, status, canonical_turn_id, turn_id, metadata_json, created_at_unix_ms, updated_at_unix_ms
+		`SELECT workspace_id, agent_session_id, client_submit_id, status, canonical_turn_id, turn_id, metadata_json, created_at_unix_ms, updated_at_unix_ms,
+		 canonical_message_id, canonical_content_hash, provider_session_id, provider_turn_id,
+		 dispatch_status, delivery_status, failure_reason
 		FROM workspace_agent_submit_claims WHERE workspace_id=? AND agent_session_id=? AND client_submit_id=?`,
 		workspaceID,
 		agentSessionID,
@@ -361,7 +638,9 @@ func getSubmitClaimTx(
 ) (SubmitClaim, bool, error) {
 	return scanSubmitClaim(tx.QueryRowContext(
 		ctx,
-		`SELECT workspace_id, agent_session_id, client_submit_id, status, canonical_turn_id, turn_id, metadata_json, created_at_unix_ms, updated_at_unix_ms
+		`SELECT workspace_id, agent_session_id, client_submit_id, status, canonical_turn_id, turn_id, metadata_json, created_at_unix_ms, updated_at_unix_ms,
+		 canonical_message_id, canonical_content_hash, provider_session_id, provider_turn_id,
+		 dispatch_status, delivery_status, failure_reason
 		FROM workspace_agent_submit_claims WHERE workspace_id=? AND agent_session_id=? AND client_submit_id=?`,
 		workspaceID,
 		agentSessionID,
@@ -373,6 +652,11 @@ func scanSubmitClaim(row rowScanner) (SubmitClaim, bool, error) {
 	var claim SubmitClaim
 	var canonicalTurnID sql.NullString
 	var turnID sql.NullString
+	var canonicalMessageID sql.NullString
+	var canonicalContentHash sql.NullString
+	var providerSessionID sql.NullString
+	var providerTurnID sql.NullString
+	var failureReason sql.NullString
 	err := row.Scan(
 		&claim.WorkspaceID,
 		&claim.AgentSessionID,
@@ -383,6 +667,13 @@ func scanSubmitClaim(row rowScanner) (SubmitClaim, bool, error) {
 		&claim.MetadataJSON,
 		&claim.CreatedAtUnixMS,
 		&claim.UpdatedAtUnixMS,
+		&canonicalMessageID,
+		&canonicalContentHash,
+		&providerSessionID,
+		&providerTurnID,
+		&claim.DispatchStatus,
+		&claim.DeliveryStatus,
+		&failureReason,
 	)
 	if err == sql.ErrNoRows {
 		return SubmitClaim{}, false, nil
@@ -395,6 +686,21 @@ func scanSubmitClaim(row rowScanner) (SubmitClaim, bool, error) {
 	}
 	if canonicalTurnID.Valid {
 		claim.CanonicalTurnID = canonicalTurnID.String
+	}
+	if canonicalMessageID.Valid {
+		claim.CanonicalMessageID = canonicalMessageID.String
+	}
+	if canonicalContentHash.Valid {
+		claim.CanonicalContentHash = canonicalContentHash.String
+	}
+	if providerSessionID.Valid {
+		claim.ProviderSessionID = providerSessionID.String
+	}
+	if providerTurnID.Valid {
+		claim.ProviderTurnID = providerTurnID.String
+	}
+	if failureReason.Valid {
+		claim.FailureReason = failureReason.String
 	}
 	return claim, true, nil
 }

--- a/packages/agent/store-sqlite/submit_claims_test.go
+++ b/packages/agent/store-sqlite/submit_claims_test.go
@@ -142,6 +142,9 @@ WHERE workspace_id = 'ws-1' AND agent_session_id = 'session-1'
 	if err := store.applyWorkspaceAgentSubmitClaimsV4(ctx); err != nil {
 		t.Fatal(err)
 	}
+	if err := store.applyWorkspaceAgentSubmitClaimsV5(ctx); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := store.db.ExecContext(ctx, `
 INSERT INTO workspace_agent_submit_claims
   (workspace_id, agent_session_id, client_submit_id, status, turn_id, created_at_unix_ms, updated_at_unix_ms, canonical_turn_id)

--- a/packages/agent/store-sqlite/submit_intent.go
+++ b/packages/agent/store-sqlite/submit_intent.go
@@ -1,0 +1,216 @@
+package storesqlite
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// SubmitIntentAdmission contains exactly one canonical user message. The
+// claim and activity report are committed by one SQLite transaction; callers
+// must not separately report the same canonical message after admission.
+type SubmitIntentAdmission struct {
+	Claim    SubmitClaimPrepare
+	Activity ActivityStateReport
+}
+
+type SubmitIntentAdmissionResult struct {
+	Claim    SubmitClaim
+	Activity ActivityStateReportResult
+}
+
+// AdmitSubmitIntent is the canonical-message ownership boundary. It creates
+// or replays one submit claim and one canonical user message atomically. A
+// replay with a different turn, message identity, or content is rejected.
+func (s *Store) AdmitSubmitIntent(ctx context.Context, input SubmitIntentAdmission) (SubmitIntentAdmissionResult, error) {
+	message, err := validateSubmitIntentAdmission(&input)
+	if err != nil {
+		return SubmitIntentAdmissionResult{}, err
+	}
+	if s == nil || s.db == nil {
+		return SubmitIntentAdmissionResult{}, errors.New("workspace database is not initialized")
+	}
+	if err := s.ensureWorkspaceExists(ctx, input.Claim.WorkspaceID); err != nil {
+		return SubmitIntentAdmissionResult{}, err
+	}
+	var result SubmitIntentAdmissionResult
+	err = retrySQLiteBusy(ctx, func(attemptCtx context.Context) error {
+		var err error
+		result, err = s.admitSubmitIntentOnce(attemptCtx, input, message)
+		return err
+	})
+	return result, err
+}
+
+func validateSubmitIntentAdmission(input *SubmitIntentAdmission) (MessageUpdate, error) {
+	input.Claim.WorkspaceID = strings.TrimSpace(input.Claim.WorkspaceID)
+	input.Claim.AgentSessionID = strings.TrimSpace(input.Claim.AgentSessionID)
+	input.Claim.ClientSubmitID = strings.TrimSpace(input.Claim.ClientSubmitID)
+	input.Claim.CanonicalTurnID = strings.TrimSpace(input.Claim.CanonicalTurnID)
+	input.Claim.CanonicalMessageID = strings.TrimSpace(input.Claim.CanonicalMessageID)
+	input.Claim.CanonicalContentHash = strings.TrimSpace(input.Claim.CanonicalContentHash)
+	input.Activity.Session.WorkspaceID = strings.TrimSpace(input.Activity.Session.WorkspaceID)
+	input.Activity.Session.AgentSessionID = strings.TrimSpace(input.Activity.Session.AgentSessionID)
+	if input.Claim.WorkspaceID == "" || input.Claim.AgentSessionID == "" || input.Claim.ClientSubmitID == "" ||
+		input.Claim.CanonicalTurnID == "" || input.Claim.NowUnixMS <= 0 {
+		return MessageUpdate{}, errors.New("submit intent claim identity is incomplete")
+	}
+	if input.Activity.Session.WorkspaceID != input.Claim.WorkspaceID || input.Activity.Session.AgentSessionID != input.Claim.AgentSessionID {
+		return MessageUpdate{}, errors.New("submit intent activity scope does not match claim")
+	}
+	if input.Activity.Turn == nil || strings.TrimSpace(input.Activity.Turn.TurnID) != input.Claim.CanonicalTurnID {
+		return MessageUpdate{}, errors.New("submit intent admission requires the claimed canonical turn")
+	}
+	if len(input.Activity.Messages) != 1 {
+		return MessageUpdate{}, errors.New("submit intent admission requires exactly one canonical message")
+	}
+	message := input.Activity.Messages[0]
+	message.MessageID = strings.TrimSpace(message.MessageID)
+	message.TurnID = strings.TrimSpace(message.TurnID)
+	if message.MessageID == "" || message.TurnID == "" || message.TurnID != input.Claim.CanonicalTurnID {
+		return MessageUpdate{}, errors.New("submit intent canonical message identity does not match claim")
+	}
+	if strings.TrimSpace(message.Role) != "user" {
+		return MessageUpdate{}, errors.New("submit intent canonical message must have user role")
+	}
+	if payloadString(message.Payload, "clientSubmitId") != input.Claim.ClientSubmitID {
+		return MessageUpdate{}, errors.New("submit intent canonical message client submit id does not match claim")
+	}
+	hash, err := canonicalSubmitContentHash(message)
+	if err != nil {
+		return MessageUpdate{}, err
+	}
+	if input.Claim.CanonicalMessageID != "" && input.Claim.CanonicalMessageID != message.MessageID {
+		return MessageUpdate{}, fmt.Errorf("%w: canonical message does not match claim", ErrSubmitClaimIdentityConflict)
+	}
+	if input.Claim.CanonicalContentHash != "" && input.Claim.CanonicalContentHash != hash {
+		return MessageUpdate{}, fmt.Errorf("%w: canonical content does not match claim", ErrSubmitClaimIdentityConflict)
+	}
+	input.Claim.CanonicalMessageID = message.MessageID
+	input.Claim.CanonicalContentHash = hash
+	input.Activity.Messages[0] = message
+	return message, nil
+}
+
+func (s *Store) admitSubmitIntentOnce(
+	ctx context.Context,
+	input SubmitIntentAdmission,
+	message MessageUpdate,
+) (SubmitIntentAdmissionResult, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return SubmitIntentAdmissionResult{}, fmt.Errorf("begin admit submit intent: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	claim, found, err := getSubmitClaimTx(ctx, tx, input.Claim.WorkspaceID, input.Claim.AgentSessionID, input.Claim.ClientSubmitID)
+	if err != nil {
+		return SubmitIntentAdmissionResult{}, err
+	}
+	if found {
+		if err := validateSubmitClaimIdentity(claim, input.Claim.CanonicalTurnID, input.Claim.CanonicalMessageID, input.Claim.CanonicalContentHash); err != nil {
+			return SubmitIntentAdmissionResult{}, err
+		}
+		if _, err := tx.ExecContext(ctx, `
+UPDATE workspace_agent_submit_claims
+SET canonical_turn_id = COALESCE(NULLIF(canonical_turn_id, ''), ?),
+    canonical_message_id = COALESCE(NULLIF(canonical_message_id, ''), ?),
+    canonical_content_hash = COALESCE(NULLIF(canonical_content_hash, ''), ?)
+WHERE workspace_id = ? AND agent_session_id = ? AND client_submit_id = ?
+`, input.Claim.CanonicalTurnID, input.Claim.CanonicalMessageID, input.Claim.CanonicalContentHash,
+			input.Claim.WorkspaceID, input.Claim.AgentSessionID, input.Claim.ClientSubmitID); err != nil {
+			return SubmitIntentAdmissionResult{}, fmt.Errorf("bind existing submit intent identity: %w", err)
+		}
+	} else {
+		if err := requireSessionForkSourceWritableTx(ctx, tx, input.Claim.WorkspaceID, input.Claim.AgentSessionID); err != nil {
+			return SubmitIntentAdmissionResult{}, err
+		}
+		result, err := tx.ExecContext(ctx, `
+INSERT INTO workspace_agent_submit_claims (
+  workspace_id, agent_session_id, client_submit_id, status, turn_id,
+  created_at_unix_ms, updated_at_unix_ms, canonical_turn_id,
+  canonical_message_id, canonical_content_hash
+) VALUES (?, ?, ?, 'prepared', NULL, ?, ?, ?, ?, ?)
+`, input.Claim.WorkspaceID, input.Claim.AgentSessionID, input.Claim.ClientSubmitID,
+			input.Claim.NowUnixMS, input.Claim.NowUnixMS, input.Claim.CanonicalTurnID,
+			nullString(input.Claim.CanonicalMessageID), nullString(input.Claim.CanonicalContentHash))
+		if err != nil {
+			return SubmitIntentAdmissionResult{}, fmt.Errorf("admit submit intent claim: %w", err)
+		}
+		if _, err := rowsWereAffected(result, "admit submit intent claim"); err != nil {
+			return SubmitIntentAdmissionResult{}, err
+		}
+	}
+
+	activity := input.Activity
+	now := input.Claim.NowUnixMS
+	goalBefore, err := readSessionGoalProjectionTx(ctx, tx, activity.Session)
+	if err != nil {
+		return SubmitIntentAdmissionResult{}, err
+	}
+	accepted, stateApplied, lastEventUnixMS, session, err := s.upsertAgentSessionTx(ctx, tx, activity.Session, now)
+	if err != nil {
+		return SubmitIntentAdmissionResult{}, err
+	}
+	if !accepted {
+		return SubmitIntentAdmissionResult{}, errors.New("submit intent activity session was rejected")
+	}
+	sessionWritable, err := sessionActivityWritableTx(ctx, tx, input.Claim.WorkspaceID, input.Claim.AgentSessionID)
+	if err != nil {
+		return SubmitIntentAdmissionResult{}, err
+	}
+	result := ActivityStateReportResult{State: StateReportResult{
+		Accepted: accepted, StateApplied: stateApplied, LastEventUnixMS: lastEventUnixMS, Session: session,
+	}}
+	result.Messages.LatestVersion = session.MessageVersion
+	result.Turn, result.TurnAccepted, err = s.recordTurnTransitionTx(ctx, tx, *activity.Turn, now)
+	if err != nil {
+		return SubmitIntentAdmissionResult{}, err
+	}
+	if !sessionWritable || (!result.TurnAccepted && !turnTransitionAlreadyApplied(result.Turn, *activity.Turn)) {
+		return SubmitIntentAdmissionResult{}, errors.New("submit intent canonical turn was rejected")
+	}
+	acceptedMessage, messageAccepted, _, err := s.upsertAgentMessageTx(ctx, tx, input.Claim.WorkspaceID, input.Claim.AgentSessionID, message, now, false, true)
+	if err != nil {
+		return SubmitIntentAdmissionResult{}, err
+	}
+	if !messageAccepted {
+		return SubmitIntentAdmissionResult{}, errors.New("submit intent canonical message was rejected")
+	}
+	result.Messages.AcceptedCount = 1
+	result.Messages.LatestVersion = acceptedMessage.Version
+	result.Messages.Messages = []Message{acceptedMessage}
+	goalMutations, err := sessionGoalMutationsTx(ctx, tx, activity.Session, goalBefore)
+	if err != nil {
+		return SubmitIntentAdmissionResult{}, err
+	}
+	turnTerminalTransition := result.TurnAccepted &&
+		strings.TrimSpace(activity.Turn.Phase) == TurnPhaseSettled
+	mutations := activityStateMutations(result, turnTerminalTransition, false)
+	mutations = append(mutations, goalMutations...)
+	delta, err := s.commitTransaction(ctx, tx, input.Claim.WorkspaceID, mutations)
+	if err != nil {
+		return SubmitIntentAdmissionResult{}, fmt.Errorf("commit admit submit intent: %w", err)
+	}
+	committed = true
+	result.TransactionID = delta.TransactionID
+	result.CommitDelta = delta
+	result.State.TransactionID = delta.TransactionID
+	result.State.CommitDelta = delta
+	result.State.Session.CommitTransactionID = delta.TransactionID
+	result.State.Session.CommitDelta = delta
+	claim, found, err = s.GetSubmitClaim(ctx, input.Claim.WorkspaceID, input.Claim.AgentSessionID, input.Claim.ClientSubmitID)
+	if err != nil {
+		return SubmitIntentAdmissionResult{}, err
+	}
+	if !found {
+		return SubmitIntentAdmissionResult{}, errors.New("admitted submit claim disappeared before it could be read")
+	}
+	return SubmitIntentAdmissionResult{Claim: claim, Activity: result}, nil
+}

--- a/services/tuttid/agent_run_outcome_reporter_test.go
+++ b/services/tuttid/agent_run_outcome_reporter_test.go
@@ -9,15 +9,21 @@ import (
 )
 
 type submitProvenanceCaptureReporter struct {
-	report agentsessionstore.ReportActivityInput
+	intent     agentsessionstore.SubmitIntentInput
+	provenance agentsessionstore.SubmitProvenanceInput
 }
 
 func (*submitProvenanceCaptureReporter) Report(context.Context, agentsessionstore.ReportActivityInput) error {
 	return nil
 }
 
-func (r *submitProvenanceCaptureReporter) ReportSubmitProvenance(_ context.Context, input agentsessionstore.ReportActivityInput) error {
-	r.report = input
+func (r *submitProvenanceCaptureReporter) AdmitSubmitIntent(_ context.Context, input agentsessionstore.SubmitIntentInput) error {
+	r.intent = input
+	return nil
+}
+
+func (r *submitProvenanceCaptureReporter) UpdateSubmitProvenance(_ context.Context, input agentsessionstore.SubmitProvenanceInput) error {
+	r.provenance = input
 	return nil
 }
 
@@ -84,14 +90,14 @@ func TestReportRunOutcomeSuccessClears(t *testing.T) {
 	}
 }
 
-func TestAgentRunOutcomeReporterPreservesRequiredAtomicSubmitProvenance(t *testing.T) {
+func TestAgentRunOutcomeReporterPreservesSubmitIntentAdmission(t *testing.T) {
 	inner := &submitProvenanceCaptureReporter{}
 	reporter := agentRunOutcomeReporter{DurableActivityReporter: inner}
-	input := agentsessionstore.ReportActivityInput{WorkspaceID: "ws-1"}
-	if err := reporter.ReportSubmitProvenance(context.Background(), input); err != nil {
-		t.Fatalf("ReportSubmitProvenance() error = %v", err)
+	input := agentsessionstore.SubmitIntentInput{WorkspaceID: "ws-1"}
+	if err := reporter.AdmitSubmitIntent(context.Background(), input); err != nil {
+		t.Fatalf("AdmitSubmitIntent() error = %v", err)
 	}
-	if inner.report.WorkspaceID != "ws-1" {
-		t.Fatalf("forwarded report = %#v", inner.report)
+	if inner.intent.WorkspaceID != "ws-1" {
+		t.Fatalf("forwarded submit intent = %#v", inner.intent)
 	}
 }

--- a/services/tuttid/agent_runtime_adapter.go
+++ b/services/tuttid/agent_runtime_adapter.go
@@ -292,19 +292,23 @@ func serviceProviderDispatchFromRuntime(
 	return projected
 }
 
-func (a agentRuntimeAdapter) DurablyReportSubmitProvenance(
+func (a agentRuntimeAdapter) UpdateSubmitProvenance(
 	ctx context.Context,
 	input agentservice.RuntimeSubmitProvenanceInput,
 ) error {
-	err := a.controller.DurablyReportSubmitProvenance(ctx, agentruntime.SubmitProvenanceInput{
-		RoomID:                          input.WorkspaceID,
-		AgentSessionID:                  input.AgentSessionID,
-		TurnID:                          input.TurnID,
-		ClientSubmitID:                  input.ClientSubmitID,
-		CanonicalSubmitOccurredAtUnixMS: input.CanonicalSubmitOccurredAtUnixMS,
-		Content:                         runtimePromptContentFromService(input.Content),
-		DisplayPrompt:                   input.DisplayPrompt,
-		Guidance:                        input.Guidance,
+	err := a.controller.UpdateSubmitProvenance(ctx, agentruntime.SubmitProvenanceInput{
+		RoomID:             input.WorkspaceID,
+		AgentSessionID:     input.AgentSessionID,
+		TurnID:             input.TurnID,
+		ClientSubmitID:     input.ClientSubmitID,
+		CanonicalMessageID: input.CanonicalMessageID,
+		ProviderSessionID:  input.ProviderSessionID,
+		ProviderTurnID:     input.ProviderTurnID,
+		DispatchStatus:     input.DispatchStatus,
+		DeliveryStatus:     input.DeliveryStatus,
+		FailureReason:      input.FailureReason,
+		OccurredAtUnixMS:   input.CanonicalSubmitOccurredAtUnixMS,
+		Guidance:           input.Guidance,
 	})
 	if err != nil {
 		return mapAgentRuntimeError(err)

--- a/services/tuttid/agent_runtime_adapter_test.go
+++ b/services/tuttid/agent_runtime_adapter_test.go
@@ -143,14 +143,18 @@ func (*providerAcceptanceMappingTestAdapter) Fork(
 }
 
 type submitProvenanceAdapterTestReporter struct {
-	provenance agentsessionstore.ReportActivityInput
+	provenance agentsessionstore.SubmitProvenanceInput
 }
 
 func (*submitProvenanceAdapterTestReporter) Report(context.Context, agentsessionstore.ReportActivityInput) error {
 	return nil
 }
 
-func (r *submitProvenanceAdapterTestReporter) ReportSubmitProvenance(_ context.Context, input agentsessionstore.ReportActivityInput) error {
+func (*submitProvenanceAdapterTestReporter) AdmitSubmitIntent(context.Context, agentsessionstore.SubmitIntentInput) error {
+	return nil
+}
+
+func (r *submitProvenanceAdapterTestReporter) UpdateSubmitProvenance(_ context.Context, input agentsessionstore.SubmitProvenanceInput) error {
 	r.provenance = input
 	return nil
 }
@@ -343,8 +347,10 @@ func TestAgentRuntimeAdapterPreservesRejectedDispatchWithProviderFailure(t *test
 
 	result, err := adapter.Exec(t.Context(), agentservice.RuntimeExecInput{
 		WorkspaceID: "workspace-1", AgentSessionID: "session-rejected",
-		TurnID: "canonical-turn-rejected", Content: agentservice.TextPromptContent("hello"),
-		RequireProviderAcceptance: true,
+		TurnID: "canonical-turn-rejected", ClientSubmitID: "submit-rejected",
+		CanonicalSubmitOccurredAtUnixMS: 1,
+		Content:                         agentservice.TextPromptContent("hello"),
+		RequireProviderAcceptance:       true,
 	})
 	var mapped *agenthost.ProviderError
 	if !errors.As(err, &mapped) || mapped.Code != "auth_required" {
@@ -356,7 +362,7 @@ func TestAgentRuntimeAdapterPreservesRejectedDispatchWithProviderFailure(t *test
 	}
 }
 
-func TestAgentRuntimeAdapterDelegatesTypedDurableSubmitProvenance(t *testing.T) {
+func TestAgentRuntimeAdapterDelegatesTypedSubmitProvenance(t *testing.T) {
 	reporter := &submitProvenanceAdapterTestReporter{}
 	controller := agentruntime.NewController(
 		[]agentruntime.Adapter{submitProvenanceAdapterTestProvider{}},
@@ -369,22 +375,22 @@ func TestAgentRuntimeAdapterDelegatesTypedDurableSubmitProvenance(t *testing.T) 
 	}
 
 	adapter := newAgentRuntimeAdapter(controller)
-	if err := adapter.DurablyReportSubmitProvenance(context.Background(), agentservice.RuntimeSubmitProvenanceInput{
+	if err := adapter.UpdateSubmitProvenance(context.Background(), agentservice.RuntimeSubmitProvenanceInput{
 		WorkspaceID: "workspace-1", AgentSessionID: "session-1", TurnID: "turn-1",
-		ClientSubmitID: "submit-1", Content: agentservice.TextPromptContent("hello"),
-		CanonicalSubmitOccurredAtUnixMS: 1_234,
-		DisplayPrompt:                   "Visible hello",
+		ClientSubmitID: "submit-1", CanonicalMessageID: "message-1",
+		ProviderSessionID: "provider-session-1", ProviderTurnID: "provider-turn-1",
+		DispatchStatus: "accepted", DeliveryStatus: "accepted", CanonicalSubmitOccurredAtUnixMS: 1_234,
 	}); err != nil {
-		t.Fatalf("DurablyReportSubmitProvenance() error = %v", err)
+		t.Fatalf("UpdateSubmitProvenance() error = %v", err)
 	}
 	got := reporter.provenance
-	if got.WorkspaceID != "workspace-1" || got.Source.AgentID != "session-1" || len(got.MessageUpdates) != 1 {
+	if got.WorkspaceID != "workspace-1" || got.AgentSessionID != "session-1" || got.CanonicalTurnID != "turn-1" {
 		t.Fatalf("provenance report = %#v", got)
 	}
-	message := got.MessageUpdates[0]
-	if message.TurnID != "turn-1" || message.Seq != 1_234 || message.OccurredAtUnixMS != 1_234 ||
-		message.Payload["clientSubmitId"] != "submit-1" || message.Payload["displayPrompt"] != "Visible hello" {
-		t.Fatalf("provenance message = %#v", message)
+	if got.CanonicalMessageID != "message-1" || got.ProviderSessionID != "provider-session-1" ||
+		got.ProviderTurnID != "provider-turn-1" || got.DispatchStatus != "accepted" || got.DeliveryStatus != "accepted" ||
+		got.OccurredAtUnixMS != 1_234 {
+		t.Fatalf("provenance fields = %#v", got)
 	}
 }
 

--- a/services/tuttid/service/agent/activity_projection_ordering_test.go
+++ b/services/tuttid/service/agent/activity_projection_ordering_test.go
@@ -155,27 +155,26 @@ func TestActivityProjectionSubmitProvenanceAllowsGeneratedPromptIdentity(t *test
 	projection := NewActivityProjection(store)
 	turnID := "turn-generated-prompt"
 	messageID := "turn-user:generated-message"
-	if err := projection.ReportSubmitProvenance(ctx, agentsessionstore.ReportActivityInput{
-		WorkspaceID: "ws-generated-prompt",
-		Source: canonical.EventSource{
-			AgentID: "session-generated-prompt", Provider: "codex",
-			SessionOrigin: agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+	clientSubmitID := "submit-generated-prompt"
+	if err := projection.AdmitSubmitIntent(ctx, agentsessionstore.SubmitIntentInput{
+		WorkspaceID: "ws-generated-prompt", AgentSessionID: "session-generated-prompt",
+		ClientSubmitID: clientSubmitID, CanonicalTurnID: turnID, CanonicalMessageID: messageID,
+		State: canonical.ReportSessionStateInput{
+			WorkspaceID: "ws-generated-prompt", AgentSessionID: "session-generated-prompt",
+			Source: canonical.EventSource{AgentID: "session-generated-prompt", Provider: "codex", SessionOrigin: agentsessionstore.WorkspaceAgentSessionOriginRuntime},
+			State: canonical.WorkspaceAgentSessionStateUpdate{
+				Kind: agentactivitybiz.SessionKindRoot, Provider: "codex", LifecycleStatus: "active", CurrentPhase: "working", OccurredAtUnixMS: 1,
+				Turn: &canonical.WorkspaceAgentTurnStateUpdate{TurnID: turnID, Origin: agentactivitybiz.TurnOriginUserPrompt, ActiveTurnID: &turnID, Phase: agentactivitybiz.TurnPhaseSubmitted},
+			},
 		},
-		StatePatches: []agentsessionstore.WorkspaceAgentStatePatch{{
-			AgentSessionID: "session-generated-prompt", Kind: agentactivitybiz.SessionKindRoot,
-			Provider: "codex", LifecycleStatus: "active", CurrentPhase: "working", OccurredAtUnixMS: 1,
-			Turn: &agentsessionstore.WorkspaceAgentTurnPatch{
-				TurnID: turnID, Origin: agentactivitybiz.TurnOriginUserPrompt,
-				ActiveTurnID: &turnID, Phase: agentactivitybiz.TurnPhaseSubmitted,
-			},
-		}},
-		MessageUpdates: []agentsessionstore.WorkspaceAgentMessageUpdate{{
-			AgentSessionID: "session-generated-prompt", TurnID: turnID, MessageID: messageID,
-			Role: "user", Kind: "text", Status: "completed", OccurredAtUnixMS: 1,
-			Payload: map[string]any{
-				"content": []map[string]any{{"type": "text", "text": "hello"}},
-			},
-		}},
+		Messages: canonical.ReportSessionMessagesInput{
+			WorkspaceID: "ws-generated-prompt", AgentSessionID: "session-generated-prompt",
+			Source: canonical.EventSource{AgentID: "session-generated-prompt", Provider: "codex", SessionOrigin: agentsessionstore.WorkspaceAgentSessionOriginRuntime},
+			Updates: []canonical.WorkspaceAgentSessionMessageUpdate{{
+				TurnID: turnID, MessageID: messageID, Role: "user", Kind: "text", Status: "completed", OccurredAtUnixMS: 1,
+				Payload: map[string]any{"clientSubmitId": clientSubmitID, "content": []map[string]any{{"type": "text", "text": "hello"}}},
+			}},
+		},
 	}); err != nil {
 		t.Fatalf("generated prompt admission error = %v", err)
 	}

--- a/services/tuttid/service/agent/activity_projection_submit_provenance.go
+++ b/services/tuttid/service/agent/activity_projection_submit_provenance.go
@@ -4,135 +4,170 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 	agentactivitybiz "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 	canonical "github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
 )
 
-// ReportSubmitProvenance is a deliberately narrower contract than Report.
-// It commits the canonical user message together with the session and optional
-// new-turn patch in one repository transaction. A client-submit id is carried
-// when the caller has one; internally allocated turns use a generated message
-// id instead. The ordinary Report compatibility path persists state and
-// messages separately and therefore cannot acknowledge provider dispatch
-// safely.
-func (p *ActivityProjection) ReportSubmitProvenance(
-	ctx context.Context,
-	input agentsessionstore.ReportActivityInput,
-) error {
+type submitIntentRepository interface {
+	AdmitSubmitIntent(context.Context, agentactivitybiz.SubmitIntentAdmission) (agentactivitybiz.SubmitIntentAdmissionResult, error)
+	UpdateSubmitProvenance(context.Context, agentactivitybiz.SubmitProvenanceUpdate) (agentactivitybiz.SubmitClaim, bool, error)
+}
+
+type canonicalAgentStoreProvider interface {
+	AgentCanonicalStore() *agentactivitybiz.Store
+}
+
+func (p *ActivityProjection) submitIntentStore() (submitIntentRepository, error) {
 	if p == nil || p.repo == nil {
-		return fmt.Errorf("agent activity repository is unavailable")
+		return nil, fmt.Errorf("agent activity repository is unavailable")
 	}
-	sourceOrigin := agentsessionstore.NormalizeSessionOrigin(input.Source.SessionOrigin)
-	if sourceOrigin == "" {
-		return ErrInvalidArgument
+	if store, ok := p.repo.(submitIntentRepository); ok {
+		return store, nil
 	}
-	input.Source.SessionOrigin = sourceOrigin
-	stateInputs := agentsessionstore.SessionStateInputsFromActivity(input)
-	messageInputs, err := agentsessionstore.SessionMessageInputsFromActivity(input)
+	provider, ok := p.repo.(canonicalAgentStoreProvider)
+	if !ok || provider.AgentCanonicalStore() == nil {
+		return nil, fmt.Errorf("agent submit intent store is unavailable")
+	}
+	return provider.AgentCanonicalStore(), nil
+}
+
+// AdmitSubmitIntent is the only ActivityProjection operation that creates a
+// canonical user message. The state, turn, claim, and message are committed
+// by the store as one admission transaction.
+func (p *ActivityProjection) AdmitSubmitIntent(
+	ctx context.Context,
+	input agentsessionstore.SubmitIntentInput,
+) error {
+	store, err := p.submitIntentStore()
 	if err != nil {
 		return err
 	}
-	if len(stateInputs) != 1 || len(messageInputs) != 1 || len(messageInputs[0].Updates) != 1 {
-		return fmt.Errorf(
-			"atomic submit provenance requires one state patch and one message update; got %d state batches, %d message batches",
-			len(stateInputs),
-			len(messageInputs),
-		)
-	}
-	stateInput := stateInputs[0]
-	messageInput := messageInputs[0]
-	if strings.TrimSpace(stateInput.WorkspaceID) != strings.TrimSpace(messageInput.WorkspaceID) ||
-		strings.TrimSpace(stateInput.AgentSessionID) != strings.TrimSpace(messageInput.AgentSessionID) {
-		return fmt.Errorf("atomic submit provenance state and message scopes do not match")
-	}
-	sessionOrigin, source, err := normalizeReportSessionOrigins(stateInput.SessionOrigin, stateInput.Source)
+	stateInput := input.State
+	messageInput := input.Messages
+	stateOrigin, stateSource, err := normalizeReportSessionOrigins(stateInput.SessionOrigin, stateInput.Source)
 	if err != nil {
 		return err
 	}
-	stateInput.SessionOrigin = sessionOrigin
-	stateInput.Source = source
-	messageInput.SessionOrigin = sessionOrigin
-	messageInput.Source = source
+	messageOrigin, messageSource, err := normalizeReportSessionOrigins(messageInput.SessionOrigin, messageInput.Source)
+	if err != nil {
+		return err
+	}
+	if stateOrigin != messageOrigin || strings.TrimSpace(stateInput.WorkspaceID) != strings.TrimSpace(messageInput.WorkspaceID) ||
+		strings.TrimSpace(stateInput.AgentSessionID) != strings.TrimSpace(messageInput.AgentSessionID) ||
+		strings.TrimSpace(stateInput.WorkspaceID) != strings.TrimSpace(input.WorkspaceID) ||
+		strings.TrimSpace(stateInput.AgentSessionID) != strings.TrimSpace(input.AgentSessionID) {
+		return fmt.Errorf("submit intent state and message scopes do not match")
+	}
+	stateInput.SessionOrigin = stateOrigin
+	stateInput.Source = stateSource
+	messageInput.SessionOrigin = messageOrigin
+	messageInput.Source = messageSource
+	if len(messageInput.Updates) != 1 {
+		return fmt.Errorf("submit intent admission requires exactly one canonical message")
+	}
 	update := messageInput.Updates[0]
-	clientSubmitID, _ := update.Payload["clientSubmitId"].(string)
-	clientSubmitID = strings.TrimSpace(clientSubmitID)
-	if strings.TrimSpace(update.MessageID) == "" || strings.TrimSpace(update.TurnID) == "" {
-		return fmt.Errorf("atomic submit provenance requires message id and turn id")
+	clientSubmitID := strings.TrimSpace(input.ClientSubmitID)
+	canonicalTurnID := strings.TrimSpace(input.CanonicalTurnID)
+	if clientSubmitID == "" || canonicalTurnID == "" || strings.TrimSpace(update.MessageID) == "" ||
+		strings.TrimSpace(update.TurnID) != canonicalTurnID || payloadString(update.Payload, "clientSubmitId") != clientSubmitID {
+		return fmt.Errorf("submit intent admission identity is incomplete or mismatched")
 	}
 
 	activityReport, canonicalTargetID, err := p.activityStateReport(ctx, stateInput)
 	if err != nil {
 		return err
 	}
-	if activityReport.Turn != nil && strings.TrimSpace(activityReport.Turn.TurnID) != strings.TrimSpace(update.TurnID) {
-		return fmt.Errorf("atomic submit provenance turn patch and message turn do not match")
+	if activityReport.Turn == nil || strings.TrimSpace(activityReport.Turn.TurnID) != canonicalTurnID {
+		return fmt.Errorf("submit intent admission requires the claimed canonical turn")
 	}
 	activityReport.Messages = activityMessageUpdates(messageInput.Updates)
-	result, err := p.repo.ReportActivityState(ctx, activityReport)
+	now := input.CanonicalSubmitOccurredAtUnixMS
+	if now <= 0 {
+		now = update.OccurredAtUnixMS
+	}
+	if now <= 0 {
+		now = stateInput.State.OccurredAtUnixMS
+	}
+	if now <= 0 {
+		now = time.Now().UnixMilli()
+	}
+	result, err := store.AdmitSubmitIntent(ctx, agentactivitybiz.SubmitIntentAdmission{
+		Claim: agentactivitybiz.SubmitClaimPrepare{
+			WorkspaceID: strings.TrimSpace(input.WorkspaceID), AgentSessionID: strings.TrimSpace(input.AgentSessionID),
+			ClientSubmitID: clientSubmitID, CanonicalTurnID: canonicalTurnID,
+			CanonicalMessageID: strings.TrimSpace(firstNonEmptyString(input.CanonicalMessageID, update.MessageID)), NowUnixMS: now,
+		},
+		Activity: activityReport,
+	})
 	if err != nil {
 		return err
 	}
-	if !result.State.Accepted || result.Messages.AcceptedCount != 1 || len(result.Messages.Messages) != 1 {
-		return fmt.Errorf(
-			"atomic submit provenance was not fully accepted: state=%t messages=%d",
-			result.State.Accepted,
-			result.Messages.AcceptedCount,
-		)
-	}
-	message := result.Messages.Messages[0]
-	if strings.TrimSpace(message.TurnID) != strings.TrimSpace(update.TurnID) ||
-		(clientSubmitID != "" && strings.TrimSpace(payloadString(message.Payload, "clientSubmitId")) != clientSubmitID) {
-		return fmt.Errorf("atomic submit provenance did not preserve canonical message identity")
+	if !result.Activity.State.Accepted || result.Activity.Messages.AcceptedCount != 1 || len(result.Activity.Messages.Messages) != 1 {
+		return fmt.Errorf("submit intent admission was not fully accepted")
 	}
 
 	stateReply := canonical.ReportSessionStateReply{
-		Accepted:          result.State.Accepted,
-		StateApplied:      result.State.StateApplied,
-		LastEventAtUnixMS: result.State.LastEventUnixMS,
-		RequestBodyBytes:  result.State.RequestBodyBytes,
+		Accepted: result.Activity.State.Accepted, StateApplied: result.Activity.State.StateApplied,
+		LastEventAtUnixMS: result.Activity.State.LastEventUnixMS, RequestBodyBytes: result.Activity.State.RequestBodyBytes,
 	}
 	provisional := activityStateIsProvisional(stateInput)
 	if !provisional {
-		p.publishPersistedTurnState(ctx, stateInput, result)
+		p.publishPersistedTurnState(ctx, stateInput, result.Activity)
 	}
 	if provisional {
 		p.observeSessionState(ctx, stateInput, stateReply)
 		p.observeSessionMessages(ctx, messageInput, canonical.ReportSessionMessagesReply{
-			AcceptedCount: result.Messages.AcceptedCount,
-			LatestVersion: result.Messages.LatestVersion,
+			AcceptedCount: result.Activity.Messages.AcceptedCount, LatestVersion: result.Activity.Messages.LatestVersion,
 		})
 		return nil
 	}
-	p.publishActivityUpdated(
-		ctx,
-		stateInput.WorkspaceID,
-		stateInput.AgentSessionID,
-		"session_reconcile_required",
-		activitySessionUpdateEventPayload(
-			stateInput.WorkspaceID,
-			stateInput.AgentSessionID,
-			result.State.LastEventUnixMS,
-			canonicalTargetID,
-		),
-	)
+	p.publishActivityUpdated(ctx, stateInput.WorkspaceID, stateInput.AgentSessionID, "session_reconcile_required",
+		activitySessionUpdateEventPayload(stateInput.WorkspaceID, stateInput.AgentSessionID, result.Activity.State.LastEventUnixMS, canonicalTargetID))
 	p.observeSessionState(ctx, stateInput, stateReply)
-
-	publishedAgentSessionID := canonicalMessageUpdateSessionID(messageInput.AgentSessionID, result.Messages.Messages)
+	publishedAgentSessionID := canonicalMessageUpdateSessionID(messageInput.AgentSessionID, result.Activity.Messages.Messages)
 	p.publishActivityUpdated(ctx, messageInput.WorkspaceID, publishedAgentSessionID, "message_update", map[string]any{
-		"acceptedCount":  result.Messages.AcceptedCount,
-		"agentSessionId": publishedAgentSessionID,
-		"eventType":      "message_update",
-		"latestVersion":  result.Messages.LatestVersion,
-		"messages":       activityMessagesEventPayload(result.Messages.Messages),
-		"workspaceId":    strings.TrimSpace(messageInput.WorkspaceID),
+		"acceptedCount": result.Activity.Messages.AcceptedCount, "agentSessionId": publishedAgentSessionID,
+		"eventType": "message_update", "latestVersion": result.Activity.Messages.LatestVersion,
+		"messages": activityMessagesEventPayload(result.Activity.Messages.Messages), "workspaceId": strings.TrimSpace(messageInput.WorkspaceID),
 	})
 	p.observeSessionMessages(ctx, messageInput, canonical.ReportSessionMessagesReply{
-		AcceptedCount: result.Messages.AcceptedCount,
-		LatestVersion: result.Messages.LatestVersion,
+		AcceptedCount: result.Activity.Messages.AcceptedCount, LatestVersion: result.Activity.Messages.LatestVersion,
 	})
 	return nil
+}
+
+// UpdateSubmitProvenance only advances submit identity and delivery facts. It
+// deliberately has no state or message payload and therefore cannot rewrite
+// the canonical user message admitted above.
+func (p *ActivityProjection) UpdateSubmitProvenance(
+	ctx context.Context,
+	input agentsessionstore.SubmitProvenanceInput,
+) error {
+	store, err := p.submitIntentStore()
+	if err != nil {
+		return err
+	}
+	input.WorkspaceID = strings.TrimSpace(input.WorkspaceID)
+	input.AgentSessionID = strings.TrimSpace(input.AgentSessionID)
+	input.ClientSubmitID = strings.TrimSpace(input.ClientSubmitID)
+	input.CanonicalTurnID = strings.TrimSpace(input.CanonicalTurnID)
+	if input.WorkspaceID == "" || input.AgentSessionID == "" || input.ClientSubmitID == "" || input.CanonicalTurnID == "" {
+		return fmt.Errorf("submit provenance identity is incomplete")
+	}
+	if input.OccurredAtUnixMS <= 0 {
+		input.OccurredAtUnixMS = time.Now().UnixMilli()
+	}
+	_, _, err = store.UpdateSubmitProvenance(ctx, agentactivitybiz.SubmitProvenanceUpdate{
+		WorkspaceID: input.WorkspaceID, AgentSessionID: input.AgentSessionID, ClientSubmitID: input.ClientSubmitID,
+		CanonicalTurnID: input.CanonicalTurnID, CanonicalMessageID: strings.TrimSpace(input.CanonicalMessageID),
+		ProviderSessionID: strings.TrimSpace(input.ProviderSessionID), ProviderTurnID: strings.TrimSpace(input.ProviderTurnID),
+		DispatchStatus: strings.TrimSpace(input.DispatchStatus), DeliveryStatus: strings.TrimSpace(input.DeliveryStatus),
+		FailureReason: strings.TrimSpace(input.FailureReason), NowUnixMS: input.OccurredAtUnixMS,
+	})
+	return err
 }
 
 func (p *ActivityProjection) activityStateReport(

--- a/services/tuttid/service/agent/canonical_session_initialization_integration_test.go
+++ b/services/tuttid/service/agent/canonical_session_initialization_integration_test.go
@@ -64,11 +64,18 @@ func (r *canonicalInitializationIntegrationReporter) Report(
 	return r.projection.Report(ctx, input)
 }
 
-func (r *canonicalInitializationIntegrationReporter) ReportSubmitProvenance(
+func (r *canonicalInitializationIntegrationReporter) AdmitSubmitIntent(
 	ctx context.Context,
-	input agentsessionstore.ReportActivityInput,
+	input agentsessionstore.SubmitIntentInput,
 ) error {
-	return r.projection.ReportSubmitProvenance(ctx, input)
+	return r.projection.AdmitSubmitIntent(ctx, input)
+}
+
+func (r *canonicalInitializationIntegrationReporter) UpdateSubmitProvenance(
+	ctx context.Context,
+	input agentsessionstore.SubmitProvenanceInput,
+) error {
+	return r.projection.UpdateSubmitProvenance(ctx, input)
 }
 
 func (r *canonicalInitializationIntegrationReporter) snapshot() agentsessionstore.ReportActivityInput {

--- a/services/tuttid/service/agent/host_test_adapters_test.go
+++ b/services/tuttid/service/agent/host_test_adapters_test.go
@@ -397,15 +397,15 @@ func (a serviceHostRuntime) Exec(ctx context.Context, input RuntimeExecInput) (R
 	result, err := a.service.controller().Exec(ctx, input)
 	return result, normalizeRuntimeError(err)
 }
-func (a serviceHostRuntime) DurablyReportSubmitProvenance(ctx context.Context, input RuntimeSubmitProvenanceInput) error {
+func (a serviceHostRuntime) UpdateSubmitProvenance(ctx context.Context, input RuntimeSubmitProvenanceInput) error {
 	reporter, ok := a.service.controller().(interface {
-		DurablyReportSubmitProvenance(context.Context, RuntimeSubmitProvenanceInput) error
+		UpdateSubmitProvenance(context.Context, RuntimeSubmitProvenanceInput) error
 	})
 	if !ok && !input.Guidance && a.service.TuttiModeActivations != nil {
 		return errors.New("agent runtime does not support durable submit provenance")
 	}
 	if ok {
-		if err := reporter.DurablyReportSubmitProvenance(ctx, input); err != nil {
+		if err := reporter.UpdateSubmitProvenance(ctx, input); err != nil {
 			return err
 		}
 	}

--- a/services/tuttid/service/agent/service_host_create_rollback_test.go
+++ b/services/tuttid/service/agent/service_host_create_rollback_test.go
@@ -131,11 +131,7 @@ func TestHostCreateRetainsVisibleFailedTurnAfterExplicitProviderRejection(t *tes
 		}, execErr
 	}
 	runtime.provenanceHook = func(input RuntimeSubmitProvenanceInput) error {
-		content := "start atomically"
-		if len(input.Content) > 0 && input.Content[0].Text != "" {
-			content = input.Content[0].Text
-		}
-		return projection.ReportSubmitProvenance(ctx, agentsessionstore.ReportActivityInput{
+		if err := projection.Report(ctx, agentsessionstore.ReportActivityInput{
 			WorkspaceID: input.WorkspaceID,
 			Source: canonical.EventSource{
 				AgentID: input.AgentSessionID, Provider: "claude-code",
@@ -143,26 +139,23 @@ func TestHostCreateRetainsVisibleFailedTurnAfterExplicitProviderRejection(t *tes
 			},
 			StatePatches: []agentsessionstore.WorkspaceAgentStatePatch{{
 				AgentSessionID: input.AgentSessionID, Kind: storesqlite.SessionKindRoot,
-				Provider: "claude-code", LifecycleStatus: "failed", CurrentPhase: "failed",
-				LastError: execErr.Error(), OccurredAtUnixMS: input.CanonicalSubmitOccurredAtUnixMS + 1,
+				Provider: "claude-code", CurrentPhase: "failed", OccurredAtUnixMS: input.CanonicalSubmitOccurredAtUnixMS + 1,
 				RuntimeContext: map[string]any{"visible": true, "provisional": false},
 				Turn: &agentsessionstore.WorkspaceAgentTurnPatch{
 					TurnID: input.TurnID, Origin: storesqlite.TurnOriginUserPrompt,
 					Phase: storesqlite.TurnPhaseSettled, Outcome: storesqlite.TurnOutcomeFailed,
+					ErrorCode: execErr.Code, ErrorMessage: execErr.Message,
 				},
 			}},
-			MessageUpdates: []agentsessionstore.WorkspaceAgentMessageUpdate{{
-				AgentSessionID: input.AgentSessionID,
-				MessageID:      "client-submit:user:" + input.ClientSubmitID,
-				TurnID:         input.TurnID, Role: "user", Kind: "text", Status: "completed",
-				OccurredAtUnixMS: input.CanonicalSubmitOccurredAtUnixMS,
-				Payload: map[string]any{
-					"clientSubmitId":          input.ClientSubmitID,
-					"clientSubmittedAtUnixMs": input.CanonicalSubmitOccurredAtUnixMS,
-					"content":                 []map[string]any{{"type": "text", "text": content}},
-					"contentMode":             "snapshot", "source": "host", "text": content,
-				},
-			}},
+		}); err != nil {
+			return err
+		}
+		return projection.UpdateSubmitProvenance(ctx, agentsessionstore.SubmitProvenanceInput{
+			WorkspaceID: input.WorkspaceID, AgentSessionID: input.AgentSessionID, ClientSubmitID: input.ClientSubmitID,
+			CanonicalTurnID: input.TurnID, CanonicalMessageID: "client-submit:user:" + input.ClientSubmitID,
+			ProviderSessionID: input.ProviderSessionID, ProviderTurnID: input.ProviderTurnID,
+			DispatchStatus: "failed", DeliveryStatus: "failed", FailureReason: execErr.Error(),
+			OccurredAtUnixMS: input.CanonicalSubmitOccurredAtUnixMS + 1,
 		})
 	}
 	service := newTestService(runtime)
@@ -197,11 +190,8 @@ func TestHostCreateRetainsVisibleFailedTurnAfterExplicitProviderRejection(t *tes
 	page, ok, err := store.ListSessionMessages(ctx, storesqlite.ListSessionMessagesInput{
 		WorkspaceID: "ws-rejected", AgentSessionID: "session-rejected", Order: storesqlite.MessageOrderAsc, Limit: 10,
 	})
-	if err != nil || !ok || len(page.Messages) != 1 {
-		t.Fatalf("canonical messages after rejection page=%#v ok=%v error=%v session=%#v provenance=%#v", page, ok, err, session, runtime.provenanceCalls)
-	}
-	if page.Messages[0].Payload["text"] != "start atomically" {
-		t.Fatalf("canonical prompt after rejection payload=%#v", page.Messages[0].Payload)
+	if err != nil || !ok || len(page.Messages) != 0 {
+		t.Fatalf("canonical messages after rejection page=%#v ok=%v error=%v session=%#v provenance=%#v, want no hook replay", page, ok, err, session, runtime.provenanceCalls)
 	}
 	if len(runtime.provenanceCalls) != 1 {
 		t.Fatalf("submit provenance calls=%d, want 1", len(runtime.provenanceCalls))

--- a/services/tuttid/service/agent/service_send_resume_test.go
+++ b/services/tuttid/service/agent/service_send_resume_test.go
@@ -220,8 +220,8 @@ func TestServiceSendInputPersistsPromptAfterRuntimeDispatchError(t *testing.T) {
 	}
 	provenance := runtime.provenanceCalls[0]
 	if provenance.ClientSubmitID != input.ClientSubmitID || provenance.TurnID == "" ||
-		len(provenance.Content) != 1 || provenance.Content[0].Text != "keep this prompt" {
-		t.Fatalf("provenance = %#v, want rejected prompt preserved", provenance)
+		provenance.CanonicalMessageID != "client-submit:user:"+input.ClientSubmitID || provenance.FailureReason != providerErr.Error() {
+		t.Fatalf("provenance = %#v, want rejected submit identity and failure only", provenance)
 	}
 }
 

--- a/services/tuttid/service/agent/service_test_runtime_test.go
+++ b/services/tuttid/service/agent/service_test_runtime_test.go
@@ -665,7 +665,7 @@ func (f *fakeRuntime) Exec(_ context.Context, input RuntimeExecInput) (RuntimeEx
 	}, nil
 }
 
-func (f *fakeRuntime) DurablyReportSubmitProvenance(_ context.Context, input RuntimeSubmitProvenanceInput) error {
+func (f *fakeRuntime) UpdateSubmitProvenance(_ context.Context, input RuntimeSubmitProvenanceInput) error {
 	f.provenanceCalls = append(f.provenanceCalls, input)
 	if f.provenanceHook != nil {
 		return f.provenanceHook(input)

--- a/services/tuttid/service/agent/service_tutti_mode_activation_test.go
+++ b/services/tuttid/service/agent/service_tutti_mode_activation_test.go
@@ -634,37 +634,12 @@ func TestSubmitClaimRejectedReplayReusesFailedTurnWithoutProviderRedispatch(t *t
 		}, wantErr
 	}
 	runtime.provenanceHook = func(input RuntimeSubmitProvenanceInput) error {
-		content := "hello"
-		if len(input.Content) > 0 && input.Content[0].Text != "" {
-			content = input.Content[0].Text
-		}
-		return projection.ReportSubmitProvenance(ctx, agentsessionstore.ReportActivityInput{
-			WorkspaceID: input.WorkspaceID,
-			Source: canonical.EventSource{
-				AgentID: input.AgentSessionID, Provider: "codex",
-				SessionOrigin: agentsessionstore.WorkspaceAgentSessionOriginRuntime,
-			},
-			StatePatches: []agentsessionstore.WorkspaceAgentStatePatch{{
-				AgentSessionID: input.AgentSessionID, Kind: agentactivitybiz.SessionKindRoot,
-				Provider: "codex", LifecycleStatus: "failed", CurrentPhase: "failed",
-				LastError: wantErr.Error(), OccurredAtUnixMS: input.CanonicalSubmitOccurredAtUnixMS + 1,
-				RuntimeContext: map[string]any{"visible": true, "provisional": false},
-				Turn: &agentsessionstore.WorkspaceAgentTurnPatch{
-					TurnID: input.TurnID, Origin: agentactivitybiz.TurnOriginUserPrompt,
-					Phase: agentactivitybiz.TurnPhaseSettled, Outcome: agentactivitybiz.TurnOutcomeFailed,
-				},
-			}},
-			MessageUpdates: []agentsessionstore.WorkspaceAgentMessageUpdate{{
-				AgentSessionID: input.AgentSessionID,
-				MessageID:      "client-submit:user:" + input.ClientSubmitID,
-				TurnID:         input.TurnID, Role: "user", Kind: "text", Status: "completed",
-				OccurredAtUnixMS: input.CanonicalSubmitOccurredAtUnixMS,
-				Payload: map[string]any{
-					"clientSubmitId": input.ClientSubmitID,
-					"content":        []map[string]any{{"type": "text", "text": content}},
-					"contentMode":    "snapshot", "source": "host", "text": content,
-				},
-			}},
+		return projection.UpdateSubmitProvenance(ctx, agentsessionstore.SubmitProvenanceInput{
+			WorkspaceID: input.WorkspaceID, AgentSessionID: input.AgentSessionID, ClientSubmitID: input.ClientSubmitID,
+			CanonicalTurnID: input.TurnID, CanonicalMessageID: "client-submit:user:" + input.ClientSubmitID,
+			ProviderSessionID: input.ProviderSessionID, ProviderTurnID: input.ProviderTurnID,
+			DispatchStatus: "failed", DeliveryStatus: "failed", FailureReason: wantErr.Error(),
+			OccurredAtUnixMS: input.CanonicalSubmitOccurredAtUnixMS + 1,
 		})
 	}
 	service := newTestService(runtime)

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -197,6 +197,7 @@ type RuntimeController interface {
 	Start(context.Context, RuntimeStartInput) (RuntimeStartResult, error)
 	SubmitInteractive(context.Context, RuntimeSubmitInteractiveInput) (RuntimeSubmitInteractiveResult, error)
 	InteractiveDisposition(workspaceID string, rootAgentSessionID string, agentSessionID string, turnID string, requestID string) RuntimeInteractiveDisposition
+	UpdateSubmitProvenance(context.Context, RuntimeSubmitProvenanceInput) error
 	Subscribe(workspaceID string, agentSessionID string) (<-chan RuntimeStreamEvent, func(), bool)
 	UpdateSettings(context.Context, RuntimeUpdateSettingsInput) error
 	ValidatePromptContent(context.Context, RuntimeExecInput) error


### PR DESCRIPTION
## Summary
- Make Controller the sole owner of canonical user-message admission.
- Add durable submit intent and provenance updates keyed by clientSubmitId, with provider/session/turn delivery facts kept separate from canonical content.
- Separate composer intent, attachment preparation, and presentation state; add revision-based draft clearing and stale upload guards.
- Preserve prompt.id as queue identity distinct from clientSubmitId.

## Why
The Controller, Provider runtime, and Host could all replay the same canonical user message. This makes admission durable before provider dispatch and makes retries idempotent state updates instead of payload rewrites.

## Tests
- `git commit` pre-commit checks passed.
- `pnpm check:changed -- --push-ready` passed all 25 lanes.
- Targeted Agent GUI and Go tests passed during iteration.

## Notes
- This is the upstream contract change consumed by the companion TSH PR.
- The branch intentionally remains behind main; no rebase was performed.