### PR TITLE
fix(agent-gui): restore manual unread for historical sessions

### DIFF
--- a/packages/agent/activity-core/src/engine/agentActivitySnapshot.projector.test.ts
+++ b/packages/agent/activity-core/src/engine/agentActivitySnapshot.projector.test.ts
@@ -5,6 +5,7 @@ import {
   createInitialAgentSessionEngineState,
   rootEngineReducer
 } from "./rootReducer.ts";
+import { canonicalTurnKey } from "./sessionEntityKeys.ts";
 import type { AgentActivitySession } from "../types.ts";
 
 test("projects canonical engine state and preserves the snapshot reference", () => {
@@ -24,6 +25,55 @@ test("projects canonical engine state and preserves the snapshot reference", () 
   assert.equal(populated.sessions[0]?.latestTurn?.turnId, "turn-1");
   assert.equal(populated.sessions[0]?.latestTurnInteractions.length, 1);
   assert.equal(populated.sessions[0]?.pendingInteractions.length, 1);
+});
+
+test("root reducer marks a historical session unread from canonical turns", () => {
+  const source = session();
+  const settledTurn = {
+    ...source.latestTurn!,
+    outcome: "completed" as const,
+    phase: "settled" as const,
+    settledAtUnixMs: 30,
+    updatedAtUnixMs: 30
+  };
+  let state = rootEngineReducer(createInitialAgentSessionEngineState(), {
+    type: "session/snapshotReceived",
+    sessions: [
+      {
+        ...source,
+        activeTurn: null,
+        activeTurnId: null,
+        endedAtUnixMs: 30,
+        lastEventUnixMs: 30,
+        latestTurn: settledTurn,
+        latestTurnInteractions: [],
+        pendingInteractions: [],
+        updatedAtUnixMs: 30
+      }
+    ]
+  }).state;
+
+  const canonicalSession = state.sessionLifecycle.sessionsById["session-1"];
+  assert.ok(canonicalSession);
+  assert.equal("latestTurn" in canonicalSession, false);
+  assert.equal(
+    state.sessionLifecycle.turnsById[canonicalTurnKey("session-1", "turn-1")]
+      ?.phase,
+    "settled"
+  );
+
+  state = rootEngineReducer(state, {
+    type: "attention/unreadRequested",
+    agentSessionId: "session-1",
+    userId: "user-1"
+  }).state;
+
+  assert.equal(
+    state.attentionReadState.partitionsByUserId["user-1"]?.recordsBySessionId[
+      "session-1"
+    ]?.completionKey,
+    "turn:session-1:turn-1:completed"
+  );
 });
 
 test("reuses expensive projections when unrelated engine slices change", () => {

--- a/packages/agent/activity-core/src/engine/attentionReadState.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/attentionReadState.reducer.test.ts
@@ -20,7 +20,7 @@ const turn = {
 
 function acceptedTurnContext(
   turns: readonly AgentActivityTurn[],
-  options: { includePrevious?: boolean; latest?: boolean } = {}
+  options: { includePrevious?: boolean } = {}
 ) {
   return {
     previousSessionsById: {},
@@ -32,12 +32,7 @@ function acceptedTurnContext(
             item
           ])
     ),
-    sessionsById: {
-      "session-1": {
-        userId: "user-1",
-        latestTurn: options.latest === false ? null : (turns.at(-1) ?? null)
-      }
-    },
+    sessionsById: { "session-1": { userId: "user-1" } },
     turnsById: Object.fromEntries(
       turns.map((item) => [
         canonicalTurnKey(item.agentSessionId, item.turnId),
@@ -242,6 +237,17 @@ test("a live detail snapshot can replay a completion once identity arrives", () 
   assert.equal(record(state)?.isUnread, true);
 });
 
+test("normalizes canonical turn session ids before looking up the user", () => {
+  const paddedTurn = { ...turn, agentSessionId: " session-1 " };
+  const state = attentionReadStateReducer(
+    createInitialAttentionReadState(),
+    { live: true, type: "turn/upserted", turn: paddedTurn },
+    liveTurn([paddedTurn])
+  ).state;
+
+  assert.equal(record(state)?.completionKey, "turn:session-1:turn-1:completed");
+});
+
 test("an authoritative history live turn marker creates unread atomically", () => {
   const state = attentionReadStateReducer(
     createInitialAttentionReadState(),
@@ -256,7 +262,7 @@ test("an authoritative history live turn marker creates unread atomically", () =
   assert.equal(record(state)?.isUnread, true);
 });
 
-test("a historical session can be manually marked unread", () => {
+test("a historical session can be manually marked unread from canonical turns", () => {
   const state = unread(createInitialAttentionReadState());
   assert.deepEqual(record(state), {
     completionKey: "turn:session-1:turn-1:completed",
@@ -266,6 +272,35 @@ test("a historical session can be manually marked unread", () => {
     observationProvenance: "live",
     readStateProvenance: "durable"
   });
+});
+
+test("manual unread uses the newest canonical turn when latestTurn is omitted", () => {
+  const olderTurn = {
+    ...turn,
+    turnId: "turn-old",
+    startedAtUnixMs: 1,
+    updatedAtUnixMs: 2
+  };
+  const newerTurn = {
+    ...turn,
+    turnId: "turn-new",
+    startedAtUnixMs: 3,
+    updatedAtUnixMs: 4
+  };
+  const state = attentionReadStateReducer(
+    createInitialAttentionReadState(),
+    {
+      type: "attention/unreadRequested",
+      agentSessionId: "session-1",
+      userId: "user-1"
+    },
+    acceptedTurnContext([olderTurn, newerTurn])
+  ).state;
+
+  assert.equal(
+    record(state)?.completionKey,
+    "turn:session-1:turn-new:completed"
+  );
 });
 
 test("a new live completion re-lights an already read session", () => {
@@ -303,9 +338,7 @@ test("a live completion outcome change replaces the unread completion", () => {
       previousTurnsById: {
         [canonicalTurnKey("session-1", turn.turnId)]: turn
       },
-      sessionsById: {
-        "session-1": { userId: "user-1", latestTurn: failedTurn }
-      },
+      sessionsById: { "session-1": { userId: "user-1" } },
       turnsById: { [canonicalTurnKey("session-1", turn.turnId)]: failedTurn }
     }
   ).state;
@@ -381,6 +414,47 @@ test("a completion observed before empty hydration remains unread", () => {
   );
 });
 
+test("manual unread before hydration is persisted after hydration completes", () => {
+  let result = attentionReadStateReducer(createInitialAttentionReadState(), {
+    commandId: "read-1",
+    type: "attention/hydrateRequested",
+    userId: "user-1",
+    workspaceId: "workspace-1"
+  });
+  result = attentionReadStateReducer(
+    result.state,
+    {
+      type: "attention/unreadRequested",
+      agentSessionId: "session-1",
+      userId: "user-1"
+    },
+    acceptedTurnContext([turn])
+  );
+  assert.deepEqual(result.commands, []);
+
+  result = attentionReadStateReducer(result.state, {
+    type: "attention/readStateHydrated",
+    userId: "user-1",
+    completed: { readIds: [], unreadIds: [] },
+    failed: { readIds: [], unreadIds: [] }
+  });
+
+  assert.deepEqual(result.commands, [
+    {
+      type: "attention/readState/write",
+      commandId: "attention-write:user-1:1",
+      correlationId: "user-1",
+      userId: "user-1",
+      workspaceId: "workspace-1",
+      completed: {
+        readIds: [],
+        unreadIds: ["turn:session-1:turn-1:completed"]
+      },
+      failed: { readIds: [], unreadIds: [] }
+    }
+  ]);
+});
+
 test("session removal deletes its durable unread key", () => {
   let state = hydrate(createInitialAttentionReadState(), {
     completed: { unreadIds: ["turn:session-1:turn-1:completed"] },
@@ -416,7 +490,10 @@ test("unread request for a removed session is ignored", () => {
       agentSessionId: "session-1",
       userId: "user-1"
     },
-    acceptedTurnContext([turn], { latest: false })
+    {
+      ...acceptedTurnContext([turn]),
+      sessionsById: {}
+    }
   ).state;
   assert.equal(record(state), undefined);
 });

--- a/packages/agent/activity-core/src/engine/attentionReadState.reducer.ts
+++ b/packages/agent/activity-core/src/engine/attentionReadState.reducer.ts
@@ -11,17 +11,14 @@ import type {
   AttentionReadState
 } from "./attentionReadState.types.ts";
 import { canonicalTurnKey } from "./sessionEntityKeys.ts";
+import { latestTurnForSession } from "./sessionTurnOrdering.ts";
 
 const NO_COMMANDS: readonly EngineCommand[] = [];
 
 interface AttentionReadStateContext {
-  previousSessionsById: Readonly<
-    Record<string, { userId?: string; latestTurn?: AgentActivityTurn | null }>
-  >;
+  previousSessionsById: Readonly<Record<string, { userId?: string }>>;
   previousTurnsById: Readonly<Record<string, AgentActivityTurn>>;
-  sessionsById: Readonly<
-    Record<string, { userId?: string; latestTurn?: AgentActivityTurn | null }>
-  >;
+  sessionsById: Readonly<Record<string, { userId?: string }>>;
   turnsById: Readonly<Record<string, AgentActivityTurn>>;
 }
 
@@ -77,7 +74,8 @@ export function attentionReadStateReducer(
         return unchanged(state);
       }
       const turn = acceptedCanonicalTurn(intent.turn, context);
-      const userId = context.sessionsById[turn?.agentSessionId ?? ""]?.userId;
+      const sessionId = turn?.agentSessionId.trim() ?? "";
+      const userId = context.sessionsById[sessionId]?.userId;
       const replayAcceptedLiveCompletion =
         intent.type === "turn/upserted" &&
         intent.replayAcceptedLiveCompletion === true;
@@ -177,8 +175,8 @@ function requestUnread(
     );
   }
 
-  const latestTurn = context.sessionsById[id]?.latestTurn;
-  const turn = latestTurn ? acceptedCanonicalTurn(latestTurn, context) : null;
+  if (!context.sessionsById[id]) return unchanged(state);
+  const turn = latestTurnForSession(context.turnsById, id);
   const parts = turn ? completionKeyParts(turn) : null;
   if (!parts) return unchanged(state);
   return upsertUnread(state, userId, parts, true);
@@ -387,6 +385,8 @@ function hydrate(
     recordsBySessionId
   );
   const firstHydration = partition.hydrated === null;
+  const hasPreHydrationRecords =
+    Object.keys(partition.recordsBySessionId).length > 0;
   const hydratedChanged =
     !firstHydration &&
     (partition.hydrated?.completedReadIds.length !== 0 ||
@@ -408,9 +408,10 @@ function hydrate(
   if (!recordsChanged && !firstHydration && !hydratedChanged) {
     return unchanged(state);
   }
-  const persistence = hydratedChanged
-    ? queuePersistence(nextPartition, userId)
-    : { commands: NO_COMMANDS, partition: nextPartition };
+  const persistence =
+    hydratedChanged || (firstHydration && hasPreHydrationRecords)
+      ? queuePersistence(nextPartition, userId)
+      : { commands: NO_COMMANDS, partition: nextPartition };
   return changed(
     replacePartition(state, userId, persistence.partition),
     persistence.commands

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.ts
@@ -14,6 +14,10 @@ import {
   canonicalInteractionKey,
   canonicalTurnKey
 } from "./sessionEntityKeys.ts";
+import {
+  compareTurnsByOccurrence,
+  latestTurnForSession
+} from "./sessionTurnOrdering.ts";
 import { selectLatestActivationForSession } from "./pendingIntents.selectors.ts";
 import { isPendingActivationViable } from "./pendingIntents.types.ts";
 import {
@@ -262,16 +266,7 @@ export function selectEngineLatestTurn(
 ): AgentActivityTurn | null {
   const id = agentSessionId?.trim() ?? "";
   if (!state.sessionLifecycle.sessionsById[id]) return null;
-  let latestTurn: AgentActivityTurn | null = null;
-  for (const turn of Object.values(state.sessionLifecycle.turnsById)) {
-    if (
-      turn.agentSessionId === id &&
-      (!latestTurn || compareTurnsByOccurrence(latestTurn, turn) < 0)
-    ) {
-      latestTurn = turn;
-    }
-  }
-  return latestTurn;
+  return latestTurnForSession(state.sessionLifecycle.turnsById, id);
 }
 
 export function selectEngineInteractionsForSession(
@@ -632,15 +627,5 @@ function compareSessionInteractionsByOccurrence(
   return (
     left.createdAtUnixMs - right.createdAtUnixMs ||
     left.requestId.localeCompare(right.requestId)
-  );
-}
-
-function compareTurnsByOccurrence(
-  left: AgentActivityTurn,
-  right: AgentActivityTurn
-): number {
-  return (
-    left.startedAtUnixMs - right.startedAtUnixMs ||
-    left.turnId.localeCompare(right.turnId)
   );
 }

--- a/packages/agent/activity-core/src/engine/sessionTurnOrdering.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionTurnOrdering.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { AgentActivityTurn } from "../types.ts";
+import {
+  compareTurnsByOccurrence,
+  latestTurnForSession
+} from "./sessionTurnOrdering.ts";
+
+function makeTurn(
+  overrides: Partial<AgentActivityTurn> = {}
+): AgentActivityTurn {
+  return {
+    turnId: "turn-1",
+    agentSessionId: "session-1",
+    origin: "user_prompt",
+    phase: "settled",
+    outcome: "completed",
+    startedAtUnixMs: 1,
+    settledAtUnixMs: 2,
+    updatedAtUnixMs: 2,
+    ...overrides
+  } as AgentActivityTurn;
+}
+
+test("returns null for blank, unknown, or empty sessions", () => {
+  const turnsById = { "turn-1": makeTurn() };
+
+  assert.equal(latestTurnForSession({}, "session-1"), null);
+  assert.equal(latestTurnForSession(turnsById, "   "), null);
+  assert.equal(latestTurnForSession(turnsById, "session-2"), null);
+});
+
+test("normalizes session ids and selects the newest turn", () => {
+  const older = makeTurn({
+    turnId: "turn-older",
+    agentSessionId: " session-1 ",
+    startedAtUnixMs: 10
+  });
+  const newer = makeTurn({
+    turnId: "turn-newer",
+    startedAtUnixMs: 11
+  });
+
+  assert.equal(
+    latestTurnForSession({ older, newer }, " session-1 ")?.turnId,
+    "turn-newer"
+  );
+});
+
+test("uses turn id as a deterministic tie-breaker", () => {
+  const first = makeTurn({ turnId: "turn-a", startedAtUnixMs: 10 });
+  const second = makeTurn({ turnId: "turn-b", startedAtUnixMs: 10 });
+
+  assert.equal(compareTurnsByOccurrence(first, second) < 0, true);
+  assert.equal(
+    latestTurnForSession({ first, second }, "session-1")?.turnId,
+    "turn-b"
+  );
+});

--- a/packages/agent/activity-core/src/engine/sessionTurnOrdering.ts
+++ b/packages/agent/activity-core/src/engine/sessionTurnOrdering.ts
@@ -1,0 +1,30 @@
+import type { AgentActivityTurn } from "../types.ts";
+
+export function compareTurnsByOccurrence(
+  left: AgentActivityTurn,
+  right: AgentActivityTurn
+): number {
+  return (
+    left.startedAtUnixMs - right.startedAtUnixMs ||
+    left.turnId.localeCompare(right.turnId)
+  );
+}
+
+export function latestTurnForSession(
+  turnsById: Readonly<Record<string, AgentActivityTurn>>,
+  rawAgentSessionId: string
+): AgentActivityTurn | null {
+  const agentSessionId = rawAgentSessionId.trim();
+  if (!agentSessionId) return null;
+
+  let latestTurn: AgentActivityTurn | null = null;
+  for (const turn of Object.values(turnsById)) {
+    if (
+      turn.agentSessionId.trim() === agentSessionId &&
+      (!latestTurn || compareTurnsByOccurrence(latestTurn, turn) < 0)
+    ) {
+      latestTurn = turn;
+    }
+  }
+  return latestTurn;
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailItem.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailItem.spec.tsx
@@ -448,6 +448,26 @@ describe("AgentGUIConversationRailItem interaction lock", () => {
     );
     expect(screen.queryByRole("menuitem")).toBeNull();
   });
+
+  it("runs the manual unread action with the selected session id", async () => {
+    const onMarkConversationUnread = vi.fn();
+    renderRailItem({
+      isRailInteractionLocked: () => false,
+      onMarkConversationUnread
+    });
+
+    fireEvent.contextMenu(
+      screen.getByTestId("agent-gui-conversation-item-session-1")
+    );
+    const markUnreadItem = await screen.findByRole("menuitem", {
+      name: "Mark as unread"
+    });
+    fireEvent.pointerUp(markUnreadItem, { button: 0 });
+
+    await waitFor(() =>
+      expect(onMarkConversationUnread).toHaveBeenCalledWith("session-1")
+    );
+  });
 });
 
 function renderRailItem(overrides: {
@@ -457,6 +477,7 @@ function renderRailItem(overrides: {
   onRequestRenameConversation?: (
     conversation: AgentGUIConversationSummary
   ) => void;
+  onMarkConversationUnread?: (agentSessionId: string) => void;
   onSelectConversation?: (agentSessionId: string) => void;
   presentation?: React.ComponentProps<
     typeof AgentGUIConversationRailItem
@@ -492,7 +513,7 @@ function renderRailItem(overrides: {
       }
       onSelectConversation={overrides.onSelectConversation ?? vi.fn()}
       onToggleConversationPinned={() => {}}
-      onMarkConversationUnread={() => {}}
+      onMarkConversationUnread={overrides.onMarkConversationUnread ?? vi.fn()}
     />
   );
   const withTargetPresentation = overrides.agentTargets ? (

--- a/tools/scripts/dev-gui.sh
+++ b/tools/scripts/dev-gui.sh
@@ -563,6 +563,21 @@ resolve_tuttid_binary_name() {
   esac
 }
 
+resolve_node_process_path() {
+  local candidate_path="$1"
+
+  if [[ "$(node -p 'process.platform')" != "win32" ]]; then
+    printf '%s\n' "${candidate_path}"
+    return
+  fi
+
+  if ! command_exists cygpath; then
+    fail "cygpath is required to launch Windows processes from the managed POSIX shell."
+  fi
+
+  cygpath -w -- "${candidate_path}"
+}
+
 ensure_workspace_dependencies() {
   local installed_lockfile="${ROOT_DIR}/node_modules/.pnpm/lock.yaml"
   local workspace_lockfile="${ROOT_DIR}/pnpm-lock.yaml"
@@ -621,6 +636,7 @@ install_dev_cli() {
 
 start_desktop_dev() {
   local tuttid_bin_path="$1"
+  local node_tuttid_bin_path
   local status
   # why-did-you-render instruments every React component and hook. On a real
   # workspace that work can block the renderer for seconds while AgentGUI
@@ -629,6 +645,7 @@ start_desktop_dev() {
   # normal development path has production-like scheduling characteristics.
   local why_did_you_render="${VITE_TUTTI_WHY_DID_YOU_RENDER:-0}"
 
+  node_tuttid_bin_path="$(resolve_node_process_path "${tuttid_bin_path}")"
   log "starting desktop dev with prebuilt tuttid"
   if [[ "${why_did_you_render}" == "1" ]]; then
     log "why-did-you-render diagnostics enabled"
@@ -637,7 +654,7 @@ start_desktop_dev() {
   DEV_GUI_DESKTOP_STARTED=1
   (
     cd "${ROOT_DIR}"
-    TUTTID_BIN="${tuttid_bin_path}" \
+    TUTTID_BIN="${node_tuttid_bin_path}" \
       TUTTID_LOG_OUTPUT="${TUTTID_LOG_OUTPUT:-tee}" \
       VITE_TUTTI_WHY_DID_YOU_RENDER="${why_did_you_render}" \
       pnpm dev:desktop < /dev/null


### PR DESCRIPTION
## Summary

Restore Agent GUI's context-menu "Mark as unread" action for historical sessions.

## Root cause

The regression was introduced by `ead4da1143715fea5235af1d4208d8aff44d7a6` (`fix(agent-gui): preserve unread for unfocused sessions (#2372)`). That change removed the historical attention snapshot fallback, while `attention/unreadRequested` still looked for `sessionsById[id].latestTurn`. Production canonical sessions intentionally omit `latestTurn`; the turn is stored in canonical `turnsById`.

Runtime A/B evidence:
- `origin/main`: historical session snapshot + `attention/unreadRequested` produced no attention record.
- Parent `8d64f889...`: the same sequence created the historical attention record and manual unread state.

## Changes

- Resolve the latest canonical turn from `turnsById` for manual unread requests.
- Normalize session ids consistently before canonical lookup.
- Persist a manual unread record created before first read-state hydration.
- Extract and directly test canonical turn ordering.
- Add root-reducer and Agent GUI context-menu regression coverage.

## Verification

- activity-core: 489/489 tests passed.
- Agent GUI targeted regression: 20/20 tests passed.
- activity-core typecheck: passed.
- agent-gui typecheck: passed.
- oxfmt check and `git diff --check`: passed (only Windows LF/CRLF notices).
- Desktop bundle build from this worktree: passed.
- Independent subagent review: APPROVE; review follow-ups were applied and re-tested.

## E2E status

The replay reached the real Desktop/daemon/renderer startup path, but semantic assertions were blocked by stale cassette/provider protocol data: cassette expected ACP `turn/start` id `7`, while the runtime emitted id `8`, ending in `ReplayDeadlineExceeded`. This is an infrastructure/cassette compatibility issue, not a manual-unread assertion failure.

## Risk

The production change is isolated to activity-core attention state and reuses canonical turn entities already owned by the Engine. The remaining validation risk is that the existing replay cassette must be refreshed or made protocol-compatible before a full semantic E2E assertion can run.
