### PR TITLE
fix(agent): ignore replayed Claude interactions

### DIFF
--- a/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
@@ -17,7 +17,7 @@ func TestDefaultControllerUsesClaudeSDKAdapterByDefault(t *testing.T) {
 	}
 }
 
-func TestClaudeCodeSDKAdapterInteractiveApprovalRoundTrip(t *testing.T) {
+func TestClaudeCodeSDKAdapterInteractiveApprovalRoundTripIgnoresReplayedTerminalRequest(t *testing.T) {
 	adapter := NewClaudeCodeSDKAdapter(nil)
 	session := standardTestSession(ProviderClaudeCode)
 	conn := &recordingClaudeSDKConnection{}
@@ -109,6 +109,36 @@ func TestClaudeCodeSDKAdapterInteractiveApprovalRoundTrip(t *testing.T) {
 	}
 	if prompt := adapter.SessionState(session).PendingInteractive; prompt != nil {
 		t.Fatalf("pending prompt after resolve = %#v, want nil", prompt)
+	}
+	if got := adapter.InteractiveDisposition(session, "turn-approval", "approval-1"); got != InteractiveDispositionAnswered {
+		t.Fatalf("disposition after resolve = %q, want answered", got)
+	}
+
+	replayed, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-approval", claudeSDKSidecarEvent{
+		Type: "approval_requested",
+		Payload: map[string]any{
+			"turnId":     "turn-approval",
+			"requestId":  "approval-1",
+			"toolCallId": "toolu-approval",
+			"toolName":   "Bash",
+			"input":      map[string]any{"command": "touch approval.txt"},
+			"options": []any{
+				map[string]any{"kind": "allow_once", "name": "Allow", "optionId": "allow"},
+				map[string]any{"kind": "reject_once", "name": "Reject", "optionId": "reject"},
+			},
+		},
+	})
+	if err != nil || terminal {
+		t.Fatalf("replayed approval_requested err=%v terminal=%v", err, terminal)
+	}
+	if len(replayed) != 0 {
+		t.Fatalf("replayed events = %#v, want none after the request is answered", replayed)
+	}
+	if got := adapter.InteractiveDisposition(session, "turn-approval", "approval-1"); got != InteractiveDispositionAnswered {
+		t.Fatalf("disposition after replay = %q, want answered", got)
+	}
+	if prompt := adapter.SessionState(session).PendingInteractive; prompt != nil {
+		t.Fatalf("pending prompt after replay = %#v, want nil", prompt)
 	}
 }
 

--- a/packages/agent/daemon/runtime/claude_sdk_event_projection_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_event_projection_test.go
@@ -703,6 +703,27 @@ func TestClaudeCodeSDKAdapterScopesChildApprovalBySDKAgentID(t *testing.T) {
 			t.Fatalf("approval resolution scope = %#v, want child session=%q turn=%q", event, child.AgentSessionID, child.TurnID)
 		}
 	}
+
+	replayed, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "provider-turn-task", claudeSDKSidecarEvent{
+		Type: "approval_requested",
+		Payload: map[string]any{
+			"turnId":     "provider-turn-task",
+			"requestId":  "approval-child-write",
+			"toolCallId": "toolu-child-write",
+			"toolName":   "Write",
+			"agentId":    "agent-1",
+			"input":      map[string]any{"file_path": "/repo/permission-probe.txt", "content": "hello"},
+		},
+	})
+	if err != nil || terminal {
+		t.Fatalf("replayed child approval terminal=%v err=%v", terminal, err)
+	}
+	if len(replayed) != 0 {
+		t.Fatalf("replayed child approval events=%#v, want none", replayed)
+	}
+	if got := adapter.InteractiveDispositionForTarget(session, child.AgentSessionID, child.TurnID, "approval-child-write"); got != InteractiveDispositionAnswered {
+		t.Fatalf("child disposition after replay=%q, want answered", got)
+	}
 }
 
 func TestClaudeCodeSDKAdapterScopesChildApprovalAckEventsToChild(t *testing.T) {

--- a/packages/agent/daemon/runtime/claude_sdk_interactive.go
+++ b/packages/agent/daemon/runtime/claude_sdk_interactive.go
@@ -414,7 +414,12 @@ func (a *ClaudeCodeSDKAdapter) claudeSDKInteractiveRequested(
 		options:         options,
 		response:        make(chan pendingInteractiveResponse, 1),
 	}
-	a.storeClaudeSDKPendingRequest(adapterSession, pending)
+	if !a.storeClaudeSDKPendingRequest(adapterSession, pending) {
+		// The SDK sidecar assigns one request ID to one interaction. A repeated
+		// identity is a replay, not a new approval: do not re-open the turn by
+		// emitting another waiting transition after the original has settled.
+		return nil, nil
+	}
 	events := []activityshared.Event{
 		newTurnActivityEvent(eventSession, EventTurnUpdated, eventTurnID, SessionStatusWaiting, "", "", map[string]any{
 			"phase":     string(activityshared.TurnPhaseWaitingApproval),
@@ -586,17 +591,28 @@ func claudeSDKInteractiveOptions(payload map[string]any, toolCall map[string]any
 	}
 }
 
-func (a *ClaudeCodeSDKAdapter) storeClaudeSDKPendingRequest(adapterSession *claudeSDKAdapterSession, pending *pendingInteractiveRequest) {
+// storeClaudeSDKPendingRequest records one provider interaction exactly once.
+// The caller must not publish its waiting events when this returns false.
+func (a *ClaudeCodeSDKAdapter) storeClaudeSDKPendingRequest(adapterSession *claudeSDKAdapterSession, pending *pendingInteractiveRequest) bool {
 	if a == nil || adapterSession == nil || pending == nil {
-		return
+		return false
 	}
-	pending.onTerminal = a.recordTerminalInteractiveRequest
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if adapterSession.pendingRequests == nil {
 		adapterSession.pendingRequests = make(map[string]*pendingInteractiveRequest)
 	}
-	adapterSession.pendingRequests[claudeSDKPendingRequestKey(pending.turnID, pending.requestID)] = pending
+	key := claudeSDKPendingRequestKey(pending.turnID, pending.requestID)
+	if _, exists := adapterSession.pendingRequests[key]; exists {
+		return false
+	}
+	terminalKey := newInteractiveRequestKey(pending.agentSessionID, pending.turnID, pending.requestID)
+	if a.terminalInteractions.get(terminalKey) != InteractiveDispositionUnknown {
+		return false
+	}
+	pending.onTerminal = a.recordTerminalInteractiveRequest
+	adapterSession.pendingRequests[key] = pending
+	return true
 }
 
 func (a *ClaudeCodeSDKAdapter) getClaudeSDKPendingRequest(agentSessionID string, turnID string, requestID string) *pendingInteractiveRequest {


### PR DESCRIPTION
## Summary

- Treat repeated Claude SDK interaction identities as replays before emitting a new waiting transition.
- Cover root and child-session/provider-turn alias replays.

## Tests

- `go test -race ./runtime -run "^TestClaudeCodeSDKAdapterInteractiveApprovalRoundTripIgnoresReplayedTerminalRequest$" -count=1`
- `pnpm check:changed -- --push-ready`

## Notes

- No public API, configuration, or documentation changes.