### PR TITLE
fix(agent-gui): space quick prompts while sorting

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/quickPrompts/AgentQuickPromptPopover.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/quickPrompts/AgentQuickPromptPopover.tsx
@@ -338,7 +338,7 @@ export function AgentQuickPromptPopover({
           ) : null}
           <ScrollArea
             className="min-h-0 flex-1"
-            viewportClassName="px-2 pb-2"
+            viewportClassName={cn("px-2 pb-2", isSorting && "pt-2")}
             viewportTestId="agent-quick-prompt-scroll-viewport"
           >
             {isTemplateView ? (


### PR DESCRIPTION
## Summary

- add 8px top padding to the quick-prompt list while reorder mode hides search
- keep the existing spacing unchanged outside reorder mode

## Validation

- UI-only presentation change: no new test was added per the repository validation-selection policy
- commit hooks passed formatting, lint, renderer/UI boundaries, and AgentGUI degradation checks
- pre-push `pnpm check:changed -- --push-ready` passed 12 lanes

## AgentGUI review

| Lane | Trigger | Result | Evidence | Affected consumers |
| --- | --- | --- | --- | --- |
| Architecture | Composer quick-prompt presentation changed | pass | Only the existing ScrollArea viewport class changes from local `isSorting`; no Host, Engine, lifecycle, identity, command, or observation path changed | Desktop AgentGUI quick-prompt popover |
| Performance | A hidden/sorting surface changes layout | pass | One conditional utility class on a bounded popover viewport; no subscriptions, selectors, measurement loops, caches, or list cardinality changed; degradation boundary passed | Desktop AgentGUI quick-prompt popover |
| Consumers | AgentGUI component presentation changed | pass | No exports, props, capabilities, controller behavior, or command behavior changed | Desktop and external AgentGUI hosts retain the same component contract |

## Risk

Low. The change affects only top spacing during reorder mode. Windows behavior is identical because no platform-specific APIs or layout assumptions were introduced.