### PR TITLE
fix(workspace-files): normalize Git Bash Windows paths

### DIFF
--- a/apps/desktop/src/main/host/workspaceFileHostAccess.test.ts
+++ b/apps/desktop/src/main/host/workspaceFileHostAccess.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -250,6 +250,45 @@ test("workspace file host access resolves terminal links for workspace, relative
   } finally {
     restoreHome();
   }
+});
+
+test("workspace file host access normalizes Git Bash paths at the native boundary", async () => {
+  if (process.platform !== "win32") {
+    return;
+  }
+
+  const openedPaths: string[] = [];
+  const revealedPaths: string[] = [];
+  const hostAccess = createWorkspaceFileHostAccess({
+    openPath: async (targetPath) => {
+      openedPaths.push(targetPath);
+      return "";
+    },
+    showItemInFolder(targetPath) {
+      revealedPaths.push(targetPath);
+    },
+    stat: (async () => ({
+      isDirectory: () => false
+    })) as unknown as typeof stat
+  });
+
+  await hostAccess.openFile({
+    path: "/c/Users/test/project/notes.txt",
+    workspaceID: "workspace-1"
+  });
+  await hostAccess.revealWorkspaceFile({
+    path: "/c/Users/test/project/notes.txt",
+    workspaceID: "workspace-1"
+  });
+  await hostAccess.openTerminalLink({
+    cwd: "C:\\Users\\test\\project",
+    path: "/c/Users/test/project/notes.txt",
+    workspaceID: "workspace-1"
+  });
+
+  const expectedPath = path.resolve("C:/Users/test/project/notes.txt");
+  assert.deepEqual(openedPaths, [expectedPath, expectedPath]);
+  assert.deepEqual(revealedPaths, [expectedPath]);
 });
 
 test("workspace file host access reveals workspace files and directories", async () => {

--- a/apps/desktop/src/main/host/workspaceFileHostAccess.ts
+++ b/apps/desktop/src/main/host/workspaceFileHostAccess.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import path, { basename } from "node:path";
 import { pathToFileURL } from "node:url";
 import { workspaceFilePreviewMaxBytes } from "@tutti-os/workspace-file-preview";
+import { formatWorkspaceFilePathForDisplay } from "@tutti-os/workspace-file-manager/services";
 import { desktopErrorCodes } from "../../shared/errors/desktopErrors.ts";
 import type {
   DesktopCreateUserDocumentsProjectDirectoryInput,
@@ -344,7 +345,10 @@ function resolveWorkspaceTargetPath(
 }
 
 function resolveWorkspaceTargetRoot(logicalPath: string): string {
-  const normalizedPath = logicalPath.trim().replaceAll("\\", "/");
+  const normalizedPath = formatWorkspaceFilePathForDisplay(
+    logicalPath,
+    process.platform
+  ).replaceAll("\\", "/");
   if (
     isWorkspaceLogicalPath(normalizedPath) ||
     !path.isAbsolute(normalizedPath)

--- a/apps/desktop/src/main/host/workspaceFilePaths.test.ts
+++ b/apps/desktop/src/main/host/workspaceFilePaths.test.ts
@@ -62,6 +62,56 @@ test("resolveWorkspaceFileAbsolutePath normalizes daemon Windows drive paths", (
   );
 });
 
+test("resolveWorkspaceFileAbsolutePath normalizes Git Bash drive paths", () => {
+  if (process.platform !== "win32") {
+    return;
+  }
+
+  assert.equal(
+    resolveWorkspaceFileAbsolutePath({
+      logicalPath: "/c/Users/test/Documents/notes.txt",
+      rootDirectory: "C:\\"
+    }),
+    path.resolve("C:/Users/test/Documents/notes.txt")
+  );
+});
+
+test("resolveWorkspaceFileAbsolutePath keeps Git Bash paths on another drive outside the root", () => {
+  if (process.platform !== "win32") {
+    return;
+  }
+
+  assert.throws(
+    () =>
+      resolveWorkspaceFileAbsolutePath({
+        logicalPath: "/d/Users/test/Documents/notes.txt",
+        rootDirectory: "C:\\"
+      }),
+    /escapes root directory/
+  );
+});
+
+test("resolveWorkspaceFileAbsolutePath preserves native and UNC Windows paths", () => {
+  if (process.platform !== "win32") {
+    return;
+  }
+
+  assert.equal(
+    resolveWorkspaceFileAbsolutePath({
+      logicalPath: "C:\\Users\\test\\Documents\\notes.txt",
+      rootDirectory: "C:\\"
+    }),
+    path.resolve("C:/Users/test/Documents/notes.txt")
+  );
+  assert.equal(
+    resolveWorkspaceFileAbsolutePath({
+      logicalPath: "\\\\server\\share\\Documents\\notes.txt",
+      rootDirectory: "\\\\server\\share"
+    }),
+    path.resolve("\\\\server\\share\\Documents\\notes.txt")
+  );
+});
+
 test("resolveWorkspaceFileAbsolutePath rejects empty workspace roots", () => {
   assert.throws(
     () =>
@@ -119,5 +169,36 @@ test("resolveTerminalLinkAbsolutePath supports home-relative, absolute, and cwd-
       path: "../README.md"
     }),
     path.resolve("/tmp/demo/README.md")
+  );
+});
+
+test("resolveTerminalLinkAbsolutePath preserves POSIX /c paths", () => {
+  if (process.platform === "win32") {
+    return;
+  }
+
+  assert.equal(
+    resolveTerminalLinkAbsolutePath({
+      defaultDirectory: "/Users/example",
+      homeDirectory: "/Users/example",
+      path: "/c/Users/example/notes.txt"
+    }),
+    path.resolve("/c/Users/example/notes.txt")
+  );
+});
+
+test("resolveTerminalLinkAbsolutePath normalizes Git Bash drive paths", () => {
+  if (process.platform !== "win32") {
+    return;
+  }
+
+  assert.equal(
+    resolveTerminalLinkAbsolutePath({
+      cwd: "C:\\Users\\test\\project",
+      defaultDirectory: "C:\\Users\\test",
+      homeDirectory: "C:\\Users\\test",
+      path: "/c/Users/test/project/notes.txt"
+    }),
+    path.resolve("C:/Users/test/project/notes.txt")
   );
 });

--- a/apps/desktop/src/main/host/workspaceFilePaths.ts
+++ b/apps/desktop/src/main/host/workspaceFilePaths.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { formatWorkspaceFilePathForDisplay } from "@tutti-os/workspace-file-manager/services";
 
 export const workspaceLogicalRoot = "/workspace" as const;
 
@@ -37,9 +38,7 @@ export function resolveWorkspaceFileAbsolutePath(input: {
     throw new Error("root directory is required");
   }
   const rootDirectory = path.resolve(rootDirectoryInput);
-  const rawPath = normalizeWindowsDriveAbsolutePath(
-    input.logicalPath.trim().replaceAll("\\", "/")
-  );
+  const rawPath = normalizeWorkspaceHostPath(input.logicalPath);
 
   const absolutePath = path.isAbsolute(rawPath)
     ? path.resolve(rawPath)
@@ -54,16 +53,11 @@ export function resolveWorkspaceFileAbsolutePath(input: {
   return absolutePath;
 }
 
-function normalizeWindowsDriveAbsolutePath(value: string): string {
-  if (path.sep !== "\\") {
-    return value;
-  }
-
-  // The daemon exposes Windows absolute paths in POSIX form (`/C:/...`) so
-  // they can travel through the logical workspace API. Node's win32 resolver
-  // treats that leading slash as the current drive root and produces
-  // `C:\\C:\\...`, which then looks like an escape from the workspace root.
-  return value.replace(/^\/([A-Za-z]:)(?=\/|$)/, "$1");
+function normalizeWorkspaceHostPath(value: string): string {
+  return formatWorkspaceFilePathForDisplay(value, process.platform).replaceAll(
+    "\\",
+    "/"
+  );
 }
 
 export function resolveTerminalLinkAbsolutePath(input: {
@@ -82,12 +76,12 @@ export function resolveTerminalLinkAbsolutePath(input: {
     return path.resolve(input.homeDirectory, relativeHomePath);
   }
 
-  const normalized = rawPath.replaceAll("\\", "/");
+  const cwd = input.cwd?.trim();
+  const normalized = normalizeWorkspaceHostPath(rawPath);
   if (path.isAbsolute(normalized)) {
     return path.resolve(normalized);
   }
 
-  const cwd = input.cwd?.trim();
   if (cwd) {
     return path.resolve(cwd, normalized);
   }

--- a/packages/agent/gui/actions/workspaceFilePathCandidate.ts
+++ b/packages/agent/gui/actions/workspaceFilePathCandidate.ts
@@ -100,11 +100,15 @@ export function normalizeWorkspaceFilePath(
   rootPath?: string | null
 ): string {
   const normalizedPath = path.trim().replaceAll("\\", "/");
+  const normalizedRootPath = rootPath?.trim().replaceAll("\\", "/");
   if (
     isWindowsAbsolutePath(normalizedPath) ||
-    isGitBashWindowsAbsolutePath(normalizedPath, rootPath)
+    isGitBashWindowsAbsolutePath(normalizedPath, normalizedRootPath)
   ) {
-    return normalizeLogicalWorkspaceFilePath(normalizedPath, rootPath);
+    return normalizeLogicalWorkspaceFilePath(
+      normalizedPath,
+      normalizedRootPath
+    );
   }
 
   const drive = /^[A-Za-z]:/.exec(normalizedPath)?.[0] ?? "";

--- a/packages/agent/gui/shared/agentConversation/components/AgentTurnSummaryRow.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTurnSummaryRow.tsx
@@ -654,7 +654,8 @@ function buildExecutablePatchBatches(
   return sourceBatches.flatMap((batch) => {
     const sourceCwd = patchBatchDirectoryCwd(
       batch.cwd ?? workspaceRoot ?? null,
-      batch.changes
+      batch.changes,
+      workspaceRoot
     );
     const executionCwd = resolvePatchExecutionCwd(sourceCwd, workspaceRoot);
     const diffCwd = resolvePatchDiffCwd({

--- a/packages/agent/gui/shared/agentConversation/rules/agentTurnSummaryPatchRuntime.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/rules/agentTurnSummaryPatchRuntime.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  patchBatchDirectoryCwd,
+  resolvePatchExecutionCwd
+} from "./agentTurnSummaryPatchRuntime";
+
+describe("Agent Turn Summary patch cwd paths", () => {
+  it("maps Git Bash drive paths to the Windows workspace drive", () => {
+    const workspaceRoot = "C:\\Users\\demo\\project";
+    const cwd = "/c/Users/demo/project";
+
+    expect(
+      patchBatchDirectoryCwd(
+        `${cwd}/README.md`,
+        [{ path: `${cwd}/README.md` }],
+        workspaceRoot
+      )
+    ).toBe("C:/Users/demo/project");
+    expect(resolvePatchExecutionCwd(cwd, workspaceRoot)).toBe(
+      "C:/Users/demo/project"
+    );
+  });
+
+  it("preserves POSIX /c paths when the workspace root is POSIX", () => {
+    expect(
+      resolvePatchExecutionCwd("/c/Users/demo/project", "/Users/demo/project")
+    ).toBe("/c/Users/demo/project");
+  });
+});

--- a/packages/agent/gui/shared/agentConversation/rules/agentTurnSummaryPatchRuntime.ts
+++ b/packages/agent/gui/shared/agentConversation/rules/agentTurnSummaryPatchRuntime.ts
@@ -1,7 +1,9 @@
+import { formatWorkspaceFilePathForDisplay } from "@tutti-os/workspace-file-manager/services";
 import type {
   AgentTurnSummaryFileVM,
   AgentTurnSummaryPatchChangeVM
 } from "../contracts/agentTurnSummaryRowVM";
+import { normalizeWorkspaceFilePath } from "../../../actions/workspaceFilePathCandidate";
 
 export function fileCanBuildPatch(file: AgentTurnSummaryFileVM): boolean {
   return (
@@ -14,24 +16,31 @@ export function fileCanBuildPatch(file: AgentTurnSummaryFileVM): boolean {
 
 export function patchBatchDirectoryCwd(
   cwd: string | null,
-  changes: readonly Pick<AgentTurnSummaryPatchChangeVM, "path">[]
+  changes: readonly Pick<AgentTurnSummaryPatchChangeVM, "path">[],
+  workspaceRoot?: string | null
 ): string | null {
-  const normalizedCwd = normalizePatchHostPath(cwd ?? "");
+  const normalizedCwd = normalizePatchHostPath(cwd ?? "", workspaceRoot);
   if (!normalizedCwd) {
     return null;
   }
   const cwdIsChangedFilePath = changes.some(
-    (change) => normalizePatchHostPath(change.path) === normalizedCwd
+    (change) =>
+      normalizePatchHostPath(change.path, workspaceRoot) === normalizedCwd
   );
-  return cwdIsChangedFilePath ? dirnameForPatchHostPath(normalizedCwd) : cwd;
+  return cwdIsChangedFilePath
+    ? dirnameForPatchHostPath(normalizedCwd)
+    : normalizedCwd;
 }
 
 export function resolvePatchExecutionCwd(
   cwd: string | null,
   workspaceRoot?: string | null
 ): string | null {
-  const normalizedCwd = normalizePatchHostPath(cwd ?? "");
-  const normalizedRoot = normalizePatchHostPath(workspaceRoot ?? "");
+  const normalizedRoot = normalizePatchHostPath(
+    workspaceRoot ?? "",
+    workspaceRoot
+  );
+  const normalizedCwd = normalizePatchHostPath(cwd ?? "", normalizedRoot);
   if (!normalizedCwd) {
     return normalizedRoot || null;
   }
@@ -84,8 +93,21 @@ export function resolvePatchDiffCwd({
     : sourceCwd;
 }
 
-function normalizePatchHostPath(path: string): string {
-  return path.trim().replaceAll("\\", "/").replace(/\/+$/, "");
+function normalizePatchHostPath(
+  path: string,
+  workspaceRoot?: string | null
+): string {
+  const trimmed = path.trim();
+  if (!trimmed) {
+    return "";
+  }
+  const normalized = normalizeWorkspaceFilePath(trimmed, workspaceRoot);
+  if (/^\/?[A-Za-z]:\//.test(normalized)) {
+    return formatWorkspaceFilePathForDisplay(normalized, "win32")
+      .replaceAll("\\", "/")
+      .replace(/\/+$/, "");
+  }
+  return normalized.replace(/\/+$/, "");
 }
 
 function dirnameForPatchHostPath(path: string): string {

--- a/packages/agent/gui/shared/workspaceAgentActivityListViewModel.spec.ts
+++ b/packages/agent/gui/shared/workspaceAgentActivityListViewModel.spec.ts
@@ -1911,6 +1911,53 @@ describe("buildWorkspaceAgentActivityListViewModel", () => {
     ]);
   });
 
+  it("treats Git Bash drive paths as Windows workspace paths", () => {
+    const gitBashPath = "/c/Users/demo/project/src/report.md";
+    const snapshot = {
+      workspaceId: "workspace-1",
+      presences: [],
+      sessions: [
+        {
+          agentSessionId: "session-23",
+          cwd: "C:\\Users\\demo\\project",
+          provider: "codex",
+          status: "completed",
+          title: "Write a Git Bash path",
+          workspaceId: "workspace-1"
+        }
+      ],
+      sessionMessagesById: {
+        "session-23": [
+          {
+            agentSessionId: "session-23",
+            kind: "tool_call",
+            messageId: "message-git-bash-file",
+            payload: {
+              toolName: "Write",
+              input: { file_path: gitBashPath }
+            },
+            role: "assistant",
+            status: "completed",
+            turnId: "turn-git-bash-file",
+            occurredAtUnixMs: 1,
+            version: 1
+          }
+        ]
+      }
+    };
+
+    expect(
+      collectWorkspaceAgentGeneratedFiles(canonicalSource(snapshot), {
+        workspaceRoot: "C:\\Users\\demo\\project"
+      })
+    ).toEqual([
+      {
+        path: "C:/Users/demo/project/src/report.md",
+        label: "report.md"
+      }
+    ]);
+  });
+
   it("collects agent-generated files from lightweight change maps", () => {
     const snapshot = {
       workspaceId: "workspace-1",

--- a/packages/agent/gui/shared/workspaceAgentGeneratedFiles.ts
+++ b/packages/agent/gui/shared/workspaceAgentGeneratedFiles.ts
@@ -1,3 +1,4 @@
+import { formatWorkspaceFilePathForDisplay } from "@tutti-os/workspace-file-manager/services";
 import { fileChangePathsFromChanges } from "./workspaceAgentFileChangePayload.ts";
 import type {
   AgentActivityMessage,
@@ -9,6 +10,10 @@ import type {
 } from "./workspaceAgentActivityListTypes";
 import { workspaceAgentSessionMessageAliases } from "./workspaceAgentSessionMessageAliases.ts";
 import { isImageGenerationToolCall } from "./imageGenerationTool.ts";
+import {
+  isInsideOrEqualWorkspaceFilePath,
+  normalizeWorkspaceFilePath
+} from "../actions/workspaceFilePathCandidate";
 
 export interface WorkspaceAgentGeneratedFilesSource {
   sessionMessagesById: Readonly<Record<string, AgentActivityMessage[]>>;
@@ -19,7 +24,13 @@ export function collectWorkspaceAgentGeneratedFiles(
   source: WorkspaceAgentGeneratedFilesSource,
   options: CollectWorkspaceAgentGeneratedFilesOptions = {}
 ): WorkspaceAgentChangedFile[] {
-  const sessionCwdFilter = normalizeComparablePath(options.sessionCwd ?? "");
+  const requestedWorkspaceRoot = normalizeComparablePath(
+    options.workspaceRoot ?? ""
+  );
+  const sessionCwdFilter = normalizeComparablePath(
+    options.sessionCwd ?? "",
+    requestedWorkspaceRoot
+  );
   const allowedAgentTargetIds = options.agentTargetIds
     ? new Set(options.agentTargetIds.map((id) => id.trim()).filter(Boolean))
     : null;
@@ -32,19 +43,21 @@ export function collectWorkspaceAgentGeneratedFiles(
     : source.sessions;
   const workspaceRoot =
     sessionCwdFilter ||
-    normalizeComparablePath(options.workspaceRoot ?? "") ||
+    requestedWorkspaceRoot ||
     resolveWorkspaceRootFromSessions(provenanceSessions);
   const sessions = sessionCwdFilter
     ? provenanceSessions.filter(
         (session) =>
-          normalizeComparablePath(session.cwd ?? "") === sessionCwdFilter
+          normalizeComparablePath(session.cwd ?? "", workspaceRoot) ===
+          sessionCwdFilter
       )
     : provenanceSessions;
   const filesByPath = new Map<string, WorkspaceAgentChangedFile>();
 
   for (const session of sessions) {
     const sessionCwd =
-      normalizeComparablePath(session.cwd ?? "") || workspaceRoot;
+      normalizeComparablePath(session.cwd ?? "", workspaceRoot) ||
+      workspaceRoot;
     const normalizePath = createAgentGeneratedFilePathNormalizer({
       sessionCwd,
       workspaceRoot
@@ -215,17 +228,35 @@ function resolveWorkspaceRootFromSessions(
   return "";
 }
 
-function normalizeComparablePath(path: string): string {
-  return path.trim().replace(/\\/g, "/").replace(/\/+$/, "");
+function normalizeComparablePath(path: string, rootPath?: string): string {
+  const trimmed = path.trim();
+  if (!trimmed) {
+    return "";
+  }
+  const normalizedInput = trimmed.replaceAll("\\", "/");
+  const normalized = normalizeWorkspaceFilePath(
+    trimmed,
+    rootPath?.trim().replaceAll("\\", "/")
+  );
+  if (
+    /^\/[A-Za-z]:\//.test(normalized) &&
+    !/^[A-Za-z]:\//.test(normalizedInput)
+  ) {
+    return formatWorkspaceFilePathForDisplay(normalized, "win32")
+      .replaceAll("\\", "/")
+      .replace(/\/+$/, "");
+  }
+  return normalizedInput.replace(/\/+$/, "");
 }
 
 function createAgentGeneratedFilePathNormalizer(input: {
   sessionCwd?: string | null;
   workspaceRoot?: string | null;
 }): ChangedFilePathNormalizer {
-  const workspaceRoot = input.workspaceRoot?.trim().replace(/\/+$/, "") ?? "";
+  const workspaceRoot = normalizeComparablePath(input.workspaceRoot ?? "");
   const sessionCwd =
-    input.sessionCwd?.trim().replace(/\/+$/, "") || workspaceRoot;
+    normalizeComparablePath(input.sessionCwd ?? "", workspaceRoot) ||
+    workspaceRoot;
   return (value: unknown) => {
     if (typeof value !== "string") {
       return null;
@@ -243,7 +274,7 @@ function resolveAgentGeneratedFilePath(
   // separator. Normalize before checking virtual namespaces such as the
   // out-of-workspace generated-image directory; otherwise a Windows path is
   // rejected because its `\\` segments are invisible to the `/`-only check.
-  const path = rawPath.trim().replace(/\\/g, "/");
+  const path = normalizeComparablePath(rawPath, workspaceRoot);
   if (!path || isStructuredPayloadPath(path)) {
     return null;
   }
@@ -256,7 +287,7 @@ function resolveAgentGeneratedFilePath(
   if (isAbsoluteAgentGeneratedFilePath(path)) {
     if (
       workspaceRoot &&
-      !isPathInsideOrEqual(path, workspaceRoot) &&
+      !isInsideOrEqualWorkspaceFilePath(path, workspaceRoot) &&
       !isAgentStateGeneratedImagePath(path)
     ) {
       return null;
@@ -271,7 +302,7 @@ function resolveAgentGeneratedFilePath(
   const resolved = joinAgentGeneratedFilePath(base, path.replace(/^\.?\//, ""));
   if (
     workspaceRoot &&
-    !isPathInsideOrEqual(resolved, workspaceRoot) &&
+    !isInsideOrEqualWorkspaceFilePath(resolved, workspaceRoot) &&
     !isAgentStateGeneratedImagePath(resolved)
   ) {
     return null;
@@ -281,24 +312,6 @@ function resolveAgentGeneratedFilePath(
 
 function isAbsoluteAgentGeneratedFilePath(path: string): boolean {
   return path.startsWith("/") || /^[A-Za-z]:[\\/]/.test(path);
-}
-
-function isPathInsideOrEqual(path: string, root: string): boolean {
-  const normalizedPath = path.replace(/\\/g, "/").replace(/\/+$/, "");
-  const normalizedRoot = root.replace(/\\/g, "/").replace(/\/+$/, "");
-  if (!normalizedRoot) {
-    return false;
-  }
-  const comparisonPath = /^[A-Za-z]:\//.test(normalizedPath)
-    ? normalizedPath.toLowerCase()
-    : normalizedPath;
-  const comparisonRoot = /^[A-Za-z]:\//.test(normalizedRoot)
-    ? normalizedRoot.toLowerCase()
-    : normalizedRoot;
-  return (
-    comparisonPath === comparisonRoot ||
-    comparisonPath.startsWith(`${comparisonRoot}/`)
-  );
 }
 
 function joinAgentGeneratedFilePath(

--- a/services/tuttid/service/agent/git_patch.go
+++ b/services/tuttid/service/agent/git_patch.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"slices"
 	"strings"
 	"syscall"
@@ -88,7 +89,7 @@ type gitPatchRepo struct {
 
 func (*Service) ApplyGitPatchForPath(ctx context.Context, workspaceID string, input ApplyGitPatchInput) (ApplyGitPatchResult, error) {
 	workspaceID = strings.TrimSpace(workspaceID)
-	input.Cwd = strings.TrimSpace(input.Cwd)
+	input.Cwd = normalizeGitPatchCwd(input.Cwd)
 	logAgentGitPatch("requested", map[string]any{
 		"workspaceId": workspaceID,
 		"cwd":         input.Cwd,
@@ -137,7 +138,7 @@ func logAgentGitPatch(event string, payload map[string]any) {
 
 func (*Service) ResolveGitPatchSupportForPath(ctx context.Context, workspaceID string, cwd string) (GitPatchSupport, error) {
 	workspaceID = strings.TrimSpace(workspaceID)
-	cwd = strings.TrimSpace(cwd)
+	cwd = normalizeGitPatchCwd(cwd)
 	if workspaceID == "" || cwd == "" {
 		return GitPatchSupport{}, ErrInvalidArgument
 	}
@@ -273,6 +274,28 @@ func resolveGitPatchRepo(ctx context.Context, cwd string) (gitPatchRepo, bool) {
 		prefix = filepath.ToSlash(rel)
 	}
 	return gitPatchRepo{Root: absRoot, DirectoryPrefix: prefix}, true
+}
+
+func normalizeGitPatchCwd(value string) string {
+	return normalizeGitPatchCwdForPlatform(value, runtime.GOOS == "windows")
+}
+
+func normalizeGitPatchCwdForPlatform(value string, windows bool) string {
+	normalized := strings.TrimSpace(strings.ReplaceAll(value, "\\", "/"))
+	if !windows {
+		return normalized
+	}
+	if len(normalized) < 2 || normalized[0] != '/' || !isASCIIPathLetter(normalized[1]) {
+		return normalized
+	}
+	if len(normalized) == 2 || normalized[2] == '/' {
+		return strings.ToUpper(string(normalized[1])) + ":" + normalized[2:]
+	}
+	return normalized
+}
+
+func isASCIIPathLetter(value byte) bool {
+	return (value >= 'a' && value <= 'z') || (value >= 'A' && value <= 'Z')
 }
 
 func existingGitPatchDirectory(path string) (string, error) {

--- a/services/tuttid/service/agent/git_patch_test.go
+++ b/services/tuttid/service/agent/git_patch_test.go
@@ -9,6 +9,49 @@ import (
 	"testing"
 )
 
+func TestNormalizeGitPatchCwdForPlatform(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   string
+		windows bool
+		want    string
+	}{
+		{
+			name:    "windows git bash drive",
+			input:   `/c/Users/demo/project`,
+			windows: true,
+			want:    `C:/Users/demo/project`,
+		},
+		{
+			name:    "windows git bash drive root",
+			input:   `/d`,
+			windows: true,
+			want:    `D:`,
+		},
+		{
+			name:    "posix path remains posix",
+			input:   `/c/Users/demo/project`,
+			windows: false,
+			want:    `/c/Users/demo/project`,
+		},
+		{
+			name:    "native windows path",
+			input:   `C:\Users\demo\project`,
+			windows: true,
+			want:    `C:/Users/demo/project`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := normalizeGitPatchCwdForPlatform(tt.input, tt.windows); got != tt.want {
+				t.Fatalf("normalizeGitPatchCwdForPlatform(%q, %t) = %q, want %q", tt.input, tt.windows, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestApplyGitPatchRevertsDiffAndCleansTempDir(t *testing.T) {
 	t.Parallel()
 	requireGitForPatchTest(t)


### PR DESCRIPTION
## Summary
- Normalize Git Bash `/c/...` paths at the AgentGUI Git patch, tuttid Git, and Electron workspace-file boundaries on Windows
- Preserve POSIX `/c/...` paths and existing native Windows, `/C:/...`, and UNC behavior
- Add regression coverage for patch cwd, generated-file containment, open/reveal, and terminal-link paths

## Tests
- `pnpm check:changed -- --push-ready` (20/20 lanes passed)
- Focused AgentGUI tests: 61/61 passed
- Focused Desktop tests: 34/34 passed
- Focused Go agent tests passed

## Notes
- Windows-native test branches are covered by the Desktop test suite; the current macOS run cannot execute those branches
- No lifecycle or public API changes