### PR TITLE
feat(desktop): open official localized changelog from updates

### DIFF
--- a/apps/desktop/src/renderer/src/features/app-update/services/internal/appUpdateService.test.ts
+++ b/apps/desktop/src/renderer/src/features/app-update/services/internal/appUpdateService.test.ts
@@ -3,7 +3,21 @@ import test from "node:test";
 import type { AppUpdateState } from "@shared/contracts/ipc";
 import type { ReporterEventInput } from "../../../analytics/services/reporterService.interface.ts";
 import type { DesktopAppUpdateClient } from "./adapters/desktopAppUpdateClient.ts";
-import { AppUpdateService } from "./appUpdateService.ts";
+import {
+  AppUpdateService,
+  resolveOfficialChangelogUrl
+} from "./appUpdateService.ts";
+
+test("AppUpdateService maps each desktop language to the official changelog", () => {
+  assert.equal(
+    resolveOfficialChangelogUrl("zh-CN"),
+    "https://tutti.sh/zh/changelog"
+  );
+  assert.equal(
+    resolveOfficialChangelogUrl("en"),
+    "https://tutti.sh/en/changelog"
+  );
+});
 
 test("AppUpdateService does not report status changes from initial state hydration", async () => {
   const reporterCalls: ReporterEventInput[][] = [];
@@ -85,7 +99,7 @@ test("AppUpdateService opens the release notes exposed by the update state", asy
 
   await service.openReleaseNotes();
 
-  assert.deepEqual(opened, [releaseNotesUrl]);
+  assert.deepEqual(opened, ["https://tutti.sh/en/changelog"]);
 });
 
 test("AppUpdateService keeps install action pending after IPC succeeds", async () => {

--- a/apps/desktop/src/renderer/src/features/app-update/services/internal/appUpdateService.test.ts
+++ b/apps/desktop/src/renderer/src/features/app-update/services/internal/appUpdateService.test.ts
@@ -75,7 +75,7 @@ test("AppUpdateService tracks primary update actions", async () => {
   ]);
 });
 
-test("AppUpdateService opens the release notes exposed by the update state", async () => {
+test("AppUpdateService opens the official changelog for an available update", async () => {
   const opened: string[] = [];
   const releaseNotesUrl =
     "https://github.com/tutti-os/tutti/releases/tag/v1.3.0";
@@ -102,7 +102,7 @@ test("AppUpdateService opens the release notes exposed by the update state", asy
   assert.deepEqual(opened, ["https://tutti.sh/en/changelog"]);
 });
 
-test("AppUpdateService keeps the release-notes action unavailable without the IPC pointer", async () => {
+test("AppUpdateService opens the official changelog without an IPC release-notes pointer", async () => {
   const opened: string[] = [];
   const service = new AppUpdateService(
     createClient({
@@ -124,7 +124,7 @@ test("AppUpdateService keeps the release-notes action unavailable without the IP
 
   await service.openReleaseNotes();
 
-  assert.deepEqual(opened, []);
+  assert.deepEqual(opened, ["https://tutti.sh/en/changelog"]);
 });
 
 test("AppUpdateService keeps install action pending after IPC succeeds", async () => {

--- a/apps/desktop/src/renderer/src/features/app-update/services/internal/appUpdateService.test.ts
+++ b/apps/desktop/src/renderer/src/features/app-update/services/internal/appUpdateService.test.ts
@@ -102,6 +102,31 @@ test("AppUpdateService opens the release notes exposed by the update state", asy
   assert.deepEqual(opened, ["https://tutti.sh/en/changelog"]);
 });
 
+test("AppUpdateService keeps the release-notes action unavailable without the IPC pointer", async () => {
+  const opened: string[] = [];
+  const service = new AppUpdateService(
+    createClient({
+      getState: async () =>
+        createState({ releaseNotesUrl: null, status: "available" })
+    }),
+    null,
+    undefined,
+    undefined,
+    {
+      hostFilesApi: {
+        async openExternal(url) {
+          opened.push(url);
+        }
+      }
+    }
+  );
+  await service.load();
+
+  await service.openReleaseNotes();
+
+  assert.deepEqual(opened, []);
+});
+
 test("AppUpdateService keeps install action pending after IPC succeeds", async () => {
   let installCalls = 0;
   const service = new AppUpdateService(

--- a/apps/desktop/src/renderer/src/features/app-update/services/internal/appUpdateService.ts
+++ b/apps/desktop/src/renderer/src/features/app-update/services/internal/appUpdateService.ts
@@ -126,7 +126,7 @@ export class AppUpdateService implements IAppUpdateService {
   }
 
   async openReleaseNotes(): Promise<void> {
-    if (this.store.updateState?.releaseNotesUrl && this.hostFilesApi) {
+    if (this.hostFilesApi) {
       await this.hostFilesApi.openExternal(
         resolveOfficialChangelogUrl(getActiveLocale())
       );

--- a/apps/desktop/src/renderer/src/features/app-update/services/internal/appUpdateService.ts
+++ b/apps/desktop/src/renderer/src/features/app-update/services/internal/appUpdateService.ts
@@ -17,6 +17,7 @@ function formatError(error: unknown): string {
   return resolveDesktopErrorMessage(error, getActiveLocale());
 }
 
+/** Map the desktop locale to the public changelog; new locales intentionally fall back to English. */
 export function resolveOfficialChangelogUrl(locale: DesktopLocale): string {
   return locale === "zh-CN"
     ? "https://tutti.sh/zh/changelog"

--- a/apps/desktop/src/renderer/src/features/app-update/services/internal/appUpdateService.ts
+++ b/apps/desktop/src/renderer/src/features/app-update/services/internal/appUpdateService.ts
@@ -1,4 +1,5 @@
 import { getActiveLocale } from "../../../../i18n/runtime.ts";
+import type { DesktopLocale } from "../../../../../../shared/i18n/index.ts";
 import { AppUpdateActionClickedReporter } from "../../../analytics/reporters/app-update-action-clicked/appUpdateActionClickedReporter.ts";
 import type { IReporterService } from "../../../analytics/services/reporterService.interface.ts";
 import { resolveDesktopErrorMessage } from "../../../../lib/desktopErrors.ts";
@@ -14,6 +15,12 @@ let nextAppUpdateServiceInstanceNumber = 0;
 
 function formatError(error: unknown): string {
   return resolveDesktopErrorMessage(error, getActiveLocale());
+}
+
+export function resolveOfficialChangelogUrl(locale: DesktopLocale): string {
+  return locale === "zh-CN"
+    ? "https://tutti.sh/zh/changelog"
+    : "https://tutti.sh/en/changelog";
 }
 
 export class AppUpdateService implements IAppUpdateService {
@@ -118,9 +125,10 @@ export class AppUpdateService implements IAppUpdateService {
   }
 
   async openReleaseNotes(): Promise<void> {
-    const url = this.store.updateState?.releaseNotesUrl;
-    if (url && this.hostFilesApi) {
-      await this.hostFilesApi.openExternal(url);
+    if (this.store.updateState?.releaseNotesUrl && this.hostFilesApi) {
+      await this.hostFilesApi.openExternal(
+        resolveOfficialChangelogUrl(getActiveLocale())
+      );
     }
   }
 

--- a/apps/desktop/src/renderer/src/features/app-update/ui/AppUpdateStatus.tsx
+++ b/apps/desktop/src/renderer/src/features/app-update/ui/AppUpdateStatus.tsx
@@ -3,6 +3,10 @@ import {
   Button,
   DownloadIcon,
   LoadingIcon,
+  Popover,
+  PopoverClose,
+  PopoverContent,
+  PopoverTrigger,
   RefreshIcon
 } from "@tutti-os/ui-system";
 import { useTranslation } from "@renderer/i18n";
@@ -29,6 +33,7 @@ export function AppUpdateStatus({
     return (
       <StandaloneAppUpdateStatus
         isActing={state.isActing}
+        openReleaseNotes={() => service.openReleaseNotes()}
         runPrimaryAction={() => service.runPrimaryAction()}
         view={view}
       />
@@ -41,6 +46,8 @@ export function AppUpdateStatus({
 
   const label = t(view.titleKey, view.titleParams);
   const compact = density === "compact";
+  const showReleaseNotesAction =
+    view.action === "download" || view.action === "install";
 
   return (
     <div
@@ -60,7 +67,7 @@ export function AppUpdateStatus({
 
       {view.action && view.actionKey ? (
         <>
-          {state.updateState?.releaseNotesUrl ? (
+          {showReleaseNotesAction ? (
             <Button
               onClick={() => void service.openReleaseNotes()}
               size={compact ? "xs" : "sm"}
@@ -102,10 +109,12 @@ export function AppUpdateStatus({
 
 function StandaloneAppUpdateStatus({
   isActing,
+  openReleaseNotes,
   runPrimaryAction,
   view
 }: {
   isActing: boolean;
+  openReleaseNotes(): Promise<void>;
   runPrimaryAction(): Promise<void>;
   view: ReturnType<typeof useAppUpdateService>["state"]["view"];
 }) {
@@ -131,28 +140,81 @@ function StandaloneAppUpdateStatus({
   }
 
   const actionLabel = t(presentation.actionKey);
+  const releaseNotesLabel = t("updates.releaseNotesAction");
+  const actionIcon =
+    presentation.actionKey === "updates.downloadAction" ? (
+      <DownloadIcon aria-hidden className="size-3.5" />
+    ) : (
+      <RefreshIcon aria-hidden className="size-3.5" />
+    );
+
   return (
-    <Button
-      aria-label={`${title}: ${actionLabel}`}
-      className="h-7 gap-1 rounded-[6px] px-2 text-[13px] font-semibold [-webkit-app-region:no-drag]"
-      disabled={isActing}
-      size="xs"
-      title={title}
-      type="button"
-      variant="secondary"
-      onClick={() => {
-        void runPrimaryAction();
-      }}
-    >
-      {isActing ? (
-        <LoadingIcon aria-hidden className="size-3 animate-spin" />
-      ) : presentation.actionKey === "updates.downloadAction" ? (
-        <DownloadIcon aria-hidden className="size-3.5" />
-      ) : (
-        <RefreshIcon aria-hidden className="size-3.5" />
-      )}
-      <span>{actionLabel}</span>
-    </Button>
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          aria-label={`${title}: ${actionLabel}`}
+          className="relative h-7 w-7 rounded-[6px] p-0 [-webkit-app-region:no-drag]"
+          disabled={isActing}
+          size="icon-sm"
+          title={title}
+          type="button"
+          variant="chrome"
+        >
+          {isActing ? (
+            <LoadingIcon aria-hidden className="size-3.5 animate-spin" />
+          ) : (
+            actionIcon
+          )}
+          <span
+            aria-hidden
+            className="absolute top-1 right-1 size-1.5 rounded-full bg-[var(--tutti-purple)] ring-2 ring-[var(--background)]"
+          />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-64 gap-3 p-3 [-webkit-app-region:no-drag]"
+        side="bottom"
+        sideOffset={8}
+      >
+        <div className="flex items-start gap-2">
+          <span className="mt-0.5 inline-flex size-7 shrink-0 items-center justify-center rounded-md bg-[color-mix(in_srgb,var(--tutti-purple)_14%,transparent)] text-[var(--tutti-purple)]">
+            {actionIcon}
+          </span>
+          <p className="min-w-0 pt-1 text-[13px] font-semibold leading-5 text-[var(--text-primary)]">
+            {title}
+          </p>
+        </div>
+        <div className="flex items-center justify-end gap-1.5">
+          <PopoverClose asChild>
+            <Button
+              disabled={isActing}
+              onClick={() => {
+                void openReleaseNotes();
+              }}
+              size="sm"
+              type="button"
+              variant="ghost"
+            >
+              {releaseNotesLabel}
+            </Button>
+          </PopoverClose>
+          <PopoverClose asChild>
+            <Button
+              disabled={isActing}
+              onClick={() => {
+                void runPrimaryAction();
+              }}
+              size="sm"
+              type="button"
+              variant="secondary"
+            >
+              {actionLabel}
+            </Button>
+          </PopoverClose>
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }
 

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -466,6 +466,13 @@ The Stage job adds the generated summary before checksums and seeds a clearly ma
 - enrich the Feishu release card with the Chinese summary when Feishu notification is enabled
 - update `changelog.json` for stable releases
 
+The desktop updater keeps `releaseNotesUrl` as the published-release pointer so
+the update action remains available only when a release has public notes. The
+renderer opens the official localized changelog landing page instead of a
+GitHub Release: `https://tutti.sh/zh/changelog` for `zh-CN`, and
+`https://tutti.sh/en/changelog` for English. It never appends a version or
+anchor, so the website owns the release-history presentation.
+
 Before staging the Draft Release, generate GitHub's detailed release notes with
 an explicit comparison tag. RC and beta notes compare against the newest tag in
 the same version/channel series, falling back to the newest stable tag; stable


### PR DESCRIPTION
## Summary
- Keep the update dialog's existing `releaseNotesUrl`/IPC pointer as the visibility gate.
- Open the official localized changelog instead of the GitHub release page: `zh-CN` → `https://tutti.sh/zh/changelog`, other locales → `https://tutti.sh/en/changelog`.
- Document the contract and fallback behavior.

## Validation
- Targeted desktop update-service test file: 8 passed.
- Desktop typecheck passed.
- `pnpm check:i18n` passed (2 locales, 4,268 keys).

## Review
An independent read-only subagent reviewed the final HEAD and found no actionable blocker/high/medium issues.