### PR TITLE
fix(agent): reconcile unconfirmed exact cancellations

### DIFF
--- a/packages/agent/claude-sdk-sidecar/src/main.ts
+++ b/packages/agent/claude-sdk-sidecar/src/main.ts
@@ -161,7 +161,7 @@ export async function handleRequest(
                 ...stagePayload
               })
           });
-          logClaudeCodeCancellation("cancel_succeeded", {
+          logClaudeCodeCancellation("cancel_responded", {
             ...diagnosticContext,
             durationMs: Date.now() - startedAt,
             canceled: result.canceled,

--- a/packages/agent/daemon/hostadapter/runtime.go
+++ b/packages/agent/daemon/hostadapter/runtime.go
@@ -348,12 +348,16 @@ func (a *RuntimeController) Cancel(ctx context.Context, input host.RuntimeCancel
 	for _, target := range result.ConfirmedTargets {
 		confirmed = append(confirmed, host.RuntimeCancelTarget{AgentSessionID: target.AgentSessionID, TurnID: target.TurnID})
 	}
-	return host.RuntimeCancelResult{
+	hostResult := host.RuntimeCancelResult{
 		AgentSessionID:   result.AgentSessionID,
 		Canceled:         result.Canceled,
 		TargetAbsent:     result.TargetAbsent,
 		ConfirmedTargets: confirmed,
-	}, mapRuntimeError(err)
+	}
+	if errors.Is(err, agentruntime.ErrCancelTargetMismatch) {
+		return hostResult, host.ErrRuntimeCancelDeliveryUnconfirmed
+	}
+	return hostResult, mapRuntimeError(err)
 }
 
 func (a *RuntimeController) SubmitInteractive(ctx context.Context, input host.RuntimeSubmitInteractiveInput) (host.RuntimeSubmitInteractiveResult, error) {

--- a/packages/agent/daemon/hostadapter/runtime_test.go
+++ b/packages/agent/daemon/hostadapter/runtime_test.go
@@ -34,6 +34,19 @@ type closeRuntimeBackend struct {
 	input agentruntime.CloseInput
 }
 
+type mismatchCancelRuntimeBackend struct {
+	RuntimeBackend
+	input agentruntime.CancelInput
+}
+
+func (b *mismatchCancelRuntimeBackend) Cancel(
+	_ context.Context,
+	input agentruntime.CancelInput,
+) (agentruntime.CancelResult, error) {
+	b.input = input
+	return agentruntime.CancelResult{AgentSessionID: input.RootAgentSessionID}, agentruntime.ErrCancelTargetMismatch
+}
+
 type workspaceDisconnectBackend struct {
 	RuntimeBackend
 	sessions  []agentruntime.Session
@@ -103,6 +116,24 @@ func TestRuntimeControllerBridgesWorkspaceRuntimeDisconnect(t *testing.T) {
 	disconnected, err = controller.DisconnectRuntimeSessionTarget(t.Context(), targets[0])
 	if err != nil || !disconnected || backend.target.ConnectionGeneration != 7 {
 		t.Fatalf("target disconnect=%v err=%v backend=%#v", disconnected, err, backend.target)
+	}
+}
+
+func TestRuntimeControllerMapsExactCancelMismatchToDeliveryUnconfirmed(t *testing.T) {
+	t.Parallel()
+	backend := &mismatchCancelRuntimeBackend{}
+	controller := &RuntimeController{Backend: backend}
+
+	result, err := controller.Cancel(t.Context(), host.RuntimeCancelInput{
+		WorkspaceID: "workspace-1", RootAgentSessionID: "root-session", Reason: "user_requested",
+		Targets: []host.RuntimeCancelTarget{{AgentSessionID: "child-session", TurnID: "child-turn"}},
+	})
+	if !errors.Is(err, host.ErrRuntimeCancelDeliveryUnconfirmed) {
+		t.Fatalf("Cancel() error = %v, want delivery-unconfirmed", err)
+	}
+	if result.TargetAbsent || result.Canceled || backend.input.RootAgentSessionID != "root-session" || len(backend.input.Targets) != 1 ||
+		backend.input.Targets[0].AgentSessionID != "child-session" || backend.input.Targets[0].TurnID != "child-turn" {
+		t.Fatalf("Cancel() result=%#v backend input=%#v", result, backend.input)
 	}
 }
 

--- a/packages/agent/daemon/runtime/controller_cancel.go
+++ b/packages/agent/daemon/runtime/controller_cancel.go
@@ -79,6 +79,17 @@ func (c *Controller) Cancel(ctx context.Context, input CancelInput) (CancelResul
 			}
 			return CancelResult{AgentSessionID: session.AgentSessionID, TargetAbsent: true}, nil
 		}
+		if errors.Is(err, ErrCancelTargetMismatch) {
+			slog.Info("agent session exact cancel delivery is unconfirmed",
+				"event", "agent_session.cancel.delivery_unconfirmed",
+				"room_id", session.RoomID,
+				"agent_session_id", session.AgentSessionID,
+				"provider", session.Provider,
+				"turn_id", requestedRootTurnID,
+				"reason", reason,
+			)
+			return CancelResult{}, err
+		}
 		slog.Warn("agent session cancel adapter failed",
 			"event", "agent_session.cancel.adapter_failed",
 			"room_id", session.RoomID,

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -186,6 +186,14 @@ that durable operation exists, even when immediate runtime readiness or
 delivery returns an error; `GoalState` then distinguishes pending delivery
 from terminal failure. A provider-accepted or applied Goal is also canonical
 resume evidence for a turnless Goal session after the live runtime disappears.
+
+An exact-provider cancel response can be delivery-unconfirmed: the provider
+received the request but could not prove it stopped the requested Turn. Host
+retains that exact durable operation for retry and canonical reconciliation; it
+does not infer either `canceled` or `failed` from the response. If the canonical
+Turn reaches a terminal state first, the operation completes as a no-op and
+preserves that existing outcome.
+
 `AdoptProviderGoal` is the narrow
 reverse boundary for a Goal created by a provider tool during an already
 accepted Turn. It atomically records the active provider generation as a

--- a/packages/agent/host/conformance/conformance.go
+++ b/packages/agent/host/conformance/conformance.go
@@ -85,8 +85,13 @@ type Fixture struct {
 	// explicit TurnID is not the Session.ActiveTurnID. It models the runtime
 	// target race without exposing a runtime/provider API to scenarios.
 	GuidanceTargetMismatch bool
-	DeleteAdmissionErr     error
-	DeleteSessionPlans     [][]string
+	// CancelDeliveryUnconfirmed makes the test runtime acknowledge the exact
+	// cancel delivery without being able to confirm that it stopped that turn.
+	// The Host must retain the durable operation instead of inventing a
+	// terminal outcome.
+	CancelDeliveryUnconfirmed bool
+	DeleteAdmissionErr        error
+	DeleteSessionPlans        [][]string
 }
 
 type SessionObservation struct {
@@ -123,6 +128,7 @@ type CancelObservation struct {
 	Session  SessionObservation
 	TurnID   string
 	Canceled bool
+	Pending  bool
 	Reason   string
 }
 

--- a/packages/agent/host/conformance/conformance_test.go
+++ b/packages/agent/host/conformance/conformance_test.go
@@ -19,7 +19,7 @@ func TestPublishedScenarioCatalogsHaveUniqueNames(t *testing.T) {
 		{name: "submission fence", scenarios: SubmissionFenceScenarios(), wantCount: 1},
 		{name: "title policy", scenarios: TitlePolicyScenarios(), wantCount: 1},
 		{name: "deletion admission", scenarios: DeletionAdmissionScenarios(), wantCount: 3},
-		{name: "coordinator", scenarios: CoordinatorScenarios(), wantCount: 7},
+		{name: "coordinator", scenarios: CoordinatorScenarios(), wantCount: 8},
 		{name: "goal", scenarios: GoalScenarios(), wantCount: 17},
 		{name: "commit observer", scenarios: CommitObserverScenarios(), wantCount: 2},
 	}
@@ -171,6 +171,7 @@ func TestScenarioOwnershipIsExplicit(t *testing.T) {
 	}
 	wantCoordinator := []string{
 		"exact turn cancel",
+		"exact turn cancel keeps delivery-unconfirmed intent pending",
 		"interactive response",
 		"interactive response reuses provider request id across turns",
 		"interactive response race",

--- a/packages/agent/host/conformance/coordinator_scenarios.go
+++ b/packages/agent/host/conformance/coordinator_scenarios.go
@@ -29,6 +29,28 @@ func runExactTurnCancel(ctx context.Context, driver Driver) error {
 	return nil
 }
 
+func runUnconfirmedTurnCancel(ctx context.Context, driver Driver) error {
+	fixture := liveSessionFixture("session-cancel-unconfirmed", "turn-cancel-unconfirmed")
+	fixture.Turn = &TurnSeed{TurnID: "turn-cancel-unconfirmed", Phase: canonical.TurnPhaseRunning}
+	fixture.CancelDeliveryUnconfirmed = true
+	if err := driver.Reset(ctx, fixture); err != nil {
+		return err
+	}
+	result, err := driver.CancelTurn(ctx, agenthost.CancelTurnInput{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-cancel-unconfirmed", TurnID: "turn-cancel-unconfirmed", Reason: "user_requested",
+	})
+	if err != nil {
+		return fmt.Errorf("delivery-unconfirmed cancel: %w", err)
+	}
+	metrics := driver.Metrics()
+	if !result.Pending || result.Canceled || result.TurnID != "turn-cancel-unconfirmed" || metrics.CancelCalls != 1 ||
+		len(metrics.LastCancelTargets) != 1 || metrics.LastCancelTargets[0].AgentSessionID != "session-cancel-unconfirmed" ||
+		metrics.LastCancelTargets[0].TurnID != "turn-cancel-unconfirmed" {
+		return fmt.Errorf("delivery-unconfirmed cancel result=%#v metrics=%#v", result, metrics)
+	}
+	return nil
+}
+
 func runPlanDecision(ctx context.Context, driver Driver) error {
 	fixture := liveSessionFixture("session-plan", "plan-turn")
 	fixture.Turn = &TurnSeed{TurnID: "plan-turn", Phase: canonical.TurnPhaseWaiting}

--- a/packages/agent/host/conformance/scenarios.go
+++ b/packages/agent/host/conformance/scenarios.go
@@ -35,6 +35,7 @@ var (
 	}
 	duplicateClientSubmitIDScenario     = Scenario{Name: "duplicate client submit id", run: runDuplicateClientSubmitID}
 	exactTurnCancelScenario             = Scenario{Name: "exact turn cancel", run: runExactTurnCancel}
+	unconfirmedTurnCancelScenario       = Scenario{Name: "exact turn cancel keeps delivery-unconfirmed intent pending", run: runUnconfirmedTurnCancel}
 	interactiveResponseScenario         = Scenario{Name: "interactive response", run: runInteractiveResponse}
 	interactiveResponseReusedIDScenario = Scenario{Name: "interactive response reuses provider request id across turns", run: runInteractiveResponseReusedRequestID}
 	interactiveResponseRaceScenario     = Scenario{Name: "interactive response race", run: runInteractiveResponseRace}
@@ -150,6 +151,7 @@ func DeletionAdmissionScenarios() []Scenario {
 func CoordinatorScenarios() []Scenario {
 	return []Scenario{
 		exactTurnCancelScenario,
+		unconfirmedTurnCancelScenario,
 		interactiveResponseScenario,
 		interactiveResponseReusedIDScenario,
 		interactiveResponseRaceScenario,

--- a/packages/agent/host/errors.go
+++ b/packages/agent/host/errors.go
@@ -9,16 +9,21 @@ import (
 )
 
 var (
-	ErrInvalidArgument                    = errors.New("invalid agent session request")
-	ErrRailPlacementConflict              = errors.New("agent session rail placement conflicts with canonical state")
-	ErrSessionNotFound                    = errors.New("workspace agent session not found")
-	ErrTurnNotFound                       = errors.New("workspace agent turn not found")
-	ErrProviderSessionNotEstablished      = errors.New("provider session was never established")
-	ErrSubmitDeliveryUnknown              = errors.New("agent submit delivery is still being confirmed")
-	ErrActiveTurnTargetRequired           = errors.New("active-turn guidance requires an exact target turn")
-	ErrActiveTurnTargetMismatch           = errors.New("active-turn guidance target is no longer active")
-	ErrSessionTitleTooLong                = errors.New("agent session title is too long")
-	ErrRuntimeSessionDisconnected         = errors.New("agent runtime session is disconnected")
+	ErrInvalidArgument               = errors.New("invalid agent session request")
+	ErrRailPlacementConflict         = errors.New("agent session rail placement conflicts with canonical state")
+	ErrSessionNotFound               = errors.New("workspace agent session not found")
+	ErrTurnNotFound                  = errors.New("workspace agent turn not found")
+	ErrProviderSessionNotEstablished = errors.New("provider session was never established")
+	ErrSubmitDeliveryUnknown         = errors.New("agent submit delivery is still being confirmed")
+	ErrActiveTurnTargetRequired      = errors.New("active-turn guidance requires an exact target turn")
+	ErrActiveTurnTargetMismatch      = errors.New("active-turn guidance target is no longer active")
+	ErrSessionTitleTooLong           = errors.New("agent session title is too long")
+	ErrRuntimeSessionDisconnected    = errors.New("agent runtime session is disconnected")
+	// ErrRuntimeCancelDeliveryUnconfirmed means the runtime received an exact
+	// cancel request but could not confirm that the requested provider turn was
+	// the one it stopped. Host keeps the durable cancel operation retryable and
+	// waits for canonical terminal evidence instead of fabricating a terminal.
+	ErrRuntimeCancelDeliveryUnconfirmed   = errors.New("agent runtime cancellation delivery is unconfirmed")
 	ErrRuntimeSessionActive               = errors.New("agent runtime session has an active turn")
 	ErrRuntimeSessionReprepareUnavailable = errors.New("agent runtime session reprepare is unavailable")
 	ErrRuntimeSessionPublishUnavailable   = errors.New("agent runtime session initialization publication is unavailable")

--- a/packages/agent/host/runtime_cancel_reconciliation_test.go
+++ b/packages/agent/host/runtime_cancel_reconciliation_test.go
@@ -1,0 +1,181 @@
+package agenthost_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+type cancelReconciliationClock struct{ at time.Time }
+
+func (c *cancelReconciliationClock) Now() time.Time { return c.at }
+
+type unconfirmedCancelRuntime struct {
+	agenthost.RuntimeController
+
+	mu        sync.Mutex
+	session   agenthost.ProviderRuntimeSession
+	responses []cancelRuntimeResponse
+	calls     int
+}
+
+type cancelRuntimeResponse struct {
+	result agenthost.RuntimeCancelResult
+	err    error
+}
+
+func (r *unconfirmedCancelRuntime) Session(workspaceID, agentSessionID string) (agenthost.ProviderRuntimeSession, bool) {
+	return r.session, workspaceID == r.session.WorkspaceID && agentSessionID == r.session.ID
+}
+
+func (r *unconfirmedCancelRuntime) Cancel(context.Context, agenthost.RuntimeCancelInput) (agenthost.RuntimeCancelResult, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	responseIndex := r.calls
+	r.calls++
+	if responseIndex >= len(r.responses) {
+		responseIndex = len(r.responses) - 1
+	}
+	return r.responses[responseIndex].result, r.responses[responseIndex].err
+}
+
+func (r *unconfirmedCancelRuntime) cancelCalls() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
+func cancelDeliveryUnconfirmed(payload map[string]any) bool {
+	value, _ := payload[storesqlite.CancelRuntimeOperationDeliveryUnconfirmedPayloadKey].(bool)
+	return value
+}
+
+func TestCancelDeliveryUnconfirmedPreservesEarlierCanonicalSuccess(t *testing.T) {
+	store := openGoalFenceHostStore(t)
+	if _, accepted, err := store.RecordTurnTransition(t.Context(), storesqlite.TurnTransition{
+		WorkspaceID: "workspace", AgentSessionID: "session", TurnID: "turn-1",
+		Phase: storesqlite.TurnPhaseRunning, OccurredAtUnixMS: 2,
+	}); err != nil || !accepted {
+		t.Fatalf("seed running turn: accepted=%v err=%v", accepted, err)
+	}
+
+	clock := &cancelReconciliationClock{at: time.UnixMilli(1_000)}
+	runtime := &unconfirmedCancelRuntime{session: agenthost.ProviderRuntimeSession{
+		ID: "session", WorkspaceID: "workspace", Provider: "claude-code",
+		ProviderSessionID: "provider-session-1",
+	}, responses: []cancelRuntimeResponse{{err: agenthost.ErrRuntimeCancelDeliveryUnconfirmed}}}
+	host := agenthost.New(agenthost.Config{
+		CanonicalStore: sqliteCanonicalStore{Store: store}, Runtime: runtime,
+		RuntimeOperations: store, OperationOwner: "cancel-reconciliation-test", Clock: clock,
+	})
+
+	result, err := host.CancelTurn(t.Context(), agenthost.CancelTurnInput{
+		WorkspaceID: "workspace", AgentSessionID: "session", TurnID: "turn-1", Reason: "user_requested",
+	})
+	if !errors.Is(err, agenthost.ErrRuntimeOperationInProgress) || !result.IntentAccepted ||
+		result.Operation.Status != storesqlite.RuntimeOperationStatusPrepared || runtime.cancelCalls() != 1 {
+		t.Fatalf("initial cancel result=%#v error=%v calls=%d", result, err, runtime.cancelCalls())
+	}
+	if !cancelDeliveryUnconfirmed(result.Operation.Payload) {
+		t.Fatalf("initial cancel payload=%#v, want delivery-unconfirmed marker", result.Operation.Payload)
+	}
+
+	if _, accepted, err := store.RecordTurnTransition(t.Context(), storesqlite.TurnTransition{
+		WorkspaceID: "workspace", AgentSessionID: "session", TurnID: "turn-1",
+		Phase: storesqlite.TurnPhaseSettled, Outcome: storesqlite.TurnOutcomeCompleted, OccurredAtUnixMS: 3,
+	}); err != nil || !accepted {
+		t.Fatalf("record canonical success: accepted=%v err=%v", accepted, err)
+	}
+	clock.at = time.UnixMilli(2_000)
+	if err := host.StepRuntimeOperationWorker(t.Context(), false); err != nil {
+		t.Fatalf("reconcile cancel operation: %v", err)
+	}
+
+	operation, found, err := store.GetRuntimeOperation(t.Context(), "workspace", result.Operation.OperationID)
+	if err != nil || !found || operation.Status != storesqlite.RuntimeOperationStatusCompleted ||
+		operation.Result != storesqlite.RuntimeOperationResultAlreadySettled {
+		t.Fatalf("cancel operation=%#v found=%v err=%v", operation, found, err)
+	}
+	turn, found, err := store.GetTurn(t.Context(), "workspace", "session", "turn-1")
+	if err != nil || !found || turn.Phase != storesqlite.TurnPhaseSettled || turn.Outcome != storesqlite.TurnOutcomeCompleted {
+		t.Fatalf("canonical turn=%#v found=%v err=%v", turn, found, err)
+	}
+	if runtime.cancelCalls() != 1 {
+		t.Fatalf("runtime cancel calls=%d, want no retry after canonical success", runtime.cancelCalls())
+	}
+}
+
+func TestCancelDeliveryUnconfirmedDoesNotTreatLaterTargetAbsentAsCanceled(t *testing.T) {
+	store := openGoalFenceHostStore(t)
+	if _, accepted, err := store.RecordTurnTransition(t.Context(), storesqlite.TurnTransition{
+		WorkspaceID: "workspace", AgentSessionID: "session", TurnID: "turn-1",
+		Phase: storesqlite.TurnPhaseRunning, OccurredAtUnixMS: 2,
+	}); err != nil || !accepted {
+		t.Fatalf("seed running turn: accepted=%v err=%v", accepted, err)
+	}
+
+	clock := &cancelReconciliationClock{at: time.UnixMilli(1_000)}
+	runtime := &unconfirmedCancelRuntime{session: agenthost.ProviderRuntimeSession{
+		ID: "session", WorkspaceID: "workspace", Provider: "claude-code",
+		ProviderSessionID: "provider-session-1",
+	}, responses: []cancelRuntimeResponse{
+		{err: agenthost.ErrRuntimeCancelDeliveryUnconfirmed},
+		{result: agenthost.RuntimeCancelResult{AgentSessionID: "session", TargetAbsent: true}},
+	}}
+	host := agenthost.New(agenthost.Config{
+		CanonicalStore: sqliteCanonicalStore{Store: store}, Runtime: runtime,
+		RuntimeOperations: store, OperationOwner: "cancel-reconciliation-test", Clock: clock,
+	})
+
+	result, err := host.CancelTurn(t.Context(), agenthost.CancelTurnInput{
+		WorkspaceID: "workspace", AgentSessionID: "session", TurnID: "turn-1", Reason: "user_requested",
+	})
+	if !errors.Is(err, agenthost.ErrRuntimeOperationInProgress) || !result.IntentAccepted || runtime.cancelCalls() != 1 {
+		t.Fatalf("initial cancel result=%#v error=%v calls=%d", result, err, runtime.cancelCalls())
+	}
+
+	clock.at = time.UnixMilli(2_000)
+	if err := host.StepRuntimeOperationWorker(t.Context(), false); err != nil {
+		t.Fatalf("retry target-absent cancel operation: %v", err)
+	}
+	operation, found, err := store.GetRuntimeOperation(t.Context(), "workspace", result.Operation.OperationID)
+	if err != nil || !found || operation.Status != storesqlite.RuntimeOperationStatusPrepared ||
+		!cancelDeliveryUnconfirmed(operation.Payload) {
+		t.Fatalf("target-absent operation=%#v found=%v err=%v", operation, found, err)
+	}
+	turn, found, err := store.GetTurn(t.Context(), "workspace", "session", "turn-1")
+	if err != nil || !found || turn.Phase != storesqlite.TurnPhaseRunning {
+		t.Fatalf("target-absent turn=%#v found=%v err=%v", turn, found, err)
+	}
+	if runtime.cancelCalls() != 2 {
+		t.Fatalf("runtime cancel calls=%d, want 2", runtime.cancelCalls())
+	}
+
+	if _, accepted, err := store.RecordTurnTransition(t.Context(), storesqlite.TurnTransition{
+		WorkspaceID: "workspace", AgentSessionID: "session", TurnID: "turn-1",
+		Phase: storesqlite.TurnPhaseSettled, Outcome: storesqlite.TurnOutcomeCompleted, OccurredAtUnixMS: 3,
+	}); err != nil || !accepted {
+		t.Fatalf("record canonical success: accepted=%v err=%v", accepted, err)
+	}
+	clock.at = time.UnixMilli(4_000)
+	if err := host.StepRuntimeOperationWorker(t.Context(), false); err != nil {
+		t.Fatalf("finish cancel operation from canonical success: %v", err)
+	}
+	operation, found, err = store.GetRuntimeOperation(t.Context(), "workspace", result.Operation.OperationID)
+	if err != nil || !found || operation.Status != storesqlite.RuntimeOperationStatusCompleted ||
+		operation.Result != storesqlite.RuntimeOperationResultAlreadySettled {
+		t.Fatalf("completed operation=%#v found=%v err=%v", operation, found, err)
+	}
+	turn, found, err = store.GetTurn(t.Context(), "workspace", "session", "turn-1")
+	if err != nil || !found || turn.Phase != storesqlite.TurnPhaseSettled || turn.Outcome != storesqlite.TurnOutcomeCompleted {
+		t.Fatalf("canonical turn=%#v found=%v err=%v", turn, found, err)
+	}
+	if runtime.cancelCalls() != 2 {
+		t.Fatalf("runtime cancel calls=%d, want no third cancellation", runtime.cancelCalls())
+	}
+}

--- a/packages/agent/host/runtime_operations.go
+++ b/packages/agent/host/runtime_operations.go
@@ -40,6 +40,11 @@ func runtimeOperationPayloadText(payload map[string]any, key string) string {
 	return strings.TrimSpace(value)
 }
 
+func runtimeOperationPayloadBool(payload map[string]any, key string) bool {
+	value, _ := payload[key].(bool)
+	return value
+}
+
 func runtimeOperationPayloadInteractiveDisposition(payload map[string]any, key string) RuntimeInteractiveDisposition {
 	switch RuntimeInteractiveDisposition(runtimeOperationPayloadText(payload, key)) {
 	case RuntimeInteractiveDispositionAnswered,
@@ -399,27 +404,122 @@ func (h *Host) executeCancelRuntimeOperation(
 		}
 	}
 	targets := runtimeCancelTargetsFromPayload(operation.Payload)
+	settled, err := h.cancelRuntimeOperationTargetsSettled(ctx, operation.WorkspaceID, targets)
+	if err != nil {
+		return h.releaseRuntimeOperation(ctx, operation, owner, err, !isRetryableRuntimeOperationError(err))
+	}
+	if settled {
+		return h.completeCancelRuntimeOperation(ctx, operation, owner, targets, nil)
+	}
 	result, err := h.runtime.Cancel(ctx, RuntimeCancelInput{
 		WorkspaceID: operation.WorkspaceID, RootAgentSessionID: runtimeOperationPayloadText(operation.Payload, "rootAgentSessionId"),
 		Targets: targets, Reason: runtimeOperationPayloadText(operation.Payload, "reason"),
 	})
 	if err != nil {
+		if errors.Is(err, ErrRuntimeCancelDeliveryUnconfirmed) {
+			checkpointed, checkpointErr := h.checkpointCancelRuntimeOperationDeliveryUnconfirmed(ctx, operation, owner)
+			if checkpointErr != nil {
+				return h.releaseRuntimeOperation(ctx, operation, owner, fmt.Errorf("checkpoint cancel delivery-unconfirmed state: %w", checkpointErr), true)
+			}
+			operation = checkpointed
+			settled, settledErr := h.cancelRuntimeOperationTargetsSettled(ctx, operation.WorkspaceID, targets)
+			if settledErr != nil {
+				return h.releaseRuntimeOperation(ctx, operation, owner, settledErr, !isRetryableRuntimeOperationError(settledErr))
+			}
+			if settled {
+				return h.completeCancelRuntimeOperation(ctx, operation, owner, targets, nil)
+			}
+			slog.Info("agent runtime cancel delivery is unconfirmed; preserving exact target for reconciliation",
+				"event", "agent_runtime_operation.cancel_delivery_unconfirmed",
+				"workspace_id", operation.WorkspaceID,
+				"agent_session_id", operation.AgentSessionID,
+				"operation_id", operation.OperationID,
+				"target_count", len(targets),
+			)
+		}
 		return h.releaseRuntimeOperation(ctx, operation, owner, err, !isRetryableRuntimeOperationError(err))
 	}
+	if result.TargetAbsent && runtimeOperationPayloadBool(operation.Payload, storesqlite.CancelRuntimeOperationDeliveryUnconfirmedPayloadKey) {
+		settled, settledErr := h.cancelRuntimeOperationTargetsSettled(ctx, operation.WorkspaceID, targets)
+		if settledErr != nil {
+			return h.releaseRuntimeOperation(ctx, operation, owner, settledErr, !isRetryableRuntimeOperationError(settledErr))
+		}
+		if settled {
+			return h.completeCancelRuntimeOperation(ctx, operation, owner, targets, nil)
+		}
+		slog.Info("agent runtime cancel target is absent after delivery-unconfirmed response; awaiting canonical settlement",
+			"event", "agent_runtime_operation.cancel_delivery_unconfirmed_target_absent",
+			"workspace_id", operation.WorkspaceID,
+			"agent_session_id", operation.AgentSessionID,
+			"operation_id", operation.OperationID,
+			"target_count", len(targets),
+		)
+		return h.releaseRuntimeOperation(ctx, operation, owner, ErrRuntimeCancelDeliveryUnconfirmed, false)
+	}
+	return h.completeCancelRuntimeOperation(ctx, operation, owner, targets, result.ConfirmedTargets)
+}
+
+func (h *Host) checkpointCancelRuntimeOperationDeliveryUnconfirmed(
+	ctx context.Context,
+	operation storesqlite.RuntimeOperation,
+	owner string,
+) (storesqlite.RuntimeOperation, error) {
+	payload := cloneMap(operation.Payload)
+	payload[storesqlite.CancelRuntimeOperationDeliveryUnconfirmedPayloadKey] = true
+	checkpointed, _, err := h.operations.CheckpointRuntimeOperation(ctx, storesqlite.CheckpointRuntimeOperationInput{
+		WorkspaceID: operation.WorkspaceID, OperationID: operation.OperationID, LeaseOwner: owner,
+		Payload: payload, NowUnixMS: h.now().UnixMilli(),
+	})
+	if err != nil {
+		return operation, err
+	}
+	return checkpointed, nil
+}
+
+func (h *Host) completeCancelRuntimeOperation(
+	ctx context.Context,
+	operation storesqlite.RuntimeOperation,
+	owner string,
+	targets []RuntimeCancelTarget,
+	confirmed []RuntimeCancelTarget,
+) (storesqlite.RuntimeOperation, error) {
 	completion, _, err := h.operations.CompleteCancelRuntimeOperation(ctx, storesqlite.CompleteCancelRuntimeOperationInput{
 		WorkspaceID: operation.WorkspaceID, OperationID: operation.OperationID, LeaseOwner: owner,
-		TargetOutcomes: runtimeCancelTargetOutcomes(runtimeOperationPayloadText(operation.Payload, "rootAgentSessionId"), targets, result.ConfirmedTargets),
+		TargetOutcomes: runtimeCancelTargetOutcomes(runtimeOperationPayloadText(operation.Payload, "rootAgentSessionId"), targets, confirmed),
 		NowUnixMS:      h.now().UnixMilli(),
 	})
 	if err != nil {
 		return operation, err
 	}
 	completion.Operation.Payload = cloneMap(completion.Operation.Payload)
-	completion.Operation.Payload["providerConfirmed"] = len(result.ConfirmedTargets) > 0
+	completion.Operation.Payload["providerConfirmed"] = len(confirmed) > 0
 	if err := h.publishRuntimeOperationEvents(ctx, operation.WorkspaceID); err != nil {
 		logRuntimeOperationFailure(completion.Operation, fmt.Errorf("publish completed cancel runtime operation: %w", err))
 	}
 	return completion.Operation, nil
+}
+
+func (h *Host) cancelRuntimeOperationTargetsSettled(
+	ctx context.Context,
+	workspaceID string,
+	targets []RuntimeCancelTarget,
+) (bool, error) {
+	if len(targets) == 0 {
+		return false, ErrRuntimeOperationIdentityMismatch
+	}
+	for _, target := range targets {
+		turn, found, err := h.store.GetTurn(ctx, workspaceID, target.AgentSessionID, target.TurnID)
+		if err != nil {
+			return false, err
+		}
+		if !found {
+			return false, ErrRuntimeOperationIdentityMismatch
+		}
+		if turn.Phase != storesqlite.TurnPhaseSettled {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 // A live Goal revocation may crash after preparing its exact-Turn cancel but
@@ -726,7 +826,7 @@ func logRuntimeOperationFailure(operation storesqlite.RuntimeOperation, err erro
 }
 
 func isRetryableRuntimeOperationError(err error) bool {
-	return err != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, ErrSessionNotFound) || errors.Is(err, ErrRuntimeSessionDisconnected))
+	return err != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, ErrSessionNotFound) || errors.Is(err, ErrRuntimeSessionDisconnected) || errors.Is(err, ErrRuntimeCancelDeliveryUnconfirmed))
 }
 
 func runtimeOperationNextAttemptAt(now time.Time, attempt int, failed bool) int64 {

--- a/packages/agent/store-sqlite/runtime_operation_types.go
+++ b/packages/agent/store-sqlite/runtime_operation_types.go
@@ -30,6 +30,11 @@ const (
 	RuntimeOperationEventEditRetryRecovery     = "edit_retry_recovery_required"
 )
 
+// CancelRuntimeOperationDeliveryUnconfirmedPayloadKey records durable evidence
+// that a provider received an exact cancel request but could not confirm it
+// stopped the requested turn. It may only transition from absent to true.
+const CancelRuntimeOperationDeliveryUnconfirmedPayloadKey = "cancelDeliveryUnconfirmed"
+
 var (
 	ErrRuntimeOperationConflict         = errors.New("runtime operation identity conflicts with an existing operation")
 	ErrRuntimeOperationIdentityMismatch = errors.New("runtime operation durable identity does not match its subject")

--- a/packages/agent/store-sqlite/runtime_operations.go
+++ b/packages/agent/store-sqlite/runtime_operations.go
@@ -430,6 +430,10 @@ func (s *Store) CheckpointRuntimeOperation(ctx context.Context, input Checkpoint
 		if !interactiveResponseCheckpointIdentityEqual(current.Payload, input.Payload) {
 			return current, false, ErrRuntimeOperationSubjectState
 		}
+	case RuntimeOperationKindCancelTurn:
+		if !cancelRuntimeOperationCheckpointIdentityEqual(current.Payload, input.Payload) {
+			return current, false, ErrRuntimeOperationSubjectState
+		}
 	case RuntimeOperationKindPlanDecision:
 		if err := validatePlanDecisionOperationPayload(input.OperationID, input.Payload); err != nil {
 			return current, false, err
@@ -790,5 +794,23 @@ func interactiveResponseCheckpointIdentityEqual(previous, next map[string]any) b
 		delete(previousIdentity, key)
 		delete(nextIdentity, key)
 	}
+	return jsonMapsEqual(previousIdentity, nextIdentity)
+}
+
+func cancelRuntimeOperationCheckpointIdentityEqual(previous, next map[string]any) bool {
+	nextDeliveryUnconfirmed, ok := next[CancelRuntimeOperationDeliveryUnconfirmedPayloadKey].(bool)
+	if !ok || !nextDeliveryUnconfirmed {
+		return false
+	}
+	if existing, exists := previous[CancelRuntimeOperationDeliveryUnconfirmedPayloadKey]; exists {
+		deliveryUnconfirmed, ok := existing.(bool)
+		if !ok || !deliveryUnconfirmed {
+			return false
+		}
+	}
+	previousIdentity := cloneJSONMap(previous)
+	nextIdentity := cloneJSONMap(next)
+	delete(previousIdentity, CancelRuntimeOperationDeliveryUnconfirmedPayloadKey)
+	delete(nextIdentity, CancelRuntimeOperationDeliveryUnconfirmedPayloadKey)
 	return jsonMapsEqual(previousIdentity, nextIdentity)
 }

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -2910,9 +2910,13 @@ export type WorkspaceAgentSessionGoal = {
 export type WorkspaceAgentTurnCancelResult = {
   canceled: boolean;
   /**
-   * turn_canceled reports an active turn was stopped. already_settled and not_found are idempotent no-op successes, not errors.
+   * turn_canceled reports an active turn was stopped. cancel_requested reports accepted cancellation whose exact provider delivery still needs canonical reconciliation. already_settled and not_found are idempotent no-op successes, not errors.
    */
-  reason: "turn_canceled" | "already_settled" | "not_found";
+  reason:
+    | "turn_canceled"
+    | "cancel_requested"
+    | "already_settled"
+    | "not_found";
 };
 
 export type WorkspaceAgentTurnCancelResponse = {

--- a/services/tuttid/api/daemon_agent_sessions_test.go
+++ b/services/tuttid/api/daemon_agent_sessions_test.go
@@ -48,6 +48,37 @@ func TestDaemonAPIGeneratedRoutesCancelExactAgentTurn(t *testing.T) {
 	}
 }
 
+func TestDaemonAPIGeneratedRoutesKeepsUnconfirmedCancelRequested(t *testing.T) {
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, NewRoutes(DaemonAPI{
+		AgentSessionService: stubAgentSessionService{
+			cancelTurnFn: func(_ context.Context, workspaceID string, agentSessionID string, turnID string) (agentservice.CancelTurnResult, error) {
+				if workspaceID != "ws-1" || agentSessionID != "session-1" || turnID != "turn-1" {
+					t.Fatalf("workspace/session/turn = %q/%q/%q", workspaceID, agentSessionID, turnID)
+				}
+				return agentservice.CancelTurnResult{Reason: agentservice.CancelTurnReasonCancelRequested}, nil
+			},
+		},
+	}))
+
+	recorder := performGeneratedRouteRequest(
+		t,
+		mux,
+		http.MethodPost,
+		"/v1/workspaces/ws-1/agent-sessions/session-1/turns/turn-1/cancel",
+		nil,
+	)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+
+	var response tuttigenerated.WorkspaceAgentTurnCancelResponse
+	decodeGeneratedRouteResponse(t, recorder, &response)
+	if response.Cancel.Canceled || response.Cancel.Reason != tuttigenerated.CancelRequested {
+		t.Fatalf("cancel = %#v", response.Cancel)
+	}
+}
+
 func TestDaemonAPIGeneratedRoutesSendAgentSessionInputForwardsGuidance(t *testing.T) {
 	mux := http.NewServeMux()
 	updatedAt := time.UnixMilli(1000)

--- a/services/tuttid/api/daemon_agent_turns.go
+++ b/services/tuttid/api/daemon_agent_turns.go
@@ -8,8 +8,8 @@ import (
 )
 
 // CancelWorkspaceAgentTurn is the protocol v2 turn-scoped cancel. Idempotent
-// by contract: settled or unknown turns return canceled=false with an
-// explanatory reason instead of an error.
+// by contract: settled, unknown, and delivery-unconfirmed turns return
+// canceled=false with an explanatory reason instead of an error.
 func (api DaemonAPI) CancelWorkspaceAgentTurn(ctx context.Context, request tuttigenerated.CancelWorkspaceAgentTurnRequestObject) (tuttigenerated.CancelWorkspaceAgentTurnResponseObject, error) {
 	if api.AgentSessionService == nil {
 		return tuttigenerated.CancelWorkspaceAgentTurn503JSONResponse{

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -3918,15 +3918,18 @@ func (e WorkspaceAgentTurnProviderForkBindingState) Valid() bool {
 
 // Defines values for WorkspaceAgentTurnCancelResultReason.
 const (
-	AlreadySettled WorkspaceAgentTurnCancelResultReason = "already_settled"
-	NotFound       WorkspaceAgentTurnCancelResultReason = "not_found"
-	TurnCanceled   WorkspaceAgentTurnCancelResultReason = "turn_canceled"
+	AlreadySettled  WorkspaceAgentTurnCancelResultReason = "already_settled"
+	CancelRequested WorkspaceAgentTurnCancelResultReason = "cancel_requested"
+	NotFound        WorkspaceAgentTurnCancelResultReason = "not_found"
+	TurnCanceled    WorkspaceAgentTurnCancelResultReason = "turn_canceled"
 )
 
 // Valid indicates whether the value is a known member of the WorkspaceAgentTurnCancelResultReason enum.
 func (e WorkspaceAgentTurnCancelResultReason) Valid() bool {
 	switch e {
 	case AlreadySettled:
+		return true
+	case CancelRequested:
 		return true
 	case NotFound:
 		return true
@@ -9407,11 +9410,11 @@ type WorkspaceAgentTurnCancelResponse struct {
 type WorkspaceAgentTurnCancelResult struct {
 	Canceled bool `json:"canceled"`
 
-	// Reason turn_canceled reports an active turn was stopped. already_settled and not_found are idempotent no-op successes, not errors.
+	// Reason turn_canceled reports an active turn was stopped. cancel_requested reports accepted cancellation whose exact provider delivery still needs canonical reconciliation. already_settled and not_found are idempotent no-op successes, not errors.
 	Reason WorkspaceAgentTurnCancelResultReason `json:"reason"`
 }
 
-// WorkspaceAgentTurnCancelResultReason turn_canceled reports an active turn was stopped. already_settled and not_found are idempotent no-op successes, not errors.
+// WorkspaceAgentTurnCancelResultReason turn_canceled reports an active turn was stopped. cancel_requested reports accepted cancellation whose exact provider delivery still needs canonical reconciliation. already_settled and not_found are idempotent no-op successes, not errors.
 type WorkspaceAgentTurnCancelResultReason string
 
 // WorkspaceAgentTurnError Protocol v2 turn-scoped error; never pollutes session state.

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -13665,10 +13665,13 @@ components:
         reason:
           type: string
           description: >-
-            turn_canceled reports an active turn was stopped. already_settled
-            and not_found are idempotent no-op successes, not errors.
+            turn_canceled reports an active turn was stopped. cancel_requested
+            reports accepted cancellation whose exact provider delivery still
+            needs canonical reconciliation. already_settled and not_found are
+            idempotent no-op successes, not errors.
           enum:
             - turn_canceled
+            - cancel_requested
             - already_settled
             - not_found
     WorkspaceAgentTurnCancelResponse:

--- a/services/tuttid/service/agent/host_conformance_test.go
+++ b/services/tuttid/service/agent/host_conformance_test.go
@@ -310,6 +310,9 @@ type legacyHostConformanceDriver struct {
 func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconformance.Fixture) error {
 	d.runtime = newFakeRuntime()
 	d.runtime.guidanceTargetMismatch = fixture.GuidanceTargetMismatch
+	if fixture.CancelDeliveryUnconfirmed {
+		d.runtime.cancelErr = agenthost.ErrRuntimeCancelDeliveryUnconfirmed
+	}
 	d.sessions = &fakeSessionReader{
 		sessions: map[string]PersistedSession{}, tombstoned: map[string]bool{}, deletedAt: map[string]int64{},
 		parentByKey: map[string]string{},
@@ -1036,19 +1039,28 @@ func (s *conformanceHistoricalStateStore) CaptureHistoricalSessionGraph(
 func (d *legacyHostConformanceDriver) CancelTurn(ctx context.Context, input agenthost.CancelTurnInput) (hostconformance.CancelObservation, error) {
 	if d.directHost {
 		result, err := d.service.ApplicationHost().CancelTurn(ctx, input)
-		if err != nil {
+		pending := errors.Is(err, agenthost.ErrRuntimeOperationInProgress) && result.IntentAccepted
+		if err != nil && !pending {
 			return hostconformance.CancelObservation{}, err
 		}
-		session, err := d.service.Get(ctx, input.WorkspaceID, input.AgentSessionID)
+		session, getErr := d.service.Get(ctx, input.WorkspaceID, input.AgentSessionID)
+		if getErr != nil {
+			return hostconformance.CancelObservation{}, getErr
+		}
 		turnID := ""
 		if result.Turn != nil {
 			turnID = result.Turn.TurnID
 		}
+		reason := CancelTurnReasonTurnCanceled
+		if pending {
+			reason = CancelTurnReasonCancelRequested
+		}
 		return hostconformance.CancelObservation{
 			Session: legacyHostSessionObservation(session), TurnID: turnID,
 			Canceled: result.Operation.Result == agentactivitybiz.RuntimeOperationResultCanceled,
-			Reason:   string(CancelTurnReasonTurnCanceled),
-		}, err
+			Pending:  pending,
+			Reason:   string(reason),
+		}, nil
 	}
 	result, err := d.service.CancelTurn(ctx, input.WorkspaceID, input.AgentSessionID, input.TurnID)
 	if err != nil {
@@ -1060,7 +1072,7 @@ func (d *legacyHostConformanceDriver) CancelTurn(ctx context.Context, input agen
 	}
 	return hostconformance.CancelObservation{
 		Session: legacyHostSessionObservation(result.Session), TurnID: turnID,
-		Canceled: result.Canceled, Reason: string(result.Reason),
+		Canceled: result.Canceled, Pending: result.Reason == CancelTurnReasonCancelRequested, Reason: string(result.Reason),
 	}, nil
 }
 

--- a/services/tuttid/service/agent/service_post_runtime_persistence_failure_test.go
+++ b/services/tuttid/service/agent/service_post_runtime_persistence_failure_test.go
@@ -107,6 +107,29 @@ func TestExactCancelCompletesFromTypedRuntimeTargetAbsentEvidence(t *testing.T) 
 	}
 }
 
+func TestCancelTurnReturnsCancelRequestedWhenCancelDeliveryIsUnconfirmed(t *testing.T) {
+	runtime := newFakeRuntime()
+	runtime.sessions["ws-1:session-1"] = ProviderRuntimeSession{
+		ID: "session-1", WorkspaceID: "ws-1", Provider: "claude-code", Status: "working",
+	}
+	runtime.cancelErr = agenthost.ErrRuntimeCancelDeliveryUnconfirmed
+	store := &runtimeOperationMemoryStore{}
+	service := newIsolatedAgentService(runtime)
+	service.RuntimeOperationStore = store
+	service.RuntimeOperationOwner = "worker-a"
+	service.RuntimeOperationClock = func() time.Time { return time.UnixMilli(1000) }
+	service.TurnStore = runtimeOperationTurnStore("turn-1", "")
+
+	result, err := service.CancelTurn(context.Background(), "ws-1", "session-1", "turn-1")
+	if err != nil {
+		t.Fatalf("CancelTurn() error = %v", err)
+	}
+	if result.Canceled || result.Reason != CancelTurnReasonCancelRequested ||
+		store.operation.Status != agentactivitybiz.RuntimeOperationStatusPrepared || len(runtime.cancelCalls) != 1 {
+		t.Fatalf("CancelTurn() result=%#v operation=%#v calls=%d", result, store.operation, len(runtime.cancelCalls))
+	}
+}
+
 func TestRootCancelRoutesDurableChildTargetsThroughRootRuntime(t *testing.T) {
 	runtime := newFakeRuntime()
 	runtime.sessions["ws-1:root"] = ProviderRuntimeSession{ID: "root", WorkspaceID: "ws-1", Provider: "codex", Status: "working"}

--- a/services/tuttid/service/agent/service_test_runtime_test.go
+++ b/services/tuttid/service/agent/service_test_runtime_test.go
@@ -29,6 +29,7 @@ type fakeRuntime struct {
 	canResumeCalls          []RuntimeResumeInput
 	canResumeHook           func(RuntimeResumeInput) bool
 	cancelCalls             []RuntimeCancelInput
+	cancelErr               error
 	cancelResult            RuntimeCancelResult
 	cancelResultSet         bool
 	closeErr                error
@@ -503,6 +504,9 @@ func (f *fakeRuntime) Cancel(_ context.Context, input RuntimeCancelInput) (Runti
 	targetAgentSessionID := input.RootAgentSessionID
 	if len(input.Targets) > 0 {
 		targetAgentSessionID = input.Targets[len(input.Targets)-1].AgentSessionID
+	}
+	if f.cancelErr != nil {
+		return RuntimeCancelResult{AgentSessionID: targetAgentSessionID}, f.cancelErr
 	}
 	if f.cancelResultSet {
 		if f.cancelResult.AgentSessionID == "" {

--- a/services/tuttid/service/agent/service_turns.go
+++ b/services/tuttid/service/agent/service_turns.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"strings"
 	"time"
@@ -39,9 +40,10 @@ type TurnCancelObserver interface {
 type CancelTurnReason string
 
 const (
-	CancelTurnReasonTurnCanceled   CancelTurnReason = "turn_canceled"
-	CancelTurnReasonAlreadySettled CancelTurnReason = "already_settled"
-	CancelTurnReasonNotFound       CancelTurnReason = "not_found"
+	CancelTurnReasonTurnCanceled    CancelTurnReason = "turn_canceled"
+	CancelTurnReasonCancelRequested CancelTurnReason = "cancel_requested"
+	CancelTurnReasonAlreadySettled  CancelTurnReason = "already_settled"
+	CancelTurnReasonNotFound        CancelTurnReason = "not_found"
 )
 
 type CancelTurnResult struct {
@@ -115,8 +117,8 @@ func (s *Service) ListTurns(ctx context.Context, workspaceID string, agentSessio
 
 // CancelTurn stops one specific turn (protocol v2). It is idempotent: a
 // settled or unknown turn is a no-op success (already_settled / not_found),
-// never an error. An active turn goes through the runtime cancel and its
-// persisted record settles with outcome=canceled.
+// never an error. An exact cancel whose provider delivery is unconfirmed is
+// accepted as cancel_requested; canonical terminal evidence determines its outcome.
 func (s *Service) CancelTurn(ctx context.Context, workspaceID string, agentSessionID string, turnID string) (CancelTurnResult, error) {
 	workspaceID = strings.TrimSpace(workspaceID)
 	agentSessionID = strings.TrimSpace(agentSessionID)
@@ -134,7 +136,8 @@ func (s *Service) CancelTurn(ctx context.Context, workspaceID string, agentSessi
 	hostResult, err := s.ApplicationHost().CancelTurn(ctx, agenthost.CancelTurnInput{
 		WorkspaceID: workspaceID, AgentSessionID: agentSessionID, TurnID: turnID,
 	})
-	if err != nil {
+	pending := errors.Is(err, agenthost.ErrRuntimeOperationInProgress) && hostResult.IntentAccepted
+	if err != nil && !pending {
 		return CancelTurnResult{}, normalizeRuntimeError(err)
 	}
 	session, err := s.Get(ctx, workspaceID, agentSessionID)
@@ -145,6 +148,9 @@ func (s *Service) CancelTurn(ctx context.Context, workspaceID string, agentSessi
 		Session:  session,
 		Canceled: hostResult.Operation.Status == agentactivitybiz.RuntimeOperationStatusCompleted && hostResult.Operation.Result == agentactivitybiz.RuntimeOperationResultCanceled,
 		Reason:   CancelTurnReasonAlreadySettled,
+	}
+	if pending {
+		result.Reason = CancelTurnReasonCancelRequested
 	}
 	switch hostResult.State {
 	case agenthost.CancelStateNotFound:


### PR DESCRIPTION
## Summary

- Preserve exact cancel operations when provider delivery is unconfirmed instead of classifying them as launch failures
- Reuse the existing `cancel_requested` activity contract and wait for canonical settlement before assigning a terminal outcome
- Add durable reconciliation and API/conformance coverage for an unconfirmed delivery followed by target absence

## Tests

- `pnpm check:changed`
- `go test -v ./services/tuttid/service/agent -run 'Test(CancelTurnReturnsCancelRequestedWhenCancelDeliveryIsUnconfirmed|HostConformance)' -count=1`
- `go test -v ./services/tuttid/api -run 'TestDaemonAPIGeneratedRoutes(CancelExactAgentTurn|KeepsUnconfirmedCancelRequested)' -count=1`
- `go test -v ./packages/agent/daemon/hostadapter ./packages/agent/daemon/runtime -run 'Test.*Cancel' -count=1`
- `pnpm typecheck && pnpm test -- --run` (from `packages/agent/claude-sdk-sidecar`)

## Notes

- TSH needs this behavior through its Host dependency upgrade after the Tutti release; no TSH-local lifecycle implementation is required
