### PR TITLE
fix(release): preserve promotion notifications after skipped approval

### DIFF
--- a/.github/workflows/desktop-release-promote.yml
+++ b/.github/workflows/desktop-release-promote.yml
@@ -728,7 +728,7 @@ jobs:
   notify-feishu:
     name: Notify Feishu
     needs: [resolve, promote]
-    if: ${{ needs.promote.result == 'success' && inputs.notify_feishu == true }}
+    if: ${{ always() && needs.promote.result == 'success' && inputs.notify_feishu == true }}
     runs-on: ubuntu-latest
     env:
       FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_RELEASE_WEBHOOK_URL }}

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -582,6 +582,17 @@ test("desktop promotion workflow does not redownload release assets for Feishu",
   assert.match(notifyJobMatch[0], /name:\s+Send release card/);
 });
 
+test("desktop promotion notification tolerates skipped optional approval", async () => {
+  const promoteWorkflow = await readFile(promoteWorkflowPath, "utf8");
+  const notifyJob = promoteWorkflow.match(
+    /notify-feishu:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
+  )?.[0];
+
+  assert.ok(notifyJob, "promotion notify job should exist");
+  assert.match(notifyJob, /if:\s+\${{\s*always\(\)\s*&&/);
+  assert.match(notifyJob, /needs\.promote\.result\s*==\s*'success'/);
+});
+
 test("desktop release workflow can mirror release assets to S3 and upsert direct download links", async () => {
   const workflow = await readFile(workflowPath, "utf8");
   const promoteWorkflow = await readFile(promoteWorkflowPath, "utf8");


### PR DESCRIPTION
## Summary

- allow the promotion Feishu notification job to run after the optional stable approval job is skipped for RC/beta releases
- keep the existing promotion-success and notification-input gates
- add regression coverage for the job-level `always()` condition

## Root cause

The reviewed stable release flow added an optional `approve-stable` job. RC and beta promotions correctly skip that approval, but the downstream notification job lacked an explicit status function, so GitHub Actions applied its implicit success gate and skipped the notification through the dependency chain.

## Validation

- `node --test tools/scripts/desktop-release-config.test.mjs`
- `pnpm check:changed -- --failed-only`
- pre-push: `pnpm check:changed -- --push-ready`