### PR TITLE
fix(agent-gui): hide quick prompt search while sorting

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/quickPrompts/AgentQuickPromptPopover.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/quickPrompts/AgentQuickPromptPopover.spec.tsx
@@ -204,7 +204,7 @@ describe("AgentQuickPromptPopover", () => {
     expect(
       screen.getByRole("button", { name: "Reorder Review" })
     ).toBeEnabled();
-    expect(screen.getByPlaceholderText("Search quick prompts")).toBeDisabled();
+    expect(screen.queryByPlaceholderText("Search quick prompts")).toBeNull();
     expect(screen.queryByRole("button", { name: "Edit" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Delete" })).toBeNull();
     expect(
@@ -280,11 +280,18 @@ describe("AgentQuickPromptPopover", () => {
     const done = screen.getByRole("button", { name: "Done" });
     fireEvent.pointerDown(done, { button: 0 });
     expect(screen.getByRole("button", { name: "Reorder" })).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Search quick prompts")
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Reorder" }));
     expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("Search quick prompts")).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Done" }));
     expect(screen.getByRole("button", { name: "Reorder" })).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Search quick prompts")
+    ).toBeInTheDocument();
   });
 
   it("reports a Composer insertion failure without reporting a save failure", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/quickPrompts/AgentQuickPromptPopover.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/quickPrompts/AgentQuickPromptPopover.tsx
@@ -265,7 +265,7 @@ export function AgentQuickPromptPopover({
               </div>
             )}
           </div>
-          {!isTemplateView ? (
+          {!isTemplateView && !isSorting ? (
             <div className="relative shrink-0 px-3 py-2.5">
               <SearchIcon
                 aria-hidden
@@ -275,7 +275,7 @@ export function AgentQuickPromptPopover({
                 ref={searchRef}
                 aria-label={labels.searchPlaceholder}
                 className="pl-8"
-                disabled={controller.isInteractionLocked || isSorting}
+                disabled={controller.isInteractionLocked}
                 placeholder={labels.searchPlaceholder}
                 value={controller.searchQuery}
                 onChange={(event) =>


### PR DESCRIPTION
## Summary

- hide the quick-prompt search field while explicit reorder mode is active
- restore the search field after sorting finishes
- cover pointer and keyboard sorting transitions with the existing component test

## Validation

- `pnpm --filter @tutti-os/agent-gui exec vitest run agent-gui/agentGuiNode/composer/quickPrompts/AgentQuickPromptPopover.spec.tsx` (18 tests passed)
- `pnpm check:changed` (11 lanes passed)
- pre-push `pnpm check:changed -- --push-ready` (12 lanes passed)
- `pnpm exec oxfmt --check ...` (2 files passed)

## AgentGUI review

| Lane | Trigger | Result | Evidence | Affected consumers |
| --- | --- | --- | --- | --- |
| Architecture | Composer quick-prompt interaction state changed | pass | Existing component-local `isSorting` remains the only owner; no Host, Engine, lifecycle, identity, command, or observation path changed | Desktop AgentGUI quick-prompt popover |
| Performance | A hidden surface changes during reorder mode | pass | Static JSX conditional removes one bounded input subtree; no subscriptions, selectors, lists, measurement, streaming, or cache paths changed; degradation boundary passed | Desktop AgentGUI quick-prompt popover |
| Consumers | AgentGUI component behavior changed | pass | No exports, props, capability shape, or command behavior changed; focused component test and package selected checks passed | Desktop host; external hosts retain the same controller contract |

## Risk

Low. The change is limited to presentation while sorting. Search remains available and retains its controller-owned query outside sorting mode.