### PR TITLE
feat(connectors): install verified remote archives

### DIFF
--- a/docs/architecture/connector-market.md
+++ b/docs/architecture/connector-market.md
@@ -130,6 +130,17 @@ permission only for that entry, then verifies its exact size and SHA-256 at
 every launch. Windows executes the declared `.exe` directly; `.cmd` remains a
 user-facing PATH projection rather than the native launch boundary.
 
+A CLI may declare `remote_archive` when its publisher distributes a signed
+platform archive directly. The connector artifact signs the exact HTTPS URL,
+redirect-host allowlist, archive size and SHA-256, expected extracted file
+count and byte count, canonical tree digest, and native entrypoint identity.
+During release installation the host downloads the archive once with bounded
+I/O, safely extracts only regular files into a release-scoped staging tree,
+verifies the complete inventory and entrypoint, and atomically promotes the
+read-only tree. Normal CLI execution never downloads or updates the runtime.
+The first implementation is Linux-only and fails closed on Windows until a
+reparse-point-safe activation adapter is available.
+
 One portable install artifact may contain binaries for multiple exact targets.
 The signed v3 manifest selects one target implementation without OS or
 architecture fallback; unused target files remain inert data in that release.
@@ -149,6 +160,15 @@ typed node_package intent
     -> shared content-addressed store + release-scoped link tree
     -> verify package name, exact version, sha512 integrity, lock, and bin entry
     -> atomically publish the installation receipt
+```
+
+```text
+typed remote_archive intent
+    -> fetch an allowlisted public HTTPS origin without credentials
+    -> verify exact Content-Length, downloaded size, and archive SHA-256
+    -> safely extract into a release-scoped staging directory
+    -> verify file count, expanded bytes, canonical inventory, and entrypoint
+    -> atomically promote the immutable tree and publish a v2 receipt
 ```
 
 A device has one active connector Node runtime. Connector manifests may state
@@ -272,7 +292,8 @@ implementation host, process, and product-command adapters. In Tutti, `managed_s
 connectors resolve an exact Node/Python runtime profile. MCP servers are
 long-lived daemon children governed by the route generation fence and process
 registry. CLI routes instead atomically publish stable shims that directly exec
-the verified release entrypoint through the Agent's normal shell; the physical
+the verified release entrypoint through the Agent's normal shell while
+preserving the caller's working directory; the physical
 installer owns receipt-based installation inspection, while the process adapter
 handles CLI readiness and credential-broker operations. Both interfaces use the same verified artifact snapshot,
 executable identity, generation lifecycle, and connection-scoped state path.

--- a/docs/architecture/connector-market.md
+++ b/docs/architecture/connector-market.md
@@ -138,8 +138,13 @@ During release installation the host downloads the archive once with bounded
 I/O, safely extracts only regular files into a release-scoped staging tree,
 verifies the complete inventory and entrypoint, and atomically promotes the
 read-only tree. Normal CLI execution never downloads or updates the runtime.
-The first implementation is Linux-only and fails closed on Windows until a
-reparse-point-safe activation adapter is available.
+The first implementation accepts ZIP archives on Linux only and fails closed
+on Windows until a reparse-point-safe activation adapter is available.
+Remote archive downloads bypass daemon and environment HTTP proxies so the
+transport can pin the public DNS addresses validated for that request. This is
+an intentional exception to the normal daemon proxy funnel: a proxy would
+resolve the CONNECT target independently and break the validation-to-socket
+binding.
 
 One portable install artifact may contain binaries for multiple exact targets.
 The signed v3 manifest selects one target implementation without OS or
@@ -170,6 +175,11 @@ typed remote_archive intent
     -> verify file count, expanded bytes, canonical inventory, and entrypoint
     -> atomically promote the immutable tree and publish a v2 receipt
 ```
+
+Protocol v1 keeps the existing `managed_stdio` runtime contract, so even a
+self-contained native archive declares and resolves `connector-node-static`.
+Removing that compatibility dependency requires a separate native-only runtime
+profile and is not implicit in `remote_archive`.
 
 A device has one active connector Node runtime. Connector manifests may state
 an explicit Node version range, but cannot download Node or select a second
@@ -297,6 +307,12 @@ preserving the caller's working directory; the physical
 installer owns receipt-based installation inspection, while the process adapter
 handles CLI readiness and credential-broker operations. Both interfaces use the same verified artifact snapshot,
 executable identity, generation lifecycle, and connection-scoped state path.
+The stable PATH shim is a same-user compatibility surface, not a per-invocation
+attestation or authorization boundary: daemon-managed readiness and `StartCLI`
+reverify tree identity, while shell invocation relies on the read-only,
+release-scoped tree verified at activation. Protecting against a process that
+already has the user's ability to chmod and rewrite connector state requires a
+future shim-to-daemon launcher and is outside this local same-user threat model.
 An installed runtime is daemon-global and is available to every Agent and the
 local Tutti CLI. TSH runs the same runtime module inside its managed VM and
 supplies a guest process adapter.

--- a/packages/connector/daemon/catalog_source.go
+++ b/packages/connector/daemon/catalog_source.go
@@ -31,9 +31,13 @@ type CatalogSourceConfig struct {
 	ExpectedMarketType string
 	HTTPClient         *http.Client
 	AuthorizeRequest   RequestAuthorizer
-	// ExecutionTarget selects a Connector v3 target. Empty defaults to the
+	// ExecutionTarget selects a Connector v3 or v4 target. Empty defaults to the
 	// daemon process GOOS/GOARCH, which is the correct target for desktop Tutti.
-	ExecutionTarget string
+	ExecutionTarget    string
+	HostProduct        string
+	HostVersion        string
+	MaxConnectorSchema int
+	HostCapabilities   []string
 }
 
 type CatalogSource struct {
@@ -42,6 +46,10 @@ type CatalogSource struct {
 	httpClient         *http.Client
 	authorizeRequest   RequestAuthorizer
 	executionTarget    string
+	hostProduct        string
+	hostVersion        string
+	maxConnectorSchema int
+	hostCapabilities   []string
 }
 
 var _ market.CatalogSource = (*CatalogSource)(nil)
@@ -73,7 +81,9 @@ func NewCatalogSource(config CatalogSourceConfig) (*CatalogSource, error) {
 		return nil, executionTargetErr
 	}
 	return &CatalogSource{baseURL: baseURL, expectedMarketType: expectedMarketType,
-		httpClient: client, authorizeRequest: config.AuthorizeRequest, executionTarget: executionTarget}, nil
+		httpClient: client, authorizeRequest: config.AuthorizeRequest, executionTarget: executionTarget,
+		hostProduct: strings.TrimSpace(config.HostProduct), hostVersion: strings.TrimSpace(config.HostVersion),
+		maxConnectorSchema: config.MaxConnectorSchema, hostCapabilities: append([]string(nil), config.HostCapabilities...)}, nil
 }
 
 func (source *CatalogSource) Refresh(ctx context.Context) (market.CatalogSnapshot, error) {
@@ -128,7 +138,9 @@ func (source *CatalogSource) Refresh(ctx context.Context) (market.CatalogSnapsho
 
 func (source *CatalogSource) ListCategories(ctx context.Context) ([]market.CatalogCategory, error) {
 	var payload wireMarketCategoriesResponse
-	if _, err := source.getJSON(ctx, connectorCategoriesPath, url.Values{"itemType": {"connector"}}, &payload); err != nil {
+	query := url.Values{"itemType": {"connector"}}
+	source.addHostCohort(query)
+	if _, err := source.getJSON(ctx, connectorCategoriesPath, query, &payload); err != nil {
 		return nil, err
 	}
 	if payload.MarketType != source.expectedMarketType {
@@ -158,6 +170,7 @@ func (source *CatalogSource) ListPage(ctx context.Context, input market.CatalogS
 	if token := strings.TrimSpace(input.PageToken); token != "" {
 		query.Set("pageToken", token)
 	}
+	source.addHostCohort(query)
 	var payload wireMarketResponse
 	if _, err := source.getJSON(ctx, connectorCatalogPath, query, &payload); err != nil {
 		return market.CatalogSourcePage{}, err
@@ -177,6 +190,19 @@ func (source *CatalogSource) ListPage(ctx context.Context, input market.CatalogS
 		entries = append(entries, market.CatalogEntry{CategoryID: item.CategoryID, Featured: item.Featured, Release: release})
 	}
 	return market.CatalogSourcePage{SectionID: strings.TrimSpace(input.SectionID), Entries: entries, NextPageToken: payload.NextPageToken}, nil
+}
+
+func (source *CatalogSource) addHostCohort(query url.Values) {
+	if source == nil || strings.TrimSpace(source.hostProduct) == "" || strings.TrimSpace(source.hostVersion) == "" || source.maxConnectorSchema <= 0 {
+		return
+	}
+	query.Set("hostProduct", source.hostProduct)
+	query.Set("hostVersion", source.hostVersion)
+	query.Set("executionTarget", source.executionTarget)
+	query.Set("maxConnectorSchema", strconv.Itoa(source.maxConnectorSchema))
+	for _, capability := range source.hostCapabilities {
+		query.Add("hostCapabilities", capability)
+	}
 }
 
 func (source *CatalogSource) getJSON(ctx context.Context, requestPath string, query url.Values, target any) ([]byte, error) {
@@ -263,7 +289,7 @@ func (source *CatalogSource) mapItem(item wireMarketItem) (market.Release, error
 		iconURL = legacyConnectorIconURL
 	}
 	// The server's v2 envelope is the generic, market-neutral publication
-	// contract. V3 selects one target first. Both project into the stable host
+	// contract. V3 and v4 select one target first. All project into the stable host
 	// manifest contract; these schema versions describe different boundaries.
 	manifest := market.Manifest{SchemaVersion: "1", DisplayName: connectorManifest.Display.Name, IconURL: iconURL,
 		Description: connectorManifest.Display.Description, AgentRouting: connectorManifest.Payload.AgentRouting,
@@ -292,9 +318,9 @@ func (source *CatalogSource) resolveManifestImplementation(manifest wireConnecto
 			return market.Implementation{}, errors.New("connector v2 manifest must provide one market-neutral implementation")
 		}
 		return *payload.Implementation, nil
-	case "3":
+	case "3", "4":
 		if payload.Implementation != nil || len(payload.TargetImplementations) == 0 {
-			return market.Implementation{}, errors.New("connector v3 manifest must provide targetImplementations")
+			return market.Implementation{}, errors.New("targeted connector manifest must provide targetImplementations")
 		}
 		return market.ResolveTargetImplementation(source.executionTarget, payload.TargetImplementations)
 	default:

--- a/packages/connector/daemon/catalog_source_test.go
+++ b/packages/connector/daemon/catalog_source_test.go
@@ -20,6 +20,11 @@ func TestCatalogSourceMapsPublishedConnectorItemsWithAdditiveFields(t *testing.T
 		if request.URL.Query().Get("itemType") != "connector" {
 			t.Fatalf("request path=%q query=%q", request.URL.Path, request.URL.RawQuery)
 		}
+		query := request.URL.Query()
+		if query.Get("hostProduct") != "tutti" || query.Get("hostVersion") != "0.2.27" || query.Get("executionTarget") != "darwin-arm64" ||
+			query.Get("maxConnectorSchema") != "4" || strings.Join(query["hostCapabilities"], ",") != "connector.install.remote-archive.v1" {
+			t.Fatalf("request path=%q cohort query=%q", request.URL.Path, request.URL.RawQuery)
+		}
 		writer.Header().Set("Content-Type", "application/json")
 		if request.URL.Path == connectorCategoriesPath {
 			_, _ = writer.Write([]byte(`{
@@ -91,6 +96,8 @@ func TestCatalogSourceMapsPublishedConnectorItemsWithAdditiveFields(t *testing.T
 			request.Header.Set("Authorization", "Bearer catalog-token")
 			return nil
 		},
+		ExecutionTarget: "darwin-arm64", HostProduct: "tutti", HostVersion: "0.2.27", MaxConnectorSchema: 4,
+		HostCapabilities: []string{"connector.install.remote-archive.v1"},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/packages/connector/host/application_receipts.go
+++ b/packages/connector/host/application_receipts.go
@@ -90,7 +90,7 @@ func validateReleaseInstallationReceipt(operation Operation, release Release, re
 	if err := validatePreparedArtifact(operation, release, receipt.Artifact); err != nil {
 		return err
 	}
-	cliInstall := releaseCLIInstallation(release)
+	cliInstall := releaseCLIInstallationIntent(release)
 	if cliInstall == nil {
 		if receipt.CLIInstallation != nil {
 			return invalidOperationReceipt("release installer returned an unexpected CLI receipt")
@@ -100,7 +100,28 @@ func validateReleaseInstallationReceipt(operation Operation, release Release, re
 	if receipt.CLIInstallation == nil {
 		return invalidOperationReceipt("release installer did not return the required CLI receipt")
 	}
-	return validateCLIInstallationReceipt(operation, release, *cliInstall, *receipt.CLIInstallation)
+	switch cliInstall.Kind {
+	case "node_package":
+		if cliInstall.NodePackage == nil {
+			return invalidOperationReceipt("release has an invalid node package installation")
+		}
+		return validateCLIInstallationReceipt(operation, release, *cliInstall.NodePackage, *receipt.CLIInstallation)
+	case "remote_archive":
+		if cliInstall.RemoteArchive == nil {
+			return invalidOperationReceipt("release has an invalid remote archive installation")
+		}
+		return validateRemoteArchiveInstallationReceipt(operation, release, *cliInstall.RemoteArchive, *receipt.CLIInstallation)
+	default:
+		return invalidOperationReceipt("release has an unsupported CLI installation")
+	}
+}
+
+func releaseCLIInstallationIntent(release Release) *CLIInstallation {
+	managed := release.Manifest.Implementation.ManagedStdio
+	if managed == nil || managed.CLI == nil {
+		return nil
+	}
+	return managed.CLI.Install
 }
 
 func releaseCLIInstallation(release Release) *NodePackageInstallation {
@@ -128,6 +149,26 @@ func validateCLIInstallationReceipt(operation Operation, release Release, instal
 	remoteReceipt := strings.TrimSpace(receipt.OpaqueInstallationRef) != ""
 	if !localReceipt && !remoteReceipt {
 		return invalidOperationReceipt("CLI installer returned a mismatched receipt")
+	}
+	return nil
+}
+
+func validateRemoteArchiveInstallationReceipt(operation Operation, release Release, install RemoteArchiveInstallation, receipt CLIInstallationReceipt) error {
+	if receipt.SchemaVersion != "tutti.connector.cli-installation.v2" || receipt.InstallKind != "remote_archive" ||
+		receipt.OperationID != operation.OperationID || receipt.ConnectorKey != release.ConnectorKey || receipt.ReleaseDigest != release.ReleaseDigest ||
+		receipt.RuntimeProfile != release.Manifest.Implementation.ManagedStdio.Runtime.Profile ||
+		receipt.RuntimeABI != release.Manifest.Implementation.ManagedStdio.Runtime.ABI ||
+		receipt.ArchiveSHA256 != install.Source.SHA256 || receipt.ArchiveSize != install.Source.SizeBytes || receipt.ArchiveFormat != install.Source.Format ||
+		receipt.InventoryAlgorithm != install.Extraction.InventoryAlgorithm || receipt.InventorySHA256 != install.Extraction.InventorySHA256 ||
+		receipt.FileCount != install.Extraction.FileCount || receipt.ExpandedSizeBytes != install.Extraction.ExpandedSizeBytes ||
+		receipt.LaunchKind != install.Launch.Kind || receipt.Entrypoint != install.Launch.Entrypoint ||
+		receipt.EntrypointSHA256 != install.Launch.SHA256 || receipt.EntrypointSize != install.Launch.SizeBytes {
+		return invalidOperationReceipt("remote archive installer returned a mismatched receipt")
+	}
+	localReceipt := filepath.IsAbs(receipt.InstallRoot) && strings.TrimSpace(receipt.OpaqueInstallationRef) == ""
+	remoteReceipt := strings.TrimSpace(receipt.OpaqueInstallationRef) != "" && receipt.InstallRoot == ""
+	if !localReceipt && !remoteReceipt {
+		return invalidOperationReceipt("remote archive installer returned an invalid location")
 	}
 	return nil
 }

--- a/packages/connector/host/application_test.go
+++ b/packages/connector/host/application_test.go
@@ -359,6 +359,43 @@ func TestCrossMachineReceiptsUseOpaqueReferences(t *testing.T) {
 	}
 }
 
+func TestRemoteArchiveReceiptRequiresExactSignedIdentityAndOneLocation(t *testing.T) {
+	release := testReleaseWithImplementation("aws-cli", "0.2.0", ImplementationKindManagedStdio)
+	managed := release.Manifest.Implementation.ManagedStdio
+	managed.MCP = nil
+	managed.Runtime = RuntimeRequirement{Language: "node", Profile: "connector-node-static", ABI: "node24-linux-arm64", VersionRange: ">=24.0.0 <25.0.0"}
+	install := RemoteArchiveInstallation{
+		Source:     RemoteArchiveSource{URL: "https://awscli.amazonaws.com/aws.zip", AllowedHosts: []string{"awscli.amazonaws.com"}, Format: "zip", SHA256: strings.Repeat("a", 64), SizeBytes: 10},
+		Extraction: RemoteArchiveExtraction{Root: "aws", FileCount: 2, ExpandedSizeBytes: 7, InventoryAlgorithm: "tutti.connector.tree.v1", InventorySHA256: strings.Repeat("b", 64)},
+		Launch:     RemoteArchiveLaunch{Kind: "native", Entrypoint: "dist/aws", SHA256: strings.Repeat("c", 64), SizeBytes: 5},
+	}
+	managed.CLI = &ManagedCLIInterface{Entrypoint: install.Launch.Entrypoint, Install: &CLIInstallation{Kind: "remote_archive", RemoteArchive: &install}}
+	operation := Operation{OperationID: "operation-1", ConnectorKey: release.ConnectorKey}
+	receipt := CLIInstallationReceipt{
+		SchemaVersion: "tutti.connector.cli-installation.v2", OperationID: operation.OperationID,
+		ConnectorKey: release.ConnectorKey, ReleaseDigest: release.ReleaseDigest,
+		RuntimeProfile: managed.Runtime.Profile, RuntimeABI: managed.Runtime.ABI,
+		InstallKind: "remote_archive", ArchiveSHA256: install.Source.SHA256, ArchiveSize: install.Source.SizeBytes, ArchiveFormat: install.Source.Format,
+		InventoryAlgorithm: install.Extraction.InventoryAlgorithm, InventorySHA256: install.Extraction.InventorySHA256,
+		FileCount: install.Extraction.FileCount, ExpandedSizeBytes: install.Extraction.ExpandedSizeBytes,
+		LaunchKind: install.Launch.Kind, Entrypoint: install.Launch.Entrypoint,
+		EntrypointSHA256: install.Launch.SHA256, EntrypointSize: install.Launch.SizeBytes,
+		InstallRoot: t.TempDir(),
+	}
+	if err := validateRemoteArchiveInstallationReceipt(operation, release, install, receipt); err != nil {
+		t.Fatal(err)
+	}
+	receipt.OpaqueInstallationRef = "guest-install-1"
+	if err := validateRemoteArchiveInstallationReceipt(operation, release, install, receipt); err == nil {
+		t.Fatal("remote archive receipt with local and opaque locations should be rejected")
+	}
+	receipt.OpaqueInstallationRef = ""
+	receipt.InventorySHA256 = strings.Repeat("d", 64)
+	if err := validateRemoteArchiveInstallationReceipt(operation, release, install, receipt); err == nil {
+		t.Fatal("remote archive receipt with mismatched inventory should be rejected")
+	}
+}
+
 func TestApplicationReconcilesInstalledRuntimeAtStartup(t *testing.T) {
 	connector := testConnector("github")
 	connector.Revision = 7

--- a/packages/connector/host/manifest.go
+++ b/packages/connector/host/manifest.go
@@ -35,6 +35,7 @@ var permissionScopePattern = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9._-]{0,126}[
 var nodePackageNamePattern = regexp.MustCompile(`^(?:@[a-z0-9][a-z0-9._-]{0,126}/)?[a-z0-9][a-z0-9._-]{0,126}$`)
 var exactPackageVersionPattern = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$`)
 var nodeVersionRangePattern = regexp.MustCompile(`^(?:[<>]=?\s*[0-9]+\.[0-9]+\.[0-9]+(?:\s+|$))+$`)
+var hostVersionPattern = regexp.MustCompile(`^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$`)
 
 type ImplementationValidator func(Implementation) error
 
@@ -158,6 +159,9 @@ func validateManifestShape(manifest Manifest, validateIcon bool) error {
 	}
 	if err := validateUniquePermissions(manifest.Permissions); err != nil {
 		return err
+	}
+	if minimum := strings.TrimSpace(manifest.Compatibility.MinimumHostVersion); minimum != "" && !hostVersionPattern.MatchString(minimum) {
+		return invalidManifest("minimumHostVersion must be an exact semantic version", nil)
 	}
 	switch manifest.AuthorizationKind {
 	case "none", "oauth2", "api_key":
@@ -402,17 +406,26 @@ func validateManagedCredentialBroker(broker *ManagedCredentialBroker, hasCLI boo
 }
 
 func validateCLIInstallation(install CLIInstallation, runtime RuntimeRequirement, executable string) error {
-	if install.Kind != "node_package" || install.NodePackage == nil {
-		return invalidManifest("managed CLI install must select the node_package branch", nil)
-	}
 	if runtime.Language != "node" || runtime.Profile != "connector-node-static" {
-		return invalidManifest("node package CLI installation requires the shared connector-node-static runtime", nil)
+		return invalidManifest("managed CLI installation requires the shared connector-node-static runtime", nil)
 	}
 	if !nodeVersionRangePattern.MatchString(strings.TrimSpace(runtime.VersionRange)) {
-		return invalidManifest("node package CLI installation requires an explicit comparator-based Node versionRange", nil)
+		return invalidManifest("managed CLI installation requires an explicit comparator-based Node versionRange", nil)
+	}
+	if !safeRelativeEntrypoint(executable) {
+		return invalidManifest("installed CLI entrypoint must be a safe relative path", nil)
+	}
+	if install.Kind == "remote_archive" {
+		if install.RemoteArchive == nil || install.NodePackage != nil {
+			return invalidManifest("remote_archive install must select exactly its typed branch", nil)
+		}
+		return validateRemoteArchiveInstallation(*install.RemoteArchive, executable)
+	}
+	if install.Kind != "node_package" || install.NodePackage == nil || install.RemoteArchive != nil {
+		return invalidManifest("managed CLI install must select exactly one supported branch", nil)
 	}
 	if !manifestIdentifierPattern.MatchString(executable) {
-		return invalidManifest("installed CLI entrypoint must be a stable executable name", nil)
+		return invalidManifest("node package CLI entrypoint must be a stable executable name", nil)
 	}
 	request := install.NodePackage
 	if !nodePackageNamePattern.MatchString(request.Package) {
@@ -452,6 +465,45 @@ func validateCLIInstallation(install CLIInstallation, runtime RuntimeRequirement
 				return invalidManifest("node package lifecycle arguments must not contain NUL", nil)
 			}
 		}
+	}
+	return nil
+}
+
+func validateRemoteArchiveInstallation(request RemoteArchiveInstallation, executable string) error {
+	sourceURL, err := url.Parse(strings.TrimSpace(request.Source.URL))
+	if err != nil || sourceURL.Scheme != "https" || sourceURL.Host == "" || sourceURL.User != nil ||
+		sourceURL.RawQuery != "" || sourceURL.Fragment != "" || sourceURL.Port() != "" || net.ParseIP(sourceURL.Hostname()) != nil {
+		return invalidManifest("remote archive source must be an exact public HTTPS URL", nil)
+	}
+	if request.Source.Format != "zip" || !artifactSHA256Pattern.MatchString(request.Source.SHA256) ||
+		request.Source.SizeBytes <= 0 || request.Source.SizeBytes > 256*1024*1024 {
+		return invalidManifest("remote archive source requires a bounded zip identity", nil)
+	}
+	hostAllowed := false
+	seenHosts := make(map[string]struct{}, len(request.Source.AllowedHosts))
+	for _, rawHost := range request.Source.AllowedHosts {
+		host := strings.ToLower(strings.TrimSpace(rawHost))
+		parsed, parseErr := url.Parse("https://" + host)
+		if parseErr != nil || host == "" || parsed.Host != host || parsed.Hostname() != host || parsed.Port() != "" || net.ParseIP(host) != nil {
+			return invalidManifest("remote archive allowedHosts must contain exact DNS hostnames", nil)
+		}
+		if _, duplicate := seenHosts[host]; duplicate {
+			return invalidManifest("remote archive allowedHosts must be unique", nil)
+		}
+		seenHosts[host] = struct{}{}
+		hostAllowed = hostAllowed || strings.EqualFold(sourceURL.Hostname(), host)
+	}
+	if !hostAllowed {
+		return invalidManifest("remote archive source host must be allowlisted", nil)
+	}
+	if !manifestIdentifierPattern.MatchString(request.Extraction.Root) || request.Extraction.FileCount < 1 || request.Extraction.FileCount > 10_000 ||
+		request.Extraction.ExpandedSizeBytes < 1 || request.Extraction.ExpandedSizeBytes > 512*1024*1024 ||
+		request.Extraction.InventoryAlgorithm != "tutti.connector.tree.v1" || !artifactSHA256Pattern.MatchString(request.Extraction.InventorySHA256) {
+		return invalidManifest("remote archive extraction identity is invalid", nil)
+	}
+	if request.Launch.Kind != "native" || request.Launch.Entrypoint != executable || !safeRelativeEntrypoint(request.Launch.Entrypoint) ||
+		!artifactSHA256Pattern.MatchString(request.Launch.SHA256) || request.Launch.SizeBytes <= 0 || request.Launch.SizeBytes > 64*1024*1024 {
+		return invalidManifest("remote archive native launch identity is invalid", nil)
 	}
 	return nil
 }

--- a/packages/connector/host/manifest.go
+++ b/packages/connector/host/manifest.go
@@ -163,6 +163,9 @@ func validateManifestShape(manifest Manifest, validateIcon bool) error {
 	if minimum := strings.TrimSpace(manifest.Compatibility.MinimumHostVersion); minimum != "" && !hostVersionPattern.MatchString(minimum) {
 		return invalidManifest("minimumHostVersion must be an exact semantic version", nil)
 	}
+	if fallback := strings.TrimSpace(manifest.Compatibility.FallbackVersion); fallback != "" && !exactPackageVersionPattern.MatchString(fallback) {
+		return invalidManifest("fallbackVersion must be an exact semantic version", nil)
+	}
 	switch manifest.AuthorizationKind {
 	case "none", "oauth2", "api_key":
 	default:
@@ -185,6 +188,10 @@ func validateManifestShape(manifest Manifest, validateIcon bool) error {
 	}
 	if branches != 1 {
 		return invalidManifest("implementation must select exactly one typed branch", nil)
+	}
+	if implementation.ManagedStdio != nil && implementation.ManagedStdio.CLI != nil && implementation.ManagedStdio.CLI.Install != nil &&
+		implementation.ManagedStdio.CLI.Install.Kind == "remote_archive" && strings.TrimSpace(manifest.Compatibility.MinimumHostVersion) == "" {
+		return invalidManifest("remote_archive requires minimumHostVersion", nil)
 	}
 	switch implementation.Kind {
 	case ImplementationKindBuiltin:

--- a/packages/connector/host/manifest_test.go
+++ b/packages/connector/host/manifest_test.go
@@ -262,6 +262,35 @@ func TestManagedCLIAllowsTypedNodePackageWithoutActionMappings(t *testing.T) {
 	}
 }
 
+func TestManagedCLIAllowsTypedRemoteArchiveWithoutActionMappings(t *testing.T) {
+	manifest := Manifest{SchemaVersion: "1", DisplayName: "AWS CLI", IconURL: testConnectorIconURL, AuthorizationKind: "none",
+		Implementation: Implementation{Kind: ImplementationKindManagedStdio, ManagedStdio: &ManagedStdioImplementation{
+			Runtime: RuntimeRequirement{Language: "node", Profile: "connector-node-static", ABI: "node24-linux-arm64", VersionRange: ">=24.0.0 <25.0.0"},
+			CLI: &ManagedCLIInterface{Entrypoint: "dist/aws", Command: "aws", TimeoutMS: 120_000, Install: &CLIInstallation{Kind: "remote_archive", RemoteArchive: &RemoteArchiveInstallation{
+				Source:     RemoteArchiveSource{URL: "https://awscli.amazonaws.com/awscliv2.zip", AllowedHosts: []string{"awscli.amazonaws.com"}, Format: "zip", SHA256: strings.Repeat("a", 64), SizeBytes: 1024},
+				Extraction: RemoteArchiveExtraction{Root: "aws", FileCount: 2, ExpandedSizeBytes: 2048, InventoryAlgorithm: "tutti.connector.tree.v1", InventorySHA256: strings.Repeat("b", 64)},
+				Launch:     RemoteArchiveLaunch{Kind: "native", Entrypoint: "dist/aws", SHA256: strings.Repeat("c", 64), SizeBytes: 512},
+			}}},
+		}}}
+	if err := ValidateManifestShape(manifest); err != nil {
+		t.Fatal(err)
+	}
+	manifest.Compatibility.MinimumHostVersion = "v0.2.27"
+	if err := ValidateManifestShape(manifest); err == nil || !strings.Contains(err.Error(), "minimumHostVersion") {
+		t.Fatalf("invalid minimumHostVersion error = %v", err)
+	}
+	manifest.Compatibility.MinimumHostVersion = "0.2.27"
+	manifest.Implementation.ManagedStdio.CLI.Install.NodePackage = &NodePackageInstallation{}
+	if err := ValidateManifestShape(manifest); err == nil || !strings.Contains(err.Error(), "exactly") {
+		t.Fatalf("mixed installation branches error = %v", err)
+	}
+	manifest.Implementation.ManagedStdio.CLI.Install.NodePackage = nil
+	manifest.Implementation.ManagedStdio.CLI.Install.RemoteArchive.Extraction.Root = "aws/dist"
+	if err := ValidateManifestShape(manifest); err == nil || !strings.Contains(err.Error(), "extraction") {
+		t.Fatalf("nested archive root error = %v", err)
+	}
+}
+
 func TestManagedCLIAllowsArtifactNativeLaunch(t *testing.T) {
 	manifest := Manifest{SchemaVersion: "1", DisplayName: "GitHub CLI", IconURL: testConnectorIconURL, AuthorizationKind: "oauth2",
 		Implementation: Implementation{Kind: ImplementationKindManagedStdio, ManagedStdio: &ManagedStdioImplementation{

--- a/packages/connector/host/manifest_test.go
+++ b/packages/connector/host/manifest_test.go
@@ -264,6 +264,7 @@ func TestManagedCLIAllowsTypedNodePackageWithoutActionMappings(t *testing.T) {
 
 func TestManagedCLIAllowsTypedRemoteArchiveWithoutActionMappings(t *testing.T) {
 	manifest := Manifest{SchemaVersion: "1", DisplayName: "AWS CLI", IconURL: testConnectorIconURL, AuthorizationKind: "none",
+		Compatibility: CompatibilityRequirements{MinimumHostVersion: "0.2.27"},
 		Implementation: Implementation{Kind: ImplementationKindManagedStdio, ManagedStdio: &ManagedStdioImplementation{
 			Runtime: RuntimeRequirement{Language: "node", Profile: "connector-node-static", ABI: "node24-linux-arm64", VersionRange: ">=24.0.0 <25.0.0"},
 			CLI: &ManagedCLIInterface{Entrypoint: "dist/aws", Command: "aws", TimeoutMS: 120_000, Install: &CLIInstallation{Kind: "remote_archive", RemoteArchive: &RemoteArchiveInstallation{

--- a/packages/connector/host/types.go
+++ b/packages/connector/host/types.go
@@ -216,8 +216,38 @@ type CLIReadinessProbe struct {
 // intent into a package-manager invocation; connector manifests never provide
 // an arbitrary shell command.
 type CLIInstallation struct {
-	Kind        string                   `json:"kind"`
-	NodePackage *NodePackageInstallation `json:"nodePackage,omitempty"`
+	Kind          string                     `json:"kind"`
+	NodePackage   *NodePackageInstallation   `json:"nodePackage,omitempty"`
+	RemoteArchive *RemoteArchiveInstallation `json:"remoteArchive,omitempty"`
+}
+
+type RemoteArchiveInstallation struct {
+	Source     RemoteArchiveSource     `json:"source"`
+	Extraction RemoteArchiveExtraction `json:"extraction"`
+	Launch     RemoteArchiveLaunch     `json:"launch"`
+}
+
+type RemoteArchiveSource struct {
+	URL          string   `json:"url"`
+	AllowedHosts []string `json:"allowedHosts"`
+	Format       string   `json:"format"`
+	SHA256       string   `json:"sha256"`
+	SizeBytes    int64    `json:"sizeBytes"`
+}
+
+type RemoteArchiveExtraction struct {
+	Root               string `json:"root"`
+	FileCount          int    `json:"fileCount"`
+	ExpandedSizeBytes  int64  `json:"expandedSizeBytes"`
+	InventoryAlgorithm string `json:"inventoryAlgorithm"`
+	InventorySHA256    string `json:"inventorySha256"`
+}
+
+type RemoteArchiveLaunch struct {
+	Kind       string `json:"kind"`
+	Entrypoint string `json:"entrypoint"`
+	SHA256     string `json:"sha256"`
+	SizeBytes  int64  `json:"sizeBytes"`
 }
 
 type NodePackageInstallation struct {
@@ -357,24 +387,32 @@ type ReleaseInstallationReceipt struct {
 }
 
 type CLIInstallationReceipt struct {
-	SchemaVersion    string `json:"schemaVersion"`
-	OperationID      string `json:"operationId"`
-	ConnectorKey     string `json:"connectorKey"`
-	ReleaseDigest    string `json:"releaseDigest"`
-	RuntimeProfile   string `json:"runtimeProfile"`
-	RuntimeABI       string `json:"runtimeAbi"`
-	NodeVersion      string `json:"nodeVersion"`
-	NodeSHA256       string `json:"nodeSha256"`
-	Package          string `json:"package"`
-	PackageVersion   string `json:"packageVersion"`
-	PackageIntegrity string `json:"packageIntegrity"`
-	LaunchKind       string `json:"launchKind"`
-	InstallRoot      string `json:"installRoot"`
-	StoreRoot        string `json:"storeRoot"`
-	Entrypoint       string `json:"entrypoint"`
-	EntrypointSHA256 string `json:"entrypointSha256"`
-	EntrypointSize   int64  `json:"entrypointSizeBytes"`
-	LockSHA256       string `json:"lockSha256"`
+	SchemaVersion      string `json:"schemaVersion"`
+	OperationID        string `json:"operationId"`
+	ConnectorKey       string `json:"connectorKey"`
+	ReleaseDigest      string `json:"releaseDigest"`
+	RuntimeProfile     string `json:"runtimeProfile"`
+	RuntimeABI         string `json:"runtimeAbi"`
+	NodeVersion        string `json:"nodeVersion"`
+	NodeSHA256         string `json:"nodeSha256"`
+	Package            string `json:"package"`
+	PackageVersion     string `json:"packageVersion"`
+	PackageIntegrity   string `json:"packageIntegrity"`
+	LaunchKind         string `json:"launchKind"`
+	InstallRoot        string `json:"installRoot"`
+	StoreRoot          string `json:"storeRoot"`
+	Entrypoint         string `json:"entrypoint"`
+	EntrypointSHA256   string `json:"entrypointSha256"`
+	EntrypointSize     int64  `json:"entrypointSizeBytes"`
+	LockSHA256         string `json:"lockSha256"`
+	InstallKind        string `json:"installKind,omitempty"`
+	ArchiveSHA256      string `json:"archiveSha256,omitempty"`
+	ArchiveSize        int64  `json:"archiveSizeBytes,omitempty"`
+	ArchiveFormat      string `json:"archiveFormat,omitempty"`
+	InventoryAlgorithm string `json:"inventoryAlgorithm,omitempty"`
+	InventorySHA256    string `json:"inventorySha256,omitempty"`
+	FileCount          int    `json:"fileCount,omitempty"`
+	ExpandedSizeBytes  int64  `json:"expandedSizeBytes,omitempty"`
 	// OpaqueInstallationRef identifies an installation owned by a remote or
 	// isolated runtime. Cross-machine hosts persist this value instead of guest
 	// filesystem paths.

--- a/packages/connector/host/types.go
+++ b/packages/connector/host/types.go
@@ -138,6 +138,7 @@ type CompatibilityRequirements struct {
 	Products           []string `json:"products,omitempty"`
 	Platforms          []string `json:"platforms,omitempty"`
 	MinimumHostVersion string   `json:"minimumHostVersion,omitempty"`
+	FallbackVersion    string   `json:"fallbackVersion,omitempty"`
 }
 
 type Implementation struct {

--- a/packages/connector/runtime/artifact/safe_archive.go
+++ b/packages/connector/runtime/artifact/safe_archive.go
@@ -1,0 +1,71 @@
+package artifact
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const TreeInventoryAlgorithmV1 = "tutti.connector.tree.v1"
+
+type TreeIdentity struct {
+	Algorithm         string
+	SHA256            string
+	FileCount         int
+	ExpandedSizeBytes int64
+}
+
+// ExtractArchive applies the same portable-path, file-type, duplicate,
+// expansion, and compression-ratio policy used for signed Connector artifacts.
+func ExtractArchive(archivePath, format, destination string, limits Limits) error {
+	if limits == (Limits{}) {
+		limits = DefaultLimits()
+	}
+	if err := validateLimits(limits); err != nil {
+		return err
+	}
+	preparer := &Preparer{limits: limits}
+	switch format {
+	case "zip":
+		return preparer.extractZIP(archivePath, destination)
+	case "tar_gzip":
+		return preparer.extractTarGzip(archivePath, destination)
+	default:
+		return fmt.Errorf("unsupported managed archive format %q", format)
+	}
+}
+
+func InspectTree(root string) (TreeIdentity, error) {
+	digest, err := inventoryDigest(root)
+	if err != nil {
+		return TreeIdentity{}, err
+	}
+	identity := TreeIdentity{Algorithm: TreeInventoryAlgorithmV1, SHA256: digest}
+	err = filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == root || entry.IsDir() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if entry.Type()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return errors.New("managed archive inventory contains an unsupported file type")
+		}
+		identity.FileCount++
+		identity.ExpandedSizeBytes += info.Size()
+		return nil
+	})
+	if err != nil {
+		return TreeIdentity{}, fmt.Errorf("inspect managed archive tree: %w", err)
+	}
+	return identity, nil
+}
+
+func RemoveAllWithin(root, target string) error { return removeAllWithin(root, target) }
+
+func SyncDirectory(path string) error { return syncDirectory(path) }

--- a/packages/connector/runtime/cli_installation_router.go
+++ b/packages/connector/runtime/cli_installation_router.go
@@ -1,0 +1,71 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	market "github.com/tutti-os/tutti/packages/connector/host"
+)
+
+type CLIInstallationRouter struct {
+	nodePackage   market.CLIInstallationManager
+	remoteArchive market.CLIInstallationManager
+}
+
+var _ market.CLIInstallationManager = (*CLIInstallationRouter)(nil)
+
+func NewCLIInstallationRouter(nodePackage, remoteArchive market.CLIInstallationManager) (*CLIInstallationRouter, error) {
+	if nodePackage == nil || remoteArchive == nil {
+		return nil, errors.New("connector CLI installation router requires every supported installer")
+	}
+	return &CLIInstallationRouter{nodePackage: nodePackage, remoteArchive: remoteArchive}, nil
+}
+
+func (router *CLIInstallationRouter) InstallCLI(ctx context.Context, request market.InstallCLIRequest) (market.CLIInstallationReceipt, error) {
+	installer, err := router.installer(request.Release)
+	if err != nil {
+		return market.CLIInstallationReceipt{}, err
+	}
+	return installer.InstallCLI(ctx, request)
+}
+
+func (router *CLIInstallationRouter) ResolveCLI(ctx context.Context, release market.Release) (market.CLIInstallationReceipt, error) {
+	installer, err := router.installer(release)
+	if err != nil {
+		return market.CLIInstallationReceipt{}, err
+	}
+	return installer.ResolveCLI(ctx, release)
+}
+
+func (router *CLIInstallationRouter) RemoveCLI(ctx context.Context, request market.RemoveCLIRequest) error {
+	if router == nil {
+		return errors.New("connector CLI installation router is unavailable")
+	}
+	return errors.Join(router.nodePackage.RemoveCLI(ctx, request), router.remoteArchive.RemoveCLI(ctx, request))
+}
+
+func (router *CLIInstallationRouter) RemoveConnector(ctx context.Context, request market.RemoveConnectorInstallationRequest) error {
+	if router == nil {
+		return errors.New("connector CLI installation router is unavailable")
+	}
+	return errors.Join(router.nodePackage.RemoveConnector(ctx, request), router.remoteArchive.RemoveConnector(ctx, request))
+}
+
+func (router *CLIInstallationRouter) installer(release market.Release) (market.CLIInstallationManager, error) {
+	if router == nil {
+		return nil, errors.New("connector CLI installation router is unavailable")
+	}
+	managed := release.Manifest.Implementation.ManagedStdio
+	if managed == nil || managed.CLI == nil || managed.CLI.Install == nil {
+		return nil, errors.New("connector release does not declare a CLI installation")
+	}
+	switch managed.CLI.Install.Kind {
+	case "node_package":
+		return router.nodePackage, nil
+	case "remote_archive":
+		return router.remoteArchive, nil
+	default:
+		return nil, fmt.Errorf("unsupported connector CLI installation kind %q", managed.CLI.Install.Kind)
+	}
+}

--- a/packages/connector/runtime/implementationhost/cli_shim_test.go
+++ b/packages/connector/runtime/implementationhost/cli_shim_test.go
@@ -18,8 +18,12 @@ func TestConnectorCLIShimExecutesVerifiedEntrypointThroughNormalShellPath(t *tes
 	}
 	root := t.TempDir()
 	working := filepath.Join(root, "working directory")
+	callerWorking := filepath.Join(root, "caller working directory")
 	binDir := filepath.Join(root, "bin")
 	if err := os.MkdirAll(working, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(callerWorking, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	entrypoint := filepath.Join(root, "connector executable")
@@ -39,11 +43,13 @@ func TestConnectorCLIShimExecutesVerifiedEntrypointThroughNormalShellPath(t *tes
 	if err := route.activateCLIShim(); err != nil {
 		t.Fatal(err)
 	}
-	output, err := exec.Command(route.cliShimPath, "user argument").CombinedOutput()
+	command := exec.Command(route.cliShimPath, "user argument")
+	command.Dir = callerWorking
+	output, err := command.CombinedOutput()
 	if err != nil {
 		t.Fatalf("execute CLI shim: %v: %s", err, output)
 	}
-	want := strings.Join([]string{"github", working, "fixed argument", "user argument"}, "|")
+	want := strings.Join([]string{"github", callerWorking, "fixed argument", "user argument"}, "|")
 	if string(output) != want {
 		t.Fatalf("CLI output = %q, want %q", output, want)
 	}

--- a/packages/connector/runtime/implementationhost/host.go
+++ b/packages/connector/runtime/implementationhost/host.go
@@ -787,7 +787,7 @@ func connectorCLIShimContent(route *connectorRoute) ([]byte, error) {
 	arguments := append([]string(nil), launch.arguments...)
 	if runtime.GOOS == "windows" {
 		values := append([]string{launch.executable.Path}, arguments...)
-		for _, value := range append(values, launch.cwd, launch.stateDir, route.userHome) {
+		for _, value := range append(values, launch.stateDir, route.userHome) {
 			if strings.ContainsAny(value, "\r\n\"") {
 				return nil, errors.New("connector CLI path cannot be represented by Windows shim")
 			}
@@ -802,8 +802,7 @@ func connectorCLIShimContent(route *connectorRoute) ([]byte, error) {
 			"set \"TUTTI_CONNECTOR_LANGUAGE=" + launch.language + "\"\r\n" +
 			"set \"TUTTI_CONNECTOR_STATE_DIR=" + launch.stateDir + "\"\r\n" +
 			"set \"HOME=" + route.userHome + "\"\r\n" +
-			"set \"USERPROFILE=" + route.userHome + "\"\r\n" +
-			"cd /d \"" + launch.cwd + "\"\r\n" + strings.Join(quoted, " ") + " %*\r\n"
+			"set \"USERPROFILE=" + route.userHome + "\"\r\n" + strings.Join(quoted, " ") + " %*\r\n"
 		return []byte(content), nil
 	}
 	values := append([]string{launch.executable.Path}, arguments...)
@@ -818,7 +817,6 @@ func connectorCLIShimContent(route *connectorRoute) ([]byte, error) {
 		"export TUTTI_CONNECTOR_STATE_DIR=" + shellQuote(launch.stateDir) + "\n" +
 		"export HOME=" + shellQuote(route.userHome) + "\n" +
 		"export USERPROFILE=" + shellQuote(route.userHome) + "\n" +
-		"cd " + shellQuote(launch.cwd) + " || exit 1\n" +
 		"exec " + strings.Join(quoted, " ") + " \"$@\"\n"
 	return []byte(content), nil
 }

--- a/packages/connector/runtime/managed_route_plan.go
+++ b/packages/connector/runtime/managed_route_plan.go
@@ -89,6 +89,9 @@ func (planner *ManagedRoutePlanner) Build(ctx context.Context, request market.Ru
 			return ManagedRoutePlan{}, fmt.Errorf("%w: %v", ErrCLIInstallationUnavailable, resolveErr)
 		}
 		installed = &receipt
+		if receipt.InventorySHA256 != "" {
+			artifactTrees = append(artifactTrees, agentruntime.ArtifactTreeIdentity{Root: receipt.InstallRoot, SHA256: receipt.InventorySHA256})
+		}
 	}
 	return ManagedRoutePlan{Managed: managed, Prepared: prepared, Resolved: resolved, Executable: executable,
 		InstalledCLI: installed, StateDir: stateDir, UserHome: planner.userHome, ArtifactTrees: artifactTrees}, nil

--- a/packages/connector/runtime/release_installer.go
+++ b/packages/connector/runtime/release_installer.go
@@ -71,7 +71,7 @@ func (installer *ReleaseInstaller) InstallRelease(
 			ReleaseDigest: request.Release.ReleaseDigest,
 		})
 		return market.ReleaseInstallationReceipt{}, fmt.Errorf(
-			"install connector CLI package: %w",
+			"install connector CLI: %w",
 			errors.Join(err, rollbackErr),
 		)
 	}
@@ -187,6 +187,5 @@ func (*ReleaseInstaller) CommitReleaseInstallation(
 
 func releaseRequiresCLIInstallation(release market.Release) bool {
 	managed := release.Manifest.Implementation.ManagedStdio
-	return managed != nil && managed.CLI != nil && managed.CLI.Install != nil &&
-		managed.CLI.Install.NodePackage != nil
+	return managed != nil && managed.CLI != nil && managed.CLI.Install != nil
 }

--- a/packages/connector/runtime/remote_archive_aws_integration_test.go
+++ b/packages/connector/runtime/remote_archive_aws_integration_test.go
@@ -1,0 +1,63 @@
+package runtime
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	market "github.com/tutti-os/tutti/packages/connector/host"
+)
+
+func TestRemoteArchiveInstallerRunsOfficialAWSCLI(t *testing.T) {
+	if os.Getenv("TUTTI_RUN_AWS_REMOTE_ARCHIVE_SMOKE") != "1" {
+		t.Skip("set TUTTI_RUN_AWS_REMOTE_ARCHIVE_SMOKE=1 for the official AWS CLI smoke")
+	}
+	if runtime.GOOS != "linux" || runtime.GOARCH != "arm64" {
+		t.Skip("the pinned AWS smoke artifact targets linux-arm64")
+	}
+	release := market.Release{
+		SchemaVersion: "1", ReleaseID: "aws-cli@0.2.0-smoke", ConnectorKey: "aws-cli", Version: "0.2.0",
+		ReleaseDigest: strings.Repeat("d", 64), ManifestDigest: strings.Repeat("e", 64), Status: market.ReleaseStatusAvailable,
+		Artifact:    market.Artifact{Key: "aws-cli.tgz", SHA256: strings.Repeat("f", 64), SizeBytes: 1, MediaType: "application/gzip"},
+		PublishedAt: time.Unix(1, 0).UTC(),
+		Manifest: market.Manifest{
+			SchemaVersion: "1", DisplayName: "AWS CLI", IconURL: "data:image/png;base64,iVBORw0KGgo=", AuthorizationKind: "none",
+			Compatibility: market.CompatibilityRequirements{MinimumHostVersion: "0.2.27", FallbackVersion: "0.1.1"},
+			Implementation: market.Implementation{Kind: market.ImplementationKindManagedStdio, ManagedStdio: &market.ManagedStdioImplementation{
+				Runtime: market.RuntimeRequirement{Language: "node", Profile: ConnectorNodeProfile, ABI: "node24-linux-arm64", VersionRange: ">=24.18.0 <25.0.0"},
+				CLI: &market.ManagedCLIInterface{Entrypoint: "dist/aws", Command: "aws", TimeoutMS: 120_000, Install: &market.CLIInstallation{Kind: "remote_archive", RemoteArchive: &market.RemoteArchiveInstallation{
+					Source: market.RemoteArchiveSource{
+						URL: "https://awscli.amazonaws.com/awscli-exe-linux-aarch64-2.36.24.zip", AllowedHosts: []string{"awscli.amazonaws.com"}, Format: "zip",
+						SHA256: "c024c45a9d22005f81c7c0fab9e23ee7118ffa210d812845b42e980cf93727a7", SizeBytes: 70_691_953,
+					},
+					Extraction: market.RemoteArchiveExtraction{
+						Root: "aws", FileCount: 7_558, ExpandedSizeBytes: 249_398_041, InventoryAlgorithm: "tutti.connector.tree.v1",
+						InventorySHA256: "4eff269010e54d59dd29c715993e95dd2d6728726f384dc3c4750607b6ea2e15",
+					},
+					Launch: market.RemoteArchiveLaunch{Kind: "native", Entrypoint: "dist/aws", SHA256: "5b35976e1a04fbaa20848b6a9538f4757bcf941d4d1c31321aff0dfbd0492806", SizeBytes: 8_958_392},
+				}}},
+			}},
+		},
+	}
+	installer, err := NewRemoteArchiveInstaller(RemoteArchiveInstallerConfig{RootDir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := installer.InstallCLI(context.Background(), market.InstallCLIRequest{OperationID: "aws-smoke", Release: release})
+	if err != nil {
+		t.Fatal(err)
+	}
+	command := exec.Command(filepath.Join(receipt.InstallRoot, "dist", "aws"), "--version")
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("aws --version failed: %v: %s", err, output)
+	}
+	if !strings.Contains(string(output), "aws-cli/2.36.24") {
+		t.Fatalf("unexpected aws --version output: %s", output)
+	}
+}

--- a/packages/connector/runtime/remote_archive_installer.go
+++ b/packages/connector/runtime/remote_archive_installer.go
@@ -1,0 +1,530 @@
+package runtime
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	market "github.com/tutti-os/tutti/packages/connector/host"
+	marketartifact "github.com/tutti-os/tutti/packages/connector/runtime/artifact"
+)
+
+const (
+	remoteArchiveReceiptSchema = "tutti.connector.cli-installation.v2"
+	remoteArchiveReceiptFile   = ".tutti-remote-archive-receipt.json"
+	maxRemoteArchiveRedirects  = 3
+)
+
+type RemoteArchiveInstallerConfig struct {
+	RootDir    string
+	HTTPClient *http.Client
+	Limits     marketartifact.Limits
+	Timeout    time.Duration
+	LookupIP   func(context.Context, string) ([]net.IPAddr, error)
+}
+
+type RemoteArchiveInstaller struct {
+	rootDir    string
+	httpClient *http.Client
+	limits     marketartifact.Limits
+	timeout    time.Duration
+	lookupIP   func(context.Context, string) ([]net.IPAddr, error)
+	mu         sync.Mutex
+	lanes      map[string]*sync.Mutex
+	cacheLanes map[string]*sync.Mutex
+	slots      chan struct{}
+}
+
+var _ market.CLIInstallationManager = (*RemoteArchiveInstaller)(nil)
+
+func NewRemoteArchiveInstaller(config RemoteArchiveInstallerConfig) (*RemoteArchiveInstaller, error) {
+	root := filepath.Clean(strings.TrimSpace(config.RootDir))
+	if !filepath.IsAbs(root) {
+		return nil, errors.New("connector remote archive root must be absolute")
+	}
+	client := config.HTTPClient
+	if client == nil {
+		client = &http.Client{}
+	}
+	clientCopy := *client
+	clientCopy.Jar = nil
+	clientCopy.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	timeout := config.Timeout
+	if timeout <= 0 {
+		timeout = 5 * time.Minute
+	}
+	limits := config.Limits
+	if limits == (marketartifact.Limits{}) {
+		limits = marketartifact.DefaultLimits()
+	}
+	lookup := config.LookupIP
+	if lookup == nil {
+		lookup = net.DefaultResolver.LookupIPAddr
+	}
+	return &RemoteArchiveInstaller{rootDir: root, httpClient: &clientCopy, limits: limits, timeout: timeout,
+		lookupIP: lookup, lanes: make(map[string]*sync.Mutex), cacheLanes: make(map[string]*sync.Mutex), slots: make(chan struct{}, 4)}, nil
+}
+
+func (installer *RemoteArchiveInstaller) InstallCLI(ctx context.Context, request market.InstallCLIRequest) (market.CLIInstallationReceipt, error) {
+	if installer == nil || runtime.GOOS == "windows" {
+		return market.CLIInstallationReceipt{}, errors.New("connector remote archive installation is unavailable on this platform")
+	}
+	if err := market.ValidateReleaseShape(request.Release); err != nil {
+		return market.CLIInstallationReceipt{}, err
+	}
+	managed, cli, install, err := remoteArchiveIntent(request.Release)
+	if err != nil {
+		return market.CLIInstallationReceipt{}, err
+	}
+	if !safeCLIPathSegment(request.OperationID) {
+		return market.CLIInstallationReceipt{}, errors.New("connector remote archive operation id is invalid")
+	}
+	unlock := installer.lock(request.Release.ConnectorKey)
+	defer unlock()
+	select {
+	case installer.slots <- struct{}{}:
+		defer func() { <-installer.slots }()
+	case <-ctx.Done():
+		return market.CLIInstallationReceipt{}, ctx.Err()
+	}
+
+	target := installer.installRoot(request.Release)
+	if receipt, verifyErr := installer.readAndVerifyReceipt(request.Release, target); verifyErr == nil {
+		receipt.OperationID = request.OperationID
+		return receipt, nil
+	}
+	archivePath, err := installer.prepareArchive(ctx, install.Source)
+	if err != nil {
+		return market.CLIInstallationReceipt{}, err
+	}
+	staging := filepath.Join(installer.rootDir, "staging", request.OperationID)
+	if !pathWithin(installer.rootDir, staging) {
+		return market.CLIInstallationReceipt{}, errors.New("connector remote archive staging path escapes root")
+	}
+	_ = marketartifact.RemoveAllWithin(installer.rootDir, staging)
+	if err := os.MkdirAll(staging, 0o700); err != nil {
+		return market.CLIInstallationReceipt{}, err
+	}
+	defer func() {
+		_ = makeRemoteArchiveWritable(staging)
+		_ = marketartifact.RemoveAllWithin(installer.rootDir, staging)
+	}()
+	extracted := filepath.Join(staging, "extracted")
+	if err := os.MkdirAll(extracted, 0o700); err != nil {
+		return market.CLIInstallationReceipt{}, err
+	}
+	if err := marketartifact.ExtractArchive(archivePath, install.Source.Format, extracted, installer.limits); err != nil {
+		return market.CLIInstallationReceipt{}, fmt.Errorf("extract connector remote archive: %w", err)
+	}
+	payloadRoot, err := exactArchiveRoot(extracted, install.Extraction.Root)
+	if err != nil {
+		return market.CLIInstallationReceipt{}, err
+	}
+	identity, err := marketartifact.InspectTree(payloadRoot)
+	if err != nil {
+		return market.CLIInstallationReceipt{}, err
+	}
+	if identity.Algorithm != install.Extraction.InventoryAlgorithm || identity.SHA256 != install.Extraction.InventorySHA256 ||
+		identity.FileCount != install.Extraction.FileCount || identity.ExpandedSizeBytes != install.Extraction.ExpandedSizeBytes {
+		return market.CLIInstallationReceipt{}, errors.New("connector remote archive inventory does not match manifest")
+	}
+	entrypoint, err := PreparedEntrypoint(payloadRoot, install.Launch.Entrypoint)
+	if err != nil {
+		return market.CLIInstallationReceipt{}, err
+	}
+	entryDigest, err := cliFileSHA256(entrypoint)
+	if err != nil {
+		return market.CLIInstallationReceipt{}, err
+	}
+	entryInfo, err := os.Stat(entrypoint)
+	if err != nil || entryDigest != install.Launch.SHA256 || entryInfo.Size() != install.Launch.SizeBytes {
+		return market.CLIInstallationReceipt{}, errors.New("connector remote archive entrypoint does not match manifest")
+	}
+	payload := filepath.Join(staging, "payload")
+	if err := os.Rename(payloadRoot, payload); err != nil {
+		return market.CLIInstallationReceipt{}, fmt.Errorf("stage connector remote archive payload: %w", err)
+	}
+	if err := marketartifact.RemoveAllWithin(staging, extracted); err != nil {
+		return market.CLIInstallationReceipt{}, err
+	}
+	entrypoint = filepath.Join(payload, filepath.FromSlash(install.Launch.Entrypoint))
+	if err := makeRemoteArchiveReadOnly(payload, entrypoint); err != nil {
+		return market.CLIInstallationReceipt{}, err
+	}
+	receipt := market.CLIInstallationReceipt{
+		SchemaVersion: remoteArchiveReceiptSchema, OperationID: request.OperationID,
+		ConnectorKey: request.Release.ConnectorKey, ReleaseDigest: request.Release.ReleaseDigest,
+		RuntimeProfile: managed.Runtime.Profile, RuntimeABI: managed.Runtime.ABI,
+		InstallKind: "remote_archive", ArchiveSHA256: install.Source.SHA256, ArchiveSize: install.Source.SizeBytes,
+		ArchiveFormat: install.Source.Format, InventoryAlgorithm: identity.Algorithm, InventorySHA256: identity.SHA256,
+		FileCount: identity.FileCount, ExpandedSizeBytes: identity.ExpandedSizeBytes,
+		LaunchKind: "native", InstallRoot: filepath.Join(target, "payload"), Entrypoint: cli.Entrypoint,
+		EntrypointSHA256: entryDigest, EntrypointSize: entryInfo.Size(),
+	}
+	if err := writeRemoteArchiveReceipt(staging, receipt); err != nil {
+		return market.CLIInstallationReceipt{}, err
+	}
+	if err := installer.promote(staging, target, request.OperationID); err != nil {
+		return market.CLIInstallationReceipt{}, err
+	}
+	return receipt, nil
+}
+
+func (installer *RemoteArchiveInstaller) ResolveCLI(ctx context.Context, release market.Release) (market.CLIInstallationReceipt, error) {
+	if installer == nil || runtime.GOOS == "windows" {
+		return market.CLIInstallationReceipt{}, errors.New("connector remote archive installation is unavailable on this platform")
+	}
+	if err := ctx.Err(); err != nil {
+		return market.CLIInstallationReceipt{}, err
+	}
+	if _, _, _, err := remoteArchiveIntent(release); err != nil {
+		return market.CLIInstallationReceipt{}, err
+	}
+	unlock := installer.lock(release.ConnectorKey)
+	defer unlock()
+	target := installer.installRoot(release)
+	if _, err := os.Stat(target); errors.Is(err, os.ErrNotExist) {
+		return market.CLIInstallationReceipt{}, market.ErrReleaseInstallationAbsent
+	} else if err != nil {
+		return market.CLIInstallationReceipt{}, err
+	}
+	receipt, err := installer.readAndVerifyReceipt(release, target)
+	if err != nil {
+		return market.CLIInstallationReceipt{}, fmt.Errorf("%w: %v", market.ErrReleaseInstallationInvalid, err)
+	}
+	return receipt, nil
+}
+
+func (installer *RemoteArchiveInstaller) RemoveCLI(ctx context.Context, request market.RemoveCLIRequest) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if installer == nil || !safeCLIPathSegment(request.ConnectorKey) || !isSHA256Hex(request.ReleaseDigest) {
+		return errors.New("connector remote archive removal identity is invalid")
+	}
+	unlock := installer.lock(request.ConnectorKey)
+	defer unlock()
+	target := filepath.Join(installer.rootDir, "releases", request.ConnectorKey, request.ReleaseDigest)
+	_ = makeRemoteArchiveWritable(target)
+	return marketartifact.RemoveAllWithin(installer.rootDir, target)
+}
+
+func (installer *RemoteArchiveInstaller) RemoveConnector(ctx context.Context, request market.RemoveConnectorInstallationRequest) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if installer == nil || !safeCLIPathSegment(request.ConnectorKey) {
+		return errors.New("connector remote archive removal identity is invalid")
+	}
+	unlock := installer.lock(request.ConnectorKey)
+	defer unlock()
+	target := filepath.Join(installer.rootDir, "releases", request.ConnectorKey)
+	_ = makeRemoteArchiveWritable(target)
+	return marketartifact.RemoveAllWithin(installer.rootDir, target)
+}
+
+func (installer *RemoteArchiveInstaller) prepareArchive(ctx context.Context, source market.RemoteArchiveSource) (string, error) {
+	unlock := installer.lockNamed(installer.cacheLanes, source.SHA256)
+	defer unlock()
+	cacheDir := filepath.Join(installer.rootDir, "cache")
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		return "", err
+	}
+	archivePath := filepath.Join(cacheDir, source.SHA256+".archive")
+	if verifyRemoteArchiveFile(archivePath, source) == nil {
+		return archivePath, nil
+	}
+	temporary := archivePath + ".partial"
+	_ = os.Remove(temporary)
+	runCtx, cancel := context.WithTimeout(ctx, installer.timeout)
+	defer cancel()
+	response, err := installer.fetch(runCtx, source)
+	if err != nil {
+		return "", err
+	}
+	defer response.Body.Close()
+	file, err := os.OpenFile(temporary, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return "", err
+	}
+	hash := sha256.New()
+	written, copyErr := io.Copy(io.MultiWriter(file, hash), io.LimitReader(response.Body, source.SizeBytes+1))
+	syncErr := file.Sync()
+	closeErr := file.Close()
+	if copyErr != nil || syncErr != nil || closeErr != nil || written != source.SizeBytes || hex.EncodeToString(hash.Sum(nil)) != source.SHA256 {
+		_ = os.Remove(temporary)
+		return "", errors.Join(errors.New("connector remote archive download identity is invalid"), copyErr, syncErr, closeErr)
+	}
+	if err := os.Rename(temporary, archivePath); err != nil {
+		_ = os.Remove(temporary)
+		if verifyRemoteArchiveFile(archivePath, source) == nil {
+			return archivePath, nil
+		}
+		return "", err
+	}
+	if err := marketartifact.SyncDirectory(cacheDir); err != nil {
+		return "", err
+	}
+	return archivePath, nil
+}
+
+func (installer *RemoteArchiveInstaller) fetch(ctx context.Context, source market.RemoteArchiveSource) (*http.Response, error) {
+	current, err := url.Parse(source.URL)
+	if err != nil {
+		return nil, err
+	}
+	for redirect := 0; redirect <= maxRemoteArchiveRedirects; redirect++ {
+		if err := installer.validateURL(ctx, current, source.AllowedHosts); err != nil {
+			return nil, err
+		}
+		request, err := http.NewRequestWithContext(ctx, http.MethodGet, current.String(), nil)
+		if err != nil {
+			return nil, err
+		}
+		request.Header.Set("Accept-Encoding", "identity")
+		response, err := installer.httpClient.Do(request)
+		if err != nil {
+			return nil, err
+		}
+		if response.StatusCode >= 300 && response.StatusCode <= 399 {
+			location := response.Header.Get("Location")
+			_ = response.Body.Close()
+			if redirect == maxRemoteArchiveRedirects || location == "" {
+				return nil, errors.New("connector remote archive redirect limit exceeded")
+			}
+			next, parseErr := current.Parse(location)
+			if parseErr != nil {
+				return nil, parseErr
+			}
+			current = next
+			continue
+		}
+		if response.StatusCode != http.StatusOK || response.ContentLength != source.SizeBytes {
+			_ = response.Body.Close()
+			return nil, fmt.Errorf("connector remote archive response identity is invalid: status=%d contentLength=%d", response.StatusCode, response.ContentLength)
+		}
+		return response, nil
+	}
+	return nil, errors.New("connector remote archive redirect limit exceeded")
+}
+
+func (installer *RemoteArchiveInstaller) validateURL(ctx context.Context, candidate *url.URL, allowedHosts []string) error {
+	if candidate == nil || candidate.Scheme != "https" || candidate.User != nil || candidate.RawQuery != "" || candidate.Fragment != "" || candidate.Port() != "" || net.ParseIP(candidate.Hostname()) != nil || !containsFold(allowedHosts, candidate.Hostname()) {
+		return errors.New("connector remote archive URL is not allowed")
+	}
+	addresses, err := installer.lookupIP(ctx, candidate.Hostname())
+	if err != nil || len(addresses) == 0 {
+		return errors.New("resolve connector remote archive host")
+	}
+	for _, address := range addresses {
+		ip := address.IP
+		if ip == nil || ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() || ip.IsMulticast() {
+			return errors.New("connector remote archive host resolved to a non-public address")
+		}
+	}
+	return nil
+}
+
+func (*RemoteArchiveInstaller) readAndVerifyReceipt(release market.Release, target string) (market.CLIInstallationReceipt, error) {
+	managed, cli, install, err := remoteArchiveIntent(release)
+	if err != nil {
+		return market.CLIInstallationReceipt{}, err
+	}
+	data, err := os.ReadFile(filepath.Join(target, remoteArchiveReceiptFile))
+	if err != nil || len(data) > 1<<20 {
+		return market.CLIInstallationReceipt{}, errors.New("connector remote archive receipt is unavailable")
+	}
+	var receipt market.CLIInstallationReceipt
+	if json.Unmarshal(data, &receipt) != nil || receipt.SchemaVersion != remoteArchiveReceiptSchema || receipt.InstallKind != "remote_archive" ||
+		receipt.ConnectorKey != release.ConnectorKey || receipt.ReleaseDigest != release.ReleaseDigest || receipt.RuntimeProfile != managed.Runtime.Profile || receipt.RuntimeABI != managed.Runtime.ABI ||
+		receipt.ArchiveSHA256 != install.Source.SHA256 || receipt.ArchiveSize != install.Source.SizeBytes || receipt.ArchiveFormat != install.Source.Format ||
+		receipt.InventoryAlgorithm != install.Extraction.InventoryAlgorithm || receipt.InventorySHA256 != install.Extraction.InventorySHA256 ||
+		receipt.FileCount != install.Extraction.FileCount || receipt.ExpandedSizeBytes != install.Extraction.ExpandedSizeBytes ||
+		receipt.LaunchKind != install.Launch.Kind || receipt.Entrypoint != cli.Entrypoint || receipt.EntrypointSHA256 != install.Launch.SHA256 || receipt.EntrypointSize != install.Launch.SizeBytes ||
+		filepath.Clean(receipt.InstallRoot) != filepath.Join(target, "payload") {
+		return market.CLIInstallationReceipt{}, errors.New("connector remote archive receipt identity is invalid")
+	}
+	identity, err := marketartifact.InspectTree(receipt.InstallRoot)
+	if err != nil || identity.SHA256 != receipt.InventorySHA256 || identity.FileCount != receipt.FileCount || identity.ExpandedSizeBytes != receipt.ExpandedSizeBytes {
+		return market.CLIInstallationReceipt{}, errors.New("connector remote archive tree changed after activation")
+	}
+	entrypoint, err := PreparedEntrypoint(receipt.InstallRoot, receipt.Entrypoint)
+	if err != nil {
+		return market.CLIInstallationReceipt{}, err
+	}
+	digest, err := cliFileSHA256(entrypoint)
+	info, statErr := os.Stat(entrypoint)
+	if err != nil || statErr != nil || digest != receipt.EntrypointSHA256 || info.Size() != receipt.EntrypointSize {
+		return market.CLIInstallationReceipt{}, errors.New("connector remote archive entrypoint changed after activation")
+	}
+	return receipt, nil
+}
+
+func (installer *RemoteArchiveInstaller) promote(staging, target, operationID string) error {
+	if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+		return err
+	}
+	quarantine := ""
+	if _, err := os.Lstat(target); err == nil {
+		quarantineRoot := filepath.Join(installer.rootDir, "quarantine")
+		if err := os.MkdirAll(quarantineRoot, 0o700); err != nil {
+			return err
+		}
+		quarantine = filepath.Join(quarantineRoot, operationID)
+		_ = marketartifact.RemoveAllWithin(installer.rootDir, quarantine)
+		if err := os.Rename(target, quarantine); err != nil {
+			return fmt.Errorf("quarantine invalid connector remote archive: %w", err)
+		}
+	}
+	if err := os.Rename(staging, target); err != nil {
+		return fmt.Errorf("activate connector remote archive: %w", err)
+	}
+	if err := marketartifact.SyncDirectory(filepath.Dir(target)); err != nil {
+		return err
+	}
+	if quarantine != "" {
+		_ = makeRemoteArchiveWritable(quarantine)
+		_ = marketartifact.RemoveAllWithin(installer.rootDir, quarantine)
+	}
+	return nil
+}
+
+func (installer *RemoteArchiveInstaller) installRoot(release market.Release) string {
+	return filepath.Join(installer.rootDir, "releases", release.ConnectorKey, release.ReleaseDigest)
+}
+
+func (installer *RemoteArchiveInstaller) lock(connectorKey string) func() {
+	return installer.lockNamed(installer.lanes, connectorKey)
+}
+
+func (installer *RemoteArchiveInstaller) lockNamed(lanes map[string]*sync.Mutex, key string) func() {
+	installer.mu.Lock()
+	lane := lanes[key]
+	if lane == nil {
+		lane = &sync.Mutex{}
+		lanes[key] = lane
+	}
+	installer.mu.Unlock()
+	lane.Lock()
+	return lane.Unlock
+}
+
+func remoteArchiveIntent(release market.Release) (*market.ManagedStdioImplementation, *market.ManagedCLIInterface, *market.RemoteArchiveInstallation, error) {
+	managed := release.Manifest.Implementation.ManagedStdio
+	if managed == nil || managed.CLI == nil || managed.CLI.Install == nil || managed.CLI.Install.Kind != "remote_archive" || managed.CLI.Install.RemoteArchive == nil {
+		return nil, nil, nil, errors.New("connector release does not declare a remote archive CLI installation")
+	}
+	return managed, managed.CLI, managed.CLI.Install.RemoteArchive, nil
+}
+
+func exactArchiveRoot(extracted, relative string) (string, error) {
+	entries, err := os.ReadDir(extracted)
+	if err != nil || len(entries) != 1 || entries[0].Name() != relative {
+		return "", errors.New("connector remote archive must contain exactly its declared root")
+	}
+	root := filepath.Join(extracted, filepath.FromSlash(relative))
+	info, err := os.Lstat(root)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return "", errors.New("connector remote archive root is invalid")
+	}
+	return root, nil
+}
+
+func makeRemoteArchiveReadOnly(root, entrypoint string) error {
+	return filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return os.Chmod(path, 0o500)
+		}
+		mode := os.FileMode(0o400)
+		if path == entrypoint {
+			mode = 0o500
+		}
+		return os.Chmod(path, mode)
+	})
+}
+
+func makeRemoteArchiveWritable(root string) error {
+	if _, err := os.Lstat(root); errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return errors.New("connector remote archive cleanup encountered a symbolic link")
+		}
+		if entry.IsDir() {
+			return os.Chmod(path, 0o700)
+		}
+		return os.Chmod(path, 0o600)
+	})
+}
+
+func writeRemoteArchiveReceipt(root string, receipt market.CLIInstallationReceipt) error {
+	data, err := json.Marshal(receipt)
+	if err != nil {
+		return err
+	}
+	file, err := os.OpenFile(filepath.Join(root, remoteArchiveReceiptFile), os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	return marketartifact.SyncDirectory(root)
+}
+
+func verifyRemoteArchiveFile(path string, source market.RemoteArchiveSource) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil || !info.Mode().IsRegular() || info.Size() != source.SizeBytes {
+		return errors.New("connector remote archive cache identity is invalid")
+	}
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return err
+	}
+	if hex.EncodeToString(hash.Sum(nil)) != source.SHA256 {
+		return errors.New("connector remote archive cache digest is invalid")
+	}
+	return nil
+}
+
+func containsFold(values []string, expected string) bool {
+	for _, value := range values {
+		if strings.EqualFold(strings.TrimSpace(value), expected) {
+			return true
+		}
+	}
+	return false
+}

--- a/packages/connector/runtime/remote_archive_installer.go
+++ b/packages/connector/runtime/remote_archive_installer.go
@@ -29,11 +29,12 @@ const (
 )
 
 type RemoteArchiveInstallerConfig struct {
-	RootDir    string
-	HTTPClient *http.Client
-	Limits     marketartifact.Limits
-	Timeout    time.Duration
-	LookupIP   func(context.Context, string) ([]net.IPAddr, error)
+	RootDir                              string
+	HTTPClient                           *http.Client
+	Limits                               marketartifact.Limits
+	Timeout                              time.Duration
+	LookupIP                             func(context.Context, string) ([]net.IPAddr, error)
+	UnsafeAllowUnpinnedTransportForTests bool
 }
 
 type RemoteArchiveInstaller struct {
@@ -46,7 +47,15 @@ type RemoteArchiveInstaller struct {
 	lanes      map[string]*sync.Mutex
 	cacheLanes map[string]*sync.Mutex
 	slots      chan struct{}
+	rename     func(string, string) error
+	syncDir    func(string) error
 }
+
+type remoteArchivePinnedAddresses struct {
+	host      string
+	addresses []net.IPAddr
+}
+type remoteArchivePinnedAddressesKey struct{}
 
 var _ market.CLIInstallationManager = (*RemoteArchiveInstaller)(nil)
 
@@ -74,8 +83,59 @@ func NewRemoteArchiveInstaller(config RemoteArchiveInstallerConfig) (*RemoteArch
 	if lookup == nil {
 		lookup = net.DefaultResolver.LookupIPAddr
 	}
+	var transport *http.Transport
+	switch configured := clientCopy.Transport.(type) {
+	case nil:
+		defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+		if !ok {
+			return nil, errors.New("connector remote archive default HTTP transport is unsupported")
+		}
+		transport = defaultTransport.Clone()
+	case *http.Transport:
+		transport = configured.Clone()
+	default:
+		if !config.UnsafeAllowUnpinnedTransportForTests {
+			return nil, errors.New("connector remote archive HTTP transport must support pinned dialing")
+		}
+	}
+	if transport != nil {
+		// DialTLS is deprecated, but callers can still set it and bypass DialContext.
+		//nolint:staticcheck // Reject both TLS dial hooks to preserve DNS pinning.
+		if transport.DialTLSContext != nil || transport.DialTLS != nil {
+			return nil, errors.New("connector remote archive HTTP transport must not override TLS dialing")
+		}
+		if transport.TLSClientConfig != nil {
+			if transport.TLSClientConfig.InsecureSkipVerify {
+				return nil, errors.New("connector remote archive HTTP transport must verify TLS")
+			}
+			transport.TLSClientConfig = transport.TLSClientConfig.Clone()
+			transport.TLSClientConfig.ServerName = ""
+		}
+		// A proxy resolves the CONNECT target independently and would break the
+		// binding between validation and the origin socket established below.
+		transport.Proxy = nil
+		baseDial := (&net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}).DialContext
+		transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+			pinned, _ := ctx.Value(remoteArchivePinnedAddressesKey{}).(remoteArchivePinnedAddresses)
+			host, port, splitErr := net.SplitHostPort(address)
+			if splitErr != nil || !strings.EqualFold(host, pinned.host) || len(pinned.addresses) == 0 {
+				return nil, errors.New("connector remote archive dial is not bound to validated DNS addresses")
+			}
+			var dialErr error
+			for _, candidate := range pinned.addresses {
+				connection, err := baseDial(ctx, network, net.JoinHostPort(candidate.IP.String(), port))
+				if err == nil {
+					return connection, nil
+				}
+				dialErr = errors.Join(dialErr, err)
+			}
+			return nil, dialErr
+		}
+		clientCopy.Transport = transport
+	}
 	return &RemoteArchiveInstaller{rootDir: root, httpClient: &clientCopy, limits: limits, timeout: timeout,
-		lookupIP: lookup, lanes: make(map[string]*sync.Mutex), cacheLanes: make(map[string]*sync.Mutex), slots: make(chan struct{}, 4)}, nil
+		lookupIP: lookup, lanes: make(map[string]*sync.Mutex), cacheLanes: make(map[string]*sync.Mutex), slots: make(chan struct{}, 4),
+		rename: os.Rename, syncDir: marketartifact.SyncDirectory}, nil
 }
 
 func (installer *RemoteArchiveInstaller) InstallCLI(ctx context.Context, request market.InstallCLIRequest) (market.CLIInstallationReceipt, error) {
@@ -114,16 +174,17 @@ func (installer *RemoteArchiveInstaller) InstallCLI(ctx context.Context, request
 	if !pathWithin(installer.rootDir, staging) {
 		return market.CLIInstallationReceipt{}, errors.New("connector remote archive staging path escapes root")
 	}
-	_ = marketartifact.RemoveAllWithin(installer.rootDir, staging)
-	if err := os.MkdirAll(staging, 0o700); err != nil {
+	if err := marketartifact.RemoveAllWithin(installer.rootDir, staging); err != nil {
+		return market.CLIInstallationReceipt{}, fmt.Errorf("clean connector remote archive staging: %w", err)
+	}
+	if err := createRemoteArchiveDirectory(installer.rootDir, staging); err != nil {
 		return market.CLIInstallationReceipt{}, err
 	}
 	defer func() {
-		_ = makeRemoteArchiveWritable(staging)
-		_ = marketartifact.RemoveAllWithin(installer.rootDir, staging)
+		_ = removeRemoteArchiveTree(installer.rootDir, staging)
 	}()
 	extracted := filepath.Join(staging, "extracted")
-	if err := os.MkdirAll(extracted, 0o700); err != nil {
+	if err := createRemoteArchiveDirectory(installer.rootDir, extracted); err != nil {
 		return market.CLIInstallationReceipt{}, err
 	}
 	if err := marketartifact.ExtractArchive(archivePath, install.Source.Format, extracted, installer.limits); err != nil {
@@ -196,10 +257,13 @@ func (installer *RemoteArchiveInstaller) ResolveCLI(ctx context.Context, release
 	unlock := installer.lock(release.ConnectorKey)
 	defer unlock()
 	target := installer.installRoot(release)
-	if _, err := os.Stat(target); errors.Is(err, os.ErrNotExist) {
+	if _, err := os.Lstat(target); errors.Is(err, os.ErrNotExist) {
 		return market.CLIInstallationReceipt{}, market.ErrReleaseInstallationAbsent
 	} else if err != nil {
 		return market.CLIInstallationReceipt{}, err
+	}
+	if err := ensureRemoteArchiveDirectory(installer.rootDir, target); err != nil {
+		return market.CLIInstallationReceipt{}, fmt.Errorf("%w: %v", market.ErrReleaseInstallationInvalid, err)
 	}
 	receipt, err := installer.readAndVerifyReceipt(release, target)
 	if err != nil {
@@ -218,8 +282,7 @@ func (installer *RemoteArchiveInstaller) RemoveCLI(ctx context.Context, request 
 	unlock := installer.lock(request.ConnectorKey)
 	defer unlock()
 	target := filepath.Join(installer.rootDir, "releases", request.ConnectorKey, request.ReleaseDigest)
-	_ = makeRemoteArchiveWritable(target)
-	return marketartifact.RemoveAllWithin(installer.rootDir, target)
+	return removeRemoteArchiveTree(installer.rootDir, target)
 }
 
 func (installer *RemoteArchiveInstaller) RemoveConnector(ctx context.Context, request market.RemoveConnectorInstallationRequest) error {
@@ -232,20 +295,22 @@ func (installer *RemoteArchiveInstaller) RemoveConnector(ctx context.Context, re
 	unlock := installer.lock(request.ConnectorKey)
 	defer unlock()
 	target := filepath.Join(installer.rootDir, "releases", request.ConnectorKey)
-	_ = makeRemoteArchiveWritable(target)
-	return marketartifact.RemoveAllWithin(installer.rootDir, target)
+	return removeRemoteArchiveTree(installer.rootDir, target)
 }
 
 func (installer *RemoteArchiveInstaller) prepareArchive(ctx context.Context, source market.RemoteArchiveSource) (string, error) {
 	unlock := installer.lockNamed(installer.cacheLanes, source.SHA256)
 	defer unlock()
 	cacheDir := filepath.Join(installer.rootDir, "cache")
-	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+	if err := createRemoteArchiveDirectory(installer.rootDir, cacheDir); err != nil {
 		return "", err
 	}
 	archivePath := filepath.Join(cacheDir, source.SHA256+".archive")
 	if verifyRemoteArchiveFile(archivePath, source) == nil {
 		return archivePath, nil
+	}
+	if err := removeInvalidRemoteArchiveCacheFile(installer.rootDir, archivePath); err != nil {
+		return "", err
 	}
 	temporary := archivePath + ".partial"
 	_ = os.Remove(temporary)
@@ -268,14 +333,14 @@ func (installer *RemoteArchiveInstaller) prepareArchive(ctx context.Context, sou
 		_ = os.Remove(temporary)
 		return "", errors.Join(errors.New("connector remote archive download identity is invalid"), copyErr, syncErr, closeErr)
 	}
-	if err := os.Rename(temporary, archivePath); err != nil {
+	if err := installer.rename(temporary, archivePath); err != nil {
 		_ = os.Remove(temporary)
 		if verifyRemoteArchiveFile(archivePath, source) == nil {
 			return archivePath, nil
 		}
 		return "", err
 	}
-	if err := marketartifact.SyncDirectory(cacheDir); err != nil {
+	if err := installer.syncDir(cacheDir); err != nil {
 		return "", err
 	}
 	return archivePath, nil
@@ -287,10 +352,12 @@ func (installer *RemoteArchiveInstaller) fetch(ctx context.Context, source marke
 		return nil, err
 	}
 	for redirect := 0; redirect <= maxRemoteArchiveRedirects; redirect++ {
-		if err := installer.validateURL(ctx, current, source.AllowedHosts); err != nil {
+		addresses, err := installer.validateURL(ctx, current, source.AllowedHosts)
+		if err != nil {
 			return nil, err
 		}
-		request, err := http.NewRequestWithContext(ctx, http.MethodGet, current.String(), nil)
+		requestContext := context.WithValue(ctx, remoteArchivePinnedAddressesKey{}, remoteArchivePinnedAddresses{host: current.Hostname(), addresses: addresses})
+		request, err := http.NewRequestWithContext(requestContext, http.MethodGet, current.String(), nil)
 		if err != nil {
 			return nil, err
 		}
@@ -321,29 +388,37 @@ func (installer *RemoteArchiveInstaller) fetch(ctx context.Context, source marke
 	return nil, errors.New("connector remote archive redirect limit exceeded")
 }
 
-func (installer *RemoteArchiveInstaller) validateURL(ctx context.Context, candidate *url.URL, allowedHosts []string) error {
+func (installer *RemoteArchiveInstaller) validateURL(ctx context.Context, candidate *url.URL, allowedHosts []string) ([]net.IPAddr, error) {
 	if candidate == nil || candidate.Scheme != "https" || candidate.User != nil || candidate.RawQuery != "" || candidate.Fragment != "" || candidate.Port() != "" || net.ParseIP(candidate.Hostname()) != nil || !containsFold(allowedHosts, candidate.Hostname()) {
-		return errors.New("connector remote archive URL is not allowed")
+		return nil, errors.New("connector remote archive URL is not allowed")
 	}
 	addresses, err := installer.lookupIP(ctx, candidate.Hostname())
 	if err != nil || len(addresses) == 0 {
-		return errors.New("resolve connector remote archive host")
+		return nil, errors.New("resolve connector remote archive host")
 	}
 	for _, address := range addresses {
 		ip := address.IP
-		if ip == nil || ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() || ip.IsMulticast() {
-			return errors.New("connector remote archive host resolved to a non-public address")
+		if ip == nil || !ip.IsGlobalUnicast() || ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() || ip.IsMulticast() {
+			return nil, errors.New("connector remote archive host resolved to a non-public address")
 		}
 	}
-	return nil
+	return addresses, nil
 }
 
-func (*RemoteArchiveInstaller) readAndVerifyReceipt(release market.Release, target string) (market.CLIInstallationReceipt, error) {
+func (installer *RemoteArchiveInstaller) readAndVerifyReceipt(release market.Release, target string) (market.CLIInstallationReceipt, error) {
 	managed, cli, install, err := remoteArchiveIntent(release)
 	if err != nil {
 		return market.CLIInstallationReceipt{}, err
 	}
-	data, err := os.ReadFile(filepath.Join(target, remoteArchiveReceiptFile))
+	if err := ensureRemoteArchiveDirectory(installer.rootDir, target); err != nil {
+		return market.CLIInstallationReceipt{}, err
+	}
+	receiptPath := filepath.Join(target, remoteArchiveReceiptFile)
+	receiptInfo, receiptStatErr := os.Lstat(receiptPath)
+	if receiptStatErr != nil || receiptInfo.Mode()&os.ModeSymlink != 0 || !receiptInfo.Mode().IsRegular() {
+		return market.CLIInstallationReceipt{}, errors.New("connector remote archive receipt is unavailable")
+	}
+	data, err := os.ReadFile(receiptPath)
 	if err != nil || len(data) > 1<<20 {
 		return market.CLIInstallationReceipt{}, errors.New("connector remote archive receipt is unavailable")
 	}
@@ -356,6 +431,9 @@ func (*RemoteArchiveInstaller) readAndVerifyReceipt(release market.Release, targ
 		receipt.LaunchKind != install.Launch.Kind || receipt.Entrypoint != cli.Entrypoint || receipt.EntrypointSHA256 != install.Launch.SHA256 || receipt.EntrypointSize != install.Launch.SizeBytes ||
 		filepath.Clean(receipt.InstallRoot) != filepath.Join(target, "payload") {
 		return market.CLIInstallationReceipt{}, errors.New("connector remote archive receipt identity is invalid")
+	}
+	if err := ensureRemoteArchiveDirectory(installer.rootDir, receipt.InstallRoot); err != nil {
+		return market.CLIInstallationReceipt{}, errors.New("connector remote archive payload path is invalid")
 	}
 	identity, err := marketartifact.InspectTree(receipt.InstallRoot)
 	if err != nil || identity.SHA256 != receipt.InventorySHA256 || identity.FileCount != receipt.FileCount || identity.ExpandedSizeBytes != receipt.ExpandedSizeBytes {
@@ -374,32 +452,123 @@ func (*RemoteArchiveInstaller) readAndVerifyReceipt(release market.Release, targ
 }
 
 func (installer *RemoteArchiveInstaller) promote(staging, target, operationID string) error {
-	if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+	if err := createRemoteArchiveDirectory(installer.rootDir, filepath.Dir(target)); err != nil {
 		return err
 	}
 	quarantine := ""
 	if _, err := os.Lstat(target); err == nil {
 		quarantineRoot := filepath.Join(installer.rootDir, "quarantine")
-		if err := os.MkdirAll(quarantineRoot, 0o700); err != nil {
+		if err := createRemoteArchiveDirectory(installer.rootDir, quarantineRoot); err != nil {
 			return err
 		}
 		quarantine = filepath.Join(quarantineRoot, operationID)
-		_ = marketartifact.RemoveAllWithin(installer.rootDir, quarantine)
-		if err := os.Rename(target, quarantine); err != nil {
+		if err := marketartifact.RemoveAllWithin(installer.rootDir, quarantine); err != nil {
+			return fmt.Errorf("clean connector remote archive quarantine: %w", err)
+		}
+		if err := installer.rename(target, quarantine); err != nil {
 			return fmt.Errorf("quarantine invalid connector remote archive: %w", err)
 		}
 	}
-	if err := os.Rename(staging, target); err != nil {
-		return fmt.Errorf("activate connector remote archive: %w", err)
+	if err := installer.rename(staging, target); err != nil {
+		restoreErr := error(nil)
+		if quarantine != "" {
+			restoreErr = installer.rename(quarantine, target)
+		}
+		return errors.Join(fmt.Errorf("activate connector remote archive: %w", err), restoreErr)
 	}
-	if err := marketartifact.SyncDirectory(filepath.Dir(target)); err != nil {
-		return err
+	if err := installer.syncDir(filepath.Dir(target)); err != nil {
+		rollbackErr := installer.rename(target, staging)
+		if rollbackErr != nil {
+			rollbackErr = errors.Join(rollbackErr, removeRemoteArchiveTree(installer.rootDir, target))
+		}
+		if quarantine != "" {
+			if _, statErr := os.Lstat(target); errors.Is(statErr, os.ErrNotExist) {
+				rollbackErr = errors.Join(rollbackErr, installer.rename(quarantine, target))
+			}
+		}
+		return errors.Join(fmt.Errorf("sync activated connector remote archive: %w", err), rollbackErr)
 	}
 	if quarantine != "" {
-		_ = makeRemoteArchiveWritable(quarantine)
-		_ = marketartifact.RemoveAllWithin(installer.rootDir, quarantine)
+		_ = removeRemoteArchiveTree(installer.rootDir, quarantine)
 	}
 	return nil
+}
+
+func createRemoteArchiveDirectory(root, target string) error {
+	root = filepath.Clean(root)
+	target = filepath.Clean(target)
+	relative, err := filepath.Rel(root, target)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return errors.New("connector remote archive directory escapes root")
+	}
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return err
+	}
+	current := root
+	parts := []string{}
+	if relative != "." {
+		parts = strings.Split(relative, string(filepath.Separator))
+	}
+	for _, part := range append([]string{""}, parts...) {
+		if part != "" {
+			current = filepath.Join(current, part)
+		}
+		info, statErr := os.Lstat(current)
+		if errors.Is(statErr, os.ErrNotExist) {
+			if mkdirErr := os.Mkdir(current, 0o700); mkdirErr != nil && !errors.Is(mkdirErr, os.ErrExist) {
+				return mkdirErr
+			}
+			info, statErr = os.Lstat(current)
+		}
+		if statErr != nil {
+			return statErr
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return errors.New("connector remote archive directory contains a symbolic link or non-directory")
+		}
+	}
+	return nil
+}
+
+func ensureRemoteArchiveDirectory(root, target string) error {
+	root = filepath.Clean(root)
+	target = filepath.Clean(target)
+	relative, err := filepath.Rel(root, target)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return errors.New("connector remote archive directory escapes root")
+	}
+	current := root
+	parts := []string{}
+	if relative != "." {
+		parts = strings.Split(relative, string(filepath.Separator))
+	}
+	for _, part := range append([]string{""}, parts...) {
+		if part != "" {
+			current = filepath.Join(current, part)
+		}
+		info, statErr := os.Lstat(current)
+		if statErr != nil {
+			return statErr
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return errors.New("connector remote archive directory contains a symbolic link or non-directory")
+		}
+	}
+	return nil
+}
+
+func removeInvalidRemoteArchiveCacheFile(root, path string) error {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || !pathWithin(root, path) {
+		return errors.New("connector remote archive cache entry is unsafe")
+	}
+	return os.Remove(path)
 }
 
 func (installer *RemoteArchiveInstaller) installRoot(release market.Release) string {
@@ -477,6 +646,19 @@ func makeRemoteArchiveWritable(root string) error {
 	})
 }
 
+func removeRemoteArchiveTree(root, target string) error {
+	if err := ensureRemoteArchiveDirectory(root, target); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return marketartifact.RemoveAllWithin(root, target)
+		}
+		return err
+	}
+	if err := makeRemoteArchiveWritable(target); err != nil {
+		return err
+	}
+	return marketartifact.RemoveAllWithin(root, target)
+}
+
 func writeRemoteArchiveReceipt(root string, receipt market.CLIInstallationReceipt) error {
 	data, err := json.Marshal(receipt)
 	if err != nil {
@@ -501,13 +683,18 @@ func writeRemoteArchiveReceipt(root string, receipt market.CLIInstallationReceip
 }
 
 func verifyRemoteArchiveFile(path string, source market.RemoteArchiveSource) error {
+	pathInfo, err := os.Lstat(path)
+	if err != nil || pathInfo.Mode()&os.ModeSymlink != 0 || !pathInfo.Mode().IsRegular() {
+		return errors.New("connector remote archive cache identity is invalid")
+	}
 	file, err := os.Open(path)
 	if err != nil {
 		return err
 	}
 	defer file.Close()
 	info, err := file.Stat()
-	if err != nil || !info.Mode().IsRegular() || info.Size() != source.SizeBytes {
+	afterInfo, afterErr := os.Lstat(path)
+	if err != nil || afterErr != nil || afterInfo.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || !afterInfo.Mode().IsRegular() || !os.SameFile(pathInfo, info) || !os.SameFile(info, afterInfo) || info.Size() != source.SizeBytes {
 		return errors.New("connector remote archive cache identity is invalid")
 	}
 	hash := sha256.New()

--- a/packages/connector/runtime/remote_archive_installer_test.go
+++ b/packages/connector/runtime/remote_archive_installer_test.go
@@ -5,10 +5,13 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"crypto/tls"
 	"encoding/hex"
+	"errors"
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -27,7 +30,8 @@ func TestRemoteArchiveInstallerInstallsAndDetectsTreeDrift(t *testing.T) {
 	archive, release := remoteArchiveFixture(t)
 	requests := 0
 	installer, err := NewRemoteArchiveInstaller(RemoteArchiveInstallerConfig{
-		RootDir: t.TempDir(),
+		RootDir:                              t.TempDir(),
+		UnsafeAllowUnpinnedTransportForTests: true,
 		HTTPClient: &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
 			requests++
 			return &http.Response{StatusCode: http.StatusOK, ContentLength: int64(len(archive)), Body: io.NopCloser(bytes.NewReader(archive)), Header: make(http.Header), Request: request}, nil
@@ -69,7 +73,7 @@ func TestRemoteArchiveInstallerInstallsAndDetectsTreeDrift(t *testing.T) {
 func TestRemoteArchiveInstallerRejectsNonPublicResolution(t *testing.T) {
 	archive, release := remoteArchiveFixture(t)
 	installer, err := NewRemoteArchiveInstaller(RemoteArchiveInstallerConfig{
-		RootDir: t.TempDir(), HTTPClient: &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		RootDir: t.TempDir(), UnsafeAllowUnpinnedTransportForTests: true, HTTPClient: &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
 			return &http.Response{StatusCode: http.StatusOK, ContentLength: int64(len(archive)), Body: io.NopCloser(bytes.NewReader(archive)), Header: make(http.Header), Request: request}, nil
 		})},
 		LookupIP: func(context.Context, string) ([]net.IPAddr, error) {
@@ -84,10 +88,267 @@ func TestRemoteArchiveInstallerRejectsNonPublicResolution(t *testing.T) {
 	}
 }
 
+func TestRemoteArchiveInstallerRejectsSymlinkedStaging(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("remote archive v1 intentionally fails closed on Windows")
+	}
+	archive, release := remoteArchiveFixture(t)
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "staging"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "staging", "install-1")); err != nil {
+		t.Fatal(err)
+	}
+	installer, err := NewRemoteArchiveInstaller(RemoteArchiveInstallerConfig{
+		RootDir:                              root,
+		UnsafeAllowUnpinnedTransportForTests: true,
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusOK, ContentLength: int64(len(archive)), Body: io.NopCloser(bytes.NewReader(archive)), Header: make(http.Header), Request: request}, nil
+		})},
+		LookupIP: func(context.Context, string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.ParseIP("8.8.8.8")}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installer.InstallCLI(t.Context(), market.InstallCLIRequest{OperationID: "install-1", Release: release}); err == nil || !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("InstallCLI() error = %v, want symlink rejection", err)
+	}
+}
+
+func TestRemoteArchivePromoteRestoresQuarantinedTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("remote archive v1 intentionally fails closed on Windows")
+	}
+	root := t.TempDir()
+	installer, err := NewRemoteArchiveInstaller(RemoteArchiveInstallerConfig{RootDir: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "releases", "aws-cli", strings.Repeat("a", 64))
+	staging := filepath.Join(root, "staging", "install-1")
+	if err := os.MkdirAll(target, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "old"), []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(staging, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	realRename := installer.rename
+	failed := false
+	installer.rename = func(oldPath, newPath string) error {
+		if oldPath == staging && newPath == target && !failed {
+			failed = true
+			return errors.New("injected activation failure")
+		}
+		return realRename(oldPath, newPath)
+	}
+	if err := installer.promote(staging, target, "install-1"); err == nil {
+		t.Fatal("promote succeeded after injected activation failure")
+	}
+	if data, err := os.ReadFile(filepath.Join(target, "old")); err != nil || string(data) != "old" {
+		t.Fatalf("old target was not restored: data=%q error=%v", data, err)
+	}
+}
+
+func TestRemoteArchivePromoteRejectsSymlinkedReleaseParent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("remote archive v1 intentionally fails closed on Windows")
+	}
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "releases")); err != nil {
+		t.Fatal(err)
+	}
+	staging := filepath.Join(root, "staging", "install-1")
+	if err := os.MkdirAll(staging, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	installer, err := NewRemoteArchiveInstaller(RemoteArchiveInstallerConfig{RootDir: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "releases", "aws-cli", strings.Repeat("a", 64))
+	if err := installer.promote(staging, target, "install-1"); err == nil || !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("promote() error = %v, want symlink rejection", err)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "aws-cli", strings.Repeat("a", 64))); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("promote wrote outside the managed root: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "aws-cli")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("promote created a directory outside the managed root: %v", err)
+	}
+}
+
+func TestRemoteArchiveRemoveRejectsSymlinkedParentBeforeChmod(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("remote archive v1 intentionally fails closed on Windows")
+	}
+	root := t.TempDir()
+	outside := t.TempDir()
+	externalConnector := filepath.Join(outside, "aws-cli")
+	if err := os.MkdirAll(externalConnector, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	externalFile := filepath.Join(externalConnector, "keep")
+	if err := os.WriteFile(externalFile, []byte("keep"), 0o400); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(externalConnector, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(externalConnector, 0o700) })
+	if err := os.Symlink(outside, filepath.Join(root, "releases")); err != nil {
+		t.Fatal(err)
+	}
+	installer, err := NewRemoteArchiveInstaller(RemoteArchiveInstallerConfig{RootDir: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = installer.RemoveConnector(t.Context(), market.RemoveConnectorInstallationRequest{ConnectorKey: "aws-cli"})
+	if err == nil || !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("RemoveConnector() error = %v, want symlink rejection", err)
+	}
+	info, statErr := os.Stat(externalFile)
+	if statErr != nil || info.Mode().Perm() != 0o400 {
+		t.Fatalf("external file mode changed before rejection: mode=%v error=%v", info.Mode().Perm(), statErr)
+	}
+}
+
+func TestRemoteArchiveCacheRejectsMatchingSymlink(t *testing.T) {
+	archive, release := remoteArchiveFixture(t)
+	source := release.Manifest.Implementation.ManagedStdio.CLI.Install.RemoteArchive.Source
+	outside := filepath.Join(t.TempDir(), "archive.zip")
+	if err := os.WriteFile(outside, archive, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(t.TempDir(), "cached.archive")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyRemoteArchiveFile(link, source); err == nil || !strings.Contains(err.Error(), "cache identity") {
+		t.Fatalf("verifyRemoteArchiveFile() error = %v, want symlink rejection", err)
+	}
+}
+
+func TestRemoteArchiveResolveRejectsSymlinkedReleaseParent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("remote archive v1 intentionally fails closed on Windows")
+	}
+	archive, release := remoteArchiveFixture(t)
+	root := t.TempDir()
+	installer, err := NewRemoteArchiveInstaller(RemoteArchiveInstallerConfig{
+		RootDir: root, UnsafeAllowUnpinnedTransportForTests: true,
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusOK, ContentLength: int64(len(archive)), Body: io.NopCloser(bytes.NewReader(archive)), Header: make(http.Header), Request: request}, nil
+		})},
+		LookupIP: func(context.Context, string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.ParseIP("8.8.8.8")}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installer.InstallCLI(t.Context(), market.InstallCLIRequest{OperationID: "install-1", Release: release}); err != nil {
+		t.Fatal(err)
+	}
+	externalReleases := filepath.Join(t.TempDir(), "releases")
+	if err := os.Rename(filepath.Join(root, "releases"), externalReleases); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = makeRemoteArchiveWritable(externalReleases) })
+	if err := os.Symlink(externalReleases, filepath.Join(root, "releases")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installer.ResolveCLI(t.Context(), release); err == nil || !strings.Contains(err.Error(), market.ErrReleaseInstallationInvalid.Error()) {
+		t.Fatalf("ResolveCLI() error = %v, want invalid installation", err)
+	}
+}
+
+func TestRemoteArchivePromoteRemovesNewTargetWhenSyncRollbackRenameFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("remote archive v1 intentionally fails closed on Windows")
+	}
+	root := t.TempDir()
+	installer, err := NewRemoteArchiveInstaller(RemoteArchiveInstallerConfig{RootDir: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "releases", "aws-cli", strings.Repeat("a", 64))
+	staging := filepath.Join(root, "staging", "install-1")
+	if err := os.MkdirAll(target, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "old"), []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(staging, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staging, "new"), []byte("new"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	realRename := installer.rename
+	installer.rename = func(oldPath, newPath string) error {
+		if oldPath == target && newPath == staging {
+			return errors.New("injected rollback rename failure")
+		}
+		return realRename(oldPath, newPath)
+	}
+	installer.syncDir = func(string) error { return errors.New("injected sync failure") }
+	if err := installer.promote(staging, target, "install-1"); err == nil {
+		t.Fatal("promote succeeded after injected sync failure")
+	}
+	if data, err := os.ReadFile(filepath.Join(target, "old")); err != nil || string(data) != "old" {
+		t.Fatalf("old target was not restored after rollback rename failure: data=%q error=%v", data, err)
+	}
+	if _, err := os.Stat(filepath.Join(target, "new")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("new target remained active after failed promote: %v", err)
+	}
+}
+
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (function roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
 	return function(request)
+}
+
+func TestRemoteArchiveInstallerRejectsUnpinnedCustomTransport(t *testing.T) {
+	_, err := NewRemoteArchiveInstaller(RemoteArchiveInstallerConfig{
+		RootDir: t.TempDir(), HTTPClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) { return nil, errors.New("unused") })},
+	})
+	if err == nil || !strings.Contains(err.Error(), "pinned dialing") {
+		t.Fatalf("NewRemoteArchiveInstaller() error = %v, want pinned transport rejection", err)
+	}
+}
+
+func TestRemoteArchiveInstallerDisablesProxyAndRejectsTLSDialOverride(t *testing.T) {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = http.ProxyURL(&url.URL{Scheme: "http", Host: "proxy.invalid"})
+	installer, err := NewRemoteArchiveInstaller(RemoteArchiveInstallerConfig{RootDir: t.TempDir(), HTTPClient: &http.Client{Transport: transport}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if installer.httpClient.Transport.(*http.Transport).Proxy != nil {
+		t.Fatal("remote archive transport retained a proxy that can bypass DNS pinning")
+	}
+	transport = http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialTLSContext = func(context.Context, string, string) (net.Conn, error) { return nil, errors.New("unused") }
+	_, err = NewRemoteArchiveInstaller(RemoteArchiveInstallerConfig{RootDir: t.TempDir(), HTTPClient: &http.Client{Transport: transport}})
+	if err == nil || !strings.Contains(err.Error(), "TLS dialing") {
+		t.Fatalf("NewRemoteArchiveInstaller() error = %v, want TLS dial override rejection", err)
+	}
+	transport = http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // The installer must reject this test input.
+	_, err = NewRemoteArchiveInstaller(RemoteArchiveInstallerConfig{RootDir: t.TempDir(), HTTPClient: &http.Client{Transport: transport}})
+	if err == nil || !strings.Contains(err.Error(), "verify TLS") {
+		t.Fatalf("NewRemoteArchiveInstaller() error = %v, want insecure TLS rejection", err)
+	}
 }
 
 func remoteArchiveFixture(t *testing.T) ([]byte, market.Release) {
@@ -140,7 +401,7 @@ func remoteArchiveFixture(t *testing.T) ([]byte, market.Release) {
 		ReleaseDigest: strings.Repeat("1", 64), ManifestDigest: strings.Repeat("2", 64),
 		Artifact:    market.Artifact{Key: "aws-cli.tgz", SHA256: strings.Repeat("3", 64), SizeBytes: 1, MediaType: "application/gzip"},
 		PublishedAt: time.Unix(1, 0).UTC(), Status: market.ReleaseStatusAvailable,
-		Manifest: market.Manifest{SchemaVersion: "1", DisplayName: "AWS CLI", IconURL: "data:image/png;base64,iVBORw0KGgo=", AuthorizationKind: "none",
+		Manifest: market.Manifest{SchemaVersion: "1", DisplayName: "AWS CLI", IconURL: "data:image/png;base64,iVBORw0KGgo=", AuthorizationKind: "none", Compatibility: market.CompatibilityRequirements{MinimumHostVersion: "0.2.27"},
 			Implementation: market.Implementation{Kind: market.ImplementationKindManagedStdio, ManagedStdio: &market.ManagedStdioImplementation{
 				Runtime: market.RuntimeRequirement{Language: "node", Profile: ConnectorNodeProfile, ABI: "node22-" + runtime.GOOS + "-" + runtime.GOARCH, VersionRange: ">=22.0.0 <23.0.0"},
 				CLI: &market.ManagedCLIInterface{Entrypoint: "dist/aws", Command: "aws", TimeoutMS: 120_000, Install: &market.CLIInstallation{Kind: "remote_archive", RemoteArchive: &market.RemoteArchiveInstallation{

--- a/packages/connector/runtime/remote_archive_installer_test.go
+++ b/packages/connector/runtime/remote_archive_installer_test.go
@@ -1,0 +1,155 @@
+package runtime
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	market "github.com/tutti-os/tutti/packages/connector/host"
+	marketartifact "github.com/tutti-os/tutti/packages/connector/runtime/artifact"
+)
+
+func TestRemoteArchiveInstallerInstallsAndDetectsTreeDrift(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("remote archive v1 intentionally fails closed on Windows")
+	}
+	archive, release := remoteArchiveFixture(t)
+	requests := 0
+	installer, err := NewRemoteArchiveInstaller(RemoteArchiveInstallerConfig{
+		RootDir: t.TempDir(),
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			requests++
+			return &http.Response{StatusCode: http.StatusOK, ContentLength: int64(len(archive)), Body: io.NopCloser(bytes.NewReader(archive)), Header: make(http.Header), Request: request}, nil
+		})},
+		LookupIP: func(context.Context, string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.ParseIP("8.8.8.8")}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = installer.RemoveConnector(context.Background(), market.RemoveConnectorInstallationRequest{ConnectorKey: release.ConnectorKey})
+	})
+	receipt, err := installer.InstallCLI(t.Context(), market.InstallCLIRequest{OperationID: "install-1", Release: release})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if requests != 1 || receipt.SchemaVersion != remoteArchiveReceiptSchema || receipt.InventorySHA256 != release.Manifest.Implementation.ManagedStdio.CLI.Install.RemoteArchive.Extraction.InventorySHA256 {
+		t.Fatalf("requests=%d receipt=%#v", requests, receipt)
+	}
+	if _, err := installer.InstallCLI(t.Context(), market.InstallCLIRequest{OperationID: "install-2", Release: release}); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 1 {
+		t.Fatalf("archive downloaded %d times, want cache reuse", requests)
+	}
+	if err := os.Chmod(filepath.Join(receipt.InstallRoot, "README.txt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(receipt.InstallRoot, "README.txt"), []byte("tampered"), 0o400); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installer.ResolveCLI(t.Context(), release); !strings.Contains(err.Error(), market.ErrReleaseInstallationInvalid.Error()) {
+		t.Fatalf("ResolveCLI() error = %v, want invalid installation", err)
+	}
+}
+
+func TestRemoteArchiveInstallerRejectsNonPublicResolution(t *testing.T) {
+	archive, release := remoteArchiveFixture(t)
+	installer, err := NewRemoteArchiveInstaller(RemoteArchiveInstallerConfig{
+		RootDir: t.TempDir(), HTTPClient: &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusOK, ContentLength: int64(len(archive)), Body: io.NopCloser(bytes.NewReader(archive)), Header: make(http.Header), Request: request}, nil
+		})},
+		LookupIP: func(context.Context, string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.ParseIP("127.0.0.1")}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installer.InstallCLI(t.Context(), market.InstallCLIRequest{OperationID: "install-1", Release: release}); err == nil || !strings.Contains(err.Error(), "non-public") {
+		t.Fatalf("InstallCLI() error = %v, want non-public host rejection", err)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
+func remoteArchiveFixture(t *testing.T) ([]byte, market.Release) {
+	t.Helper()
+	root := t.TempDir()
+	awsRoot := filepath.Join(root, "aws")
+	if err := os.MkdirAll(filepath.Join(awsRoot, "dist"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	entrypointContent := []byte("aws fixture")
+	if err := os.WriteFile(filepath.Join(awsRoot, "dist", "aws"), entrypointContent, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(awsRoot, "README.txt"), []byte("license"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := marketartifact.InspectTree(awsRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buffer bytes.Buffer
+	writer := zip.NewWriter(&buffer)
+	for _, relative := range []string{"aws/", "aws/dist/", "aws/dist/aws", "aws/README.txt"} {
+		header := &zip.FileHeader{Name: relative, Method: zip.Deflate}
+		if strings.HasSuffix(relative, "/") {
+			header.SetMode(os.ModeDir | 0o700)
+		}
+		entry, err := writer.CreateHeader(header)
+		if err != nil {
+			t.Fatal(err)
+		}
+		switch relative {
+		case "aws/dist/aws":
+			_, err = entry.Write(entrypointContent)
+		case "aws/README.txt":
+			_, err = entry.Write([]byte("license"))
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	archive := buffer.Bytes()
+	archiveDigest := sha256.Sum256(archive)
+	entryDigest := sha256.Sum256(entrypointContent)
+	release := market.Release{
+		SchemaVersion: "1", ReleaseID: "aws-cli@0.2.0", ConnectorKey: "aws-cli", Version: "0.2.0",
+		ReleaseDigest: strings.Repeat("1", 64), ManifestDigest: strings.Repeat("2", 64),
+		Artifact:    market.Artifact{Key: "aws-cli.tgz", SHA256: strings.Repeat("3", 64), SizeBytes: 1, MediaType: "application/gzip"},
+		PublishedAt: time.Unix(1, 0).UTC(), Status: market.ReleaseStatusAvailable,
+		Manifest: market.Manifest{SchemaVersion: "1", DisplayName: "AWS CLI", IconURL: "data:image/png;base64,iVBORw0KGgo=", AuthorizationKind: "none",
+			Implementation: market.Implementation{Kind: market.ImplementationKindManagedStdio, ManagedStdio: &market.ManagedStdioImplementation{
+				Runtime: market.RuntimeRequirement{Language: "node", Profile: ConnectorNodeProfile, ABI: "node22-" + runtime.GOOS + "-" + runtime.GOARCH, VersionRange: ">=22.0.0 <23.0.0"},
+				CLI: &market.ManagedCLIInterface{Entrypoint: "dist/aws", Command: "aws", TimeoutMS: 120_000, Install: &market.CLIInstallation{Kind: "remote_archive", RemoteArchive: &market.RemoteArchiveInstallation{
+					Source:     market.RemoteArchiveSource{URL: "https://awscli.amazonaws.com/awscliv2.zip", AllowedHosts: []string{"awscli.amazonaws.com"}, Format: "zip", SHA256: hex.EncodeToString(archiveDigest[:]), SizeBytes: int64(len(archive))},
+					Extraction: market.RemoteArchiveExtraction{Root: "aws", FileCount: identity.FileCount, ExpandedSizeBytes: identity.ExpandedSizeBytes, InventoryAlgorithm: identity.Algorithm, InventorySHA256: identity.SHA256},
+					Launch:     market.RemoteArchiveLaunch{Kind: "native", Entrypoint: "dist/aws", SHA256: hex.EncodeToString(entryDigest[:]), SizeBytes: int64(len(entrypointContent))},
+				}}},
+			}},
+		},
+	}
+	return archive, release
+}

--- a/services/tuttid/service/connectormarket/implementation_host.go
+++ b/services/tuttid/service/connectormarket/implementation_host.go
@@ -5,12 +5,15 @@ import (
 	"errors"
 	"os"
 	"runtime"
+	"strings"
 	"time"
 
 	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
 	market "github.com/tutti-os/tutti/packages/connector/host"
 	connectorruntime "github.com/tutti-os/tutti/packages/connector/runtime"
 	implementationhost "github.com/tutti-os/tutti/packages/connector/runtime/implementationhost"
+	tuttitypes "github.com/tutti-os/tutti/services/tuttid/types"
+	"golang.org/x/mod/semver"
 )
 
 type PreparedArtifactResolver = implementationhost.PreparedArtifactResolver
@@ -151,15 +154,19 @@ func (host *ImplementationHost) Close() error {
 }
 
 func ProductionPorts(host *ImplementationHost, external market.AuthorizationProvider) (market.ImplementationHost, market.AuthorizationProvider, market.CompatibilityEvaluator, market.ImplementationRegistry) {
-	return host, market.NewImplementationAuthorizationRouter(host, external), productionCompatibility{}, market.NewImplementationRegistry(map[string]market.ImplementationValidator{
+	return host, market.NewImplementationAuthorizationRouter(host, external), productionCompatibility{hostVersion: canonicalHostVersion(tuttitypes.ResolveAppVersion())}, market.NewImplementationRegistry(map[string]market.ImplementationValidator{
 		market.ImplementationKindManagedStdio:         nil,
 		market.ImplementationKindRemoteStreamableHTTP: nil,
 	})
 }
 
-type productionCompatibility struct{}
+type productionCompatibility struct{ hostVersion string }
 
-func (productionCompatibility) Evaluate(manifest market.Manifest) market.Compatibility {
+func (compatibility productionCompatibility) Evaluate(manifest market.Manifest) market.Compatibility {
+	if minimum := canonicalHostVersion(manifest.Compatibility.MinimumHostVersion); manifest.Compatibility.MinimumHostVersion != "" &&
+		(minimum == "" || compatibility.hostVersion == "" || semver.Compare(compatibility.hostVersion, minimum) < 0) {
+		return market.Compatibility{State: market.CompatibilityStateUnsupportedVersion, Reason: "minimum_host_version"}
+	}
 	switch manifest.Implementation.Kind {
 	case market.ImplementationKindRemoteStreamableHTTP:
 		return market.Compatibility{State: market.CompatibilityStateSupported}
@@ -179,4 +186,18 @@ func (productionCompatibility) Evaluate(manifest market.Manifest) market.Compati
 		return market.Compatibility{State: market.CompatibilityStateUnsupportedPlatform, Reason: "platform is not supported"}
 	}
 	return market.Compatibility{State: market.CompatibilityStateSupported}
+}
+
+func canonicalHostVersion(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if !strings.HasPrefix(value, "v") {
+		value = "v" + value
+	}
+	if !semver.IsValid(value) {
+		return ""
+	}
+	return semver.Canonical(value)
 }

--- a/services/tuttid/service/connectormarket/implementation_host_test.go
+++ b/services/tuttid/service/connectormarket/implementation_host_test.go
@@ -523,3 +523,13 @@ func TestImplementationHostBoundsMCPProcessStart(t *testing.T) {
 		t.Fatal("MCP process Start was not bounded")
 	}
 }
+
+func TestProductionCompatibilityEnforcesMinimumHostVersion(t *testing.T) {
+	manifest := market.Manifest{AuthorizationKind: "none", Implementation: market.Implementation{Kind: market.ImplementationKindManagedStdio, ManagedStdio: &market.ManagedStdioImplementation{}}, Compatibility: market.CompatibilityRequirements{MinimumHostVersion: "0.2.27"}}
+	if got := (productionCompatibility{hostVersion: "v0.2.26"}).Evaluate(manifest); got.State != market.CompatibilityStateUnsupportedVersion || got.Reason != "minimum_host_version" {
+		t.Fatalf("older host compatibility = %#v", got)
+	}
+	if got := (productionCompatibility{hostVersion: "v0.2.27"}).Evaluate(manifest); got.State != market.CompatibilityStateSupported {
+		t.Fatalf("equal host compatibility = %#v", got)
+	}
+}

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	goruntime "runtime"
 	"strings"
 	"sync"
 	"time"
@@ -278,6 +279,10 @@ func (w *tuttiWiring) buildWorkspaceModule(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("configure connector market account authorization: %w", err)
 		}
+		connectorHostCapabilities := []string(nil)
+		if goruntime.GOOS == "linux" {
+			connectorHostCapabilities = []string{"connector.install.remote-archive.v1"}
+		}
 		connectorCatalog, err := connectormarketdaemon.NewCatalogSource(connectormarketdaemon.CatalogSourceConfig{
 			BaseURL:            connectorMarketBaseURL,
 			ExpectedMarketType: connectorMarketType,
@@ -286,7 +291,7 @@ func (w *tuttiWiring) buildWorkspaceModule(ctx context.Context) error {
 			HostProduct:        "tutti",
 			HostVersion:        tuttitypes.ResolveAppVersion(),
 			MaxConnectorSchema: 4,
-			HostCapabilities:   []string{"connector.install.remote-archive.v1"},
+			HostCapabilities:   connectorHostCapabilities,
 		})
 		if err != nil {
 			_ = connectorMarketStore.Close()

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -283,6 +283,10 @@ func (w *tuttiWiring) buildWorkspaceModule(ctx context.Context) error {
 			ExpectedMarketType: connectorMarketType,
 			HTTPClient:         agenthttpx.NewClient(30 * time.Second),
 			AuthorizeRequest:   marketAuthorizer.Authorize,
+			HostProduct:        "tutti",
+			HostVersion:        tuttitypes.ResolveAppVersion(),
+			MaxConnectorSchema: 4,
+			HostCapabilities:   []string{"connector.install.remote-archive.v1"},
 		})
 		if err != nil {
 			_ = connectorMarketStore.Close()
@@ -328,7 +332,17 @@ func (w *tuttiWiring) buildWorkspaceModule(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("configure connector node package installer: %w", err)
 		}
-		releaseInstaller, err := connectorruntime.NewReleaseInstaller(artifactPreparer, nodePackageInstaller)
+		remoteArchiveInstaller, err := connectorruntime.NewRemoteArchiveInstaller(connectorruntime.RemoteArchiveInstallerConfig{
+			RootDir: filepath.Join(connectorStateRoot, "remote-archives"), HTTPClient: agenthttpx.NewClient(5 * time.Minute),
+		})
+		if err != nil {
+			return fmt.Errorf("configure connector remote archive installer: %w", err)
+		}
+		cliInstallationRouter, err := connectorruntime.NewCLIInstallationRouter(nodePackageInstaller, remoteArchiveInstaller)
+		if err != nil {
+			return fmt.Errorf("configure connector CLI installation router: %w", err)
+		}
+		releaseInstaller, err := connectorruntime.NewReleaseInstaller(artifactPreparer, cliInstallationRouter)
 		if err != nil {
 			return fmt.Errorf("configure connector release installer: %w", err)
 		}
@@ -349,7 +363,7 @@ func (w *tuttiWiring) buildWorkspaceModule(ctx context.Context) error {
 			return fmt.Errorf("configure remote connector MCP client factory: %w", err)
 		}
 		implementationHost, err := connectormarketservice.NewImplementationHost(connectormarketservice.ImplementationHostConfig{
-			Artifacts: artifactPreparer, CLIInstallations: nodePackageInstaller,
+			Artifacts: artifactPreparer, CLIInstallations: cliInstallationRouter,
 			Runtimes: runtimeResolver, Processes: processTransport, Registry: connectorRegistry,
 			RemoteMCPClientFactory: remoteMCPClientFactory,
 			StateRoot:              filepath.Join(connectorStateRoot, "user-state"),


### PR DESCRIPTION
## Summary
- add the strict remote_archive CLI installation union and v2 installation receipt
- download exact public HTTPS ZIPs with redirect, DNS pinning, size, digest, extraction, inventory, and entrypoint verification
- bypass HTTP proxies for remote archives so validated DNS addresses stay bound to the origin socket
- atomically activate release-scoped read-only trees with rollback and symlink-safe staging, cache, resolve, and removal paths
- route node_package and remote_archive through one installation manager
- send Host cohort metadata to Market, enforce minimumHostVersion locally, and preserve caller working directories in stable CLI shims

## Rollout dependency
Requires tutti-lab/tsh-server#847 to be deployed before any v4 Connector is activated. Older Market clients remain on the explicit legacy fallback. Windows installation intentionally fails closed; the first AWS target is linux-arm64 only.

## Credential boundary
The Host keeps the real user HOME and inherited environment for normal CLI execution. The AWS Connector therefore reuses the users existing global AWS credential chain; this installer does not create or persist AWS credentials.

## Validation
- corepack pnpm@10.11.0 check:changed
- corepack pnpm@10.11.0 check:changed -- --push-ready
- targeted connector Host/runtime/daemon Go tests
- go test -race ./packages/connector/runtime
- Linux ARM64 Docker smoke against official AWS CLI 2.36.24: download, full inventory verification, and aws --version PASS

Documentation impact: updated the Connector Market architecture for install-time remote archives, proxy security, v1 limits, and caller cwd semantics.