### PR TITLE
fix(agent): exclude optional CLI absence from failure telemetry

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusDiagnostics.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusDiagnostics.ts
@@ -128,6 +128,15 @@ export class DesktopAgentProviderStatusDiagnostics {
         continue;
       }
       this.lastEnvSignatures.set(status.provider, signature);
+      // Desktop discovers every managed provider so the picker can show its
+      // local readiness. A missing CLI is therefore an expected inventory
+      // state for an optional provider, not an environment failure. Keep it in
+      // the status snapshot, but do not send it through the automatic failure
+      // telemetry path. Explicit, consent-gated problem reports remain
+      // available from the provider management surface.
+      if (isExpectedOptionalProviderAbsence(status)) {
+        continue;
+      }
       void this.reportEnvDetected(status);
     }
   }
@@ -230,6 +239,16 @@ export class DesktopAgentProviderStatusDiagnostics {
   private now(): number {
     return this.dependencies.now?.() ?? Date.now();
   }
+}
+
+function isExpectedOptionalProviderAbsence(
+  status: AgentProviderStatus
+): boolean {
+  return (
+    status.availability.status === "not_installed" &&
+    status.availability.reasonCode === "cli_not_found" &&
+    !status.cli.installed
+  );
 }
 
 function statusRequestDetails(input: AgentProviderStatusRequestInput) {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.test.ts
@@ -793,6 +793,56 @@ test("requestStatuses fires agent.env_detected once per detection outcome", asyn
   assert.equal(events[0]?.params?.availability_status, "ready");
 });
 
+test("background detection does not report an absent optional provider as an environment failure", async () => {
+  const events: ReporterEventInput[] = [];
+  const missingOptionalProvider = createProviderStatus({
+    actions: [],
+    availability: "not_installed",
+    cliInstalled: false,
+    provider: "cursor",
+    reasonCode: "cli_not_found"
+  });
+  const launchFailure = createProviderStatus({
+    actions: [],
+    adapterInstalled: false,
+    availability: "unknown",
+    cliInstalled: true,
+    provider: "opencode",
+    reasonCode: "acp_adapter_launch_failed"
+  });
+  const service = new DesktopAgentProviderStatusService({
+    tuttidClient: createTuttidClient({
+      snapshots: [
+        createStatusResponse([missingOptionalProvider, launchFailure])
+      ]
+    }),
+    reporterService: {
+      async trackEvents(nextEvents) {
+        events.push(
+          ...legacyAgentEvents(nextEvents).filter(
+            (event) => event.name === "agent.env_detected"
+          )
+        );
+      }
+    },
+    terminalCommandRunner: {
+      async runTerminalCommand() {}
+    }
+  });
+
+  await service.refresh();
+  await flushAsyncWork();
+
+  assert.equal(
+    service.getStatus("cursor")?.availability.reasonCode,
+    "cli_not_found"
+  );
+  assert.deepEqual(
+    events.map((event) => event.params?.provider),
+    ["opencode"]
+  );
+});
+
 test("automatic login requests reuse one terminal and one status poll", async () => {
   const commands: AgentProviderTerminalCommand[] = [];
   const statusCalls: Array<readonly WorkspaceAgentProvider[] | undefined> = [];

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -23,7 +23,8 @@ Use the focused runtime index or open one area directly:
   Also covers Kimi Code ACP sessions that advertise no model or hide provider
   failures behind an empty `end_turn`.
   Also covers focus-driven provider CLI scans, repeated Extension Target version
-  probes, extension release refresh delaying daemon startup, and CPU spikes.
+  probes, optional Provider absence misclassified as an environment failure,
+  extension release refresh delaying daemon startup, and CPU spikes.
 - [Agent Sessions And Lifecycle](./agent-session-lifecycle.md): Turn state, activation, planning-mode classification, capability snapshots, Tutti workflow response contracts, loading, cancel, goal controls, restore, file-change undo, rail projection, realtime completion provenance, event updates, imports, and performance.
   Includes shared-device recovery that looks terminal while the host is still retrying.
   Also covers new or derived conversations that silently fail or lose

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -82,6 +82,40 @@ provider-status-focus-refresh --all-process-time-profile` on macOS when a
   [desktopAgentProviderStatusService.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.ts)
   [agent-provider-status-performance-scenario.mjs](../../../tools/scripts/agent-provider-status-performance-scenario.mjs)
 
+### Missing optional Agent CLIs inflate environment failure analytics
+
+- Symptom:
+  `agent.env_detected` reports many `cli_not_found` outcomes for providers the
+  user never selected, and an analytics view that treats every non-ready status
+  as a failure makes the Agent environment failure rate look much higher than
+  actual launch failures.
+- Quick checks:
+  Group `agent.env_detected` by `provider`, `reason_code`, and `cli_installed`.
+  If the dominant rows are `cli_not_found` with `cli_installed=false` across
+  several managed providers for the same users, compare them with the desktop's
+  background all-provider status request before investigating installation.
+- Root cause:
+  Desktop intentionally discovers every managed provider so Agent pickers and
+  setup surfaces can show local readiness. The automatic environment reporter
+  previously treated every changed status as failure telemetry, so the expected
+  absence of an optional CLI crossed the same reporting boundary as a provider
+  that was installed but failed its runtime probe.
+- Fix:
+  Keep `cli_not_found` in the canonical provider-status snapshot and continue
+  full catalog discovery, but exclude the exact `not_installed` +
+  `cli_not_found` + `cli.installed=false` state from automatic
+  `agent.env_detected` reporting. Preserve explicit consent-gated problem
+  reports and continue reporting installed-provider failures such as
+  `acp_adapter_launch_failed`.
+- Validation:
+  Reconcile one missing optional provider and one installed provider with a
+  runtime launch failure in the same response. Assert both remain visible in
+  the status snapshot while only the launch failure produces
+  `agent.env_detected`.
+- References:
+  [desktopAgentProviderStatusDiagnostics.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusDiagnostics.ts)
+  [desktopAgentProviderStatusService.test.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.test.ts)
+
 ### Loading Agent Targets repeatedly starts Extension CLIs
 
 - Symptom:


### PR DESCRIPTION
## Summary

- keep optional provider `cli_not_found` states in the local provider-status snapshot
- exclude the exact expected absence state from automatic `agent.env_detected` reporting
- continue reporting installed-provider runtime failures such as `acp_adapter_launch_failed`
- document the analytics failure pattern and add regression coverage

## Verification

- `pnpm check:changed`
- `pnpm check:changed -- --push-ready`
- regression negative control: before the fix, the focused test reported both optional Cursor absence and OpenCode launch failure; after the fix, only the launch failure is emitted while both statuses remain available locally

## Checklist

- [x] This PR does not change agent lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required.