### PR TITLE
feat(agent-gui): add shared caller error presentation

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2474,6 +2474,15 @@ login/logout, external navigation, reward receipt persistence, clipboard
 writes, notifications, localization, feature gating, and menu lifecycle.
 Neither AgentGUI nor the frontend Commerce package may receive a Cookie or
 start a Commerce request.
+For a shared Agent conversation, the Host sets the presentation-only
+`hostCapabilities.visibleErrorPresentationScope` to `shared_caller`.
+AgentGUI preserves the canonical structured reason and existing diagnostic
+disclosure, substitutes caller-safe contact guidance only when the structured
+code identifies an Owner-remediable failure, and suppresses current-device and
+current-account remediation actions. Transport and ambiguous failure copy stays
+neutral and retry-oriented. Omitting the scope preserves `local_owner`
+behavior. The scope must not enter Turn, activity, Engine, event, persistence,
+or provider contracts.
 The optional `renderSlots.agentConfigAccount` is a presentation-only Host
 chrome seam for the exact selected Agent Target. Its paired
 `hostActions.onAgentConfigMenuOpen` notification lets the Host refresh account

--- a/packages/agent/gui/AgentGUI.tsx
+++ b/packages/agent/gui/AgentGUI.tsx
@@ -173,6 +173,7 @@ export const AgentGUI = memo(function AgentGUI({
           agentHostApi={agentHostApi}
         >
           <AgentVisibleErrorPresentationProvider
+            scope={props.hostCapabilities?.visibleErrorPresentationScope}
             value={props.hostCapabilities?.visibleErrorPresentationOverrides}
           >
             <AgentGUINode {...nodeProps} />

--- a/packages/agent/gui/README.md
+++ b/packages/agent/gui/README.md
@@ -17,6 +17,16 @@ and are rendered only behind an explicit disclosure, never in the product error
 headline. Environment, authentication,
 network, and runtime errors are not overridable and remain AgentGUI policy.
 
+Hosts that render an Agent owned by somebody else must pass
+`hostCapabilities.visibleErrorPresentationScope: "shared_caller"`. AgentGUI
+then preserves structured failure reasons and diagnostic disclosure, replaces
+Owner-remediable guidance with caller-safe contact guidance, and suppresses
+current-device and current-account recovery actions. Omission defaults to
+`"local_owner"` for backward compatibility. The scope is presentation-only;
+it never changes a Turn, activity event, persistence, or provider error.
+Hosts that inject an application i18n runtime must also provide
+`agentHost.agentGui.visibleErrorSharedCallerHint` in every supported locale.
+
 This is an intentional public API break. The former `accountMenuState`,
 `commercePresentation`, `AgentGUIAccountMenu*`, and
 `AgentGUIAccountRewardToast` surfaces were removed instead of being retained as

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
@@ -43,7 +43,10 @@ import type {
   AgentMentionReferenceTargetResolver,
   AgentWorkspaceReferenceInitialTargetResolver
 } from "./AgentGUINodeView";
-import type { AgentVisibleErrorOverrides } from "../../shared/agentEnv/agentErrorPresentation";
+import type {
+  AgentVisibleErrorOverrides,
+  AgentVisibleErrorPresentationScope
+} from "../../shared/agentEnv/agentErrorPresentation";
 import type {
   AgentComposerCapabilityMenuState,
   AgentComposerCapabilitySettingsTarget,
@@ -147,6 +150,11 @@ export interface AgentGUINodeHostCapabilities {
    * AgentGUI owns the generic card; product domains own product semantics.
    */
   visibleErrorPresentationOverrides?: AgentVisibleErrorOverrides | null;
+  /**
+   * Presentation-only remediation authority for visible errors. Omission
+   * retains local-owner behavior for backwards compatibility.
+   */
+  visibleErrorPresentationScope?: AgentVisibleErrorPresentationScope;
   agentTargets?: readonly AgentGUIAgentTarget[];
   agentTargetsLoading?: boolean;
   /** Complete presentation-only catalog for resolving Agent mention identity. */

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentTargetSetupGate.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentTargetSetupGate.spec.tsx
@@ -28,6 +28,7 @@ import {
   serializeAgentGUIProviderRailPreferences
 } from "../model/agentGuiProviderRailOrder.ts";
 import { AgentTargetSetupGate } from "./AgentTargetSetupGate.tsx";
+import { AgentVisibleErrorPresentationProvider } from "../../../shared/visibleError/AgentVisibleErrorPresentationContext.tsx";
 import {
   AgentTargetSetupRoot,
   useAgentTargetSetupRoot
@@ -53,6 +54,25 @@ const codebuddyTarget = target("codebuddy", "CodeBuddy Code");
 const geminiTarget = target("gemini", "Gemini CLI");
 
 describe("AgentTargetSetupGate", () => {
+  it("does not expose this device's setup workflow to a shared caller", () => {
+    const install = vi.fn<AgentHostAgentTargetSetupWatch["install"]>();
+    const setup = createWatch(notInstalled("extension:codebuddy"), {
+      install
+    });
+    installHost(new Map([["extension:codebuddy", setup.watch]]));
+
+    render(
+      <AgentVisibleErrorPresentationProvider scope="shared_caller">
+        <Harness target={codebuddyTarget} />
+      </AgentVisibleErrorPresentationProvider>
+    );
+
+    expect(screen.getByText("composer ready")).toBeTruthy();
+    expect(screen.queryByTestId("agent-target-setup-gate")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Open setup" })).toBeNull();
+    expect(install).not.toHaveBeenCalled();
+  });
+
   it("gates while checking, then reveals the composer when ready", async () => {
     const setup = createWatch({ snapshot: null, loading: true, failed: false });
     installHost(new Map([["extension:codebuddy", setup.watch]]));

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentTargetSetupGate.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentTargetSetupGate.tsx
@@ -20,6 +20,7 @@ import {
 } from "../../../shared/agentEnv/AgentSetupDialog.tsx";
 import { useAgentTargetSetupController } from "../../../shared/agentEnv/agentTargetSetupController.tsx";
 import { resolveAgentErrorPresentation } from "../../../shared/agentEnv/agentErrorPresentation.ts";
+import { useAgentVisibleErrorPresentation } from "../../../shared/visibleError/AgentVisibleErrorPresentationContext.tsx";
 import { useAgentHostApi } from "../../../agentActivityHost.tsx";
 import type { AgentHostAgentTargetSetupSnapshot } from "../../../host/agentHostApi.ts";
 import { useTranslation } from "../../../i18n/index.ts";
@@ -39,6 +40,7 @@ export function AgentTargetSetupGate({
   gateVisible = true
 }: AgentTargetSetupGateProps): React.JSX.Element {
   const controller = useAgentTargetSetupController();
+  const { scope } = useAgentVisibleErrorPresentation();
   const { terminalLogin } = useAgentHostApi();
   const { t } = useTranslation();
   const state = useExternalStoreSnapshot(controller);
@@ -77,7 +79,10 @@ export function AgentTargetSetupGate({
       ? (effectiveAuthMethod.terminalStartupAction ?? null)
       : null;
 
-  if (!enabled) {
+  // A shared caller can observe the Owner target's readiness, but must never
+  // be routed into this device's setup/login/install workflow. Shared hosts
+  // own their separate availability presentation and execution errors.
+  if (!enabled || scope === "shared_caller") {
     return <>{children}</>;
   }
 

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGuiRuntimeNotices.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGuiRuntimeNotices.ts
@@ -5,6 +5,8 @@ export const enAgentGuiRuntimeNotices = {
     "{{provider}} needs authentication or configuration",
   visibleErrorAuthRequiredLocalAgentHint:
     "Please sign in to local {{provider}}, then retry.",
+  visibleErrorSharedCallerHint:
+    "Contact the person who shared this Agent, then try again.",
   visibleErrorRequestTimedOut: "{{provider}} request timed out",
   visibleErrorRuntimeUnavailable:
     "{{provider}} could not start because the runtime is unavailable",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGuiRuntimeNotices.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGuiRuntimeNotices.ts
@@ -4,6 +4,7 @@ export const zhCNAgentGuiRuntimeNotices = {
   visibleErrorAuthRequired: "{{provider}} 需要认证或配置",
   visibleErrorAuthRequiredLocalAgentHint:
     "请在本地登录 {{provider}}，然后重试。",
+  visibleErrorSharedCallerHint: "请联系分享者完成处理后再试。",
   visibleErrorRequestTimedOut: "{{provider}} 请求超时",
   visibleErrorRuntimeUnavailable: "{{provider}} 因运行环境不可用而无法启动",
   visibleErrorQuotaOrRateLimit: "{{provider}} 请求失败：额度或频率限制已触发",

--- a/packages/agent/gui/index.ts
+++ b/packages/agent/gui/index.ts
@@ -78,7 +78,8 @@ export type {
   AgentRunErrorCode,
   AgentVisibleErrorOverride,
   AgentVisibleErrorOverrideCode,
-  AgentVisibleErrorOverrides
+  AgentVisibleErrorOverrides,
+  AgentVisibleErrorPresentationScope
 } from "./shared/agentEnv/agentErrorPresentation";
 export type {
   AgentGUIComposerContentType,

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.visibleError.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.visibleError.spec.tsx
@@ -8,7 +8,10 @@ import type {
 } from "../contracts/agentMessageRowVM";
 import { AgentEnvPanelActionProvider } from "../../agentEnv";
 import { AgentVisibleErrorPresentationProvider } from "../../visibleError/AgentVisibleErrorPresentationContext";
-import type { AgentVisibleErrorOverrides } from "../../agentEnv/agentErrorPresentation";
+import type {
+  AgentVisibleErrorOverrides,
+  AgentVisibleErrorPresentationScope
+} from "../../agentEnv/agentErrorPresentation";
 
 function buildRow(
   visibleError: AgentMessageContentVM["visibleError"],
@@ -39,13 +42,15 @@ function renderBlock(
   row: AgentMessageRowVM,
   provider?: string,
   onLinkAction?: ComponentProps<typeof AgentMessageBlock>["onLinkAction"],
-  visibleErrorPresentationOverrides?: AgentVisibleErrorOverrides | null
+  visibleErrorPresentationOverrides?: AgentVisibleErrorOverrides | null,
+  visibleErrorPresentationScope?: AgentVisibleErrorPresentationScope
 ) {
   const onOpenAgentEnvPanel = vi.fn();
   return {
     ...render(
       <AgentEnvPanelActionProvider openPanel={onOpenAgentEnvPanel}>
         <AgentVisibleErrorPresentationProvider
+          scope={visibleErrorPresentationScope}
           value={visibleErrorPresentationOverrides}
         >
           <AgentMessageBlock
@@ -296,6 +301,98 @@ describe("AgentVisibleErrorMessage", () => {
         url: "https://example.test/credits"
       })
     );
+  });
+
+  it("shows sharer guidance instead of local authentication recovery", () => {
+    const { getByRole, getByText, queryByText, onOpenAgentEnvPanel } =
+      renderBlock(
+        buildRow({
+          code: "auth_required",
+          phase: "turn",
+          provider: "codex",
+          detail: "owner diagnostic: local Codex login is required",
+          detailAvailable: true,
+          retryable: false
+        }),
+        "codex",
+        undefined,
+        undefined,
+        "shared_caller"
+      );
+
+    expect(
+      getByText("Codex needs authentication or configuration")
+    ).toBeTruthy();
+    expect(
+      getByText("Contact the person who shared this Agent, then try again.")
+    ).toBeTruthy();
+    expect(queryByText("Sign in")).toBeNull();
+    expect(onOpenAgentEnvPanel).not.toHaveBeenCalled();
+
+    fireEvent.click(getByRole("button", { name: "Raw error" }));
+    expect(
+      getByText("owner diagnostic: local Codex login is required")
+    ).toBeTruthy();
+  });
+
+  it("does not expose a caller Commerce action for an Owner credit failure", () => {
+    const onLinkAction = vi.fn();
+    const { getByText, queryByText } = renderBlock(
+      buildRow({
+        code: "insufficient_credits",
+        phase: "turn",
+        provider: "tutti-agent",
+        detail: "owner balance is insufficient",
+        retryable: false
+      }),
+      "tutti-agent",
+      onLinkAction,
+      {
+        insufficient_credits: {
+          message: "Recharge credits to continue",
+          providers: ["tutti-agent"],
+          action: {
+            label: "Recharge credits",
+            url: "https://example.test/credits"
+          }
+        }
+      },
+      "shared_caller"
+    );
+
+    expect(
+      getByText("Tutti has insufficient credits or account balance to continue")
+    ).toBeTruthy();
+    expect(
+      getByText("Contact the person who shared this Agent, then try again.")
+    ).toBeTruthy();
+    expect(queryByText("Recharge credits to continue")).toBeNull();
+    expect(queryByText("Recharge credits")).toBeNull();
+    expect(onLinkAction).not.toHaveBeenCalled();
+  });
+
+  it("preserves neutral transient copy while suppressing local setup actions", () => {
+    const { getByText, queryByText } = renderBlock(
+      buildRow({
+        code: "network_error",
+        phase: "turn",
+        provider: "codex",
+        detail: null,
+        retryable: true
+      }),
+      "codex",
+      undefined,
+      undefined,
+      "shared_caller"
+    );
+
+    expect(
+      getByText("Codex couldn't reach the network to complete this request.")
+    ).toBeTruthy();
+    expect(
+      queryByText("Contact the person who shared this Agent, then try again.")
+    ).toBeNull();
+    expect(queryByText("Check network")).toBeNull();
   });
 
   it("does not apply a Tutti Commerce override to another provider", () => {

--- a/packages/agent/gui/shared/agentConversation/components/AgentVisibleErrorMessage.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentVisibleErrorMessage.tsx
@@ -6,9 +6,10 @@ import { useOpenAgentEnvPanel } from "../../agentEnv";
 import { AgentMessageDetailsDisclosure } from "./AgentMessageDetailsDisclosure";
 import {
   classifyRecoverableAgentMessage,
+  isSharedCallerOwnerRemediableError,
   resolveAgentErrorPresentation
 } from "../../agentEnv/agentErrorPresentation";
-import { useAgentVisibleErrorPresentationOverrides } from "../../visibleError/AgentVisibleErrorPresentationContext";
+import { useAgentVisibleErrorPresentation } from "../../visibleError/AgentVisibleErrorPresentationContext";
 import type { AgentMessageContentVM } from "../contracts/agentMessageRowVM";
 
 // All error banners use the light-red danger surface. Yellow/warning surfaces
@@ -52,7 +53,8 @@ export function AgentVisibleErrorMessage({
 }): JSX.Element {
   "use memo";
   const openAgentEnvPanel = useOpenAgentEnvPanel();
-  const presentationOverrides = useAgentVisibleErrorPresentationOverrides();
+  const { overrides: presentationOverrides, scope } =
+    useAgentVisibleErrorPresentation();
   const error = message.visibleError;
 
   // One card for every run-failure code. The presentation (keyed on the codes
@@ -63,10 +65,11 @@ export function AgentVisibleErrorMessage({
   const providerLabel = workspaceAgentProviderLabel(
     error?.provider ?? "unknown"
   );
-  const presentation = resolveAgentErrorPresentation(error?.code);
+  const presentation = resolveAgentErrorPresentation(error?.code, scope);
   const insufficientCreditsOverride =
     presentationOverrides?.insufficient_credits;
   const presentationOverride =
+    scope !== "shared_caller" &&
     error?.code === "insufficient_credits" &&
     insufficientCreditsOverride?.providers.includes(error.provider ?? "")
       ? insufficientCreditsOverride
@@ -79,7 +82,7 @@ export function AgentVisibleErrorMessage({
   const focus = presentation?.focus ?? null;
   const actionKey = presentation?.actionKey ?? null;
   const externalAction = presentationOverride?.action ?? null;
-  const hint = visibleErrorHint(message);
+  const hint = visibleErrorHint(message, scope);
   const rawDetail = error?.detail ?? "";
   const showRawDetail = error?.detailAvailable === true && rawDetail !== "";
   // Account limits are status notices, not process crashes. Provider payloads
@@ -173,8 +176,17 @@ function visibleErrorTitle(message: AgentMessageContentVM): string {
   }
 }
 
-function visibleErrorHint(message: AgentMessageContentVM): string | null {
+function visibleErrorHint(
+  message: AgentMessageContentVM,
+  scope: "local_owner" | "shared_caller"
+): string | null {
   const error = message.visibleError;
+  if (
+    scope === "shared_caller" &&
+    isSharedCallerOwnerRemediableError(error?.code)
+  ) {
+    return translate("agentHost.agentGui.visibleErrorSharedCallerHint");
+  }
   if (error?.code !== "auth_required") {
     return null;
   }

--- a/packages/agent/gui/shared/agentEnv/agentErrorPresentation.ts
+++ b/packages/agent/gui/shared/agentEnv/agentErrorPresentation.ts
@@ -29,6 +29,15 @@ export type AgentRunErrorCode =
   | "provider_error"
   | "unknown";
 
+/**
+ * Identifies who can remediate a visible error in the current AgentGUI view.
+ * This is presentation-only host context; it does not alter canonical Turns
+ * or provider error data.
+ */
+export type AgentVisibleErrorPresentationScope =
+  | "local_owner"
+  | "shared_caller";
+
 export interface AgentVisibleErrorOverride {
   message: string;
   /** Provider ids for which this product-owned override is valid. */
@@ -68,6 +77,34 @@ export interface AgentErrorPresentation {
 }
 
 const NO_CTA = { focus: null, actionKey: null } as const;
+
+const SHARED_CALLER_OWNER_REMEDIABLE_CODES: readonly string[] = [
+  "auth_required",
+  "cli_not_found",
+  "cli_version_unsupported",
+  "runtime_unavailable",
+  "execution_start_failed",
+  "execution_lost",
+  "insufficient_credits",
+  "subscription_required",
+  "quota_exhausted",
+  "model_not_allowed",
+  "plugin_unavailable"
+];
+
+/**
+ * Returns whether a structured failure requires the shared Agent owner to
+ * remediate it. Transport and ambiguous failures deliberately stay neutral so
+ * callers retain the existing retry guidance.
+ */
+export function isSharedCallerOwnerRemediableError(
+  code: string | null | undefined
+): boolean {
+  return (
+    typeof code === "string" &&
+    SHARED_CALLER_OWNER_REMEDIABLE_CODES.includes(code)
+  );
+}
 
 // The escape hatch for hard failures whose cause is ambiguous from the message
 // alone (a non-zero exit, an unclassified provider error): send the user into
@@ -164,12 +201,20 @@ const PRESENTATIONS: Record<AgentRunErrorCode, AgentErrorPresentation> = {
  * no call-to-action.
  */
 export function resolveAgentErrorPresentation(
-  code: string | null | undefined
+  code: string | null | undefined,
+  scope: AgentVisibleErrorPresentationScope = "local_owner"
 ): AgentErrorPresentation | null {
   if (!code) {
     return null;
   }
-  return PRESENTATIONS[code as AgentRunErrorCode] ?? null;
+  const presentation = PRESENTATIONS[code as AgentRunErrorCode] ?? null;
+  if (!presentation || scope !== "shared_caller") {
+    return presentation;
+  }
+  // Shared callers must never be sent to the current device's Agent Env
+  // wizard. The caller-contact copy is rendered separately for structured
+  // Owner-remediable failures; transient failures preserve their current copy.
+  return { ...presentation, ...NO_CTA };
 }
 
 const FAILED_MESSAGE_CODE_MARKERS: ReadonlyArray<

--- a/packages/agent/gui/shared/visibleError/AgentVisibleErrorPresentationContext.tsx
+++ b/packages/agent/gui/shared/visibleError/AgentVisibleErrorPresentationContext.tsx
@@ -1,27 +1,45 @@
 import {
   createContext,
   useContext,
+  useMemo,
   type JSX,
   type PropsWithChildren
 } from "react";
-import type { AgentVisibleErrorOverrides } from "../agentEnv/agentErrorPresentation";
+import type {
+  AgentVisibleErrorOverrides,
+  AgentVisibleErrorPresentationScope
+} from "../agentEnv/agentErrorPresentation";
+
+interface AgentVisibleErrorPresentationContextValue {
+  overrides: AgentVisibleErrorOverrides | null;
+  scope: AgentVisibleErrorPresentationScope;
+}
 
 const AgentVisibleErrorPresentationContext =
-  createContext<AgentVisibleErrorOverrides | null>(null);
+  createContext<AgentVisibleErrorPresentationContextValue>({
+    overrides: null,
+    scope: "local_owner"
+  });
 
 export function AgentVisibleErrorPresentationProvider({
   children,
+  scope = "local_owner",
   value
 }: PropsWithChildren<{
+  scope?: AgentVisibleErrorPresentationScope;
   value?: AgentVisibleErrorOverrides | null;
 }>): JSX.Element {
+  const contextValue = useMemo(
+    () => ({ overrides: value ?? null, scope }),
+    [scope, value]
+  );
   return (
-    <AgentVisibleErrorPresentationContext.Provider value={value ?? null}>
+    <AgentVisibleErrorPresentationContext.Provider value={contextValue}>
       {children}
     </AgentVisibleErrorPresentationContext.Provider>
   );
 }
 
-export function useAgentVisibleErrorPresentationOverrides(): AgentVisibleErrorOverrides | null {
+export function useAgentVisibleErrorPresentation(): AgentVisibleErrorPresentationContextValue {
   return useContext(AgentVisibleErrorPresentationContext);
 }


### PR DESCRIPTION
## Summary

- Add the display-only `shared_caller` error-presentation scope to AgentGUI.
- Route Owner-remediable failures to sharer guidance and suppress local setup and Commerce actions.
- Document the host contract and cover card and setup-gate paths.

## Tests

- `pnpm --filter @tutti-os/agent-gui test -- AgentMessageBlock.visibleError.spec.tsx AgentTargetSetupGate.spec.tsx agentErrorPresentation.spec.ts`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm check:changed`

## Notes

- TSH integration follows after a released Tutti cohort; this PR does not alter activity data or canonical Turns.
