### PR TITLE
fix(agent): fail Codex lifecycle on MCP startup failure

### DIFF
--- a/docs/adr/0003-step3-thread-registry-subagent-routing.md
+++ b/docs/adr/0003-step3-thread-registry-subagent-routing.md
@@ -30,8 +30,11 @@ parent turn (t3code's re-tag path, rejected — see Concurrency).
    the collab card's final status/output (`appServerCollabAgentRawOutput`); Step 0
    `TestAppServerCollabAgentCompletedCarriesResultOutput` stays green untouched.
 5. **Unknown/foreign threads** (not in the child map, e.g. grandchildren — nested
-   spawns are suppressed so we never learn their mapping) fall through to the
-   ADR-0002 unknown-fallback (log + drop), same net effect as today's mismatch.
+   spawns are suppressed so we never learn their mapping) keep the ADR-0002
+   unknown-fallback (log + drop) for ordinary progress. A bounded one-entry-per-
+   thread terminal buffer retains `turn/completed` and non-retry `error` until
+   `receiverThreadIds` registers the child, then replays the terminal with the
+   child identity. Threads that never register still age out and are dropped.
 
 ### Data-model change (seam into Step 4)
 
@@ -77,10 +80,11 @@ parent turn (t3code's re-tag path, rejected — see Concurrency).
   `OwnerThreadID` lane → future UI renders separate cards, no garble.
 - **Parent + child simultaneous:** parent deltas flow on the parent stream;
   child deltas carry `OwnerThreadID` → never corrupt the parent's text.
-- **Ordering:** mapping is known at child announce time (`receiverThreadIds`
-  required on item/started). Early child event before the announce → unknown-fallback
-  (log+drop), validate against real logs. Registry map is owned by the single
-  sequential reducer (or mutex-guarded).
+- **Ordering:** mapping is normally known at child announce time
+  (`receiverThreadIds` required on item/started). Early ordinary child progress
+  before the announce → unknown-fallback (log+drop); early terminal evidence is
+  retained in the bounded terminal buffer and replayed only after registration.
+  Registry map and pending terminal buffer are mutex-guarded.
 
 ## Ordering verification (2026-07-02, Phase 0)
 
@@ -95,9 +99,10 @@ ADR question: can child-thread events arrive before the parent
 - **Empirical:** across all four exported log bundles (2026-07-02 sessions with
   4-5 concurrent children each), every declared receiver had a complete row
   set; no early-drop evidence.
-- **Permanent telemetry:** the daemon now tracks unknown-thread drops per
-  session (bounded) and, when a child registers late, logs
+- **Permanent telemetry:** the daemon tracks unknown-thread drops per session
+  (bounded) and, when a child registers late, logs
   `child events arrived before registration` with the lost-event count and
   records it on the thread context (`droppedBeforeRegistration`, pinned by
-  `TestCodexAppServerChildRegistrationReportsEarlyDrops`). If real deployments
-  ever hit the window, the log answers it; no speculative buffer added.
+  `TestCodexAppServerChildRegistrationReportsEarlyDrops`). Terminal evidence is
+  separately replayed exactly once when available, pinned by
+  `TestCodexAppServerChildTerminalBeforeRegistrationIsReplayed`.

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -1484,6 +1484,48 @@ inline data URL instead`. Claude or standard ACP may instead receive no
   [codex_appserver_turn_machine.go](../../../packages/agent/daemon/runtime/codex_appserver_turn_machine.go)
   [codex_appserver_adapter_test.go](../../../packages/agent/daemon/runtime/codex_appserver_adapter_test.go)
 
+### Codex app-server Start/Resume waits after a lifecycle notification
+
+- Symptom:
+  Session start or resume reaches the provider, but Tutti waits for the
+  lifecycle RPC timeout even though Codex sent `thread/started`. A required MCP
+  server can show the same symptom when the only failure evidence is
+  `mcpServer/startupStatus/updated` with `status = failed` and there is no
+  stderr or JSON-RPC response.
+- Quick checks:
+  Inspect the app-server wire trace for `thread/started` or
+  `mcpServer/startupStatus/updated` before the missing `thread/start` or
+  `thread/resume` response. Distinguish this from a completely silent provider:
+  without an authoritative lifecycle notification, process termination, or
+  transport error, the call must still time out rather than manufacture success.
+- Root cause:
+  App-server notifications and the response for their triggering RPC have no
+  safe application-order guarantee. Waiting only on the response leaves the
+  lifecycle call blocked when Codex has already published the authoritative
+  thread snapshot. Required MCP startup failure is also a terminal lifecycle
+  fact, but it can arrive without stderr or a response. Child terminal
+  notifications can arrive before `receiverThreadIds` registers their thread;
+  dropping those unknown-thread terminal events loses the only completion fact.
+- Fix:
+  Complete only the active method-matched `thread/start` or `thread/resume` wait
+  from a valid `thread/started` snapshot. Schedule the structured MCP failure
+  after a short response grace window so a normal response wins the race. Keep
+  ordinary foreign-thread progress dropped, but retain a bounded terminal
+  notification until child registration and replay it with child identity.
+  Keep confirmed provider turn-id fences; only the existing unconfirmed steer
+  stub and goal-adopted exceptions may settle from a different or empty id.
+- Validation:
+  Run the notification-only Start/Resume wire test, the MCP failed-status
+  response-grace tests, and the child terminal-before-registration replay test.
+  Run the focused app-server suite with `-race` and the full
+  `go test ./packages/agent/daemon/runtime` package suite.
+- References:
+  [codex_appserver_client.go](../../../packages/agent/daemon/runtime/codex_appserver_client.go)
+  [codex_appserver_event_routing.go](../../../packages/agent/daemon/runtime/codex_appserver_event_routing.go)
+  [codex_appserver_turn_machine.go](../../../packages/agent/daemon/runtime/codex_appserver_turn_machine.go)
+  [codex_appserver_lifecycle_test.go](../../../packages/agent/daemon/runtime/codex_appserver_lifecycle_test.go)
+  [codex_appserver_events_test.go](../../../packages/agent/daemon/runtime/codex_appserver_events_test.go)
+
 ### Busy-turn message insertion fails or ends without sending the prompt
 
 - Symptom:

--- a/packages/agent/daemon/runtime/acp_client.go
+++ b/packages/agent/daemon/runtime/acp_client.go
@@ -63,8 +63,10 @@ type acpPendingCall struct {
 
 type acpActiveHandler struct {
 	ctx     context.Context
+	method  string
 	handler acpMessageHandler
 	errors  chan error
+	results chan json.RawMessage
 }
 
 type acpError struct {
@@ -260,7 +262,13 @@ func (c *acpClient) callLocked(
 	if params != nil {
 		message["params"] = params
 	}
-	active := &acpActiveHandler{ctx: ctx, handler: handler, errors: make(chan error, 1)}
+	active := &acpActiveHandler{
+		ctx:     ctx,
+		method:  method,
+		handler: handler,
+		errors:  make(chan error, 1),
+		results: make(chan json.RawMessage, 1),
+	}
 	pending := &acpPendingCall{response: make(chan acpMessage, 1)}
 	c.registerCall(id, pending, active)
 	defer c.unregisterCall(id, active)
@@ -285,6 +293,8 @@ func (c *acpClient) callLocked(
 				err = io.EOF
 			}
 			return nil, err
+		case result := <-active.results:
+			return result, nil
 		case message := <-pending.response:
 			if message.Error != nil {
 				slog.Warn("agent session ACP request failed",
@@ -399,6 +409,26 @@ func (c *acpClient) failActiveHandler(err error) {
 	}
 	select {
 	case active.errors <- err:
+	default:
+	}
+}
+
+// completeActiveHandler supplies a synthetic success result to the active
+// request when the provider emits an authoritative lifecycle notification but
+// loses the matching JSON-RPC response. The method fence prevents an
+// unrelated notification from completing another request's waiter.
+func (c *acpClient) completeActiveHandler(method string, result json.RawMessage) {
+	if c == nil || method == "" || len(result) == 0 {
+		return
+	}
+	c.mu.Lock()
+	active := c.active
+	c.mu.Unlock()
+	if active == nil || active.method != method {
+		return
+	}
+	select {
+	case active.results <- result:
 	default:
 	}
 }

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -325,9 +325,15 @@ type codexAppServerSession struct {
 	canceledProviderThreads map[string]struct{}
 	activeTurn              *codexAppServerActiveTurn
 	childThreads            map[string]*codexAppServerThreadContext
-	// recentForeignDrops remembers recently dropped unknown thread ids so a
-	// late registration can report how many events the ordering gap lost.
+	// recentForeignDrops remembers recently observed unknown thread ids so a
+	// late registration can report the ordering gap; terminal notifications are
+	// retained separately for replay while ordinary progress remains dropped.
 	recentForeignDrops map[string]int
+	// pendingForeignTerminalNotifications retains one terminal notification per
+	// unknown child thread until receiverThreadIds registers that child. This
+	// closes the provider announce/stream ordering gap without admitting
+	// ordinary foreign-thread progress into the parent session.
+	pendingForeignTerminalNotifications map[string]appServerBufferedNotification
 	acpLiveState
 	pendingRequests map[string]*pendingInteractiveRequest
 }
@@ -343,9 +349,15 @@ type codexAppServerThreadContext struct {
 	parentItemID         string
 	normalizer           *acpTurnNormalizer
 	// droppedBeforeRegistration counts events for this thread that arrived
-	// (and were dropped as unknown) before its receiverThreadIds registration
-	// - permanent telemetry for ADR 0003's ordering question.
+	// before its receiverThreadIds registration - permanent telemetry for ADR
+	// 0003's ordering question. Terminal events are replayed after registration;
+	// ordinary progress remains dropped.
 	droppedBeforeRegistration int
+}
+
+type appServerBufferedNotification struct {
+	method string
+	params map[string]any
 }
 
 // codexAppServerActiveTurn carries the streaming context of an in-flight

--- a/packages/agent/daemon/runtime/codex_appserver_client.go
+++ b/packages/agent/daemon/runtime/codex_appserver_client.go
@@ -108,6 +108,22 @@ func (c *codexAppServerClient) observeMCPStartupStatus(status map[string]any) {
 	c.scheduleMCPFailure(codexMCPServerStartupFailureFromStatus(status), "notification")
 }
 
+func (c *codexAppServerClient) completeThreadLifecycleFromNotification(thread map[string]any) {
+	if c == nil || c.raw == nil || len(thread) == 0 {
+		return
+	}
+	threadID := strings.TrimSpace(asString(thread["id"]))
+	if threadID == "" {
+		return
+	}
+	result, err := json.Marshal(map[string]any{"thread": clonePayload(thread)})
+	if err != nil {
+		return
+	}
+	c.raw.completeActiveHandler(appServerMethodThreadStart, result)
+	c.raw.completeActiveHandler(appServerMethodThreadResume, result)
+}
+
 func (c *codexAppServerClient) scheduleMCPFailure(failure error, source string) {
 	if c == nil || failure == nil {
 		return

--- a/packages/agent/daemon/runtime/codex_appserver_client.go
+++ b/packages/agent/daemon/runtime/codex_appserver_client.go
@@ -28,7 +28,7 @@ type codexAppServerClient struct {
 	// parsedNotificationMethods tracks notification methods already run
 	// through the typed schema parse (telemetry only).
 	parsedNotificationMethods sync.Map
-	stderrMu                  sync.Mutex
+	mcpFailureMu              sync.Mutex
 	mcpFailureScheduled       bool
 }
 
@@ -101,18 +101,27 @@ func (c *codexAppServerClient) observeMCPStderr(chunk []byte) {
 	diagnostics := c.raw.Diagnostics()
 	detail := diagnostics.StderrTail
 	failure := codexMCPServerStartupFailureFromStderr(detail)
-	if failure == nil {
+	c.scheduleMCPFailure(failure, "stderr")
+}
+
+func (c *codexAppServerClient) observeMCPStartupStatus(status map[string]any) {
+	c.scheduleMCPFailure(codexMCPServerStartupFailureFromStatus(status), "notification")
+}
+
+func (c *codexAppServerClient) scheduleMCPFailure(failure error, source string) {
+	if c == nil || failure == nil {
 		return
 	}
-	c.stderrMu.Lock()
+	c.mcpFailureMu.Lock()
 	if c.mcpFailureScheduled {
-		c.stderrMu.Unlock()
+		c.mcpFailureMu.Unlock()
 		return
 	}
 	c.mcpFailureScheduled = true
-	c.stderrMu.Unlock()
+	c.mcpFailureMu.Unlock()
 	slog.Warn("agent session Codex MCP server startup failed",
 		"event", "agent_session.codex.mcp.startup_failed",
+		"source", source,
 		"error", failure.Error(),
 		"grace_ms", defaultCodexAppServerMCPFailureGraceWindow.Milliseconds(),
 	)

--- a/packages/agent/daemon/runtime/codex_appserver_event_routing.go
+++ b/packages/agent/daemon/runtime/codex_appserver_event_routing.go
@@ -47,6 +47,7 @@ func (a *CodexAppServerAdapter) appServerNotificationRoute(
 			return appServerNotificationRoute{drop: true}
 		}
 		a.recordForeignThreadDrop(session.AgentSessionID, eventThreadID)
+		a.bufferForeignThreadTerminal(session.AgentSessionID, eventThreadID, method, params)
 		a.logAppServerForeignThreadDrop(session, method, params, eventThreadID)
 		return appServerNotificationRoute{drop: true}
 	}
@@ -101,10 +102,13 @@ func appServerEventsForChild(events []activityshared.Event, child *codexAppServe
 
 const appServerForeignDropTrackerCap = 64
 
-// recordForeignThreadDrop remembers an unknown-thread drop so a later child
-// registration can report events lost to the announce/stream ordering gap
-// (ADR 0003 verification telemetry). Bounded; unrelated foreign threads age
-// out by never being registered.
+const appServerForeignTerminalBufferCap = 64
+
+// recordForeignThreadDrop remembers an unknown-thread arrival so a later child
+// registration can report the announce/stream ordering gap (ADR 0003
+// verification telemetry). Ordinary progress remains dropped; terminal
+// notifications are buffered separately. Bounded; unrelated foreign threads
+// age out by never being registered.
 func (a *CodexAppServerAdapter) recordForeignThreadDrop(agentSessionID string, threadID string) {
 	if a == nil {
 		return
@@ -124,6 +128,52 @@ func (a *CodexAppServerAdapter) recordForeignThreadDrop(agentSessionID string, t
 		}
 	}
 	appSession.recentForeignDrops[threadID]++
+}
+
+func (a *CodexAppServerAdapter) bufferForeignThreadTerminal(
+	agentSessionID string,
+	threadID string,
+	method string,
+	params map[string]any,
+) {
+	if a == nil || !appServerIsForeignTerminalNotification(method, params) {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	appSession := a.sessions[strings.TrimSpace(agentSessionID)]
+	if appSession == nil {
+		return
+	}
+	if appSession.pendingForeignTerminalNotifications == nil {
+		appSession.pendingForeignTerminalNotifications = make(map[string]appServerBufferedNotification)
+	}
+	if len(appSession.pendingForeignTerminalNotifications) >= appServerForeignTerminalBufferCap {
+		if _, tracked := appSession.pendingForeignTerminalNotifications[threadID]; !tracked {
+			return
+		}
+	}
+	if existing, tracked := appSession.pendingForeignTerminalNotifications[threadID]; tracked {
+		if existing.method == appServerNotifyTurnCompleted || method != appServerNotifyTurnCompleted {
+			return
+		}
+	}
+	appSession.pendingForeignTerminalNotifications[threadID] = appServerBufferedNotification{
+		method: method,
+		params: clonePayload(params),
+	}
+}
+
+func appServerIsForeignTerminalNotification(method string, params map[string]any) bool {
+	switch method {
+	case appServerNotifyTurnCompleted:
+		return true
+	case appServerNotifyError:
+		willRetry, _ := params["willRetry"].(bool)
+		return !willRetry
+	default:
+		return false
+	}
 }
 
 func (a *CodexAppServerAdapter) rememberAppServerChildThreads(
@@ -193,6 +243,7 @@ func (a *CodexAppServerAdapter) rememberAppServerChildThreads(
 	}
 	added := make([]string, 0, len(childThreadIDs))
 	addedContexts := make([]*codexAppServerThreadContext, 0, len(childThreadIDs))
+	bufferedTerminals := make(map[string]appServerBufferedNotification)
 	for _, childThreadID := range childThreadIDs {
 		if childThreadID == "" || childThreadID == parentThreadID {
 			continue
@@ -222,6 +273,10 @@ func (a *CodexAppServerAdapter) rememberAppServerChildThreads(
 			)
 		}
 		appSession.childThreads[childThreadID] = context
+		if buffered, ok := appSession.pendingForeignTerminalNotifications[childThreadID]; ok {
+			bufferedTerminals[childThreadID] = buffered
+			delete(appSession.pendingForeignTerminalNotifications, childThreadID)
+		}
 		added = append(added, childThreadID)
 		addedContexts = append(addedContexts, context)
 	}
@@ -231,6 +286,10 @@ func (a *CodexAppServerAdapter) rememberAppServerChildThreads(
 		childSession := appServerChildSession(session, added[index], child)
 		if event := appServerChildStartedEvent(childSession, child); event.Type != "" {
 			events = append(events, event)
+		}
+		if buffered, ok := bufferedTerminals[added[index]]; ok {
+			terminalEvents := appServerChildTerminalEvents(childSession, child, buffered.method, buffered.params)
+			events = append(events, appServerEventsForChild(terminalEvents, child)...)
 		}
 	}
 	return added, events

--- a/packages/agent/daemon/runtime/codex_appserver_events_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events_test.go
@@ -1390,6 +1390,83 @@ func TestCodexAppServerChildRegistrationReportsEarlyDrops(t *testing.T) {
 	}
 }
 
+func TestCodexAppServerChildTerminalBeforeRegistrationIsReplayed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		method        string
+		params        map[string]any
+		terminalEvent activityshared.EventType
+	}{
+		{
+			name:          "turn completed",
+			method:        appServerNotifyTurnCompleted,
+			params:        map[string]any{"turn": map[string]any{"id": "child-turn-1", "status": "completed"}},
+			terminalEvent: activityshared.EventTurnCompleted,
+		},
+		{
+			name:          "terminal error",
+			method:        appServerNotifyError,
+			params:        map[string]any{"willRetry": false, "error": map[string]any{"message": "child failed"}},
+			terminalEvent: activityshared.EventTurnFailed,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			adapter := NewCodexAppServerAdapter(nil)
+			session := Session{
+				AgentSessionID:    "agent-session-1",
+				Provider:          ProviderCodex,
+				ProviderSessionID: "parent-thread-1",
+				CWD:               "/workspace",
+			}
+			adapter.storeSession(session.AgentSessionID, &codexAppServerSession{threadID: session.ProviderSessionID})
+			reducer := newCodexAppServerReducer(adapter)
+			normalizer := newACPTurnNormalizer()
+
+			terminalParams := clonePayload(test.params)
+			terminalParams["threadId"] = "child-thread-1"
+			terminalParams["turnId"] = "child-turn-1"
+			if events := reducer.ReduceNotification(nil, session, "parent-turn-1", acpMessage{
+				Method: test.method,
+				Params: mustJSONRawMessage(t, terminalParams),
+			}, normalizer, nil).Events; len(events) != 0 {
+				t.Fatalf("early terminal events = %#v, want buffered until child registration", events)
+			}
+
+			events := reducer.ReduceNotification(nil, session, "parent-turn-1", acpMessage{
+				Method: appServerNotifyItemStarted,
+				Params: mustJSONRawMessage(t, map[string]any{
+					"threadId": session.ProviderSessionID,
+					"turnId":   "parent-turn-1",
+					"item": map[string]any{
+						"type":              "collabAgentToolCall",
+						"id":                "spawn-child-1",
+						"tool":              "spawnAgent",
+						"status":            "inProgress",
+						"receiverThreadIds": []any{"child-thread-1"},
+					},
+				}),
+			}, normalizer, nil).Events
+
+			terminalCount := 0
+			for _, event := range events {
+				if event.Type == test.terminalEvent {
+					terminalCount++
+					if event.SessionKind != "child" || event.ProviderSessionID != "child-thread-1" {
+						t.Fatalf("terminal event = %#v, want child routing", event)
+					}
+				}
+			}
+			if terminalCount != 1 {
+				t.Fatalf("terminal events = %#v, want exactly one replayed %s", events, test.terminalEvent)
+			}
+		})
+	}
+}
+
 func TestCodexAppServerChildThreadNameUpdateEmitsNameMarker(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/codex_appserver_lifecycle_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_lifecycle_test.go
@@ -533,6 +533,58 @@ func TestCodexAppServerAdapterMCPStartupStatusResponseWinsGraceRace(t *testing.T
 	}
 }
 
+func TestCodexAppServerAdapterThreadStartedNotificationCompletesLifecycleWithoutRPCResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		resume    bool
+		configure func(*fakeCodexAppServer)
+	}{
+		{
+			name: "start",
+			configure: func(server *fakeCodexAppServer) {
+				server.threadStartedOnStart = true
+			},
+		},
+		{
+			name:   "resume",
+			resume: true,
+			configure: func(server *fakeCodexAppServer) {
+				server.threadStartedOnResume = true
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			transport := &multiProcAppServerTransport{}
+			adapter := NewCodexAppServerAdapter(transport)
+			session := testAppServerSession()
+			if test.resume {
+				if _, err := adapter.Start(context.Background(), session); err != nil {
+					t.Fatalf("Start: %v", err)
+				}
+				session.ProviderSessionID = "codex-thread-1"
+			}
+			transport.setConfigure(test.configure)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			if test.resume {
+				if err := adapter.Resume(ctx, session); err != nil {
+					t.Fatalf("Resume should use thread/started as lifecycle success: %v", err)
+				}
+			} else if _, err := adapter.Start(ctx, session); err != nil {
+				t.Fatalf("Start should use thread/started as lifecycle success: %v", err)
+			}
+			if !adapter.HasLiveSession(session) {
+				t.Fatal("HasLiveSession = false after notification-only lifecycle success")
+			}
+		})
+	}
+}
+
 func TestCodexAppServerAdapterStartReleaseRaceLeavesNoOrphanProcess(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/codex_appserver_lifecycle_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_lifecycle_test.go
@@ -435,6 +435,104 @@ func TestCodexAppServerAdapterResumeResponseWinsMCPAuthGraceRace(t *testing.T) {
 	}
 }
 
+func TestCodexAppServerAdapterMCPStartupStatusFailureDoesNotBecomeLifecycleTimeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		configure   func(*fakeCodexAppServer)
+		resume      bool
+		wantOldLive bool
+	}{
+		{
+			name: "start",
+			configure: func(server *fakeCodexAppServer) {
+				server.mcpStartupStatusFailedOnStart = true
+			},
+		},
+		{
+			name: "resume",
+			configure: func(server *fakeCodexAppServer) {
+				server.mcpStartupStatusFailedOnResume = true
+			},
+			resume:      true,
+			wantOldLive: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			transport := &multiProcAppServerTransport{}
+			adapter := NewCodexAppServerAdapter(transport)
+			session := testAppServerSession()
+			if test.resume {
+				if _, err := adapter.Start(context.Background(), session); err != nil {
+					t.Fatalf("Start: %v", err)
+				}
+				session.ProviderSessionID = "codex-thread-1"
+			}
+			transport.setConfigure(test.configure)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			startedAt := time.Now()
+			var err error
+			if test.resume {
+				err = adapter.Resume(ctx, session)
+			} else {
+				_, err = adapter.Start(ctx, session)
+			}
+			if err == nil {
+				t.Fatal("MCP startup status failure unexpectedly succeeded")
+			}
+			if elapsed := time.Since(startedAt); elapsed >= 3*time.Second {
+				t.Fatalf("lifecycle call took %s; MCP failure became a timeout: %v", elapsed, err)
+			}
+			var mcpErr *codexMCPServerStartupError
+			if !errors.As(err, &mcpErr) {
+				t.Fatalf("lifecycle error = %v, want codexMCPServerStartupError", err)
+			}
+			if mcpErr.Name != "figma" || mcpErr.FailureReason != "reauthenticationRequired" ||
+				mcpErr.Detail != "MCP server requires authentication" {
+				t.Fatalf("MCP error = %#v, want structured notification fields", mcpErr)
+			}
+			spawned, live := transport.snapshot()
+			if test.wantOldLive {
+				if spawned != 2 || len(live) != 1 || live[0] != transport.conn(0) {
+					t.Fatalf("spawned=%d live=%d, want only the original process live after failed resume", spawned, len(live))
+				}
+				if !adapter.HasLiveSession(session) {
+					t.Fatal("HasLiveSession = false: failed resume must preserve the previous session")
+				}
+			} else if spawned != 1 || len(live) != 0 {
+				t.Fatalf("spawned=%d live=%d, want failed start process closed", spawned, len(live))
+			}
+		})
+	}
+}
+
+func TestCodexAppServerAdapterMCPStartupStatusResponseWinsGraceRace(t *testing.T) {
+	t.Parallel()
+
+	transport := &multiProcAppServerTransport{}
+	adapter := NewCodexAppServerAdapter(transport)
+	session := testAppServerSession()
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	transport.setConfigure(func(server *fakeCodexAppServer) {
+		server.mcpStartupStatusFailedOnResume = true
+		server.mcpStartupStatusFailureResponse = true
+	})
+	session.ProviderSessionID = "codex-thread-1"
+	if err := adapter.Resume(context.Background(), session); err != nil {
+		t.Fatalf("Resume response lost MCP startup failure grace race: %v", err)
+	}
+	if !adapter.HasLiveSession(session) {
+		t.Fatal("HasLiveSession = false after successful resume")
+	}
+}
+
 func TestCodexAppServerAdapterStartReleaseRaceLeavesNoOrphanProcess(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/codex_appserver_mcp.go
+++ b/packages/agent/daemon/runtime/codex_appserver_mcp.go
@@ -9,9 +9,9 @@ import (
 )
 
 // defaultCodexAppServerMCPFailureGraceWindow gives the app-server a short
-// chance to finish an in-flight lifecycle response after rmcp reports a fatal
-// MCP authentication failure. A broken MCP worker must not turn into the
-// generic 30-second thread/start or thread/resume timeout, while a response
+// chance to finish an in-flight lifecycle response after rmcp or app-server
+// reports a fatal MCP startup failure. A broken MCP worker must not turn into
+// the generic 30-second thread/start or thread/resume timeout, while a response
 // already in flight still wins the race.
 const defaultCodexAppServerMCPFailureGraceWindow = time.Second
 
@@ -52,6 +52,18 @@ func codexMCPServerStartupFailureFromStderr(detail string) error {
 		Status:        "failed",
 		FailureReason: "reauthenticationRequired",
 		Detail:        truncateACPLogValue(detail, 1200),
+	}
+}
+
+func codexMCPServerStartupFailureFromStatus(status map[string]any) error {
+	if !strings.EqualFold(asString(status["status"]), "failed") {
+		return nil
+	}
+	return &codexMCPServerStartupError{
+		Name:          asString(status["name"]),
+		Status:        asString(status["status"]),
+		FailureReason: asString(status["failureReason"]),
+		Detail:        truncateACPLogValue(strings.TrimSpace(asString(status["error"])), 1200),
 	}
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_reducer.go
+++ b/packages/agent/daemon/runtime/codex_appserver_reducer.go
@@ -338,6 +338,7 @@ func (r codexAppServerReducer) reduceNotification(
 			}),
 		}
 		if strings.EqualFold(asString(status["status"]), "failed") {
+			client.observeMCPStartupStatus(status)
 			events = append(events, codexMCPServerStartupWarningEvent(client, session, turnID, status))
 		}
 		a.emitSessionEvents(session.AgentSessionID, events)

--- a/packages/agent/daemon/runtime/codex_appserver_reducer.go
+++ b/packages/agent/daemon/runtime/codex_appserver_reducer.go
@@ -359,6 +359,7 @@ func (r codexAppServerReducer) reduceNotification(
 		})
 		return emit(nil)
 	case appServerNotifyThreadStarted:
+		client.completeThreadLifecycleFromNotification(payloadObject(params["thread"]))
 		return codexAppServerReduction{}
 	default:
 		_ = emitCommands

--- a/packages/agent/daemon/runtime/codex_appserver_scripted_session_rpc_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_scripted_session_rpc_test.go
@@ -38,6 +38,9 @@ type scriptedSessionState struct {
 	mcpStartupStatusFailedOnStart   bool
 	mcpStartupStatusFailedOnResume  bool
 	mcpStartupStatusFailureResponse bool
+	threadStartedOnStart            bool
+	threadStartedOnResume           bool
+	threadStartedResponse           bool
 	extraRootsError                 bool
 }
 
@@ -207,6 +210,9 @@ func (s *fakeCodexAppServer) handleSessionRPC(message scriptedAppServerMessage) 
 		mcpStartupStatusFailed := (s.mcpStartupStatusFailedOnStart && message.Method == appServerMethodThreadStart) ||
 			(s.mcpStartupStatusFailedOnResume && message.Method == appServerMethodThreadResume)
 		mcpStartupStatusFailureResponse := s.mcpStartupStatusFailureResponse
+		threadStarted := (s.threadStartedOnStart && message.Method == appServerMethodThreadStart) ||
+			(s.threadStartedOnResume && message.Method == appServerMethodThreadResume)
+		threadStartedResponse := s.threadStartedResponse
 		replayTokenUsage := s.replayTokenUsageOnResume && message.Method == appServerMethodThreadResume
 		s.mu.Unlock()
 		if mcpAuthStderrOnResume {
@@ -234,9 +240,14 @@ func (s *fakeCodexAppServer) handleSessionRPC(message scriptedAppServerMessage) 
 			})
 			return true
 		}
-		s.notify(appServerNotifyThreadStarted, map[string]any{
-			"thread": map[string]any{"id": "codex-thread-1"},
-		})
+		if threadStarted {
+			s.notify(appServerNotifyThreadStarted, map[string]any{
+				"thread": map[string]any{"id": "codex-thread-1"},
+			})
+			if !threadStartedResponse {
+				return true
+			}
+		}
 		if replayTokenUsage {
 			// Real codex 0.140.0 replays thread/tokenUsage/updated during
 			// thread/resume so the GUI can show context fill before a new
@@ -261,6 +272,11 @@ func (s *fakeCodexAppServer) handleSessionRPC(message scriptedAppServerMessage) 
 				"modelProvider":   "openai",
 			},
 		})
+		if !threadStarted {
+			s.notify(appServerNotifyThreadStarted, map[string]any{
+				"thread": map[string]any{"id": "codex-thread-1"},
+			})
+		}
 	case appServerMethodThreadFork:
 		if s.forkRPCError {
 			s.sendJSON(map[string]any{

--- a/packages/agent/daemon/runtime/codex_appserver_scripted_session_rpc_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_scripted_session_rpc_test.go
@@ -6,36 +6,39 @@ import (
 )
 
 type scriptedSessionState struct {
-	modelList                      []any
-	userAgent                      string
-	forkChildThreadID              string
-	forkedFromThreadID             string
-	omitForkedFromThreadID         bool
-	emptyForkedFromThreadID        bool
-	forkResponseLastTurnID         string
-	forkResponseTurnIDs            []string
-	forkNotificationBeforeResponse bool
-	forkResponseDelay              time.Duration
-	threadReadTurnIDs              []string
-	forkRPCError                   bool
-	requiresAuth                   bool
-	collaborationModeUnsupported   bool
-	accountReadError               bool
-	accountReadErrorCode           int
-	accountReadErrorMessage        string
-	rateLimitsReadError            bool
-	rateLimitsReadErrorCode        int
-	rateLimitsReadErrorMessage     string
-	childNicknames                 map[string]string
-	historyTurns                   []any
-	rollbackHistoryTurns           []any
-	rollbackUnsupported            bool
-	threadName                     string
-	replayTokenUsageOnResume       bool
-	threadResumeError              bool
-	mcpAuthStderrOnResume          bool
-	mcpAuthStderrResumeResponse    bool
-	extraRootsError                bool
+	modelList                       []any
+	userAgent                       string
+	forkChildThreadID               string
+	forkedFromThreadID              string
+	omitForkedFromThreadID          bool
+	emptyForkedFromThreadID         bool
+	forkResponseLastTurnID          string
+	forkResponseTurnIDs             []string
+	forkNotificationBeforeResponse  bool
+	forkResponseDelay               time.Duration
+	threadReadTurnIDs               []string
+	forkRPCError                    bool
+	requiresAuth                    bool
+	collaborationModeUnsupported    bool
+	accountReadError                bool
+	accountReadErrorCode            int
+	accountReadErrorMessage         string
+	rateLimitsReadError             bool
+	rateLimitsReadErrorCode         int
+	rateLimitsReadErrorMessage      string
+	childNicknames                  map[string]string
+	historyTurns                    []any
+	rollbackHistoryTurns            []any
+	rollbackUnsupported             bool
+	threadName                      string
+	replayTokenUsageOnResume        bool
+	threadResumeError               bool
+	mcpAuthStderrOnResume           bool
+	mcpAuthStderrResumeResponse     bool
+	mcpStartupStatusFailedOnStart   bool
+	mcpStartupStatusFailedOnResume  bool
+	mcpStartupStatusFailureResponse bool
+	extraRootsError                 bool
 }
 
 func (s *fakeCodexAppServer) handleSessionRPC(message scriptedAppServerMessage) bool {
@@ -201,11 +204,26 @@ func (s *fakeCodexAppServer) handleSessionRPC(message scriptedAppServerMessage) 
 		threadResumeError := s.threadResumeError && message.Method == appServerMethodThreadResume
 		mcpAuthStderrOnResume := s.mcpAuthStderrOnResume && message.Method == appServerMethodThreadResume
 		mcpAuthStderrResumeResponse := s.mcpAuthStderrResumeResponse && message.Method == appServerMethodThreadResume
+		mcpStartupStatusFailed := (s.mcpStartupStatusFailedOnStart && message.Method == appServerMethodThreadStart) ||
+			(s.mcpStartupStatusFailedOnResume && message.Method == appServerMethodThreadResume)
+		mcpStartupStatusFailureResponse := s.mcpStartupStatusFailureResponse
 		replayTokenUsage := s.replayTokenUsageOnResume && message.Method == appServerMethodThreadResume
 		s.mu.Unlock()
 		if mcpAuthStderrOnResume {
 			s.sendStderr([]byte(`rmcp::transport::worker: worker quit with fatal: Transport channel closed, when AuthRequired(AuthRequiredError { www_authenticate_header: "Bearer resource_metadata=\"https://mcp.figma.com/.well-known/oauth-protected-resource\",scope=\"mcp:connect\"" })`))
 			if !mcpAuthStderrResumeResponse {
+				return true
+			}
+		}
+		if mcpStartupStatusFailed {
+			s.notify(appServerNotifyMCPServerStartupStatusUpdated, map[string]any{
+				"threadId":      "codex-thread-1",
+				"name":          "figma",
+				"status":        "failed",
+				"failureReason": "reauthenticationRequired",
+				"error":         "MCP server requires authentication",
+			})
+			if !mcpStartupStatusFailureResponse {
 				return true
 			}
 		}

--- a/packages/agent/daemon/runtime/codex_appserver_session.go
+++ b/packages/agent/daemon/runtime/codex_appserver_session.go
@@ -101,11 +101,12 @@ func (a *CodexAppServerAdapter) Start(ctx context.Context, session Session) (eve
 
 	threadParams := appServerThreadStartParams(session, a.sessionCWD(session))
 	trace.Log("thread.start.params", codexAppServerTraceThreadStartParams(session, threadParams, false))
+	callbackSession := session
 	threadResult, err := trace.TypedCall(acpStartCallTimeout, appServerMethodThreadStart, func() (json.RawMessage, error) {
 		return client.ThreadStart(ctx, acpStartCallTimeout, threadParams,
 			func(ctx context.Context, message acpMessage) error {
 				trace.LogMessage(message.Method, len(message.ID) > 0, len(message.Params))
-				_, err := a.handleAppServerMessage(ctx, client, session, "", message, nil, nil, nil)
+				_, err := a.handleAppServerMessage(ctx, client, callbackSession, "", message, nil, nil, nil)
 				return err
 			})
 	})
@@ -323,6 +324,7 @@ func (a *CodexAppServerAdapter) Resume(ctx context.Context, session Session) (er
 	// usage here and fold it into the live state below.
 	var replayedUsage acpUsageState
 	replayedUsageKnown := false
+	callbackSession := session
 	threadResult, err := trace.TypedCall(acpStartCallTimeout, appServerMethodThreadResume, func() (json.RawMessage, error) {
 		return client.ThreadResume(ctx, acpStartCallTimeout, params,
 			func(ctx context.Context, message acpMessage) error {
@@ -336,7 +338,7 @@ func (a *CodexAppServerAdapter) Resume(ctx context.Context, session Session) (er
 						}
 					}
 				}
-				_, err := a.handleAppServerMessage(ctx, client, session, "", message, nil, nil, nil)
+				_, err := a.handleAppServerMessage(ctx, client, callbackSession, "", message, nil, nil, nil)
 				return err
 			})
 	})


### PR DESCRIPTION
## Summary

- Treat authoritative `mcpServer/startupStatus/updated(status=failed)` as a lifecycle failure, including the notification-only case with no stderr and no JSON-RPC response.
- Complete an active `thread/start` or `thread/resume` from the authoritative `thread/started` snapshot when the matching JSON-RPC response is missing. The completion is method-fenced and lifecycle callbacks use an immutable session snapshot.
- Retain bounded terminal notifications for unknown child threads until `receiverThreadIds` registers the child, then replay `turn/completed` and non-retry `error` exactly once. Ordinary foreign-thread progress remains dropped.
- Preserve the confirmed provider turn/thread identity fence; existing steer-stub adoption and stray-turn protections remain intact.

## Validation

- `go test ./packages/agent/daemon/runtime -count=1`
- `go test ./packages/agent/daemon/runtime -run '^TestCodexAppServer' -count=1`
- `go test -race ./packages/agent/daemon/runtime -run 'TestCodexAppServer(ChildTerminalBeforeRegistrationIsReplayed|AdapterThreadStartedNotificationCompletesLifecycleWithoutRPCResponse|AdapterMCPStartupStatus)' -count=1`
- `pnpm check:changed -- --push-ready` (8 lanes passed)

## Tests added

- Wire-style Start/Resume notification-only lifecycle coverage.
- Child terminal-before-registration replay coverage for completed and failed outcomes.
