### PR TITLE
chore(release): backport #2457 to release/0818

### DIFF
--- a/apps/desktop/src/main/agentPowerSaveBlocker.test.ts
+++ b/apps/desktop/src/main/agentPowerSaveBlocker.test.ts
@@ -323,6 +323,9 @@ function createFakePreferences(
   let mode = initialMode;
 
   return {
+    async ensureInitialized() {
+      throw new Error("not used");
+    },
     getAgentCliUpdateCheckEnabled() {
       return true;
     },
@@ -394,6 +397,11 @@ function createFakePreferences(
       return () => {
         listeners.delete(listener);
       };
+    },
+    syncAuthoritative(input) {
+      if (input.sleepPreventionMode !== undefined) {
+        mode = input.sleepPreventionMode;
+      }
     },
     sync(input) {
       if (input.sleepPreventionMode !== undefined) {

--- a/apps/desktop/src/main/desktopAppServices.test.ts
+++ b/apps/desktop/src/main/desktopAppServices.test.ts
@@ -59,6 +59,9 @@ function createHostServices(): DesktopHostServices {
       }
     },
     preferences: {
+      async ensureInitialized() {
+        throw new Error("not used");
+      },
       getAgentCliUpdateCheckEnabled() {
         return true;
       },
@@ -121,6 +124,9 @@ function createHostServices(): DesktopHostServices {
       },
       subscribe() {
         return () => undefined;
+      },
+      syncAuthoritative() {
+        return undefined;
       },
       sync() {
         return undefined;

--- a/apps/desktop/src/main/desktopHostPreferences.initialization.test.ts
+++ b/apps/desktop/src/main/desktopHostPreferences.initialization.test.ts
@@ -1,0 +1,264 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import type { PutDesktopPreferencesRequest } from "@tutti-os/client-tuttid-ts";
+import { defaultDesktopWorkbenchShortcuts } from "../shared/preferences/index.ts";
+import { createDesktopHostPreferencesState } from "./desktopHostPreferences.ts";
+import type { DesktopLogger } from "./logging.ts";
+
+const standaloneAgentModeFlag = "workspace.standaloneAgentMode";
+
+test("desktop preferences keep the legacy OS fallback when the initial identity read fails", async () => {
+  let putCalls = 0;
+  const state = await createDesktopHostPreferencesState({
+    fallbackLocale: "en",
+    logger: createLogger(),
+    tuttidClient: {
+      async getDesktopPreferences() {
+        throw new Error("read unavailable");
+      },
+      async putDesktopPreferences() {
+        putCalls++;
+        throw new Error("putDesktopPreferences should not be called");
+      }
+    }
+  });
+
+  assert.equal(state.getFeatureFlags()[standaloneAgentModeFlag], undefined);
+  assert.equal(putCalls, 0);
+});
+
+test("desktop preferences keep a fresh Agent default when initialization fails before commit", async () => {
+  let getCalls = 0;
+  let capturedRequest: PutDesktopPreferencesRequest | undefined;
+  const state = await createDesktopHostPreferencesState({
+    fallbackLocale: "en",
+    logger: createLogger(),
+    tuttidClient: {
+      async getDesktopPreferences() {
+        getCalls++;
+        return {
+          initialized: false,
+          preferences: createPreferences({
+            [standaloneAgentModeFlag]: true
+          })
+        };
+      },
+      async putDesktopPreferences(request) {
+        capturedRequest = request;
+        throw new Error("write failed before commit");
+      }
+    }
+  });
+
+  assert.equal(capturedRequest?.writeMode, "initializeIfAbsent");
+  assert.equal(state.getFeatureFlags()[standaloneAgentModeFlag], true);
+  assert.equal(getCalls, 2);
+});
+
+test("desktop preferences reconcile a lost initialization response with the committed Agent preference", async () => {
+  let getCalls = 0;
+  const state = await createDesktopHostPreferencesState({
+    fallbackLocale: "en",
+    logger: createLogger(),
+    tuttidClient: {
+      async getDesktopPreferences() {
+        getCalls++;
+        return getCalls === 1
+          ? {
+              initialized: false,
+              preferences: createPreferences({
+                [standaloneAgentModeFlag]: true
+              })
+            }
+          : {
+              initialized: true,
+              preferences: createPreferences({
+                [standaloneAgentModeFlag]: true
+              })
+            };
+      },
+      async putDesktopPreferences() {
+        throw new Error("response lost after commit");
+      }
+    }
+  });
+
+  assert.equal(state.getFeatureFlags()[standaloneAgentModeFlag], true);
+  assert.equal(getCalls, 2);
+});
+
+test("desktop preferences preserve a concurrent existing OS preference after an ambiguous initialization", async () => {
+  let getCalls = 0;
+  const state = await createDesktopHostPreferencesState({
+    fallbackLocale: "en",
+    logger: createLogger(),
+    tuttidClient: {
+      async getDesktopPreferences() {
+        getCalls++;
+        return getCalls === 1
+          ? {
+              initialized: false,
+              preferences: createPreferences({
+                [standaloneAgentModeFlag]: true
+              })
+            }
+          : {
+              initialized: true,
+              preferences: createPreferences({
+                [standaloneAgentModeFlag]: false
+              })
+            };
+      },
+      async putDesktopPreferences() {
+        throw new Error("initialization outcome unknown");
+      }
+    }
+  });
+
+  assert.equal(state.getFeatureFlags()[standaloneAgentModeFlag], false);
+  assert.equal(getCalls, 2);
+});
+
+test("desktop preferences retry failed initialization once before mutation and only then write the installed-version marker", async () => {
+  const migrationStateRootDir = await mkdtemp(
+    join(tmpdir(), "tutti-preferences-initialization-")
+  );
+  const installedVersionStatePath = join(
+    migrationStateRootDir,
+    "migrations",
+    "desktop-update-channel-installed-version-v1"
+  );
+  let getCalls = 0;
+  let putCalls = 0;
+  let releaseRecovery: (() => void) | undefined;
+  const recoveryBarrier = new Promise<void>((resolve) => {
+    releaseRecovery = resolve;
+  });
+  const state = await createDesktopHostPreferencesState({
+    appVersion: "0.2.2-rc.1",
+    fallbackLocale: "en",
+    isPackaged: true,
+    logger: createLogger(),
+    migrationStateRootDir,
+    tuttidClient: {
+      async getDesktopPreferences() {
+        getCalls++;
+        return {
+          initialized: false,
+          preferences: createPreferences({
+            [standaloneAgentModeFlag]: true
+          })
+        };
+      },
+      async putDesktopPreferences(request) {
+        putCalls++;
+        if (putCalls === 1) {
+          throw new Error("write failed before commit");
+        }
+        await recoveryBarrier;
+        return {
+          initialized: true,
+          preferences: request.preferences
+        };
+      }
+    }
+  });
+
+  await assert.rejects(readFile(installedVersionStatePath, "utf8"));
+
+  const first = state.ensureInitialized();
+  const second = state.ensureInitialized();
+  await Promise.resolve();
+  releaseRecovery?.();
+  const [firstResult, secondResult] = await Promise.all([first, second]);
+
+  assert.deepEqual(firstResult, secondResult);
+  assert.equal(firstResult.initialized, true);
+  assert.equal(
+    firstResult.preferences.featureFlags[standaloneAgentModeFlag],
+    true
+  );
+  assert.equal(getCalls, 3);
+  assert.equal(putCalls, 2);
+  assert.equal(await readFile(installedVersionStatePath, "utf8"), "0.2.2-rc.1");
+});
+
+test("desktop preferences recover an unknown startup identity before initializing the Agent default", async () => {
+  let getCalls = 0;
+  let putCalls = 0;
+  const state = await createDesktopHostPreferencesState({
+    fallbackLocale: "en",
+    logger: createLogger(),
+    tuttidClient: {
+      async getDesktopPreferences() {
+        getCalls++;
+        if (getCalls === 1) {
+          throw new Error("startup read unavailable");
+        }
+        return {
+          initialized: false,
+          preferences: createPreferences({
+            [standaloneAgentModeFlag]: true
+          })
+        };
+      },
+      async putDesktopPreferences(request) {
+        putCalls++;
+        return {
+          initialized: true,
+          preferences: request.preferences
+        };
+      }
+    }
+  });
+
+  assert.equal(state.getFeatureFlags()[standaloneAgentModeFlag], undefined);
+
+  const recovered = await state.ensureInitialized();
+
+  assert.equal(recovered.initialized, true);
+  assert.equal(state.getFeatureFlags()[standaloneAgentModeFlag], true);
+  assert.equal(getCalls, 2);
+  assert.equal(putCalls, 1);
+});
+
+function createPreferences(
+  featureFlags: Record<string, boolean>
+): PutDesktopPreferencesRequest["preferences"] {
+  return {
+    agentCliUpdateCheckEnabled: true,
+    agentComposerDefaultsByProvider: {},
+    agentGuiConversationRailCollapsedByProvider: {},
+    agentConversationDetailMode: "coding",
+    agentDockLayout: "unified",
+    appCatalogChannel: "production",
+    browserUseConnectionMode: "isolated",
+    defaultAgentProvider: "tutti-agent",
+    deletedAgentConversationRetentionDays: 30,
+    dockIconStyle: "default",
+    dockPlacement: "bottom",
+    featureFlags,
+    fileDefaultOpenersByExtension: {},
+    locale: "en",
+    minimizeAnimation: "genie",
+    showAppDeveloperSources: false,
+    sleepPreventionMode: "never",
+    themeSource: "dark",
+    updateChannel: "stable",
+    updatePolicy: "prompt",
+    workbenchShortcuts: defaultDesktopWorkbenchShortcuts
+  };
+}
+
+function createLogger(): DesktopLogger {
+  return {
+    debug() {},
+    info() {},
+    warn() {},
+    error() {},
+    async close() {}
+  };
+}

--- a/apps/desktop/src/main/desktopHostPreferences.test.ts
+++ b/apps/desktop/src/main/desktopHostPreferences.test.ts
@@ -8,7 +8,7 @@ import { defaultDesktopWorkbenchShortcuts } from "../shared/preferences/index.ts
 import { createDesktopHostPreferencesState } from "./desktopHostPreferences.ts";
 import type { DesktopLogger } from "./logging.ts";
 
-test("createDesktopHostPreferencesState initializes missing preferences with dark theme and default icons", async () => {
+test("createDesktopHostPreferencesState initializes a new profile from daemon defaults with desktop runtime overrides", async () => {
   const putRequests: PutDesktopPreferencesRequest[] = [];
   const state = await createDesktopHostPreferencesState({
     fallbackLocale: "zh-CN",
@@ -27,7 +27,10 @@ test("createDesktopHostPreferencesState initializes missing preferences with dar
             appCatalogChannel: "production",
             browserUseConnectionMode: "isolated",
             defaultAgentProvider: "codex",
-            featureFlags: {},
+            featureFlags: {
+              "agent.extension.gemini": true,
+              "workspace.standaloneAgentMode": true
+            },
             workbenchShortcuts: defaultDesktopWorkbenchShortcuts,
             dockIconStyle: "flat",
             dockPlacement: "bottom",
@@ -54,6 +57,7 @@ test("createDesktopHostPreferencesState initializes missing preferences with dar
 
   assert.deepEqual(putRequests, [
     {
+      writeMode: "initializeIfAbsent",
       preferences: {
         agentCliUpdateCheckEnabled: true,
         agentComposerDefaultsByProvider: {},
@@ -63,22 +67,20 @@ test("createDesktopHostPreferencesState initializes missing preferences with dar
         deletedAgentConversationRetentionDays: 30,
         appCatalogChannel: "production",
         browserUseConnectionMode: "isolated",
-        defaultAgentProvider: "tutti-agent",
-        featureFlags: {},
-        workbenchShortcuts: defaultDesktopWorkbenchShortcuts,
-        dockIconStyle: "default",
-        dockPlacement: "bottom",
-        fileDefaultOpenersByExtension: {
-          htm: "appBrowser",
-          html: "appBrowser",
-          shtml: "appBrowser",
-          xhtml: "appBrowser"
+        defaultAgentProvider: "codex",
+        featureFlags: {
+          "agent.extension.gemini": true,
+          "workspace.standaloneAgentMode": true
         },
+        workbenchShortcuts: defaultDesktopWorkbenchShortcuts,
+        dockIconStyle: "flat",
+        dockPlacement: "bottom",
+        fileDefaultOpenersByExtension: { html: "defaultBrowser" },
         locale: "zh-CN",
         minimizeAnimation: "genie",
         sleepPreventionMode: "never",
         showAppDeveloperSources: false,
-        themeSource: "dark",
+        themeSource: "system",
         updateChannel: "stable",
         updatePolicy: "prompt"
       }
@@ -87,12 +89,16 @@ test("createDesktopHostPreferencesState initializes missing preferences with dar
   assert.equal(state.getAgentCliUpdateCheckEnabled(), true);
   assert.equal(state.getDockPlacement(), "bottom");
   assert.equal(state.getLocale(), "zh-CN");
-  assert.equal(state.getDefaultAgentProvider(), "tutti-agent");
+  assert.equal(state.getDefaultAgentProvider(), "codex");
+  assert.deepEqual(state.getFeatureFlags(), {
+    "agent.extension.gemini": true,
+    "workspace.standaloneAgentMode": true
+  });
   assert.deepEqual(state.getAgentGUIConversationRailCollapsedByProvider(), {});
   assert.equal(state.getBrowserUseConnectionMode(), "isolated");
   assert.equal(state.getSleepPreventionMode(), "never");
-  assert.equal(state.getDockIconStyle(), "default");
-  assert.equal(state.getThemeSource(), "dark");
+  assert.equal(state.getDockIconStyle(), "flat");
+  assert.equal(state.getThemeSource(), "system");
   assert.equal(state.getUpdateChannel(), "stable");
 });
 
@@ -116,7 +122,9 @@ test("createDesktopHostPreferencesState defaults missing rc package preferences 
             appCatalogChannel: "production",
             browserUseConnectionMode: "isolated",
             defaultAgentProvider: "codex",
-            featureFlags: {},
+            featureFlags: {
+              "workspace.standaloneAgentMode": true
+            },
             workbenchShortcuts: defaultDesktopWorkbenchShortcuts,
             dockIconStyle: "flat",
             dockPlacement: "bottom",
@@ -165,7 +173,9 @@ test("createDesktopHostPreferencesState keeps missing beta package preferences o
             appCatalogChannel: "production",
             browserUseConnectionMode: "isolated",
             defaultAgentProvider: "codex",
-            featureFlags: {},
+            featureFlags: {
+              "workspace.standaloneAgentMode": true
+            },
             workbenchShortcuts: defaultDesktopWorkbenchShortcuts,
             dockIconStyle: "flat",
             dockPlacement: "bottom",
@@ -194,7 +204,7 @@ test("createDesktopHostPreferencesState keeps missing beta package preferences o
   assert.equal(putRequests[0]?.preferences.updateChannel, "stable");
 });
 
-test("createDesktopHostPreferencesState keeps initialized theme preferences", async () => {
+test("createDesktopHostPreferencesState preserves initialized preferences with the legacy missing workspace mode", async () => {
   let putCalls = 0;
   const state = await createDesktopHostPreferencesState({
     fallbackLocale: "zh-CN",
@@ -236,6 +246,7 @@ test("createDesktopHostPreferencesState keeps initialized theme preferences", as
   });
 
   assert.equal(putCalls, 0);
+  assert.deepEqual(state.getFeatureFlags(), {});
   assert.equal(state.getDockPlacement(), "bottom");
   assert.equal(state.getLocale(), "en");
   assert.equal(state.getDefaultAgentProvider(), "codex");

--- a/apps/desktop/src/main/desktopHostPreferences.ts
+++ b/apps/desktop/src/main/desktopHostPreferences.ts
@@ -1,14 +1,7 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
-import type {
-  TuttidClient,
-  PutDesktopPreferencesRequest
-} from "@tutti-os/client-tuttid-ts";
+import type { DesktopPreferencesStateResponse } from "@tutti-os/client-tuttid-ts";
 import {
   defaultDesktopBrowserUseConnectionMode,
-  defaultDesktopAgentCliUpdateCheckEnabled,
   defaultDesktopAppCatalogChannel,
-  defaultDesktopAgentConversationDetailMode,
   desktopAgentComposerDefaultsByProviderEqual,
   desktopAgentGuiConversationRailCollapsedByProviderEqual,
   isDesktopBrowserUseConnectionMode,
@@ -20,21 +13,12 @@ import {
   type DesktopAgentComposerDefaultsByProvider,
   type DesktopAgentGuiConversationRailCollapsedByProvider,
   defaultDesktopAgentProvider,
-  defaultDesktopDockIconStyle,
-  defaultDesktopDockPlacement,
-  defaultDeletedAgentConversationRetentionDays,
-  defaultDesktopFeatureFlags,
   defaultDesktopFileDefaultOpenersByExtension,
   defaultDesktopMinimizeAnimation,
-  defaultDesktopShowAppDeveloperSources,
-  defaultDesktopSleepPreventionMode,
-  defaultDesktopUpdateChannel,
-  defaultDesktopUpdatePolicy,
-  defaultDesktopWorkbenchShortcuts,
+  isDesktopMinimizeAnimation,
   desktopFeatureFlagsEqual,
   desktopFileDefaultOpenersByExtensionEqual,
   desktopWorkbenchShortcutsEqual,
-  isDesktopMinimizeAnimation,
   normalizeDesktopFeatureFlags,
   normalizeDesktopWorkbenchShortcuts,
   normalizeDesktopWorkbenchWindowSnapping,
@@ -55,20 +39,17 @@ import {
   type DesktopWorkbenchShortcutsInput,
   type DesktopWorkbenchWindowSnapping
 } from "../shared/preferences/index.ts";
-import {
-  defaultDesktopThemeSource,
-  type DesktopThemeSource
-} from "../shared/theme/index.ts";
+import type { DesktopThemeSource } from "../shared/theme/index.ts";
 import type { DesktopLocale } from "../shared/i18n/index.ts";
-import type { DesktopLogger } from "./logging.ts";
-import { resolveDesktopDefaultsFromEnv } from "./defaults.ts";
+import {
+  createDesktopHostPreferencesInitialization,
+  type CreateDesktopHostPreferencesOptions
+} from "./desktopHostPreferencesInitialization.ts";
 
-const updateChannelDefaultMigrationID =
-  "desktop-update-channel-default-stable-v1";
-const updateChannelInstalledVersionStateID =
-  "desktop-update-channel-installed-version-v1";
+export type { CreateDesktopHostPreferencesOptions } from "./desktopHostPreferencesInitialization.ts";
 
 export interface DesktopHostPreferencesState {
+  ensureInitialized(): Promise<DesktopPreferencesStateResponse>;
   getAgentCliUpdateCheckEnabled(): boolean;
   getAgentComposerDefaultsByProvider(): DesktopAgentComposerDefaultsByProvider;
   getAgentGUIConversationRailCollapsedByProvider(): DesktopAgentGuiConversationRailCollapsedByProvider;
@@ -89,6 +70,9 @@ export interface DesktopHostPreferencesState {
   getWorkbenchShortcuts(): DesktopWorkbenchShortcuts;
   getWorkbenchWindowSnapping(): DesktopWorkbenchWindowSnapping;
   subscribe(listener: () => void): () => void;
+  syncAuthoritative(
+    preferences: DesktopPreferencesStateResponse["preferences"]
+  ): void;
   sync(input: {
     agentCliUpdateCheckEnabled?: boolean;
     agentComposerDefaultsByProvider?: DesktopAgentComposerDefaultsByProvider;
@@ -112,22 +96,12 @@ export interface DesktopHostPreferencesState {
   }): void;
 }
 
-export interface CreateDesktopHostPreferencesOptions {
-  appVersion?: string;
-  fallbackLocale: DesktopLocale;
-  isPackaged?: boolean;
-  logger: DesktopLogger;
-  migrationStateRootDir?: string;
-  tuttidClient: Pick<
-    TuttidClient,
-    "getDesktopPreferences" | "putDesktopPreferences"
-  >;
-}
-
 export async function createDesktopHostPreferencesState(
   options: CreateDesktopHostPreferencesOptions
 ): Promise<DesktopHostPreferencesState> {
-  const initialPreferences = await resolveInitialDesktopPreferences(options);
+  const initialization =
+    await createDesktopHostPreferencesInitialization(options);
+  const initialPreferences = initialization.initialPreferences;
   let agentCliUpdateCheckEnabled = normalizeDesktopAgentCliUpdateCheckEnabled(
     initialPreferences.agentCliUpdateCheckEnabled
   );
@@ -178,7 +152,12 @@ export async function createDesktopHostPreferencesState(
   );
   const listeners = new Set<() => void>();
 
-  return {
+  const state: DesktopHostPreferencesState = {
+    async ensureInitialized() {
+      const response = await initialization.ensureInitialized();
+      state.sync(response.preferences);
+      return response;
+    },
     getAgentCliUpdateCheckEnabled() {
       return agentCliUpdateCheckEnabled;
     },
@@ -241,6 +220,10 @@ export async function createDesktopHostPreferencesState(
       return () => {
         listeners.delete(listener);
       };
+    },
+    syncAuthoritative(preferences) {
+      initialization.observeAuthoritativePreferences(preferences);
+      state.sync(preferences);
     },
     sync(input) {
       const previousAgentCliUpdateCheckEnabled = agentCliUpdateCheckEnabled;
@@ -422,6 +405,7 @@ export async function createDesktopHostPreferencesState(
       }
     }
   };
+  return state;
 }
 
 function normalizeDesktopDefaultAgentProvider(
@@ -430,341 +414,4 @@ function normalizeDesktopDefaultAgentProvider(
   return isDesktopDefaultAgentProvider(value)
     ? value
     : defaultDesktopAgentProvider;
-}
-
-async function resolveInitialDesktopPreferences(
-  options: CreateDesktopHostPreferencesOptions
-): Promise<PutDesktopPreferencesRequest["preferences"]> {
-  const defaultUpdateChannel = resolveDefaultDesktopUpdateChannel(options);
-  try {
-    const response = await options.tuttidClient.getDesktopPreferences();
-    if (response.initialized) {
-      const shouldMigrateDefaultUpdateChannel =
-        await shouldMigrateDefaultDesktopUpdateChannel(options);
-      const migratedPreferences = await migrateInitializedDesktopPreferences(
-        options,
-        response.preferences,
-        defaultUpdateChannel,
-        shouldMigrateDefaultUpdateChannel
-      );
-      return alignUpdateChannelWithInstalledVersion(
-        options,
-        migratedPreferences
-      );
-    }
-
-    const initializedPreferences = (
-      await options.tuttidClient.putDesktopPreferences({
-        preferences: {
-          agentCliUpdateCheckEnabled: defaultDesktopAgentCliUpdateCheckEnabled,
-          agentComposerDefaultsByProvider: {},
-          agentGuiConversationRailCollapsedByProvider: {},
-          agentConversationDetailMode:
-            defaultDesktopAgentConversationDetailMode,
-          // The dual-dock (legacySplit) layout has been removed; the stored
-          // preference is pinned to the unified layout.
-          agentDockLayout: "unified",
-          appCatalogChannel: defaultDesktopAppCatalogChannel,
-          browserUseConnectionMode: defaultDesktopBrowserUseConnectionMode,
-          defaultAgentProvider: defaultDesktopAgentProvider,
-          dockIconStyle: defaultDesktopDockIconStyle,
-          dockPlacement: defaultDesktopDockPlacement,
-          deletedAgentConversationRetentionDays:
-            defaultDeletedAgentConversationRetentionDays,
-          featureFlags: defaultDesktopFeatureFlags,
-          fileDefaultOpenersByExtension:
-            defaultDesktopFileDefaultOpenersByExtension,
-          locale: options.fallbackLocale,
-          minimizeAnimation: defaultDesktopMinimizeAnimation,
-          showAppDeveloperSources: defaultDesktopShowAppDeveloperSources,
-          sleepPreventionMode: defaultDesktopSleepPreventionMode,
-          themeSource: defaultDesktopThemeSource,
-          updateChannel: defaultUpdateChannel,
-          updatePolicy: defaultDesktopUpdatePolicy,
-          workbenchShortcuts: defaultDesktopWorkbenchShortcuts
-        }
-      })
-    ).preferences;
-    return alignUpdateChannelWithInstalledVersion(
-      options,
-      initializedPreferences
-    );
-  } catch (error) {
-    options.logger.warn("failed to resolve desktop preferences from tuttid", {
-      error: error instanceof Error ? error.message : String(error)
-    });
-    return {
-      agentCliUpdateCheckEnabled: defaultDesktopAgentCliUpdateCheckEnabled,
-      agentComposerDefaultsByProvider: {},
-      agentGuiConversationRailCollapsedByProvider: {},
-      agentConversationDetailMode: defaultDesktopAgentConversationDetailMode,
-      agentDockLayout: "unified",
-      appCatalogChannel: defaultDesktopAppCatalogChannel,
-      browserUseConnectionMode: defaultDesktopBrowserUseConnectionMode,
-      defaultAgentProvider: defaultDesktopAgentProvider,
-      dockIconStyle: defaultDesktopDockIconStyle,
-      dockPlacement: defaultDesktopDockPlacement,
-      deletedAgentConversationRetentionDays:
-        defaultDeletedAgentConversationRetentionDays,
-      featureFlags: defaultDesktopFeatureFlags,
-      fileDefaultOpenersByExtension:
-        defaultDesktopFileDefaultOpenersByExtension,
-      locale: options.fallbackLocale,
-      minimizeAnimation: defaultDesktopMinimizeAnimation,
-      showAppDeveloperSources: defaultDesktopShowAppDeveloperSources,
-      sleepPreventionMode: defaultDesktopSleepPreventionMode,
-      themeSource: defaultDesktopThemeSource,
-      updateChannel: defaultUpdateChannel,
-      updatePolicy: defaultDesktopUpdatePolicy,
-      workbenchShortcuts: defaultDesktopWorkbenchShortcuts
-    };
-  }
-}
-
-async function alignUpdateChannelWithInstalledVersion(
-  options: CreateDesktopHostPreferencesOptions,
-  preferences: PutDesktopPreferencesRequest["preferences"]
-): Promise<PutDesktopPreferencesRequest["preferences"]> {
-  const installedVersion = resolveInstalledDesktopVersion(options);
-  if (!options.isPackaged || !installedVersion) {
-    return preferences;
-  }
-
-  const statePath = resolveUpdateChannelInstalledVersionStatePath(options);
-  if ((await readInstalledDesktopVersion(statePath)) === installedVersion) {
-    return preferences;
-  }
-
-  const installedChannel = resolveDefaultDesktopUpdateChannel(options);
-  let alignedPreferences = preferences;
-  if (preferences.updateChannel !== installedChannel) {
-    try {
-      alignedPreferences = (
-        await options.tuttidClient.putDesktopPreferences({
-          preferences: {
-            ...preferences,
-            updateChannel: installedChannel
-          }
-        })
-      ).preferences;
-      options.logger.info(
-        "desktop update channel aligned with installed version",
-        {
-          app_version: installedVersion,
-          previous_channel: preferences.updateChannel,
-          update_channel: installedChannel
-        }
-      );
-    } catch (error) {
-      options.logger.warn(
-        "failed to align desktop update channel with installed version",
-        {
-          app_version: installedVersion,
-          error: error instanceof Error ? error.message : String(error),
-          update_channel: installedChannel
-        }
-      );
-      return preferences;
-    }
-  }
-
-  try {
-    await writeInstalledDesktopVersion(statePath, installedVersion);
-  } catch (error) {
-    options.logger.warn("failed to record installed desktop version", {
-      app_version: installedVersion,
-      error: error instanceof Error ? error.message : String(error)
-    });
-  }
-  return alignedPreferences;
-}
-
-async function migrateInitializedDesktopPreferences(
-  options: CreateDesktopHostPreferencesOptions,
-  preferences: PutDesktopPreferencesRequest["preferences"],
-  defaultUpdateChannel: DesktopUpdateChannel,
-  shouldMigrateDefaultUpdateChannel: boolean
-): Promise<PutDesktopPreferencesRequest["preferences"]> {
-  const normalizedMinimizeAnimation = isDesktopMinimizeAnimation(
-    preferences.minimizeAnimation
-  )
-    ? preferences.minimizeAnimation
-    : defaultDesktopMinimizeAnimation;
-  const normalizedAgentConversationDetailMode =
-    normalizeDesktopAgentConversationDetailMode(
-      preferences.agentConversationDetailMode
-    );
-  // The dual-dock (legacySplit) layout has been removed; stored preferences
-  // are pinned to the unified layout.
-  const normalizedAgentDockLayout = "unified" as const;
-  const normalizedFeatureFlags = normalizeDesktopFeatureFlags(
-    preferences.featureFlags
-  );
-  const normalizedWorkbenchShortcuts = normalizeDesktopWorkbenchShortcuts(
-    preferences.workbenchShortcuts
-  );
-  if (
-    !shouldMigrateDefaultUpdateChannel ||
-    preferences.updateChannel !== "rc" ||
-    defaultUpdateChannel !== "stable"
-  ) {
-    if (
-      preferences.minimizeAnimation === normalizedMinimizeAnimation &&
-      preferences.agentConversationDetailMode ===
-        normalizedAgentConversationDetailMode &&
-      preferences.agentDockLayout === normalizedAgentDockLayout
-    ) {
-      return {
-        ...preferences,
-        featureFlags: normalizedFeatureFlags,
-        workbenchShortcuts: normalizedWorkbenchShortcuts
-      };
-    }
-    return {
-      ...preferences,
-      agentConversationDetailMode: normalizedAgentConversationDetailMode,
-      agentDockLayout: normalizedAgentDockLayout,
-      featureFlags: normalizedFeatureFlags,
-      minimizeAnimation: normalizedMinimizeAnimation,
-      workbenchShortcuts: normalizedWorkbenchShortcuts
-    };
-  }
-
-  const markerPath = resolveUpdateChannelDefaultMigrationMarkerPath(options);
-  if (await hasMigrationMarker(markerPath)) {
-    if (
-      preferences.minimizeAnimation === normalizedMinimizeAnimation &&
-      preferences.agentConversationDetailMode ===
-        normalizedAgentConversationDetailMode &&
-      preferences.agentDockLayout === normalizedAgentDockLayout
-    ) {
-      return {
-        ...preferences,
-        featureFlags: normalizedFeatureFlags,
-        workbenchShortcuts: normalizedWorkbenchShortcuts
-      };
-    }
-    return {
-      ...preferences,
-      agentConversationDetailMode: normalizedAgentConversationDetailMode,
-      agentDockLayout: normalizedAgentDockLayout,
-      featureFlags: normalizedFeatureFlags,
-      minimizeAnimation: normalizedMinimizeAnimation,
-      workbenchShortcuts: normalizedWorkbenchShortcuts
-    };
-  }
-
-  try {
-    const response = await options.tuttidClient.putDesktopPreferences({
-      preferences: {
-        ...preferences,
-        agentConversationDetailMode: normalizedAgentConversationDetailMode,
-        agentDockLayout: normalizedAgentDockLayout,
-        featureFlags: normalizedFeatureFlags,
-        minimizeAnimation: normalizedMinimizeAnimation,
-        updateChannel: defaultUpdateChannel,
-        workbenchShortcuts: normalizedWorkbenchShortcuts
-      }
-    });
-    await writeMigrationMarker(markerPath);
-    return response.preferences;
-  } catch (error) {
-    options.logger.warn("failed to migrate default desktop update channel", {
-      error: error instanceof Error ? error.message : String(error)
-    });
-    return {
-      ...preferences,
-      agentConversationDetailMode: normalizedAgentConversationDetailMode,
-      agentDockLayout: normalizedAgentDockLayout,
-      featureFlags: normalizedFeatureFlags,
-      minimizeAnimation: normalizedMinimizeAnimation,
-      workbenchShortcuts: normalizedWorkbenchShortcuts
-    };
-  }
-}
-
-async function shouldMigrateDefaultDesktopUpdateChannel(
-  options: CreateDesktopHostPreferencesOptions
-): Promise<boolean> {
-  const installedVersion = resolveInstalledDesktopVersion(options);
-  if (!options.isPackaged || !installedVersion) {
-    return true;
-  }
-
-  const statePath = resolveUpdateChannelInstalledVersionStatePath(options);
-  return (await readInstalledDesktopVersion(statePath)) !== installedVersion;
-}
-
-function resolveDefaultDesktopUpdateChannel(
-  options: CreateDesktopHostPreferencesOptions
-): DesktopUpdateChannel {
-  const version = resolveInstalledDesktopVersion(options) ?? "";
-  if (/^\d+\.\d+\.\d+-rc\.\d+$/u.test(version)) {
-    return "rc";
-  }
-
-  return defaultDesktopUpdateChannel;
-}
-
-function resolveInstalledDesktopVersion(
-  options: CreateDesktopHostPreferencesOptions
-): string | null {
-  const version = options.appVersion?.trim().replace(/^v/iu, "") ?? "";
-  return version.length > 0 ? version : null;
-}
-
-function resolveUpdateChannelDefaultMigrationMarkerPath(
-  options: CreateDesktopHostPreferencesOptions
-): string {
-  const stateRootDir = resolveDesktopPreferencesStateRootDir(options);
-  return join(stateRootDir, "migrations", updateChannelDefaultMigrationID);
-}
-
-function resolveUpdateChannelInstalledVersionStatePath(
-  options: CreateDesktopHostPreferencesOptions
-): string {
-  const stateRootDir = resolveDesktopPreferencesStateRootDir(options);
-  return join(stateRootDir, "migrations", updateChannelInstalledVersionStateID);
-}
-
-function resolveDesktopPreferencesStateRootDir(
-  options: CreateDesktopHostPreferencesOptions
-): string {
-  return (
-    options.migrationStateRootDir ??
-    resolveDesktopDefaultsFromEnv().state.rootDir
-  );
-}
-
-async function readInstalledDesktopVersion(
-  path: string
-): Promise<string | null> {
-  try {
-    const version = (await readFile(path, "utf8")).trim();
-    return version.length > 0 ? version : null;
-  } catch {
-    return null;
-  }
-}
-
-async function writeInstalledDesktopVersion(
-  path: string,
-  version: string
-): Promise<void> {
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, version, "utf8");
-}
-
-async function hasMigrationMarker(markerPath: string): Promise<boolean> {
-  try {
-    await readFile(markerPath, "utf8");
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function writeMigrationMarker(markerPath: string): Promise<void> {
-  await mkdir(dirname(markerPath), { recursive: true });
-  await writeFile(markerPath, new Date().toISOString(), "utf8");
 }

--- a/apps/desktop/src/main/desktopHostPreferencesEventStream.test.ts
+++ b/apps/desktop/src/main/desktopHostPreferencesEventStream.test.ts
@@ -227,6 +227,9 @@ function createHostPreferencesState(): DesktopHostPreferencesState {
   };
 
   return {
+    async ensureInitialized() {
+      throw new Error("not used");
+    },
     getAgentCliUpdateCheckEnabled() {
       return agentCliUpdateCheckEnabled;
     },
@@ -286,6 +289,9 @@ function createHostPreferencesState(): DesktopHostPreferencesState {
     },
     subscribe() {
       return () => undefined;
+    },
+    syncAuthoritative(input) {
+      this.sync(input);
     },
     sync(input) {
       if (input.agentCliUpdateCheckEnabled !== undefined) {

--- a/apps/desktop/src/main/desktopHostPreferencesEventStream.ts
+++ b/apps/desktop/src/main/desktopHostPreferencesEventStream.ts
@@ -48,29 +48,7 @@ export function connectDesktopHostPreferencesEventStream(
         deps.preferences.getUpdateChannel() !== nextPreferences.updateChannel ||
         deps.preferences.getUpdatePolicy() !== nextPreferences.updatePolicy;
 
-      deps.preferences.sync({
-        agentCliUpdateCheckEnabled: nextPreferences.agentCliUpdateCheckEnabled,
-        agentComposerDefaultsByProvider:
-          nextPreferences.agentComposerDefaultsByProvider,
-        agentGuiConversationRailCollapsedByProvider:
-          nextPreferences.agentGuiConversationRailCollapsedByProvider,
-        agentConversationDetailMode:
-          nextPreferences.agentConversationDetailMode,
-        appCatalogChannel: nextPreferences.appCatalogChannel,
-        browserUseConnectionMode: nextPreferences.browserUseConnectionMode,
-        defaultAgentProvider: nextPreferences.defaultAgentProvider,
-        dockIconStyle: nextPreferences.dockIconStyle,
-        dockPlacement: nextPreferences.dockPlacement,
-        featureFlags: nextPreferences.featureFlags,
-        locale: nextPreferences.locale,
-        minimizeAnimation: nextPreferences.minimizeAnimation,
-        sleepPreventionMode: nextPreferences.sleepPreventionMode,
-        themeSource: nextPreferences.themeSource,
-        updateChannel: nextPreferences.updateChannel,
-        updatePolicy: nextPreferences.updatePolicy,
-        workbenchShortcuts: nextPreferences.workbenchShortcuts,
-        workbenchWindowSnapping: nextPreferences.workbenchWindowSnapping
-      });
+      deps.preferences.syncAuthoritative(nextPreferences);
 
       if (updatePreferencesChanged) {
         void deps.updateService

--- a/apps/desktop/src/main/desktopHostPreferencesInitialization.ts
+++ b/apps/desktop/src/main/desktopHostPreferencesInitialization.ts
@@ -1,0 +1,499 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import type {
+  DesktopPreferencesStateResponse,
+  PutDesktopPreferencesRequest,
+  TuttidClient
+} from "@tutti-os/client-tuttid-ts";
+import {
+  defaultDesktopAgentCliUpdateCheckEnabled,
+  defaultDesktopAgentConversationDetailMode,
+  defaultDesktopAgentProvider,
+  defaultDesktopAppCatalogChannel,
+  defaultDesktopBrowserUseConnectionMode,
+  defaultDesktopDockIconStyle,
+  defaultDesktopDockPlacement,
+  defaultDeletedAgentConversationRetentionDays,
+  defaultDesktopFeatureFlags,
+  defaultDesktopFileDefaultOpenersByExtension,
+  defaultDesktopMinimizeAnimation,
+  defaultDesktopShowAppDeveloperSources,
+  defaultDesktopSleepPreventionMode,
+  defaultDesktopUpdateChannel,
+  defaultDesktopUpdatePolicy,
+  defaultDesktopWorkbenchShortcuts,
+  isDesktopMinimizeAnimation,
+  normalizeDesktopAgentConversationDetailMode,
+  normalizeDesktopFeatureFlags,
+  normalizeDesktopWorkbenchShortcuts,
+  type DesktopUpdateChannel
+} from "../shared/preferences/index.ts";
+import { defaultDesktopThemeSource } from "../shared/theme/index.ts";
+import type { DesktopLocale } from "../shared/i18n/index.ts";
+import { resolveDesktopDefaultsFromEnv } from "./defaults.ts";
+import type { DesktopLogger } from "./logging.ts";
+
+const updateChannelDefaultMigrationID =
+  "desktop-update-channel-default-stable-v1";
+const updateChannelInstalledVersionStateID =
+  "desktop-update-channel-installed-version-v1";
+
+type DesktopPreferences = PutDesktopPreferencesRequest["preferences"];
+type InitializationStatus = "initialized" | "missing" | "unknown";
+
+export interface CreateDesktopHostPreferencesOptions {
+  appVersion?: string;
+  fallbackLocale: DesktopLocale;
+  isPackaged?: boolean;
+  logger: DesktopLogger;
+  migrationStateRootDir?: string;
+  tuttidClient: Pick<
+    TuttidClient,
+    "getDesktopPreferences" | "putDesktopPreferences"
+  >;
+}
+
+export interface DesktopHostPreferencesInitialization {
+  initialPreferences: DesktopPreferences;
+  ensureInitialized(): Promise<DesktopPreferencesStateResponse>;
+  observeAuthoritativePreferences(preferences: DesktopPreferences): void;
+}
+
+export async function createDesktopHostPreferencesInitialization(
+  options: CreateDesktopHostPreferencesOptions
+): Promise<DesktopHostPreferencesInitialization> {
+  const defaultUpdateChannel = resolveDefaultDesktopUpdateChannel(options);
+  let status: InitializationStatus = "unknown";
+  let authoritativePreferences: DesktopPreferences | null = null;
+  let initializationCandidate: DesktopPreferences | null = null;
+  let ensurePromise: Promise<DesktopPreferencesStateResponse> | null = null;
+
+  const initialPreferences = await resolveInitialPreferences();
+
+  return {
+    initialPreferences,
+    ensureInitialized() {
+      if (status === "initialized" && authoritativePreferences) {
+        return Promise.resolve({
+          initialized: true,
+          preferences: authoritativePreferences
+        });
+      }
+      if (ensurePromise) {
+        return ensurePromise;
+      }
+
+      ensurePromise = ensureDurablePreferences().finally(() => {
+        ensurePromise = null;
+      });
+      return ensurePromise;
+    },
+    observeAuthoritativePreferences(preferences) {
+      status = "initialized";
+      authoritativePreferences = preferences;
+      initializationCandidate = null;
+    }
+  };
+
+  async function resolveInitialPreferences(): Promise<DesktopPreferences> {
+    let response: DesktopPreferencesStateResponse;
+    try {
+      response = await options.tuttidClient.getDesktopPreferences();
+    } catch (error) {
+      options.logger.warn("failed to read desktop preferences from tuttid", {
+        error: error instanceof Error ? error.message : String(error)
+      });
+      status = "unknown";
+      return createLegacyFallbackDesktopPreferences(
+        options,
+        defaultUpdateChannel
+      );
+    }
+
+    if (response.initialized) {
+      return await adoptDurablePreferences(response.preferences);
+    }
+
+    status = "missing";
+    initializationCandidate = createFreshDesktopPreferences(
+      options,
+      response.preferences,
+      defaultUpdateChannel
+    );
+    const initialized = await tryInitialize(initializationCandidate);
+    if (initialized) {
+      return initialized.preferences;
+    }
+
+    // The read proved that this identity had no stored preferences. Keep the
+    // fresh Agent default in memory, but do not run durable migrations or
+    // write local markers until the row is confirmed persisted.
+    return initializationCandidate;
+  }
+
+  async function ensureDurablePreferences(): Promise<DesktopPreferencesStateResponse> {
+    let current: DesktopPreferencesStateResponse;
+    try {
+      current = await options.tuttidClient.getDesktopPreferences();
+    } catch (error) {
+      options.logger.warn(
+        "failed to recover desktop preferences before mutation",
+        {
+          error: error instanceof Error ? error.message : String(error)
+        }
+      );
+      throw error;
+    }
+
+    if (current.initialized) {
+      const preferences = await adoptDurablePreferences(current.preferences);
+      return { initialized: true, preferences };
+    }
+
+    status = "missing";
+    initializationCandidate = createFreshDesktopPreferences(
+      options,
+      current.preferences,
+      defaultUpdateChannel
+    );
+    const initialized = await tryInitialize(initializationCandidate, true);
+    if (initialized) {
+      return initialized;
+    }
+
+    throw new Error(
+      "Desktop preferences could not be initialized before mutation."
+    );
+  }
+
+  async function tryInitialize(
+    candidate: DesktopPreferences,
+    rethrowFailure = false
+  ): Promise<DesktopPreferencesStateResponse | null> {
+    let initializationError: unknown;
+    try {
+      const initialized = await options.tuttidClient.putDesktopPreferences({
+        writeMode: "initializeIfAbsent",
+        preferences: candidate
+      });
+      if (initialized.initialized) {
+        const preferences = await adoptDurablePreferences(
+          initialized.preferences
+        );
+        return { initialized: true, preferences };
+      }
+      initializationError = new Error(
+        "Desktop preference initialization returned an uninitialized state."
+      );
+    } catch (error) {
+      initializationError = error;
+      options.logger.warn(
+        "failed to initialize desktop preferences in tuttid",
+        {
+          error: error instanceof Error ? error.message : String(error)
+        }
+      );
+    }
+
+    try {
+      const reconciled = await options.tuttidClient.getDesktopPreferences();
+      if (reconciled.initialized) {
+        const preferences = await adoptDurablePreferences(
+          reconciled.preferences
+        );
+        return { initialized: true, preferences };
+      }
+    } catch (error) {
+      options.logger.warn(
+        "failed to reconcile desktop preferences after initialization",
+        {
+          error: error instanceof Error ? error.message : String(error)
+        }
+      );
+    }
+
+    status = "missing";
+    authoritativePreferences = null;
+    if (rethrowFailure && initializationError) {
+      throw initializationError;
+    }
+    return null;
+  }
+
+  async function adoptDurablePreferences(
+    preferences: DesktopPreferences
+  ): Promise<DesktopPreferences> {
+    const shouldMigrateDefaultUpdateChannel =
+      await shouldMigrateDefaultDesktopUpdateChannel(options);
+    const migratedPreferences = await migrateInitializedDesktopPreferences(
+      options,
+      preferences,
+      defaultUpdateChannel,
+      shouldMigrateDefaultUpdateChannel
+    );
+    const alignedPreferences = await alignUpdateChannelWithInstalledVersion(
+      options,
+      migratedPreferences
+    );
+    status = "initialized";
+    authoritativePreferences = alignedPreferences;
+    initializationCandidate = null;
+    return alignedPreferences;
+  }
+}
+
+function createFreshDesktopPreferences(
+  options: CreateDesktopHostPreferencesOptions,
+  daemonDefaults: DesktopPreferences,
+  updateChannel: DesktopUpdateChannel
+): DesktopPreferences {
+  return {
+    ...daemonDefaults,
+    // These values depend on the desktop runtime rather than daemon policy.
+    agentDockLayout: "unified",
+    featureFlags: normalizeDesktopFeatureFlags(daemonDefaults.featureFlags),
+    locale: options.fallbackLocale,
+    minimizeAnimation: defaultDesktopMinimizeAnimation,
+    updateChannel
+  };
+}
+
+function createLegacyFallbackDesktopPreferences(
+  options: CreateDesktopHostPreferencesOptions,
+  updateChannel: DesktopUpdateChannel
+): DesktopPreferences {
+  return {
+    agentCliUpdateCheckEnabled: defaultDesktopAgentCliUpdateCheckEnabled,
+    agentComposerDefaultsByProvider: {},
+    agentGuiConversationRailCollapsedByProvider: {},
+    agentConversationDetailMode: defaultDesktopAgentConversationDetailMode,
+    agentDockLayout: "unified",
+    appCatalogChannel: defaultDesktopAppCatalogChannel,
+    browserUseConnectionMode: defaultDesktopBrowserUseConnectionMode,
+    defaultAgentProvider: defaultDesktopAgentProvider,
+    dockIconStyle: defaultDesktopDockIconStyle,
+    dockPlacement: defaultDesktopDockPlacement,
+    deletedAgentConversationRetentionDays:
+      defaultDeletedAgentConversationRetentionDays,
+    featureFlags: defaultDesktopFeatureFlags,
+    fileDefaultOpenersByExtension: defaultDesktopFileDefaultOpenersByExtension,
+    locale: options.fallbackLocale,
+    minimizeAnimation: defaultDesktopMinimizeAnimation,
+    showAppDeveloperSources: defaultDesktopShowAppDeveloperSources,
+    sleepPreventionMode: defaultDesktopSleepPreventionMode,
+    themeSource: defaultDesktopThemeSource,
+    updateChannel,
+    updatePolicy: defaultDesktopUpdatePolicy,
+    workbenchShortcuts: defaultDesktopWorkbenchShortcuts
+  };
+}
+
+async function alignUpdateChannelWithInstalledVersion(
+  options: CreateDesktopHostPreferencesOptions,
+  preferences: DesktopPreferences
+): Promise<DesktopPreferences> {
+  const installedVersion = resolveInstalledDesktopVersion(options);
+  if (!options.isPackaged || !installedVersion) {
+    return preferences;
+  }
+
+  const statePath = resolveUpdateChannelInstalledVersionStatePath(options);
+  if ((await readInstalledDesktopVersion(statePath)) === installedVersion) {
+    return preferences;
+  }
+
+  const installedChannel = resolveDefaultDesktopUpdateChannel(options);
+  let alignedPreferences = preferences;
+  if (preferences.updateChannel !== installedChannel) {
+    try {
+      alignedPreferences = (
+        await options.tuttidClient.putDesktopPreferences({
+          preferences: {
+            ...preferences,
+            updateChannel: installedChannel
+          }
+        })
+      ).preferences;
+      options.logger.info(
+        "desktop update channel aligned with installed version",
+        {
+          app_version: installedVersion,
+          previous_channel: preferences.updateChannel,
+          update_channel: installedChannel
+        }
+      );
+    } catch (error) {
+      options.logger.warn(
+        "failed to align desktop update channel with installed version",
+        {
+          app_version: installedVersion,
+          error: error instanceof Error ? error.message : String(error),
+          update_channel: installedChannel
+        }
+      );
+      return preferences;
+    }
+  }
+
+  try {
+    await writeInstalledDesktopVersion(statePath, installedVersion);
+  } catch (error) {
+    options.logger.warn("failed to record installed desktop version", {
+      app_version: installedVersion,
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
+  return alignedPreferences;
+}
+
+async function migrateInitializedDesktopPreferences(
+  options: CreateDesktopHostPreferencesOptions,
+  preferences: DesktopPreferences,
+  defaultUpdateChannel: DesktopUpdateChannel,
+  shouldMigrateDefaultUpdateChannel: boolean
+): Promise<DesktopPreferences> {
+  const normalizedMinimizeAnimation = isDesktopMinimizeAnimation(
+    preferences.minimizeAnimation
+  )
+    ? preferences.minimizeAnimation
+    : defaultDesktopMinimizeAnimation;
+  const normalizedAgentConversationDetailMode =
+    normalizeDesktopAgentConversationDetailMode(
+      preferences.agentConversationDetailMode
+    );
+  const normalizedAgentDockLayout = "unified" as const;
+  const normalizedFeatureFlags = normalizeDesktopFeatureFlags(
+    preferences.featureFlags
+  );
+  const normalizedWorkbenchShortcuts = normalizeDesktopWorkbenchShortcuts(
+    preferences.workbenchShortcuts
+  );
+  const normalizedPreferences = {
+    ...preferences,
+    agentConversationDetailMode: normalizedAgentConversationDetailMode,
+    agentDockLayout: normalizedAgentDockLayout,
+    featureFlags: normalizedFeatureFlags,
+    minimizeAnimation: normalizedMinimizeAnimation,
+    workbenchShortcuts: normalizedWorkbenchShortcuts
+  };
+  if (
+    !shouldMigrateDefaultUpdateChannel ||
+    preferences.updateChannel !== "rc" ||
+    defaultUpdateChannel !== "stable"
+  ) {
+    return normalizedPreferences;
+  }
+
+  const markerPath = resolveUpdateChannelDefaultMigrationMarkerPath(options);
+  if (await hasMigrationMarker(markerPath)) {
+    return normalizedPreferences;
+  }
+
+  try {
+    const response = await options.tuttidClient.putDesktopPreferences({
+      preferences: {
+        ...normalizedPreferences,
+        updateChannel: defaultUpdateChannel
+      }
+    });
+    await writeMigrationMarker(markerPath);
+    return response.preferences;
+  } catch (error) {
+    options.logger.warn("failed to migrate default desktop update channel", {
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return normalizedPreferences;
+  }
+}
+
+async function shouldMigrateDefaultDesktopUpdateChannel(
+  options: CreateDesktopHostPreferencesOptions
+): Promise<boolean> {
+  const installedVersion = resolveInstalledDesktopVersion(options);
+  if (!options.isPackaged || !installedVersion) {
+    return true;
+  }
+
+  const statePath = resolveUpdateChannelInstalledVersionStatePath(options);
+  return (await readInstalledDesktopVersion(statePath)) !== installedVersion;
+}
+
+function resolveDefaultDesktopUpdateChannel(
+  options: CreateDesktopHostPreferencesOptions
+): DesktopUpdateChannel {
+  const version = resolveInstalledDesktopVersion(options) ?? "";
+  if (/^\d+\.\d+\.\d+-rc\.\d+$/u.test(version)) {
+    return "rc";
+  }
+
+  return defaultDesktopUpdateChannel;
+}
+
+function resolveInstalledDesktopVersion(
+  options: CreateDesktopHostPreferencesOptions
+): string | null {
+  const version = options.appVersion?.trim().replace(/^v/iu, "") ?? "";
+  return version.length > 0 ? version : null;
+}
+
+function resolveUpdateChannelDefaultMigrationMarkerPath(
+  options: CreateDesktopHostPreferencesOptions
+): string {
+  return join(
+    resolveDesktopPreferencesStateRootDir(options),
+    "migrations",
+    updateChannelDefaultMigrationID
+  );
+}
+
+function resolveUpdateChannelInstalledVersionStatePath(
+  options: CreateDesktopHostPreferencesOptions
+): string {
+  return join(
+    resolveDesktopPreferencesStateRootDir(options),
+    "migrations",
+    updateChannelInstalledVersionStateID
+  );
+}
+
+function resolveDesktopPreferencesStateRootDir(
+  options: CreateDesktopHostPreferencesOptions
+): string {
+  return (
+    options.migrationStateRootDir ??
+    resolveDesktopDefaultsFromEnv().state.rootDir
+  );
+}
+
+async function readInstalledDesktopVersion(
+  path: string
+): Promise<string | null> {
+  try {
+    const version = (await readFile(path, "utf8")).trim();
+    return version.length > 0 ? version : null;
+  } catch {
+    return null;
+  }
+}
+
+async function writeInstalledDesktopVersion(
+  path: string,
+  version: string
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, version, "utf8");
+}
+
+async function hasMigrationMarker(markerPath: string): Promise<boolean> {
+  try {
+    await readFile(markerPath, "utf8");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writeMigrationMarker(markerPath: string): Promise<void> {
+  await mkdir(dirname(markerPath), { recursive: true });
+  await writeFile(markerPath, new Date().toISOString(), "utf8");
+}

--- a/apps/desktop/src/main/desktopHostServices.ts
+++ b/apps/desktop/src/main/desktopHostServices.ts
@@ -8,15 +8,12 @@ import {
   createDesktopFileDialogAccess,
   type DesktopFileDialogAccess
 } from "./host/desktopFileDialogAccess";
-import {
-  createWorkspaceLaunch,
-  type WorkspaceLaunch
-} from "./host/workspaceLaunch";
+import type { WorkspaceLaunch } from "./host/workspaceLaunch";
 import { createWorkspaceLaunchDesktopAdapters } from "./host/workspaceLaunchDesktopAdapters";
+import { createDesktopWorkspaceLaunch } from "./host/desktopWorkspaceLaunch.ts";
 import type { DesktopLogger } from "./logging";
 import { getDesktopThemeState } from "./desktopTheme";
 import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
-import { resolveWorkspaceLaunchWindowKind } from "./host/workspaceLaunchMode.ts";
 import {
   createDesktopCaptureService,
   type DesktopCaptureService
@@ -64,25 +61,20 @@ export async function createDesktopHostServices(
     getDefaultPath: (name) => app.getPath(name),
     getLocale: () => preferences.getLocale()
   });
-  const workspaceLaunch = createWorkspaceLaunch({
+  const workspaceLaunch = createDesktopWorkspaceLaunch({
     adapters: createWorkspaceLaunchDesktopAdapters({
       enableDevelopmentReloadShortcut:
         options.enableDevelopmentReloadShortcut === true,
       browserNodeGuestPreloadPath: options.browserNodeGuestPreloadPath,
       getDockPlacement: () => preferences.getDockPlacement(),
       getLocale: () => preferences.getLocale(),
-      getPrimaryWorkspaceWindowKind: () =>
-        resolveWorkspaceLaunchWindowKind(preferences.getFeatureFlags()),
       getTheme: () => getDesktopThemeState(preferences.getThemeSource()),
       preloadPath: options.preloadPath,
       rendererUrl: options.rendererUrl,
       workspaceAppPreloadPath: options.workspaceAppPreloadPath
     }),
-    onAnalyticsError(error) {
-      options.logger.warn("failed to record workspace UI mode analytics", {
-        error: error instanceof Error ? error.message : String(error)
-      });
-    },
+    logger: options.logger,
+    preferences,
     tuttidClient: options.tuttidClient
   });
   const capture = createDesktopCaptureService({

--- a/apps/desktop/src/main/desktopPreferencesInitialization.integration.test.ts
+++ b/apps/desktop/src/main/desktopPreferencesInitialization.integration.test.ts
@@ -1,0 +1,264 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import type {
+  DesktopPreferencesStateResponse,
+  PutDesktopPreferencesRequest
+} from "@tutti-os/client-tuttid-ts";
+import { DesktopPreferencesService } from "../renderer/src/features/desktop-preferences/services/internal/desktopPreferencesService.ts";
+import type { DesktopPreferencesClient } from "../renderer/src/features/desktop-preferences/services/internal/adapters/desktopPreferencesClient.ts";
+import { defaultDesktopWorkbenchShortcuts } from "../shared/preferences/index.ts";
+import { createDesktopHostPreferencesState } from "./desktopHostPreferences.ts";
+import type { DesktopLogger } from "./logging.ts";
+
+type Preferences = PutDesktopPreferencesRequest["preferences"];
+type SessionLaunchModePatch = Parameters<
+  DesktopPreferencesClient["patchAgentSessionLaunchMode"]
+>[0];
+
+const standaloneAgentModeFlag = "workspace.standaloneAgentMode";
+const installedVersion = "0.2.2-rc.1";
+
+test("failed fresh-profile startup initializes before a session patch and preserves the complete profile across restart", async (t) => {
+  const migrationStateRootDir = await mkdtemp(
+    join(tmpdir(), "tutti-preferences-vertical-")
+  );
+  t.after(async () => {
+    await rm(migrationStateRootDir, { force: true, recursive: true });
+  });
+  const installedVersionStatePath = join(
+    migrationStateRootDir,
+    "migrations",
+    "desktop-update-channel-installed-version-v1"
+  );
+  let storedPreferences: Preferences | null = null;
+  let initializationAttempts = 0;
+  let replaceAttempts = 0;
+  let sessionPatchAttempts = 0;
+  const api = {
+    async getDesktopPreferences(): Promise<DesktopPreferencesStateResponse> {
+      return storedPreferences
+        ? { initialized: true, preferences: storedPreferences }
+        : { initialized: false, preferences: createDaemonDefaults() };
+    },
+    async patchAgentSessionLaunchMode(
+      input: SessionLaunchModePatch
+    ): Promise<void> {
+      sessionPatchAttempts++;
+      const current = storedPreferences;
+      assert.ok(
+        current,
+        "session launch mode patch must follow durable profile initialization"
+      );
+      const workspaceModes =
+        current.agentSessionLaunchModesByWorkspace?.[input.workspaceId] ?? {};
+      storedPreferences = {
+        ...current,
+        agentSessionLaunchModesByWorkspace: {
+          ...current.agentSessionLaunchModesByWorkspace,
+          [input.workspaceId]: {
+            ...workspaceModes,
+            [input.projectSectionKey]: input.mode
+          }
+        }
+      };
+    },
+    async putDesktopPreferences(
+      request: PutDesktopPreferencesRequest
+    ): Promise<DesktopPreferencesStateResponse> {
+      if (request.writeMode === "initializeIfAbsent") {
+        initializationAttempts++;
+        if (initializationAttempts === 1) {
+          throw new Error("simulated failure before commit");
+        }
+        storedPreferences ??= {
+          ...request.preferences,
+          featureFlags: {
+            ...request.preferences.featureFlags,
+            [standaloneAgentModeFlag]: true
+          }
+        };
+      } else {
+        replaceAttempts++;
+        assert.ok(storedPreferences, "replace must follow initialization");
+        storedPreferences = request.preferences;
+      }
+      return { initialized: true, preferences: storedPreferences };
+    }
+  };
+
+  const hostPreferences = await createDesktopHostPreferencesState({
+    appVersion: installedVersion,
+    fallbackLocale: "zh-CN",
+    isPackaged: true,
+    logger: createLogger(),
+    migrationStateRootDir,
+    tuttidClient: api
+  });
+  assert.equal(
+    hostPreferences.getFeatureFlags()[standaloneAgentModeFlag],
+    true
+  );
+  assert.equal(storedPreferences, null);
+
+  const rendererPreferences = createRendererPreferences(
+    api,
+    hostPreferences.ensureInitialized
+  );
+  await rendererPreferences.whenInitialPreferencesHydrated();
+  assert.equal(storedPreferences, null);
+  assert.equal(sessionPatchAttempts, 0);
+  assert.equal(
+    rendererPreferences.store.featureFlags[standaloneAgentModeFlag],
+    true
+  );
+  await assert.rejects(readFile(installedVersionStatePath, "utf8"), {
+    code: "ENOENT"
+  });
+
+  await rendererPreferences.rememberAgentSessionLaunchMode(
+    "workspace-a",
+    "project:/alpha",
+    "worktree"
+  );
+  rendererPreferences.dispose();
+
+  const persisted = await api.getDesktopPreferences();
+  assert.equal(initializationAttempts, 2);
+  assert.equal(replaceAttempts, 0);
+  assert.equal(sessionPatchAttempts, 1);
+  assert.equal(persisted.initialized, true);
+  assert.equal(persisted.preferences.locale, "zh-CN");
+  assert.equal(persisted.preferences.minimizeAnimation, "genie");
+  assert.equal(persisted.preferences.updateChannel, "rc");
+  assert.equal(
+    persisted.preferences.featureFlags[standaloneAgentModeFlag],
+    true
+  );
+  assert.equal(
+    persisted.preferences.agentSessionLaunchModesByWorkspace?.["workspace-a"]?.[
+      "project:/alpha"
+    ],
+    "worktree"
+  );
+  assert.equal(
+    await readFile(installedVersionStatePath, "utf8"),
+    installedVersion
+  );
+
+  const restartedHostPreferences = await createDesktopHostPreferencesState({
+    appVersion: installedVersion,
+    fallbackLocale: "en",
+    isPackaged: true,
+    logger: createLogger(),
+    migrationStateRootDir,
+    tuttidClient: api
+  });
+  assert.equal(restartedHostPreferences.getLocale(), "zh-CN");
+  assert.equal(restartedHostPreferences.getMinimizeAnimation(), "genie");
+  assert.equal(restartedHostPreferences.getUpdateChannel(), "rc");
+  assert.equal(
+    restartedHostPreferences.getFeatureFlags()[standaloneAgentModeFlag],
+    true
+  );
+
+  const restartedRendererPreferences = createRendererPreferences(
+    api,
+    restartedHostPreferences.ensureInitialized
+  );
+  await restartedRendererPreferences.whenInitialPreferencesHydrated();
+  assert.equal(
+    restartedRendererPreferences.store.agentSessionLaunchModesByWorkspace[
+      "workspace-a"
+    ]?.["project:/alpha"],
+    "worktree"
+  );
+  restartedRendererPreferences.dispose();
+  assert.equal(initializationAttempts, 2);
+  assert.equal(replaceAttempts, 0);
+  assert.equal(sessionPatchAttempts, 1);
+});
+
+interface PreferencesApi {
+  getDesktopPreferences(): Promise<DesktopPreferencesStateResponse>;
+  patchAgentSessionLaunchMode(input: SessionLaunchModePatch): Promise<void>;
+  putDesktopPreferences(
+    request: PutDesktopPreferencesRequest
+  ): Promise<DesktopPreferencesStateResponse>;
+}
+
+function createRendererPreferences(
+  api: PreferencesApi,
+  ensureInitialized: () => Promise<DesktopPreferencesStateResponse>
+): DesktopPreferencesService {
+  return new DesktopPreferencesService({
+    applyLocale() {},
+    applyTheme() {},
+    client: createRendererClient(api),
+    ensureInitialized,
+    initialLocale: "zh-CN",
+    initialTheme: { appearance: "dark", source: "dark" },
+    initialWorkspaceUiMode: "agent",
+    resolveTheme: (source) => ({
+      appearance: source === "light" ? "light" : "dark",
+      source
+    })
+  });
+}
+
+function createRendererClient(api: PreferencesApi): DesktopPreferencesClient {
+  return {
+    async connect() {},
+    dispose() {},
+    getDesktopPreferences: () => api.getDesktopPreferences(),
+    async patchAgentComposerDefaultsForTarget() {
+      throw new Error("unexpected agent composer defaults patch");
+    },
+    patchAgentSessionLaunchMode: (input) =>
+      api.patchAgentSessionLaunchMode(input),
+    subscribeToDesktopPreferencesUpdated() {
+      return () => {};
+    },
+    async updateDesktopPreferences(request) {
+      return (await api.putDesktopPreferences(request)).preferences;
+    }
+  };
+}
+
+function createDaemonDefaults(): Preferences {
+  return {
+    agentCliUpdateCheckEnabled: true,
+    agentComposerDefaultsByProvider: {},
+    agentGuiConversationRailCollapsedByProvider: {},
+    agentConversationDetailMode: "coding",
+    agentDockLayout: "unified",
+    appCatalogChannel: "production",
+    browserUseConnectionMode: "isolated",
+    defaultAgentProvider: "tutti-agent",
+    deletedAgentConversationRetentionDays: 30,
+    dockIconStyle: "default",
+    dockPlacement: "bottom",
+    featureFlags: { [standaloneAgentModeFlag]: true },
+    fileDefaultOpenersByExtension: {},
+    locale: "en",
+    minimizeAnimation: "scale",
+    showAppDeveloperSources: false,
+    sleepPreventionMode: "never",
+    themeSource: "dark",
+    updateChannel: "stable",
+    updatePolicy: "prompt",
+    workbenchShortcuts: defaultDesktopWorkbenchShortcuts
+  };
+}
+
+function createLogger(): DesktopLogger {
+  return {
+    debug() {},
+    info() {},
+    warn() {},
+    error() {},
+    async close() {}
+  };
+}

--- a/apps/desktop/src/main/host/desktopWorkspaceLaunch.test.ts
+++ b/apps/desktop/src/main/host/desktopWorkspaceLaunch.test.ts
@@ -1,0 +1,278 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+  DesktopPreferencesStateResponse,
+  PutDesktopPreferencesRequest,
+  TuttidClient
+} from "@tutti-os/client-tuttid-ts";
+import { defaultDesktopWorkbenchShortcuts } from "../../shared/preferences/index.ts";
+import { createDesktopHostPreferencesState } from "../desktopHostPreferences.ts";
+import type { DesktopLogger } from "../logging.ts";
+import { createDesktopWorkspaceLaunch } from "./desktopWorkspaceLaunch.ts";
+import type {
+  WorkspaceLaunchAdapters,
+  WorkspaceLaunchWorkspaceWindowOptions
+} from "./workspaceLaunch.ts";
+
+const standaloneAgentModeFlag = "workspace.standaloneAgentMode";
+
+test("desktop startup opens the Agent window after fresh profile initialization", async () => {
+  const putRequests: PutDesktopPreferencesRequest[] = [];
+  const client = createClient({
+    async getDesktopPreferences() {
+      return createPreferencesState(false, {
+        [standaloneAgentModeFlag]: true
+      });
+    },
+    async putDesktopPreferences(request) {
+      putRequests.push(request);
+      return {
+        initialized: true,
+        preferences: request.preferences
+      };
+    }
+  });
+  const preferences = await createDesktopHostPreferencesState({
+    fallbackLocale: "en",
+    logger: createLogger(),
+    tuttidClient: client
+  });
+  const opened = await openStartupWindow(preferences, client);
+
+  assert.equal(putRequests.length, 1);
+  assert.equal(putRequests[0]?.writeMode, "initializeIfAbsent");
+  assert.deepEqual(opened, {
+    options: { windowKind: "agent", workspaceUiMode: "agent" },
+    workspaceID: "workspace-1"
+  });
+});
+
+test("desktop startup honors an existing OS preference returned by successful initialization", async () => {
+  let getCalls = 0;
+  let capturedRequest: PutDesktopPreferencesRequest | undefined;
+  const client = createClient({
+    async getDesktopPreferences() {
+      getCalls++;
+      return createPreferencesState(false, {
+        [standaloneAgentModeFlag]: true
+      });
+    },
+    async putDesktopPreferences(request) {
+      capturedRequest = request;
+      return createPreferencesState(true, {
+        [standaloneAgentModeFlag]: false
+      });
+    }
+  });
+  const preferences = await createDesktopHostPreferencesState({
+    fallbackLocale: "en",
+    logger: createLogger(),
+    tuttidClient: client
+  });
+  const opened = await openStartupWindow(preferences, client);
+
+  assert.equal(capturedRequest?.writeMode, "initializeIfAbsent");
+  assert.equal(
+    capturedRequest?.preferences.featureFlags[standaloneAgentModeFlag],
+    true
+  );
+  assert.equal(getCalls, 1);
+  assert.deepEqual(opened, {
+    options: { windowKind: "workspace", workspaceUiMode: "os" },
+    workspaceID: "workspace-1"
+  });
+});
+
+test("desktop startup carries the fresh Agent fallback when initialization and reconciliation do not commit", async () => {
+  let getCalls = 0;
+  const client = createClient({
+    async getDesktopPreferences() {
+      getCalls += 1;
+      return createPreferencesState(false, {
+        [standaloneAgentModeFlag]: true
+      });
+    },
+    async putDesktopPreferences() {
+      throw new Error("preferences write unavailable");
+    }
+  });
+  const preferences = await createDesktopHostPreferencesState({
+    fallbackLocale: "en",
+    logger: createLogger(),
+    tuttidClient: client
+  });
+
+  const opened = await openStartupWindow(preferences, client);
+
+  assert.equal(getCalls, 2);
+  assert.deepEqual(opened, {
+    options: { windowKind: "agent", workspaceUiMode: "agent" },
+    workspaceID: "workspace-1"
+  });
+});
+
+test("desktop startup maps persisted and unavailable preference states to the expected window kind", async (t) => {
+  const cases: Array<{
+    getDesktopPreferences: () => Promise<DesktopPreferencesStateResponse>;
+    name: string;
+    want: "agent" | "workspace";
+  }> = [
+    {
+      name: "explicit Agent",
+      async getDesktopPreferences() {
+        return createPreferencesState(true, {
+          [standaloneAgentModeFlag]: true
+        });
+      },
+      want: "agent"
+    },
+    {
+      name: "explicit OS",
+      async getDesktopPreferences() {
+        return createPreferencesState(true, {
+          [standaloneAgentModeFlag]: false
+        });
+      },
+      want: "workspace"
+    },
+    {
+      name: "legacy missing key",
+      async getDesktopPreferences() {
+        return createPreferencesState(true, {});
+      },
+      want: "workspace"
+    },
+    {
+      name: "initial read error",
+      async getDesktopPreferences() {
+        throw new Error("preferences unavailable");
+      },
+      want: "workspace"
+    }
+  ];
+
+  for (const testCase of cases) {
+    await t.test(testCase.name, async () => {
+      let putCalls = 0;
+      const client = createClient({
+        getDesktopPreferences: testCase.getDesktopPreferences,
+        async putDesktopPreferences() {
+          putCalls++;
+          throw new Error("putDesktopPreferences should not be called");
+        }
+      });
+      const preferences = await createDesktopHostPreferencesState({
+        fallbackLocale: "en",
+        logger: createLogger(),
+        tuttidClient: client
+      });
+      const opened = await openStartupWindow(preferences, client);
+
+      assert.equal(opened.options.windowKind, testCase.want);
+      assert.equal(
+        opened.options.workspaceUiMode,
+        testCase.want === "agent" ? "agent" : "os"
+      );
+      assert.equal(putCalls, 0);
+    });
+  }
+});
+
+type TestClient = Pick<
+  TuttidClient,
+  | "getDesktopPreferences"
+  | "getStartupWorkspace"
+  | "putDesktopPreferences"
+  | "trackEvents"
+>;
+
+function createClient(
+  overrides: Pick<TestClient, "getDesktopPreferences" | "putDesktopPreferences">
+): TestClient {
+  return {
+    ...overrides,
+    async getStartupWorkspace() {
+      return {
+        id: "workspace-1",
+        lastOpenedAt: "2026-08-17T00:00:00Z",
+        name: "Workspace 1"
+      };
+    },
+    async trackEvents() {}
+  };
+}
+
+async function openStartupWindow(
+  preferences: Awaited<ReturnType<typeof createDesktopHostPreferencesState>>,
+  client: TestClient
+): Promise<{
+  options: WorkspaceLaunchWorkspaceWindowOptions;
+  workspaceID: string;
+}> {
+  let opened:
+    | {
+        options: WorkspaceLaunchWorkspaceWindowOptions;
+        workspaceID: string;
+      }
+    | undefined;
+  const adapters: WorkspaceLaunchAdapters = {
+    async ensureAgentBrowserHost() {},
+    async showAgentWindow() {},
+    async showWorkspaceWindow(workspaceID, options) {
+      opened = { options, workspaceID };
+    },
+    warnStartupWindowResolutionFailure() {}
+  };
+  const launch = createDesktopWorkspaceLaunch({
+    adapters,
+    logger: createLogger(),
+    preferences,
+    tuttidClient: client
+  });
+
+  await launch.openStartupWindow();
+  assert.ok(opened);
+  return opened;
+}
+
+function createPreferencesState(
+  initialized: boolean,
+  featureFlags: Record<string, boolean>
+): DesktopPreferencesStateResponse {
+  return {
+    initialized,
+    preferences: {
+      agentCliUpdateCheckEnabled: true,
+      agentComposerDefaultsByProvider: {},
+      agentGuiConversationRailCollapsedByProvider: {},
+      agentConversationDetailMode: "coding",
+      agentDockLayout: "unified",
+      appCatalogChannel: "production",
+      browserUseConnectionMode: "isolated",
+      defaultAgentProvider: "tutti-agent",
+      deletedAgentConversationRetentionDays: 30,
+      dockIconStyle: "default",
+      dockPlacement: "bottom",
+      featureFlags,
+      fileDefaultOpenersByExtension: {},
+      locale: "en",
+      minimizeAnimation: "genie",
+      showAppDeveloperSources: false,
+      sleepPreventionMode: "never",
+      themeSource: "dark",
+      updateChannel: "stable",
+      updatePolicy: "prompt",
+      workbenchShortcuts: defaultDesktopWorkbenchShortcuts
+    }
+  };
+}
+
+function createLogger(): DesktopLogger {
+  return {
+    debug() {},
+    info() {},
+    warn() {},
+    error() {},
+    async close() {}
+  };
+}

--- a/apps/desktop/src/main/host/desktopWorkspaceLaunch.ts
+++ b/apps/desktop/src/main/host/desktopWorkspaceLaunch.ts
@@ -1,0 +1,34 @@
+import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
+import type { DesktopHostPreferencesState } from "../desktopHostPreferences.ts";
+import type { DesktopLogger } from "../logging.ts";
+import {
+  createWorkspaceLaunch,
+  type WorkspaceLaunch,
+  type WorkspaceLaunchAdapters
+} from "./workspaceLaunch.ts";
+import { resolveWorkspaceLaunchWindowOptions } from "./workspaceLaunchMode.ts";
+
+export interface CreateDesktopWorkspaceLaunchOptions {
+  adapters: WorkspaceLaunchAdapters;
+  logger: Pick<DesktopLogger, "warn">;
+  preferences: Pick<DesktopHostPreferencesState, "getFeatureFlags">;
+  tuttidClient: Pick<TuttidClient, "getStartupWorkspace" | "trackEvents">;
+}
+
+export function createDesktopWorkspaceLaunch(
+  options: CreateDesktopWorkspaceLaunchOptions
+): WorkspaceLaunch {
+  return createWorkspaceLaunch({
+    adapters: options.adapters,
+    getPrimaryWorkspaceWindowOptions: () =>
+      resolveWorkspaceLaunchWindowOptions(
+        options.preferences.getFeatureFlags()
+      ),
+    onAnalyticsError(error) {
+      options.logger.warn("failed to record workspace UI mode analytics", {
+        error: error instanceof Error ? error.message : String(error)
+      });
+    },
+    tuttidClient: options.tuttidClient
+  });
+}

--- a/apps/desktop/src/main/host/durableWorkspaceWindowCoordinator.test.ts
+++ b/apps/desktop/src/main/host/durableWorkspaceWindowCoordinator.test.ts
@@ -33,20 +33,30 @@ test("durable workspace window coordinator shares one pending open per workspace
   const openWindow = new Promise<{ id: string }>((resolve) => {
     resolveOpen = resolve;
   });
-  const coordinator = createDurableWorkspaceWindowCoordinator<TestWindow>({
+  const openedModes: string[] = [];
+  const coordinator = createDurableWorkspaceWindowCoordinator<
+    TestWindow,
+    [{ workspaceUiMode: "agent" | "os" }]
+  >({
     activate() {},
     find() {
       return null;
     },
-    open() {
+    open(_workspaceID, options) {
       openCount += 1;
+      openedModes.push(options.workspaceUiMode);
       return openWindow;
     }
   });
 
-  const firstShow = coordinator.show("workspace-1");
-  const secondShow = coordinator.show("workspace-1");
+  const firstShow = coordinator.show("workspace-1", {
+    workspaceUiMode: "agent"
+  });
+  const secondShow = coordinator.show("workspace-1", {
+    workspaceUiMode: "os"
+  });
   assert.equal(openCount, 1);
+  assert.deepEqual(openedModes, ["agent"]);
 
   const window = { id: "opened" };
   resolveOpen(window);

--- a/apps/desktop/src/main/host/durableWorkspaceWindowCoordinator.ts
+++ b/apps/desktop/src/main/host/durableWorkspaceWindowCoordinator.ts
@@ -1,16 +1,22 @@
-export interface DurableWorkspaceWindowCoordinator<TWindow> {
-  show(workspaceID: string): Promise<TWindow>;
+export interface DurableWorkspaceWindowCoordinator<
+  TWindow,
+  TOpenArgs extends unknown[] = []
+> {
+  show(workspaceID: string, ...openArgs: TOpenArgs): Promise<TWindow>;
 }
 
-export function createDurableWorkspaceWindowCoordinator<TWindow>(input: {
+export function createDurableWorkspaceWindowCoordinator<
+  TWindow,
+  TOpenArgs extends unknown[] = []
+>(input: {
   activate(window: TWindow): void;
   find(workspaceID: string): TWindow | null;
-  open(workspaceID: string): Promise<TWindow>;
-}): DurableWorkspaceWindowCoordinator<TWindow> {
+  open(workspaceID: string, ...openArgs: TOpenArgs): Promise<TWindow>;
+}): DurableWorkspaceWindowCoordinator<TWindow, TOpenArgs> {
   const pendingWindows = new Map<string, Promise<TWindow>>();
 
   return {
-    async show(workspaceID) {
+    async show(workspaceID, ...openArgs) {
       const pendingWindow = pendingWindows.get(workspaceID);
       if (pendingWindow) {
         return await pendingWindow;
@@ -20,7 +26,7 @@ export function createDurableWorkspaceWindowCoordinator<TWindow>(input: {
         input.activate(existingWindow);
         return existingWindow;
       }
-      const openWindow = input.open(workspaceID);
+      const openWindow = input.open(workspaceID, ...openArgs);
       pendingWindows.set(workspaceID, openWindow);
       try {
         return await openWindow;

--- a/apps/desktop/src/main/host/workspaceHostAccess.test.ts
+++ b/apps/desktop/src/main/host/workspaceHostAccess.test.ts
@@ -642,6 +642,10 @@ test("workspace host access delegates workspace window handoff", async () => {
           events.push(`workspace:${workspaceID}`);
         }
       }),
+      getPrimaryWorkspaceWindowOptions: () => ({
+        windowKind: "workspace",
+        workspaceUiMode: "os"
+      }),
       tuttidClient: createTransportClient()
     })
   });
@@ -659,6 +663,10 @@ test("workspace host access delegates open workspace app folder without exposing
     },
     workspaceLaunch: createWorkspaceLaunch({
       adapters: createAdapters(),
+      getPrimaryWorkspaceWindowOptions: () => ({
+        windowKind: "workspace",
+        workspaceUiMode: "os"
+      }),
       tuttidClient: createTransportClient()
     })
   });

--- a/apps/desktop/src/main/host/workspaceLaunch.test.ts
+++ b/apps/desktop/src/main/host/workspaceLaunch.test.ts
@@ -6,8 +6,10 @@ import type {
   WorkspaceSummary
 } from "@tutti-os/client-tuttid-ts";
 import {
-  createWorkspaceLaunch,
+  createWorkspaceLaunch as createWorkspaceLaunchCore,
+  type WorkspaceLaunch,
   type WorkspaceLaunchAdapters,
+  type WorkspaceLaunchDependencies,
   type WorkspaceLaunchOwnerWindow
 } from "./workspaceLaunch.ts";
 
@@ -44,9 +46,30 @@ function createAdapters(
   };
 }
 
+function createWorkspaceLaunch(
+  deps: Omit<
+    WorkspaceLaunchDependencies,
+    "getPrimaryWorkspaceWindowOptions"
+  > & {
+    getPrimaryWorkspaceWindowOptions?: WorkspaceLaunchDependencies["getPrimaryWorkspaceWindowOptions"];
+  }
+): WorkspaceLaunch {
+  return createWorkspaceLaunchCore({
+    ...deps,
+    getPrimaryWorkspaceWindowOptions:
+      deps.getPrimaryWorkspaceWindowOptions ??
+      (() => ({ windowKind: "workspace", workspaceUiMode: "os" }))
+  });
+}
+
 test("workspace launch ensures an exact User Browser host", async () => {
   const calls: Array<{
-    options: { windowKind?: "agent" | "workspace" } | undefined;
+    options:
+      | {
+          windowKind: "agent" | "workspace";
+          workspaceUiMode: "agent" | "os";
+        }
+      | undefined;
     workspaceID: string;
   }> = [];
   const launch = createWorkspaceLaunch({
@@ -55,6 +78,10 @@ test("workspace launch ensures an exact User Browser host", async () => {
         calls.push({ options, workspaceID });
       }
     }),
+    getPrimaryWorkspaceWindowOptions: () => ({
+      windowKind: "agent",
+      workspaceUiMode: "agent"
+    }),
     tuttidClient: createStartupWorkspaceClient()
   });
 
@@ -62,7 +89,7 @@ test("workspace launch ensures an exact User Browser host", async () => {
 
   assert.deepEqual(calls, [
     {
-      options: { windowKind: "workspace" },
+      options: { windowKind: "workspace", workspaceUiMode: "agent" },
       workspaceID: "ws-browser"
     }
   ]);
@@ -70,13 +97,23 @@ test("workspace launch ensures an exact User Browser host", async () => {
 
 test("workspace launch opens the daemon-resolved startup workspace", async () => {
   let startupCalls = 0;
-  let openedWorkspaceID: string | null = null;
+  let openedWindow:
+    | {
+        windowKind: "agent" | "workspace";
+        workspaceID: string;
+        workspaceUiMode: "agent" | "os";
+      }
+    | undefined;
 
   const launch = createWorkspaceLaunch({
     adapters: createAdapters({
-      async showWorkspaceWindow(workspaceID) {
-        openedWorkspaceID = workspaceID;
+      async showWorkspaceWindow(workspaceID, options) {
+        openedWindow = { ...options, workspaceID };
       }
+    }),
+    getPrimaryWorkspaceWindowOptions: () => ({
+      windowKind: "agent",
+      workspaceUiMode: "agent"
     }),
     tuttidClient: createStartupWorkspaceClient(async () => {
       startupCalls += 1;
@@ -87,7 +124,35 @@ test("workspace launch opens the daemon-resolved startup workspace", async () =>
   await launch.openStartupWindow();
 
   assert.equal(startupCalls, 1);
-  assert.equal(openedWorkspaceID, "ws-start");
+  assert.deepEqual(openedWindow, {
+    windowKind: "agent",
+    workspaceUiMode: "agent",
+    workspaceID: "ws-start"
+  });
+});
+
+test("workspace launch gives an auxiliary Agent window the global OS preference bootstrap", async () => {
+  let openedInput:
+    | { workspaceID: string; workspaceUiMode: "agent" | "os" }
+    | undefined;
+  const launch = createWorkspaceLaunch({
+    adapters: createAdapters({
+      async showAgentWindow(input) {
+        openedInput = {
+          workspaceID: input.workspaceID,
+          workspaceUiMode: input.workspaceUiMode
+        };
+      }
+    }),
+    tuttidClient: createStartupWorkspaceClient()
+  });
+
+  await launch.showAgentWindow({ workspaceID: "ws-agent" });
+
+  assert.deepEqual(openedInput, {
+    workspaceID: "ws-agent",
+    workspaceUiMode: "os"
+  });
 });
 
 test("workspace launch warns and rejects when startup resolution fails", async () => {
@@ -150,7 +215,9 @@ test("workspace launch hands analytics to main after the new window is ready and
   const launch = createWorkspaceLaunch({
     adapters: createAdapters({
       async showWorkspaceWindow(workspaceID, options) {
-        events.push(`${workspaceID}:${options?.windowKind}`);
+        events.push(
+          `${workspaceID}:${options.windowKind}:${options.workspaceUiMode}`
+        );
       }
     }),
     tuttidClient: createStartupWorkspaceClient(
@@ -170,7 +237,7 @@ test("workspace launch hands analytics to main after the new window is ready and
   });
 
   assert.deepEqual(events, [
-    "ws-alpha:agent",
+    "ws-alpha:agent:agent",
     "analytics:accepted",
     "owner:closed"
   ]);

--- a/apps/desktop/src/main/host/workspaceLaunch.ts
+++ b/apps/desktop/src/main/host/workspaceLaunch.ts
@@ -1,6 +1,7 @@
 import type { TrackEvent, TuttidClient } from "@tutti-os/client-tuttid-ts";
 import type { DesktopAgentDirectorySnapshot } from "../../shared/contracts/agentDirectory.ts";
 import type { DesktopAgentProviderStatusSnapshot } from "../../shared/contracts/ipc.ts";
+import type { DesktopWorkspaceUiMode } from "../../shared/preferences/index.ts";
 
 export interface WorkspaceLaunchOwnerWindow {
   close(): void;
@@ -8,17 +9,22 @@ export interface WorkspaceLaunchOwnerWindow {
 }
 
 export interface WorkspaceLaunchAdapters {
-  ensureAgentBrowserHost(input: WorkspaceLaunchAgentWindowInput): Promise<void>;
-  showAgentWindow(input: WorkspaceLaunchAgentWindowInput): Promise<void>;
+  ensureAgentBrowserHost(
+    input: WorkspaceLaunchResolvedAgentWindowInput
+  ): Promise<void>;
+  showAgentWindow(
+    input: WorkspaceLaunchResolvedAgentWindowInput
+  ): Promise<void>;
   showWorkspaceWindow(
     workspaceID: string,
-    options?: WorkspaceLaunchWorkspaceWindowOptions
+    options: WorkspaceLaunchWorkspaceWindowOptions
   ): Promise<WorkspaceLaunchOwnerWindow | null | void>;
   warnStartupWindowResolutionFailure(error: unknown): void;
 }
 
 export interface WorkspaceLaunchWorkspaceWindowOptions {
-  windowKind?: "agent" | "workspace";
+  windowKind: "agent" | "workspace";
+  workspaceUiMode: DesktopWorkspaceUiMode;
 }
 
 export interface WorkspaceLaunchAgentWindowInput {
@@ -34,6 +40,10 @@ export interface WorkspaceLaunchAgentWindowInput {
   provider?: string | null;
   userProjectPath?: string | null;
   workspaceID: string;
+}
+
+export interface WorkspaceLaunchResolvedAgentWindowInput extends WorkspaceLaunchAgentWindowInput {
+  workspaceUiMode: DesktopWorkspaceUiMode;
 }
 
 export interface WorkspaceLaunch {
@@ -60,6 +70,7 @@ export interface WorkspaceLaunchReplacementInput {
 
 export interface WorkspaceLaunchDependencies {
   adapters: WorkspaceLaunchAdapters;
+  getPrimaryWorkspaceWindowOptions: () => WorkspaceLaunchWorkspaceWindowOptions;
   onAnalyticsError?: (error: unknown) => void;
   tuttidClient: Pick<TuttidClient, "getStartupWorkspace" | "trackEvents">;
 }
@@ -69,17 +80,25 @@ export function createWorkspaceLaunch(
 ): WorkspaceLaunch {
   return {
     ensureAgentBrowserHost(input) {
-      return deps.adapters.ensureAgentBrowserHost(input);
+      return deps.adapters.ensureAgentBrowserHost({
+        ...input,
+        workspaceUiMode: deps.getPrimaryWorkspaceWindowOptions().workspaceUiMode
+      });
     },
     async ensureUserBrowserHost(workspaceID) {
+      const { workspaceUiMode } = deps.getPrimaryWorkspaceWindowOptions();
       await deps.adapters.showWorkspaceWindow(workspaceID, {
-        windowKind: "workspace"
+        windowKind: "workspace",
+        workspaceUiMode
       });
     },
     async openStartupWindow() {
       try {
         const workspaceID = await resolveStartupWorkspaceID();
-        await deps.adapters.showWorkspaceWindow(workspaceID);
+        await deps.adapters.showWorkspaceWindow(
+          workspaceID,
+          deps.getPrimaryWorkspaceWindowOptions()
+        );
       } catch (error) {
         deps.adapters.warnStartupWindowResolutionFailure(error);
         throw error;
@@ -87,7 +106,10 @@ export function createWorkspaceLaunch(
     },
 
     showAgentWindow(input) {
-      return deps.adapters.showAgentWindow(input);
+      return deps.adapters.showAgentWindow({
+        ...input,
+        workspaceUiMode: deps.getPrimaryWorkspaceWindowOptions().workspaceUiMode
+      });
     },
     showWorkspace,
     replaceWorkspaceWindow
@@ -105,8 +127,10 @@ export function createWorkspaceLaunch(
     ownerWindow: WorkspaceLaunchOwnerWindow | null,
     workspaceID: string
   ): Promise<void> {
-    const workspaceWindow =
-      await deps.adapters.showWorkspaceWindow(workspaceID);
+    const workspaceWindow = await deps.adapters.showWorkspaceWindow(
+      workspaceID,
+      deps.getPrimaryWorkspaceWindowOptions()
+    );
     if (workspaceWindow === ownerWindow) {
       return;
     }
@@ -122,7 +146,8 @@ export function createWorkspaceLaunch(
       workspaceWindow = await deps.adapters.showWorkspaceWindow(
         input.workspaceID,
         {
-          windowKind: input.mode === "agent" ? "agent" : "workspace"
+          windowKind: input.mode === "agent" ? "agent" : "workspace",
+          workspaceUiMode: input.mode
         }
       );
     } catch (error) {

--- a/apps/desktop/src/main/host/workspaceLaunchDesktopAdapters.ts
+++ b/apps/desktop/src/main/host/workspaceLaunchDesktopAdapters.ts
@@ -8,7 +8,8 @@ import {
 import { getDesktopLogger } from "../logging";
 import type {
   WorkspaceLaunchAdapters,
-  WorkspaceLaunchAgentWindowInput
+  WorkspaceLaunchResolvedAgentWindowInput,
+  WorkspaceLaunchWorkspaceWindowOptions
 } from "./workspaceLaunch";
 import {
   createWorkspaceWindow,
@@ -26,7 +27,6 @@ export interface WorkspaceLaunchDesktopAdapterOptions {
   enableDevelopmentReloadShortcut?: boolean;
   getDockPlacement: () => DesktopDockPlacement;
   getLocale: () => DesktopLocale;
-  getPrimaryWorkspaceWindowKind: () => WorkspaceLaunchWindowKind;
   getTheme: () => DesktopThemeState;
   preloadPath: string;
   rendererUrl?: string;
@@ -38,13 +38,16 @@ export function createWorkspaceLaunchDesktopAdapters(
 ): WorkspaceLaunchAdapters {
   const pendingAgentBrowserHosts = new Map<string, Promise<void>>();
   const performanceHeadless = resolveDesktopPerformanceHeadless();
-  const durableWorkspaceWindows = createDurableWorkspaceWindowCoordinator({
+  const durableWorkspaceWindows = createDurableWorkspaceWindowCoordinator<
+    Electron.BrowserWindow,
+    [WorkspaceLaunchWorkspaceWindowOptions]
+  >({
     activate: (workspaceWindow) =>
       activateWorkspaceWindow(workspaceWindow, performanceHeadless),
     find: (workspaceID: string) =>
       findWorkspaceWindow(workspaceID, "workspace"),
-    open: (workspaceID: string) =>
-      createAndShowWorkspaceWindow(options, workspaceID)
+    open: (workspaceID, windowOptions) =>
+      createAndShowWorkspaceWindow(options, workspaceID, windowOptions)
   });
   return {
     async ensureAgentBrowserHost(input) {
@@ -68,13 +71,15 @@ export function createWorkspaceLaunchDesktopAdapters(
     },
 
     async showWorkspaceWindow(workspaceID, input) {
-      const windowKind =
-        input?.windowKind ?? options.getPrimaryWorkspaceWindowKind();
+      const windowKind: WorkspaceLaunchWindowKind = input.windowKind;
       try {
         if (windowKind === "agent") {
-          return await showStandaloneAgentWindow(options, { workspaceID });
+          return await showStandaloneAgentWindow(options, {
+            workspaceID,
+            workspaceUiMode: input.workspaceUiMode
+          });
         }
-        return await durableWorkspaceWindows.show(workspaceID);
+        return await durableWorkspaceWindows.show(workspaceID, input);
       } catch (error) {
         getDesktopLogger().warn("failed to show workspace window", {
           error: formatErrorMessage(error),
@@ -97,7 +102,8 @@ export function createWorkspaceLaunchDesktopAdapters(
 
 async function createAndShowWorkspaceWindow(
   options: WorkspaceLaunchDesktopAdapterOptions,
-  workspaceID: string
+  workspaceID: string,
+  windowOptions: WorkspaceLaunchWorkspaceWindowOptions
 ): Promise<Electron.BrowserWindow> {
   const workspaceWindow = createWorkspaceWindow({
     browserNodeGuestPreloadPath: options.browserNodeGuestPreloadPath,
@@ -118,6 +124,7 @@ async function createAndShowWorkspaceWindow(
         locale: options.getLocale(),
         rendererUrl: options.rendererUrl,
         theme: options.getTheme(),
+        workspaceUiMode: windowOptions.workspaceUiMode,
         workspaceID
       });
     },
@@ -147,7 +154,7 @@ function activateWorkspaceWindow(
 
 async function showStandaloneAgentWindow(
   options: WorkspaceLaunchDesktopAdapterOptions,
-  input: WorkspaceLaunchAgentWindowInput,
+  input: WorkspaceLaunchResolvedAgentWindowInput,
   readyOptions: { showOnReady?: boolean } = {}
 ): Promise<Electron.BrowserWindow> {
   const agentWindow = createWorkspaceWindow({
@@ -181,6 +188,7 @@ async function showStandaloneAgentWindow(
         rendererUrl: options.rendererUrl,
         theme: options.getTheme(),
         userProjectPath: input.userProjectPath,
+        workspaceUiMode: input.workspaceUiMode,
         workspaceID: input.workspaceID
       });
     },

--- a/apps/desktop/src/main/host/workspaceLaunchMode.ts
+++ b/apps/desktop/src/main/host/workspaceLaunchMode.ts
@@ -1,12 +1,20 @@
-import type { DesktopFeatureFlags } from "../../shared/preferences/index.ts";
+import type {
+  DesktopFeatureFlags,
+  DesktopWorkspaceUiMode
+} from "../../shared/preferences/index.ts";
 import { resolveDesktopWorkspaceUiMode } from "../../shared/featureFlags/catalog.ts";
 
 export type WorkspaceLaunchWindowKind = "agent" | "workspace";
 
-export function resolveWorkspaceLaunchWindowKind(
+export function resolveWorkspaceLaunchWindowOptions(
   featureFlags: DesktopFeatureFlags
-): WorkspaceLaunchWindowKind {
-  return resolveDesktopWorkspaceUiMode(featureFlags) === "agent"
-    ? "agent"
-    : "workspace";
+): {
+  windowKind: WorkspaceLaunchWindowKind;
+  workspaceUiMode: DesktopWorkspaceUiMode;
+} {
+  const workspaceUiMode = resolveDesktopWorkspaceUiMode(featureFlags);
+  return {
+    windowKind: workspaceUiMode === "agent" ? "agent" : "workspace",
+    workspaceUiMode
+  };
 }

--- a/apps/desktop/src/main/ipc/host.ts
+++ b/apps/desktop/src/main/ipc/host.ts
@@ -2,8 +2,10 @@ import type { DesktopFileDialogAccess } from "../host/desktopFileDialogAccess";
 import type { DesktopWorkspaceAppPayload } from "../../shared/contracts/ipc";
 import type { WorkspaceFileIconCacheStore } from "../host/workspaceFileIconCacheStore.ts";
 import type { WorkspaceLaunch } from "../host/workspaceLaunch";
+import type { DesktopHostPreferencesState } from "../desktopHostPreferences.ts";
 import { registerHostFilesIpc } from "./hostFiles";
 import { registerHostNotificationsIpc } from "./hostNotifications";
+import { registerHostPreferencesIpc } from "./hostPreferences.ts";
 import { registerHostWindowIpc } from "./hostWindow";
 import { registerHostWorkspaceIpc } from "./hostWorkspace";
 
@@ -19,6 +21,7 @@ export interface HostIpcDependencies {
   openWorkspaceAppFolder?: (
     payload: DesktopWorkspaceAppPayload
   ) => Promise<void>;
+  preferences: Pick<DesktopHostPreferencesState, "ensureInitialized">;
   workspaceFileIconCache?: WorkspaceFileIconCacheStore;
   workspaceLaunch: Pick<
     WorkspaceLaunch,
@@ -30,6 +33,7 @@ export interface HostIpcDependencies {
 }
 
 export function registerHostIpc(deps: HostIpcDependencies): void {
+  registerHostPreferencesIpc(deps.preferences);
   registerHostWindowIpc({
     workspaceLaunch: deps.workspaceLaunch
   });

--- a/apps/desktop/src/main/ipc/hostPreferences.ts
+++ b/apps/desktop/src/main/ipc/hostPreferences.ts
@@ -1,0 +1,12 @@
+import { desktopIpcChannels } from "../../shared/contracts/ipc.ts";
+import type { DesktopHostPreferencesState } from "../desktopHostPreferences.ts";
+import { registerDesktopIpcHandler } from "./handle.ts";
+
+export function registerHostPreferencesIpc(
+  preferences: Pick<DesktopHostPreferencesState, "ensureInitialized">
+): void {
+  registerDesktopIpcHandler(
+    desktopIpcChannels.host.preferences.ensureInitialized,
+    () => preferences.ensureInitialized()
+  );
+}

--- a/apps/desktop/src/main/ipc/register.ts
+++ b/apps/desktop/src/main/ipc/register.ts
@@ -91,6 +91,7 @@ export async function registerIpcHandlers(
   registerHostIpc({
     fileDialogs: deps.fileDialogs,
     openWorkspaceAppFolder: deps.openWorkspaceAppFolder,
+    preferences: deps.preferences,
     workspaceFileIconCache: deps.workspaceFileIconCache,
     workspaceLaunch: deps.workspaceLaunch
   });

--- a/apps/desktop/src/main/windows/workspaceWindow.ts
+++ b/apps/desktop/src/main/windows/workspaceWindow.ts
@@ -13,7 +13,10 @@ import { resolveDesktopWindowBackgroundColor } from "../desktopTheme";
 import { resolveDesktopPerformanceHeadless } from "../defaults.ts";
 import { getDesktopLogger } from "../logging";
 import type { DesktopLocale } from "../../shared/i18n";
-import type { DesktopDockPlacement } from "../../shared/preferences/index.ts";
+import type {
+  DesktopDockPlacement,
+  DesktopWorkspaceUiMode
+} from "../../shared/preferences/index.ts";
 import type { DesktopThemeState } from "../../shared/theme/index.ts";
 import {
   applyDesktopWindowIntent,
@@ -402,6 +405,7 @@ export function loadAgentWindowContent(
     provider?: string | null;
     theme: DesktopThemeState;
     userProjectPath?: string | null;
+    workspaceUiMode: DesktopWorkspaceUiMode;
   }
 ): void {
   const windowIntentSearchOptions = {
@@ -410,7 +414,8 @@ export function loadAgentWindowContent(
     reportPredefinePageview:
       reportPredefinePageviewByWindow.get(agentWindow) === true,
     themeAppearance: options.theme.appearance,
-    themeSource: options.theme.source
+    themeSource: options.theme.source,
+    workspaceUiMode: options.workspaceUiMode
   };
   const intent = createAgentWindowIntent({
     agentDirectorySnapshot: options.agentDirectorySnapshot,
@@ -450,6 +455,7 @@ export function loadWorkspaceWindowContent(
   > & {
     dockPlacement: DesktopDockPlacement;
     theme: DesktopThemeState;
+    workspaceUiMode: DesktopWorkspaceUiMode;
   }
 ): void {
   const windowIntentSearchOptions = {
@@ -458,7 +464,8 @@ export function loadWorkspaceWindowContent(
     reportPredefinePageview:
       reportPredefinePageviewByWindow.get(workspaceWindow) === true,
     themeAppearance: options.theme.appearance,
-    themeSource: options.theme.source
+    themeSource: options.theme.source,
+    workspaceUiMode: options.workspaceUiMode
   };
   if (options.rendererUrl) {
     void workspaceWindow.loadURL(

--- a/apps/desktop/src/preload/api/host.ts
+++ b/apps/desktop/src/preload/api/host.ts
@@ -5,6 +5,13 @@ import { ipcRenderer, type IpcRendererEvent } from "electron";
 
 export function createHostDesktopApi(): DesktopHostApi {
   return {
+    preferences: {
+      ensureInitialized() {
+        return invokeDesktopApi(
+          desktopIpcChannels.host.preferences.ensureInitialized
+        );
+      }
+    },
     files: {
       createUserDocumentsProjectDirectory(input) {
         return invokeDesktopApi(

--- a/apps/desktop/src/preload/types.ts
+++ b/apps/desktop/src/preload/types.ts
@@ -2,6 +2,7 @@ import type {
   AgentProviderProbeListInput,
   AgentProviderProbeListResult
 } from "@tutti-os/agent-gui";
+import type { DesktopPreferencesStateResponse } from "@tutti-os/client-tuttid-ts";
 import type {
   DesktopFeatureAvailabilityApi,
   DesktopMinimumVersionApi
@@ -281,8 +282,13 @@ export interface DesktopHostFilesApi {
 export interface DesktopHostApi {
   files: DesktopHostFilesApi;
   notifications: DesktopHostNotificationsApi;
+  preferences?: DesktopHostPreferencesApi;
   window: DesktopHostWindowApi;
   workspace: DesktopHostWorkspaceApi;
+}
+
+export interface DesktopHostPreferencesApi {
+  ensureInitialized(): Promise<DesktopPreferencesStateResponse>;
 }
 
 export type DesktopBrowserApi = Pick<

--- a/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
+++ b/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
@@ -15,6 +15,7 @@ import {
 } from "@renderer/features/connector-market";
 import { addTuttiDesktopClientToConnectorAuthorizationUrl } from "@renderer/features/connector-market/services/connectorAuthorizationClientUrl.ts";
 import { registerDesktopPreferencesServices } from "@renderer/features/desktop-preferences/services/registerDesktopPreferencesServices.ts";
+import type { DesktopWorkspaceUiMode } from "@shared/preferences";
 import { registerRichTextAtServices } from "@renderer/features/rich-text-at/services/registerRichTextAtServices";
 import { createDesktopAgentSessionStatusViewResolver } from "@renderer/features/rich-text-at/providers/desktopAgentSessionStatusView.ts";
 import { registerWorkspaceAgentServices } from "@renderer/features/workspace-agent/services/registerWorkspaceAgentServices";
@@ -107,6 +108,7 @@ export async function createWorkspaceWindowContainer(): Promise<WorkspaceWindowC
   const activeWorkspaceID =
     routeWorkspaceID || environment.startupWorkspaceID || "__default__";
   const routeView = routeParameters.get("view") || "workspace";
+  const initialWorkspaceUiMode = readInitialWorkspaceUiMode(routeParameters);
   const runtimeInstanceId =
     createWorkspaceWindowInstanceId("workspace-runtime");
   const tuttidClient = createDesktopTuttidClient(desktopApi.runtime);
@@ -152,10 +154,19 @@ export async function createWorkspaceWindowContainer(): Promise<WorkspaceWindowC
     "workspace-renderer",
     reporterService
   );
+  const hostPreferences = desktopApi.host.preferences;
   const desktopPreferencesService = await registerDesktopPreferencesServices(
     registry,
     tuttidClient,
-    tuttidEventStreamClient
+    tuttidEventStreamClient,
+    {
+      ...(hostPreferences
+        ? {
+            ensureInitialized: () => hostPreferences.ensureInitialized()
+          }
+        : {}),
+      ...(initialWorkspaceUiMode ? { initialWorkspaceUiMode } : {})
+    }
   );
   const daemonConnectionAnalytics = startDesktopDaemonConnectionAnalytics({
     eventStreamClient: tuttidEventStreamClient,
@@ -505,6 +516,13 @@ export async function createWorkspaceWindowContainer(): Promise<WorkspaceWindowC
     dispose,
     markCommitted
   };
+}
+
+function readInitialWorkspaceUiMode(
+  parameters: URLSearchParams
+): DesktopWorkspaceUiMode | undefined {
+  const mode = parameters.get("workspaceUiMode");
+  return mode === "agent" || mode === "os" ? mode : undefined;
 }
 
 function createWorkspaceWindowInstanceId(prefix: string): string {

--- a/apps/desktop/src/renderer/src/features/desktop-preferences/services/internal/desktopPreferencesService.test.ts
+++ b/apps/desktop/src/renderer/src/features/desktop-preferences/services/internal/desktopPreferencesService.test.ts
@@ -8,18 +8,23 @@ import type {
 import type { DesktopLocale } from "@shared/i18n";
 import {
   defaultDesktopWorkbenchShortcuts,
-  desktopFeatureFlagsEqual
+  desktopFeatureFlagsEqual,
+  type DesktopWorkspaceUiMode
 } from "../../../../../../shared/preferences/index.ts";
 import type { DesktopThemeSource, DesktopThemeState } from "@shared/theme";
 import type { DesktopPreferencesClient } from "./adapters/desktopPreferencesClient.ts";
 import { createDesktopPreferencesClient as createDesktopPreferencesFeatureClient } from "./adapters/desktopPreferencesClient.ts";
-import { DesktopPreferencesService } from "./desktopPreferencesService.ts";
+import {
+  DesktopPreferencesService,
+  type DesktopPreferencesServiceDependencies
+} from "./desktopPreferencesService.ts";
 
 type Preferences = DesktopPreferencesStateResponse["preferences"];
 type PublishedPreferences = Omit<
   Preferences,
   "agentComposerDefaultsByAgentTarget"
 >;
+const standaloneAgentModeFlag = "workspace.standaloneAgentMode";
 
 test("DesktopPreferencesService bootstraps persisted preferences before connecting the event stream", async () => {
   const appliedLocales: DesktopLocale[] = [];
@@ -139,7 +144,8 @@ test("initial preference hydration failure releases startup with defaults", asyn
   service.dispose();
 });
 
-test("DesktopPreferencesService keeps in-memory defaults when preferences are not initialized", async () => {
+test("DesktopPreferencesService restores authoritative preferences before the first mutation", async () => {
+  const calls: string[] = [];
   const updatedRequests: Preferences[] = [];
   const client = createDesktopPreferencesClient({
     getDesktopPreferences: async () => ({
@@ -147,6 +153,7 @@ test("DesktopPreferencesService keeps in-memory defaults when preferences are no
       preferences: createPreferences()
     }),
     updateDesktopPreferences: async (request) => {
+      calls.push("update");
       updatedRequests.push(request.preferences);
       return request.preferences;
     }
@@ -154,15 +161,134 @@ test("DesktopPreferencesService keeps in-memory defaults when preferences are no
   const { service, cleanup } = await createServiceHarness({
     client,
     initialLocale: "zh-CN",
-    initialTheme: { appearance: "dark", source: "dark" }
+    initialTheme: { appearance: "dark", source: "dark" },
+    initialWorkspaceUiMode: "agent",
+    ensureInitialized: async (candidate) => {
+      calls.push("ensure");
+      assert.equal(candidate.featureFlags[standaloneAgentModeFlag], true);
+      return {
+        initialized: true,
+        preferences: createPreferences({
+          featureFlags: { [standaloneAgentModeFlag]: false },
+          locale: "zh-CN"
+        })
+      };
+    }
   });
 
-  assert.deepEqual(updatedRequests, []);
+  assert.equal(service.store.featureFlags[standaloneAgentModeFlag], true);
   assert.equal(service.store.locale, "zh-CN");
   assert.deepEqual(service.store.theme, {
     appearance: "dark",
     source: "dark"
   });
+  await service.setLocale("en");
+  assert.deepEqual(calls, ["ensure", "update"]);
+  assert.equal(
+    updatedRequests[0]?.featureFlags[standaloneAgentModeFlag],
+    false
+  );
+  cleanup();
+});
+
+test("DesktopPreferencesService blocks mutation when initialization recovery fails", async () => {
+  const client = createDesktopPreferencesClient({
+    getDesktopPreferences: async () => ({
+      initialized: false,
+      preferences: createPreferences()
+    })
+  });
+  const { service, cleanup } = await createServiceHarness({
+    client,
+    initialWorkspaceUiMode: "agent",
+    ensureInitialized: async () => {
+      throw new Error("initialization unavailable");
+    }
+  });
+
+  await assert.rejects(
+    service.setLocale("zh-CN"),
+    /initialization unavailable/
+  );
+  assert.equal(service.store.locale, "en");
+  assert.equal(client.updatedRequests.length, 0);
+  cleanup();
+});
+
+test("DesktopPreferencesService shares one recovery across full and dedicated mutations", async () => {
+  const calls: string[] = [];
+  const updatedRequests: Preferences[] = [];
+  let ensureCalls = 0;
+  let releaseRecovery: (() => void) | undefined;
+  const recoveryBarrier = new Promise<void>((resolve) => {
+    releaseRecovery = resolve;
+  });
+  const client = createDesktopPreferencesClient({
+    getDesktopPreferences: async () => ({
+      initialized: false,
+      preferences: createPreferences()
+    }),
+    patchAgentComposerDefaultsForTarget: async () => {
+      calls.push("composer-patch");
+    },
+    updateDesktopPreferences: async (request) => {
+      calls.push("full-update");
+      updatedRequests.push(request.preferences);
+      return request.preferences;
+    }
+  });
+  const { service, cleanup } = await createServiceHarness({
+    client,
+    initialWorkspaceUiMode: "agent",
+    ensureInitialized: async () => {
+      ensureCalls++;
+      calls.push("ensure");
+      await recoveryBarrier;
+      return {
+        initialized: true,
+        preferences: createPreferences({
+          featureFlags: { [standaloneAgentModeFlag]: false }
+        })
+      };
+    }
+  });
+
+  const localeMutation = service.setLocale("zh-CN");
+  const composerMutation = service.rememberAgentComposerDefaultsForAgentTarget(
+    "local:codex",
+    { model: "gpt-5" }
+  );
+  await Promise.resolve();
+  assert.equal(ensureCalls, 1);
+  assert.deepEqual(calls, ["ensure"]);
+
+  releaseRecovery?.();
+  await Promise.all([localeMutation, composerMutation]);
+
+  assert.equal(ensureCalls, 1);
+  assert.deepEqual(calls.slice(1).sort(), ["composer-patch", "full-update"]);
+  assert.equal(
+    updatedRequests[0]?.featureFlags[standaloneAgentModeFlag],
+    false
+  );
+  cleanup();
+});
+
+test("DesktopPreferencesService lets initialized OS preferences override an Agent bootstrap", async () => {
+  const client = createDesktopPreferencesClient({
+    getDesktopPreferences: async () => ({
+      initialized: true,
+      preferences: createPreferences({
+        featureFlags: { [standaloneAgentModeFlag]: false }
+      })
+    })
+  });
+  const { service, cleanup } = await createServiceHarness({
+    client,
+    initialWorkspaceUiMode: "agent"
+  });
+
+  assert.equal(service.store.featureFlags[standaloneAgentModeFlag], false);
   cleanup();
 });
 
@@ -807,8 +933,10 @@ async function createServiceHarness(
     appliedLocales?: DesktopLocale[];
     appliedThemes?: DesktopThemeState[];
     client?: DesktopPreferencesClient;
+    ensureInitialized?: DesktopPreferencesServiceDependencies["ensureInitialized"];
     initialLocale?: DesktopLocale;
     initialTheme?: DesktopThemeState;
+    initialWorkspaceUiMode?: DesktopWorkspaceUiMode;
   } = {}
 ) {
   const client = options.client ?? createDesktopPreferencesClient({});
@@ -820,11 +948,20 @@ async function createServiceHarness(
       options.appliedThemes?.push(theme);
     },
     client,
+    ensureInitialized:
+      options.ensureInitialized ??
+      (async (candidate) => ({
+        initialized: true,
+        preferences: candidate
+      })),
     initialLocale: options.initialLocale ?? "en",
     initialTheme: options.initialTheme ?? {
       appearance: "light",
       source: "system"
     },
+    ...(options.initialWorkspaceUiMode
+      ? { initialWorkspaceUiMode: options.initialWorkspaceUiMode }
+      : {}),
     resolveTheme
   });
   await settle();

--- a/apps/desktop/src/renderer/src/features/desktop-preferences/services/internal/desktopPreferencesService.ts
+++ b/apps/desktop/src/renderer/src/features/desktop-preferences/services/internal/desktopPreferencesService.ts
@@ -1,5 +1,10 @@
 import type { DesktopLocale } from "@shared/i18n";
 import type { DesktopThemeSource, DesktopThemeState } from "@shared/theme";
+import type {
+  DesktopPreferencesStateResponse,
+  PutDesktopPreferencesRequest
+} from "@tutti-os/client-tuttid-ts";
+import { withDesktopWorkspaceUiMode } from "../../../../../../shared/featureFlags/catalog.ts";
 import type { IDesktopPreferencesService } from "../desktopPreferencesService.interface.ts";
 import type { DesktopAgentComposerDefaultsPatchResult } from "../desktopPreferencesService.interface.ts";
 import type { DesktopPreferencesClient } from "./adapters/desktopPreferencesClient.ts";
@@ -57,6 +62,7 @@ import {
   type DesktopDockPlacement,
   type DeletedAgentConversationRetentionDays,
   type DesktopFeatureFlags,
+  type DesktopWorkspaceUiMode,
   type DesktopFileDefaultOpenersByExtension,
   type DesktopMinimizeAnimation,
   type DesktopSleepPreventionMode,
@@ -70,9 +76,13 @@ export interface DesktopPreferencesServiceDependencies {
   applyLocale: (locale: DesktopLocale) => void;
   applyTheme: (theme: DesktopThemeState) => void;
   client: DesktopPreferencesClient;
+  ensureInitialized?: (
+    candidate: PutDesktopPreferencesRequest["preferences"]
+  ) => Promise<DesktopPreferencesStateResponse>;
   initialDockPlacement?: DesktopDockPlacement;
   initialLocale: DesktopLocale;
   initialTheme: DesktopThemeState;
+  initialWorkspaceUiMode?: DesktopWorkspaceUiMode;
   resolveTheme: (source: DesktopThemeSource) => DesktopThemeState;
 }
 
@@ -85,6 +95,8 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
   private readonly initialPreferencesHydration: Promise<void>;
   private readonly unsubscribePreferencesUpdates: () => void;
   private disposed = false;
+  private preferencesInitialized = false;
+  private preferencesInitialization: Promise<void> | null = null;
 
   constructor(dependencies: DesktopPreferencesServiceDependencies) {
     this.dependencies = dependencies;
@@ -109,7 +121,12 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
         this.dependencies.initialDockPlacement ?? defaultDesktopDockPlacement,
       deletedAgentConversationRetentionDays:
         defaultDeletedAgentConversationRetentionDays,
-      featureFlags: defaultDesktopFeatureFlags,
+      featureFlags: this.dependencies.initialWorkspaceUiMode
+        ? withDesktopWorkspaceUiMode(
+            defaultDesktopFeatureFlags,
+            this.dependencies.initialWorkspaceUiMode
+          )
+        : defaultDesktopFeatureFlags,
       fileDefaultOpenersByExtension:
         defaultDesktopFileDefaultOpenersByExtension,
       locale: this.dependencies.initialLocale,
@@ -126,6 +143,7 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
       this.dependencies.client.subscribeToDesktopPreferencesUpdated(
         (preferences) => {
           this.applyPreferences(preferences);
+          this.preferencesInitialized = true;
         }
       );
     this.initialPreferencesHydration = this.hydrateInitialPreferences();
@@ -148,6 +166,9 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
       return enabled;
     }
 
+    if (!this.preferencesInitialized) {
+      await this.ensureInitializedForMutation();
+    }
     const previousEnabled = this.store.agentCliUpdateCheckEnabled;
     this.store.changingAgentCliUpdateCheckEnabled = enabled;
     this.store.agentCliUpdateCheckEnabled = enabled;
@@ -178,6 +199,9 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
       return provider;
     }
 
+    if (!this.preferencesInitialized) {
+      await this.ensureInitializedForMutation();
+    }
     const previousProvider = this.store.defaultAgentProvider;
     this.store.changingDefaultAgentProvider = provider;
     this.store.defaultAgentProvider = provider;
@@ -207,6 +231,9 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
       return nextMode;
     }
 
+    if (!this.preferencesInitialized) {
+      await this.ensureInitializedForMutation();
+    }
     const previousMode = this.store.agentConversationDetailMode;
     this.store.changingAgentConversationDetailMode = nextMode;
     this.store.agentConversationDetailMode = nextMode;
@@ -237,6 +264,9 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
       return channel;
     }
 
+    if (!this.preferencesInitialized) {
+      await this.ensureInitializedForMutation();
+    }
     const previousChannel = this.store.appCatalogChannel;
     this.store.changingAppCatalogChannel = channel;
     this.store.appCatalogChannel = channel;
@@ -265,6 +295,9 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
       return mode;
     }
 
+    if (!this.preferencesInitialized) {
+      await this.ensureInitializedForMutation();
+    }
     const previousMode = this.store.browserUseConnectionMode;
     this.store.changingBrowserUseConnectionMode = mode;
     this.store.browserUseConnectionMode = mode;
@@ -296,6 +329,9 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
       return placement;
     }
 
+    if (!this.preferencesInitialized) {
+      await this.ensureInitializedForMutation();
+    }
     const previousPlacement = this.store.dockPlacement;
     this.store.changingDockPlacement = placement;
     this.store.dockPlacement = placement;
@@ -323,6 +359,9 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
     const nextDays = normalizeDeletedAgentConversationRetentionDays(days);
     if (this.store.changingDeletedAgentConversationRetentionDays === nextDays) {
       return nextDays;
+    }
+    if (!this.preferencesInitialized) {
+      await this.ensureInitializedForMutation();
     }
     const previousDays = this.store.deletedAgentConversationRetentionDays;
     this.store.changingDeletedAgentConversationRetentionDays = nextDays;
@@ -356,6 +395,9 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
       return style;
     }
 
+    if (!this.preferencesInitialized) {
+      await this.ensureInitializedForMutation();
+    }
     const previousStyle = this.store.dockIconStyle;
     this.store.changingDockIconStyle = style;
     this.store.dockIconStyle = style;
@@ -391,6 +433,9 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
       return this.store.fileDefaultOpenersByExtension;
     }
 
+    if (!this.preferencesInitialized) {
+      await this.ensureInitializedForMutation();
+    }
     const previousOpenersByExtension = this.store.fileDefaultOpenersByExtension;
     this.store.fileDefaultOpenersByExtension = nextOpenersByExtension;
     try {
@@ -414,6 +459,9 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
       return locale;
     }
 
+    if (!this.preferencesInitialized) {
+      await this.ensureInitializedForMutation();
+    }
     const previousLocale = this.store.locale;
     this.store.changingLocale = locale;
     applyDesktopPreferenceLocale(
@@ -455,6 +503,9 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
       return this.store.featureFlags;
     }
 
+    if (!this.preferencesInitialized) {
+      await this.ensureInitializedForMutation();
+    }
     const previousFlags = this.store.featureFlags;
     this.store.changingFeatureFlags = nextFlags;
     this.store.featureFlags = nextFlags;
@@ -492,6 +543,9 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
       return this.store.workbenchShortcuts;
     }
 
+    if (!this.preferencesInitialized) {
+      await this.ensureInitializedForMutation();
+    }
     const previousShortcuts = this.store.workbenchShortcuts;
     this.store.workbenchShortcuts = nextShortcuts;
     try {
@@ -517,6 +571,9 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
       return animation;
     }
 
+    if (!this.preferencesInitialized) {
+      await this.ensureInitializedForMutation();
+    }
     const previousAnimation = this.store.minimizeAnimation;
     this.store.changingMinimizeAnimation = animation;
     this.store.minimizeAnimation = animation;
@@ -555,6 +612,9 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
       return nextValue;
     }
 
+    if (!this.preferencesInitialized) {
+      await this.ensureInitializedForMutation();
+    }
     const previousValue = this.store.workbenchWindowSnapping;
     this.store.changingWorkbenchWindowSnapping = nextValue;
     this.store.workbenchWindowSnapping = nextValue;
@@ -589,6 +649,9 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
       return this.store.theme;
     }
 
+    if (!this.preferencesInitialized) {
+      await this.ensureInitializedForMutation();
+    }
     const previousTheme = this.store.theme;
     const nextTheme = this.dependencies.resolveTheme(source);
     this.store.changingThemeSource = source;
@@ -626,6 +689,9 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
       return mode;
     }
 
+    if (!this.preferencesInitialized) {
+      await this.ensureInitializedForMutation();
+    }
     const previousMode = this.store.sleepPreventionMode;
     this.store.changingSleepPreventionMode = mode;
     this.store.sleepPreventionMode = mode;
@@ -652,6 +718,9 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
       return show;
     }
 
+    if (!this.preferencesInitialized) {
+      await this.ensureInitializedForMutation();
+    }
     const previousShow = this.store.showAppDeveloperSources;
     this.store.changingShowAppDeveloperSources = show;
     this.store.showAppDeveloperSources = show;
@@ -680,6 +749,9 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
       return policy;
     }
 
+    if (!this.preferencesInitialized) {
+      await this.ensureInitializedForMutation();
+    }
     const previousPolicy = this.store.updatePolicy;
     this.store.changingUpdatePolicy = policy;
     this.store.updatePolicy = policy;
@@ -708,6 +780,9 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
       return channel;
     }
 
+    if (!this.preferencesInitialized) {
+      await this.ensureInitializedForMutation();
+    }
     const previousChannel = this.store.updateChannel;
     this.store.changingUpdateChannel = channel;
     this.store.updateChannel = channel;
@@ -733,6 +808,15 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
     agentTargetId: string,
     defaults: DesktopAgentComposerDefaultsPatch | null
   ): Promise<DesktopAgentComposerDefaultsPatchResult> {
+    if (!agentTargetId.trim() || Object.keys(defaults ?? {}).length === 0) {
+      return this.agentComposerDefaultsPatchCoordinator.patch(
+        agentTargetId,
+        defaults
+      );
+    }
+    if (!this.preferencesInitialized) {
+      await this.ensureInitializedForMutation();
+    }
     return this.agentComposerDefaultsPatchCoordinator.patch(
       agentTargetId,
       defaults
@@ -743,9 +827,29 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
     provider: DesktopAgentProvider,
     collapsed: boolean
   ): Promise<void> {
-    const previousCollapsedByProvider =
+    let previousCollapsedByProvider =
       this.store.agentGuiConversationRailCollapsedByProvider;
-    const nextCollapsedByProvider =
+    let nextCollapsedByProvider =
+      mergeDesktopAgentGuiConversationRailCollapsedByProvider(
+        previousCollapsedByProvider,
+        provider,
+        collapsed
+      );
+    if (
+      desktopAgentGuiConversationRailCollapsedByProviderEqual(
+        previousCollapsedByProvider,
+        nextCollapsedByProvider
+      )
+    ) {
+      return;
+    }
+
+    if (!this.preferencesInitialized) {
+      await this.ensureInitializedForMutation();
+    }
+    previousCollapsedByProvider =
+      this.store.agentGuiConversationRailCollapsedByProvider;
+    nextCollapsedByProvider =
       mergeDesktopAgentGuiConversationRailCollapsedByProvider(
         previousCollapsedByProvider,
         provider,
@@ -780,8 +884,24 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
     projectSectionKey: string,
     mode: DesktopAgentSessionLaunchMode
   ): Promise<void> {
-    const previousModes = this.store.agentSessionLaunchModesByWorkspace;
-    const nextModes = mergeDesktopAgentSessionLaunchMode(
+    let previousModes = this.store.agentSessionLaunchModesByWorkspace;
+    let nextModes = mergeDesktopAgentSessionLaunchMode(
+      previousModes,
+      workspaceId,
+      projectSectionKey,
+      mode
+    );
+    if (
+      desktopAgentSessionLaunchModesByWorkspaceEqual(previousModes, nextModes)
+    ) {
+      return;
+    }
+
+    if (!this.preferencesInitialized) {
+      await this.ensureInitializedForMutation();
+    }
+    previousModes = this.store.agentSessionLaunchModesByWorkspace;
+    nextModes = mergeDesktopAgentSessionLaunchMode(
       previousModes,
       workspaceId,
       projectSectionKey,
@@ -819,6 +939,7 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
         await this.dependencies.client.getDesktopPreferences();
       if (!this.disposed && preferences.initialized) {
         this.applyPreferences(preferences.preferences);
+        this.preferencesInitialized = true;
       }
     } catch {
       // Keep the current in-memory defaults when initial preference hydration fails.
@@ -849,6 +970,44 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
       resolveTheme: this.dependencies.resolveTheme,
       store: this.store
     });
+  }
+
+  private async ensureInitializedForMutation(): Promise<void> {
+    if (this.preferencesInitialized) {
+      return;
+    }
+    if (this.preferencesInitialization) {
+      return this.preferencesInitialization;
+    }
+
+    const ensureInitialized = this.dependencies.ensureInitialized;
+    if (!ensureInitialized) {
+      throw new Error(
+        "Desktop preferences initialization is unavailable for mutation."
+      );
+    }
+
+    const initialization = (async () => {
+      const response = await ensureInitialized(this.currentPreferences());
+      if (!response.initialized) {
+        throw new Error(
+          "Desktop preferences remained uninitialized before mutation."
+        );
+      }
+      if (this.disposed) {
+        throw new Error("Desktop preferences service was disposed.");
+      }
+      this.applyPreferences(response.preferences);
+      this.preferencesInitialized = true;
+    })();
+    this.preferencesInitialization = initialization;
+    try {
+      await initialization;
+    } finally {
+      if (this.preferencesInitialization === initialization) {
+        this.preferencesInitialization = null;
+      }
+    }
   }
 
   private currentPreferences(overrides: DesktopPreferencesOverrides = {}) {

--- a/apps/desktop/src/renderer/src/features/desktop-preferences/services/registerDesktopPreferencesServices.ts
+++ b/apps/desktop/src/renderer/src/features/desktop-preferences/services/registerDesktopPreferencesServices.ts
@@ -1,5 +1,6 @@
 import type { ServiceRegistry } from "@tutti-os/infra/di";
 import type {
+  DesktopPreferencesStateResponse,
   TuttidClient,
   TuttidEventStreamClient
 } from "@tutti-os/client-tuttid-ts";
@@ -10,6 +11,7 @@ import {
   resolveDesktopThemeState
 } from "@renderer/theme/runtime";
 import { readInitialDockPlacementFromLocation } from "@shared/preferences";
+import type { DesktopWorkspaceUiMode } from "@shared/preferences";
 import { IDesktopPreferencesService } from "./desktopPreferencesService.interface.ts";
 import { createDesktopPreferencesClient } from "./internal/adapters/desktopPreferencesClient.ts";
 import { DesktopPreferencesService } from "./internal/desktopPreferencesService.ts";
@@ -17,15 +19,29 @@ import { DesktopPreferencesService } from "./internal/desktopPreferencesService.
 export async function registerDesktopPreferencesServices(
   registry: ServiceRegistry,
   tuttidClient: TuttidClient,
-  eventStreamClient: TuttidEventStreamClient
+  eventStreamClient: TuttidEventStreamClient,
+  options: {
+    ensureInitialized?: () => Promise<DesktopPreferencesStateResponse>;
+    initialWorkspaceUiMode?: DesktopWorkspaceUiMode;
+  } = {}
 ): Promise<IDesktopPreferencesService> {
   const service = new DesktopPreferencesService({
     applyLocale,
     applyTheme,
     client: createDesktopPreferencesClient(tuttidClient, eventStreamClient),
+    ensureInitialized: (candidate) =>
+      options.ensureInitialized
+        ? options.ensureInitialized()
+        : tuttidClient.putDesktopPreferences({
+            writeMode: "initializeIfAbsent",
+            preferences: candidate
+          }),
     initialDockPlacement: readInitialDockPlacementFromLocation(),
     initialLocale: getActiveLocale(),
     initialTheme: getActiveTheme(),
+    ...(options.initialWorkspaceUiMode
+      ? { initialWorkspaceUiMode: options.initialWorkspaceUiMode }
+      : {}),
     resolveTheme: resolveDesktopThemeState
   });
   await service.whenInitialPreferencesHydrated();

--- a/apps/desktop/src/shared/contracts/ipc.ts
+++ b/apps/desktop/src/shared/contracts/ipc.ts
@@ -18,6 +18,7 @@ import type {
 import type { DesktopAgentDirectorySnapshot } from "./agentDirectory.ts";
 import type {
   AgentProviderStatus,
+  DesktopPreferencesStateResponse,
   WorkspaceAgentProvider
 } from "@tutti-os/client-tuttid-ts";
 import type {
@@ -264,6 +265,9 @@ export const desktopIpcChannels = {
     setCustom: "wallpaper:setCustom"
   },
   host: {
+    preferences: {
+      ensureInitialized: "host:preferences:ensureInitialized"
+    },
     files: {
       createUserDocumentsProjectDirectory:
         "host:files:createUserDocumentsProjectDirectory",
@@ -1260,6 +1264,7 @@ export interface DesktopInvokePayloadByChannel {
   [desktopIpcChannels.wallpaper.clearCustom]: undefined;
   [desktopIpcChannels.wallpaper.getCustom]: undefined;
   [desktopIpcChannels.wallpaper.setCustom]: DesktopSetCustomWallpaperInput;
+  [desktopIpcChannels.host.preferences.ensureInitialized]: undefined;
   [desktopIpcChannels.host.files
     .createUserDocumentsProjectDirectory]: DesktopCreateUserDocumentsProjectDirectoryInput;
   [desktopIpcChannels.host.files.openExternal]: string;
@@ -1475,6 +1480,8 @@ export interface DesktopInvokeResultByChannel {
   [desktopIpcChannels.wallpaper.clearCustom]: void;
   [desktopIpcChannels.wallpaper.getCustom]: DesktopCustomWallpaperImage | null;
   [desktopIpcChannels.wallpaper.setCustom]: DesktopCustomWallpaperImage;
+  [desktopIpcChannels.host.preferences
+    .ensureInitialized]: DesktopPreferencesStateResponse;
   [desktopIpcChannels.host.files
     .createUserDocumentsProjectDirectory]: DesktopCreateUserDocumentsProjectDirectoryResult;
   [desktopIpcChannels.host.files.openExternal]: void;

--- a/apps/desktop/src/shared/contracts/windowIntent.test.ts
+++ b/apps/desktop/src/shared/contracts/windowIntent.test.ts
@@ -42,6 +42,20 @@ test("encodeDesktopWindowIntent disables predefine pageview for secondary window
   assert.equal(new URLSearchParams(search).get("reportPredefinePageview"), "0");
 });
 
+test("encodeDesktopWindowIntent keeps an Agent view separate from the OS preference bootstrap", () => {
+  const search = encodeDesktopWindowIntent(
+    createAgentWindowIntent({
+      provider: "codex",
+      workspaceID: "workspace-1"
+    }),
+    { workspaceUiMode: "os" }
+  );
+
+  const params = new URLSearchParams(search);
+  assert.equal(params.get("view"), "agent");
+  assert.equal(params.get("workspaceUiMode"), "os");
+});
+
 test("applyDesktopWindowIntent preserves theme bootstrap parameters in development URLs", () => {
   const url = applyDesktopWindowIntent(
     "http://localhost:5173/",

--- a/apps/desktop/src/shared/contracts/windowIntent.ts
+++ b/apps/desktop/src/shared/contracts/windowIntent.ts
@@ -1,5 +1,8 @@
 import type { DesktopLocale } from "../i18n";
-import type { DesktopDockPlacement } from "../preferences/index.ts";
+import type {
+  DesktopDockPlacement,
+  DesktopWorkspaceUiMode
+} from "../preferences/index.ts";
 import type {
   DesktopThemeAppearance,
   DesktopThemeSource
@@ -39,6 +42,7 @@ export interface DesktopWindowIntentSearchOptions {
   reportPredefinePageview?: boolean;
   themeAppearance?: DesktopThemeAppearance;
   themeSource?: DesktopThemeSource;
+  workspaceUiMode?: DesktopWorkspaceUiMode;
 }
 
 export function createWorkspaceWindowIntent(
@@ -108,6 +112,9 @@ export function encodeDesktopWindowIntent(
   }
   if (options.themeAppearance) {
     params.set("theme", options.themeAppearance);
+  }
+  if (options.workspaceUiMode) {
+    params.set("workspaceUiMode", options.workspaceUiMode);
   }
 
   if (intent.kind === "agent") {

--- a/docs/architecture/analytics-tracking.md
+++ b/docs/architecture/analytics-tracking.md
@@ -176,6 +176,17 @@ It does not set the renderer-owned common `mode` field: after an earlier
 replacement failure, the durable preference and the actual native owner-window
 route can temporarily differ, and the main process must not guess that route.
 
+tuttid reports `settings.workspace_ui_mode_initialized` exactly once per fresh
+profile, from the `initializeIfAbsent` write branch that owns every
+fresh-preference-row creation (the dedicated field patch writers refuse to
+materialize a missing row). The `workspace_ui_mode` param carries the assigned
+initial mode derived from the authoritative stored row, so cohort analysis can
+separate "assigned by default" from "explicitly chosen" and from later escapes
+measured by `settings.workspace_ui_mode_changed`. The param is deliberately not
+named `mode` to avoid colliding with the renderer-owned window-mode common
+param. As a daemon-side event it usually fires before login, so it attributes
+to the device identity like early `account.login` stages.
+
 ## API Contract
 
 ### Renderer → tuttid

--- a/docs/architecture/desktop-transport.md
+++ b/docs/architecture/desktop-transport.md
@@ -187,6 +187,14 @@ Current acceptable preload bootstrap helpers include:
 - resolved terminal stream URL helpers for terminal-specific WebSocket routes
 - resolved business-event stream URL helpers for `/v1/events/ws`
 
+Desktop preference recovery is a typed host capability rather than renderer
+transport policy. `host.preferences.ensureInitialized` crosses
+renderer -> preload -> main without input; main owns the single-flight recovery
+state and returns the generated `DesktopPreferencesStateResponse`. The daemon's
+`initializeIfAbsent` API and SQLite transaction remain the authoritative
+creation boundary. Web development, where Electron host IPC is absent, invokes
+the same daemon API directly with the renderer's complete bootstrapped candidate.
+
 ## Daemon-Side Rules
 
 In `services/tuttid`:

--- a/docs/architecture/desktop-windows.md
+++ b/docs/architecture/desktop-windows.md
@@ -8,7 +8,8 @@ The desktop app currently has three user-facing shells:
 
 - a launcher-style dashboard window for no-context startup
 - a workspace window for an opened workspace
-- an Agent-only window used as an optional focused Agent experience
+- an Agent-only window used as the focused Agent experience and fresh-profile
+  default
 
 The window model is intentionally simple:
 
@@ -73,8 +74,9 @@ The current renderer content is intentionally minimal. The shell exists so the s
 
 ### Agent-Only Window
 
-The Agent-only window is the focused product shell for users who select Agent
-mode and want AgentGUI without the full workspace desktop around it.
+The Agent-only window is the focused product shell for fresh profiles and for
+users who select Agent mode and want AgentGUI without the full workspace desktop
+around it.
 
 It is responsible for:
 
@@ -101,11 +103,41 @@ It is not responsible for:
 Desktop startup currently follows this sequence:
 
 1. start or reconnect to `tuttid`
-2. ask `tuttid` for the daemon-selected startup workspace
-3. if a startup workspace exists, read the desktop startup-interface preference
-4. create the OS workspace window by default, or the Agent-only window when the
-   user explicitly selected Agent mode
-5. otherwise open the dashboard window
+2. read the desktop startup-interface preference
+3. when no preference row exists, atomically initialize a complete row with
+   Agent mode; if another writer already created the row, use that stored value
+   unchanged
+4. ask `tuttid` for the daemon-selected startup workspace
+5. when a startup workspace exists, create the Agent-only window for a freshly initialized desktop profile or an
+   explicit Agent selection; an initialized profile with an explicit OS
+   selection or the legacy absent preference creates the OS workspace window
+6. otherwise open the dashboard window
+
+For every workspace or Agent window open, main resolves the current global
+workspace UI mode once and includes it as the narrow `workspaceUiMode` URL
+bootstrap. This value is separate from `view`, which selects the native window
+content: for example, a secondary Agent window can use `view=agent` while the
+global preference remains `workspaceUiMode=os`. The renderer seeds its
+in-memory preference state from this bootstrap until an initialized daemon row
+is available. An initialized row always overrides the bootstrap; an absent row
+or hydration failure retains it so an unrelated full preference write cannot
+silently invert the mode already selected by main.
+
+An initial preference read failure does not prove that the identity is fresh,
+so startup keeps the legacy OS fallback and does not initialize. If a confirmed
+fresh identity's initialization response is lost, Desktop reads the preference
+row again and uses the authoritative result. If the write failed before commit
+and the row is still absent, the current process keeps the fresh Agent default
+in memory. Main retains the startup identity as `initialized`, `missing`, or
+`unknown`; before any renderer preference mutation, a typed host capability
+recovers unknown state or atomically retries a confirmed missing initialization.
+The renderer applies the returned authoritative complete row before constructing
+or publishing the requested mutation. Recovery is single-flight in each
+renderer and in main, while SQLite `INSERT ... ON CONFLICT DO NOTHING` remains
+the cross-window and cross-process arbiter. Failed recovery blocks the mutation
+without optimistic state changes or partial daemon writes. Update-channel
+migrations and installed-version markers run only after a durable row is
+confirmed.
 
 On macOS activation with no open windows, the app follows the same startup resolution instead of always forcing the dashboard.
 
@@ -149,10 +181,30 @@ preference and immediately replaces the current native window with the selected
 Agent-only or OS workspace window. The replacement request carries the selected
 window kind explicitly, so it does not depend on asynchronous preference-event
 delivery in the main process. Desktop waits until the replacement is ready
-before closing the source window. An absent preference resolves to OS mode;
-manual selections persist `true` for Agent mode and `false` for OS mode.
+before closing the source window. Initializing a fresh desktop preference
+profile persists `true` for Agent mode. Existing initialized profiles are not
+backfilled: an absent preference remains the legacy OS mode, while manual
+selections persist `true` for Agent mode and `false` for OS mode.
 If the requested OS window already exists, desktop reuses it and does not close
 that same window as the handoff owner.
+
+### Startup Mode Acceptance Gates
+
+The preference decision is platform-neutral, but acceptance must exercise the
+native Electron startup path because window creation and restoration differ by
+platform. A release containing this behavior must pass all of these gates:
+
+- on Windows, launch a packaged build with an isolated empty state root and
+  verify that the first workspace opens an Agent window; then select OS mode,
+  relaunch, and verify that the workspace window is restored
+- on Linux under the supported X11/Xwayland path, repeat the isolated-state and
+  persisted-OS relaunch checks
+- on macOS, repeat the same checks and also verify app activation with no open
+  windows follows the persisted mode
+
+Unit and integration tests remain required for the true, false, legacy-missing,
+initial-read-error, initialization-failure, and lost-response branches, but they
+do not replace these native startup gates.
 
 ## Current Renderer Shell Mapping
 

--- a/docs/conventions/local-state-storage.md
+++ b/docs/conventions/local-state-storage.md
@@ -129,6 +129,22 @@ Device-global desktop preferences are durable daemon state in the
 must be changed through the preferences service/API so the daemon can persist,
 normalize, and publish the authoritative preferences event.
 
+Fresh-profile creation is daemon-owned. A client uses the desktop preferences
+`initializeIfAbsent` write mode. Before the atomic write, the preferences
+service applies the daemon's fresh-profile workspace-mode default to the
+normalized client candidate, so the Agent default cannot vary by caller while
+other candidate fields and feature flags are preserved. The store writes that
+complete row with a single `INSERT ... ON CONFLICT DO NOTHING` and returns the
+authoritative stored row. If a concurrent initializer created the row first,
+that stored row wins without being overwritten. Only `initializeIfAbsent` may
+create this identity row. Field-specific writers fail without side effects when
+the row is missing, so a partial patch can never decide whether the identity is
+new or accidentally replace the complete initialization contract. The normal
+omitted/`replace` write mode remains the full preference update. The daemon-owned
+complete default uses the stable desktop update channel; packaged RC builds may
+subsequently align that preference from their installed version. Existing rows
+are never backfilled by initialization.
+
 `agent_cli_update_check_enabled` stores the
 `agentCliUpdateCheckEnabled` preference as a non-null SQLite boolean and
 defaults to `true`, including for existing databases upgraded by migration. It

--- a/packages/clients/tuttid-ts/src/generated/index.ts
+++ b/packages/clients/tuttid-ts/src/generated/index.ts
@@ -836,6 +836,7 @@ export type {
   DesktopMinimizeAnimation,
   DesktopPreferences,
   DesktopPreferencesStateResponse,
+  DesktopPreferencesWriteMode,
   DesktopSleepPreventionMode,
   DesktopThemeSource,
   DesktopUpdateAdmissionArchitecture,

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -619,8 +619,14 @@ export type WorkspaceAppAgentPreferencesResponse = {
 };
 
 export type PutDesktopPreferencesRequest = {
+  writeMode?: DesktopPreferencesWriteMode;
   preferences: DesktopPreferences;
 };
+
+/**
+ * replace performs the normal full preference update, and omitting writeMode is equivalent to replace. initializeIfAbsent atomically creates the preference row only when it does not exist after applying the daemon-owned Agent workspace-mode default to the supplied preferences. If the row already exists, it returns the authoritative stored preferences unchanged.
+ */
+export type DesktopPreferencesWriteMode = "replace" | "initializeIfAbsent";
 
 export type DesktopUpdateAdmissionProduct = "tsh-desktop" | "tutti-desktop";
 

--- a/services/tuttid/api/daemon_preferences.go
+++ b/services/tuttid/api/daemon_preferences.go
@@ -56,6 +56,22 @@ func (api DaemonAPI) PutDesktopPreferences(ctx context.Context, request tuttigen
 		}, nil
 	}
 
+	writeMode := tuttigenerated.DesktopPreferencesWriteModeReplace
+	if request.Body.WriteMode != nil {
+		writeMode = *request.Body.WriteMode
+		if !writeMode.Valid() {
+			return tuttigenerated.PutDesktopPreferences400JSONResponse{
+				InvalidRequestErrorJSONResponse: invalidRequestError(
+					apierrors.InvalidRequest(
+						apierrors.ReasonUnsupportedDesktopPreferencesWriteMode,
+						apierrors.WithDeveloperMessage("desktop preferences write mode is unsupported"),
+						apierrors.WithParams(map[string]any{"field": "writeMode"}),
+					),
+				),
+			}, nil
+		}
+	}
+
 	defaultAgentProvider := agentproviderbiz.Normalize(string(request.Body.Preferences.DefaultAgentProvider))
 	if defaultAgentProvider == "" || !preferencesbiz.IsDesktopDefaultAgentProvider(defaultAgentProvider) {
 		return tuttigenerated.PutDesktopPreferences400JSONResponse{
@@ -408,6 +424,8 @@ func (api DaemonAPI) PutDesktopPreferences(ctx context.Context, request tuttigen
 		}
 	}
 	preferences, err := api.PreferencesService.Put(ctx, preferencesservice.PutInput{
+		WriteMode: preferencesservice.DesktopPreferencesWriteMode(writeMode),
+
 		AgentCLIUpdateCheckEnabled: request.Body.Preferences.AgentCliUpdateCheckEnabled,
 		AgentComposerDefaultsByProvider: agentComposerDefaultsByProviderFromGenerated(
 			request.Body.Preferences.AgentComposerDefaultsByProvider,

--- a/services/tuttid/api/daemon_preferences_test.go
+++ b/services/tuttid/api/daemon_preferences_test.go
@@ -133,6 +133,7 @@ func TestDaemonAPIGeneratedRoutesPutDesktopPreferencesPersistsAgentGUIConversati
 	}))
 
 	recorder := performGeneratedRouteRequest(t, mux, http.MethodPut, "/v1/preferences/desktop", map[string]any{
+		"writeMode": "initializeIfAbsent",
 		"preferences": map[string]any{
 			"agentCliUpdateCheckEnabled":      false,
 			"agentComposerDefaultsByProvider": map[string]any{},
@@ -156,6 +157,9 @@ func TestDaemonAPIGeneratedRoutesPutDesktopPreferencesPersistsAgentGUIConversati
 	})
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d; body: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if captured.WriteMode != preferencesservice.DesktopPreferencesWriteModeInitializeIfAbsent {
+		t.Fatalf("captured write mode = %q, want initializeIfAbsent", captured.WriteMode)
 	}
 	if captured.AgentCLIUpdateCheckEnabled {
 		t.Fatal("captured agent CLI update check = true, want false")
@@ -194,6 +198,34 @@ func TestDaemonAPIGeneratedRoutesPutDesktopPreferencesPersistsAgentGUIConversati
 	if response.Preferences.AppCatalogChannel != tuttigenerated.Staging {
 		t.Fatalf("response appCatalogChannel = %q, want staging", response.Preferences.AppCatalogChannel)
 	}
+}
+
+func TestDaemonAPIGeneratedRoutesPutDesktopPreferencesRejectsUnsupportedWriteMode(t *testing.T) {
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, NewRoutes(DaemonAPI{
+		PreferencesService: stubPreferencesService{
+			putFn: func(context.Context, preferencesservice.PutInput) (preferencesbiz.DesktopPreferences, error) {
+				t.Fatal("Put should not be called when write mode is invalid")
+				return preferencesbiz.DesktopPreferences{}, nil
+			},
+		},
+	}))
+
+	recorder := performGeneratedRouteRequest(t, mux, http.MethodPut, "/v1/preferences/desktop", map[string]any{
+		"writeMode":   "merge",
+		"preferences": map[string]any{},
+	})
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body: %s", recorder.Code, http.StatusBadRequest, recorder.Body.String())
+	}
+
+	assertGeneratedRouteError(
+		t,
+		recorder,
+		tuttigenerated.InvalidRequest,
+		"unsupported_desktop_preferences_write_mode",
+		"desktop preferences write mode is unsupported",
+	)
 }
 
 func TestDaemonAPIGeneratedRoutesPutDesktopPreferencesRequiresAgentConversationDetailMode(t *testing.T) {

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -2011,6 +2011,24 @@ func (e DesktopMinimizeAnimation) Valid() bool {
 	}
 }
 
+// Defines values for DesktopPreferencesWriteMode.
+const (
+	DesktopPreferencesWriteModeInitializeIfAbsent DesktopPreferencesWriteMode = "initializeIfAbsent"
+	DesktopPreferencesWriteModeReplace            DesktopPreferencesWriteMode = "replace"
+)
+
+// Valid indicates whether the value is a known member of the DesktopPreferencesWriteMode enum.
+func (e DesktopPreferencesWriteMode) Valid() bool {
+	switch e {
+	case DesktopPreferencesWriteModeInitializeIfAbsent:
+		return true
+	case DesktopPreferencesWriteModeReplace:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for DesktopSleepPreventionMode.
 const (
 	Always            DesktopSleepPreventionMode = "always"
@@ -6968,6 +6986,9 @@ type DesktopPreferencesStateResponse struct {
 	Preferences DesktopPreferences `json:"preferences"`
 }
 
+// DesktopPreferencesWriteMode replace performs the normal full preference update, and omitting writeMode is equivalent to replace. initializeIfAbsent atomically creates the preference row only when it does not exist after applying the daemon-owned Agent workspace-mode default to the supplied preferences. If the row already exists, it returns the authoritative stored preferences unchanged.
+type DesktopPreferencesWriteMode string
+
 // DesktopSleepPreventionMode defines model for DesktopSleepPreventionMode.
 type DesktopSleepPreventionMode string
 
@@ -8053,6 +8074,9 @@ type PutAutomationRuleRequest struct {
 // PutDesktopPreferencesRequest defines model for PutDesktopPreferencesRequest.
 type PutDesktopPreferencesRequest struct {
 	Preferences DesktopPreferences `json:"preferences"`
+
+	// WriteMode replace performs the normal full preference update, and omitting writeMode is equivalent to replace. initializeIfAbsent atomically creates the preference row only when it does not exist after applying the daemon-owned Agent workspace-mode default to the supplied preferences. If the row already exists, it returns the authoritative stored preferences unchanged.
+	WriteMode *DesktopPreferencesWriteMode `json:"writeMode,omitempty"`
 }
 
 // PutModelPlanRequest defines model for PutModelPlanRequest.

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -8394,8 +8394,26 @@ components:
       required:
         - preferences
       properties:
+        writeMode:
+          $ref: "#/components/schemas/DesktopPreferencesWriteMode"
         preferences:
           $ref: "#/components/schemas/DesktopPreferences"
+    DesktopPreferencesWriteMode:
+      type: string
+      description: >-
+        replace performs the normal full preference update, and omitting
+        writeMode is equivalent to replace. initializeIfAbsent atomically
+        creates the preference row only when it does not exist after applying
+        the daemon-owned Agent workspace-mode default to the supplied
+        preferences. If the row already exists, it returns the authoritative
+        stored preferences unchanged.
+      default: replace
+      enum:
+        - replace
+        - initializeIfAbsent
+      x-enum-varnames:
+        - DesktopPreferencesWriteModeReplace
+        - DesktopPreferencesWriteModeInitializeIfAbsent
     DesktopUpdateAdmissionProduct:
       type: string
       enum:

--- a/services/tuttid/apierrors/apierrors.go
+++ b/services/tuttid/apierrors/apierrors.go
@@ -81,6 +81,7 @@ const (
 	ReasonUnsupportedDesktopBrowserUseConnectionMode     = "unsupported_desktop_browser_use_connection_mode"
 	ReasonUnsupportedDesktopLocale                       = "unsupported_desktop_locale"
 	ReasonUnsupportedDesktopMinimizeAnimation            = "unsupported_desktop_minimize_animation"
+	ReasonUnsupportedDesktopPreferencesWriteMode         = "unsupported_desktop_preferences_write_mode"
 	ReasonUnsupportedDesktopSleepPreventionMode          = "unsupported_desktop_sleep_prevention_mode"
 	ReasonUnsupportedDesktopThemeSource                  = "unsupported_desktop_theme_source"
 	ReasonUnsupportedDesktopUpdateChannel                = "unsupported_desktop_update_channel"

--- a/services/tuttid/biz/preferences/model.go
+++ b/services/tuttid/biz/preferences/model.go
@@ -13,6 +13,7 @@ const (
 
 	DesktopAgentConversationDetailModeCoding  = "coding"
 	DesktopAgentConversationDetailModeGeneral = "general"
+	DesktopStandaloneAgentModeFeatureFlag     = "workspace.standaloneAgentMode"
 
 	DefaultDesktopAppCatalogChannel              = "production"
 	DefaultDesktopAgentDockLayout                = DesktopAgentDockLayoutUnified
@@ -27,7 +28,7 @@ const (
 	DefaultDesktopSleepPreventionMode            = "never"
 	DefaultDesktopShowAppDeveloperSources        = false
 	DefaultDesktopThemeSource                    = "dark"
-	DefaultDesktopUpdateChannel                  = "rc"
+	DefaultDesktopUpdateChannel                  = "stable"
 	DefaultDesktopUpdatePolicy                   = "prompt"
 	DefaultDesktopWindowSnappingEnabled          = false
 	DefaultDesktopWindowSnappingShortcut         = "commandArrows"
@@ -138,7 +139,9 @@ func DefaultDesktopPreferences() DesktopPreferences {
 		DockIconStyle:                               DefaultDesktopDockIconStyle,
 		DockPlacement:                               DefaultDesktopDockPlacement,
 		DeletedAgentConversationRetentionDays:       DefaultDeletedAgentConversationRetentionDays,
-		FeatureFlags:                                map[string]bool{},
+		FeatureFlags: map[string]bool{
+			DesktopStandaloneAgentModeFeatureFlag: true,
+		},
 		FileDefaultOpenersByExtension: map[string]string{
 			"htm":   "appBrowser",
 			"html":  "appBrowser",

--- a/services/tuttid/biz/preferences/model_test.go
+++ b/services/tuttid/biz/preferences/model_test.go
@@ -23,13 +23,16 @@ func TestNormalizeDesktopShortcutBindingClampsLongValues(t *testing.T) {
 	}
 }
 
-func TestDefaultDesktopPreferencesHasEmptyFlags(t *testing.T) {
+func TestDefaultDesktopPreferencesStartsNewProfilesInAgentMode(t *testing.T) {
 	d := DefaultDesktopPreferences()
 	if !d.AgentCLIUpdateCheckEnabled {
 		t.Fatal("want agent CLI update checks enabled by default")
 	}
-	if len(d.FeatureFlags) != 0 {
-		t.Fatalf("want empty flags, got %v", d.FeatureFlags)
+	if !d.FeatureFlags[DesktopStandaloneAgentModeFeatureFlag] {
+		t.Fatalf("want standalone Agent mode enabled, got %v", d.FeatureFlags)
+	}
+	if d.UpdateChannel != "stable" {
+		t.Fatalf("want stable desktop updates by default, got %q", d.UpdateChannel)
 	}
 }
 

--- a/services/tuttid/data/workspace/sqlite_preferences.go
+++ b/services/tuttid/data/workspace/sqlite_preferences.go
@@ -112,108 +112,6 @@ WHERE id = ?
 	}, nil
 }
 
-func (s *SQLiteStore) PutDesktopPreferences(ctx context.Context, preferences preferencesbiz.DesktopPreferences) (preferencesbiz.DesktopPreferences, error) {
-	if s == nil || s.writeDB == nil {
-		return preferencesbiz.DesktopPreferences{}, errors.New("workspace database is not initialized")
-	}
-
-	now := unixMs(time.Now().UTC())
-	agentComposerDefaultsJSON, err := encodeAgentComposerDefaultsByProvider(preferences.AgentComposerDefaultsByProvider)
-	if err != nil {
-		return preferencesbiz.DesktopPreferences{}, fmt.Errorf("encode desktop preferences agent composer defaults: %w", err)
-	}
-	agentComposerDefaultsByAgentTargetJSON, err := encodeAgentComposerDefaultsByProvider(preferences.AgentComposerDefaultsByAgentTarget)
-	if err != nil {
-		return preferencesbiz.DesktopPreferences{}, fmt.Errorf("encode desktop preferences agent composer defaults by agent target: %w", err)
-	}
-	agentGUIConversationRailCollapsedJSON, err := encodeAgentGUIConversationRailCollapsedByProvider(preferences.AgentGUIConversationRailCollapsedByProvider)
-	if err != nil {
-		return preferencesbiz.DesktopPreferences{}, fmt.Errorf("encode desktop preferences agent gui conversation rail: %w", err)
-	}
-	agentSessionLaunchModesJSON, err := encodeAgentSessionLaunchModesByWorkspace(preferences.AgentSessionLaunchModesByWorkspace)
-	if err != nil {
-		return preferencesbiz.DesktopPreferences{}, fmt.Errorf("encode desktop preferences Agent Session launch modes: %w", err)
-	}
-	fileDefaultOpenersJSON, err := encodeFileDefaultOpenersByExtension(preferences.FileDefaultOpenersByExtension)
-	if err != nil {
-		return preferencesbiz.DesktopPreferences{}, fmt.Errorf("encode desktop preferences file default openers: %w", err)
-	}
-	featureFlagsJSON, err := encodeFeatureFlags(preferences.FeatureFlags)
-	if err != nil {
-		return preferencesbiz.DesktopPreferences{}, fmt.Errorf("encode desktop preferences feature flags: %w", err)
-	}
-	workbenchShortcutsJSON, err := encodeWorkbenchShortcuts(preferences.WorkbenchShortcuts)
-	if err != nil {
-		return preferencesbiz.DesktopPreferences{}, fmt.Errorf("encode desktop preferences workbench shortcuts: %w", err)
-	}
-	_, err = s.writeDB.ExecContext(ctx, `
-INSERT INTO desktop_preferences (
-  id,
-  agent_cli_update_check_enabled,
-  default_agent_provider,
-  agent_conversation_detail_mode,
-  agent_dock_layout,
-  dock_icon_style,
-  dock_placement,
-  deleted_agent_conversation_retention_days,
-  locale,
-  theme_source,
-  sleep_prevention_mode,
-  update_channel,
-  update_policy,
-  agent_composer_defaults_by_provider_json,
-  agent_composer_defaults_by_agent_target_json,
-  agent_gui_conversation_rail_collapsed_by_provider_json,
-  agent_session_launch_modes_by_workspace_json,
-  file_default_openers_by_extension_json,
-  app_catalog_channel,
-  browser_use_connection_mode,
-  minimize_animation,
-  show_app_developer_sources,
-  workbench_window_snapping_enabled,
-  workbench_window_snapping_shortcut_preset,
-  feature_flags_json,
-  workbench_shortcuts_json,
-  updated_at_unix_ms
-)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-ON CONFLICT(id) DO UPDATE SET
-  agent_cli_update_check_enabled = excluded.agent_cli_update_check_enabled,
-  default_agent_provider = excluded.default_agent_provider,
-  agent_conversation_detail_mode = excluded.agent_conversation_detail_mode,
-  agent_dock_layout = excluded.agent_dock_layout,
-  dock_icon_style = excluded.dock_icon_style,
-  dock_placement = excluded.dock_placement,
-  deleted_agent_conversation_retention_days = excluded.deleted_agent_conversation_retention_days,
-  locale = excluded.locale,
-  theme_source = excluded.theme_source,
-  sleep_prevention_mode = excluded.sleep_prevention_mode,
-  update_channel = excluded.update_channel,
-  update_policy = excluded.update_policy,
-  agent_composer_defaults_by_provider_json = excluded.agent_composer_defaults_by_provider_json,
-  agent_gui_conversation_rail_collapsed_by_provider_json = excluded.agent_gui_conversation_rail_collapsed_by_provider_json,
-  file_default_openers_by_extension_json = excluded.file_default_openers_by_extension_json,
-  app_catalog_channel = excluded.app_catalog_channel,
-  browser_use_connection_mode = excluded.browser_use_connection_mode,
-  minimize_animation = excluded.minimize_animation,
-  show_app_developer_sources = excluded.show_app_developer_sources,
-  workbench_window_snapping_enabled = excluded.workbench_window_snapping_enabled,
-  workbench_window_snapping_shortcut_preset = excluded.workbench_window_snapping_shortcut_preset,
-  feature_flags_json = excluded.feature_flags_json,
-  workbench_shortcuts_json = excluded.workbench_shortcuts_json,
-  updated_at_unix_ms = excluded.updated_at_unix_ms
-`, desktopPreferencesRowID, preferences.AgentCLIUpdateCheckEnabled, preferences.DefaultAgentProvider, preferencesbiz.NormalizeDesktopAgentConversationDetailMode(preferences.AgentConversationDetailMode), preferencesbiz.NormalizeDesktopAgentDockLayout(preferences.AgentDockLayout), preferences.DockIconStyle, preferences.DockPlacement, preferencesbiz.NormalizeDeletedAgentConversationRetentionDays(preferences.DeletedAgentConversationRetentionDays), preferences.Locale, preferences.ThemeSource, preferences.SleepPreventionMode, preferences.UpdateChannel, preferences.UpdatePolicy, agentComposerDefaultsJSON, agentComposerDefaultsByAgentTargetJSON, agentGUIConversationRailCollapsedJSON, agentSessionLaunchModesJSON, fileDefaultOpenersJSON, preferences.AppCatalogChannel, preferences.BrowserUseConnectionMode, preferences.MinimizeAnimation, preferences.ShowAppDeveloperSources, preferences.WindowSnappingEnabled, preferences.WindowSnappingShortcutPreset, featureFlagsJSON, workbenchShortcutsJSON, now)
-	if err != nil {
-		return preferencesbiz.DesktopPreferences{}, fmt.Errorf("put desktop preferences: %w", err)
-	}
-
-	// Re-read after the write because the dedicated target-defaults or launch-mode
-	// patch may have committed between a full preferences caller's read and this
-	// update. The conflict clause deliberately preserves those columns, so
-	// returning the input object here would publish a stale snapshot.
-	return s.GetDesktopPreferences(ctx)
-}
-
 func (s *SQLiteStore) PatchAgentComposerDefaultsForTarget(
 	ctx context.Context,
 	agentTargetID string,
@@ -232,16 +130,6 @@ func (s *SQLiteStore) PatchAgentComposerDefaultsForTarget(
 		return preferencesbiz.AgentComposerDefaults{}, fmt.Errorf("begin agent composer defaults patch: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
-	defaultPreferences := preferencesbiz.DefaultDesktopPreferences()
-	if _, err := tx.ExecContext(ctx, `
-INSERT INTO desktop_preferences (
-  id, locale, theme_source, dock_icon_style, updated_at_unix_ms
-)
-VALUES (?, ?, ?, ?, ?)
-ON CONFLICT(id) DO NOTHING
-`, desktopPreferencesRowID, defaultPreferences.Locale, defaultPreferences.ThemeSource, defaultPreferences.DockIconStyle, unixMs(time.Now().UTC())); err != nil {
-		return preferencesbiz.AgentComposerDefaults{}, fmt.Errorf("initialize desktop preferences for agent composer defaults patch: %w", err)
-	}
 
 	var raw string
 	if err := tx.QueryRowContext(ctx, `
@@ -249,6 +137,9 @@ SELECT agent_composer_defaults_by_agent_target_json
 FROM desktop_preferences
 WHERE id = ?
 `, desktopPreferencesRowID).Scan(&raw); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return preferencesbiz.AgentComposerDefaults{}, fmt.Errorf("read agent composer defaults for patch: %w", ErrDesktopPreferencesNotInitialized)
+		}
 		return preferencesbiz.AgentComposerDefaults{}, fmt.Errorf("read agent composer defaults for patch: %w", err)
 	}
 	defaultsByTarget, err := decodeAgentComposerDefaultsByProvider(raw)
@@ -301,7 +192,7 @@ WHERE id = ?
 		return preferencesbiz.AgentComposerDefaults{}, fmt.Errorf("count agent composer defaults patch rows: %w", err)
 	}
 	if rows != 1 {
-		return preferencesbiz.AgentComposerDefaults{}, errors.New("desktop preferences row is not initialized")
+		return preferencesbiz.AgentComposerDefaults{}, ErrDesktopPreferencesNotInitialized
 	}
 	if err := tx.Commit(); err != nil {
 		return preferencesbiz.AgentComposerDefaults{}, fmt.Errorf("commit agent composer defaults patch: %w", err)
@@ -330,16 +221,6 @@ func (s *SQLiteStore) PatchAgentSessionLaunchMode(
 		return preferencesbiz.DesktopPreferences{}, fmt.Errorf("begin agent session launch mode patch: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
-	defaultPreferences := preferencesbiz.DefaultDesktopPreferences()
-	if _, err := tx.ExecContext(ctx, `
-INSERT INTO desktop_preferences (
-  id, locale, theme_source, dock_icon_style, updated_at_unix_ms
-)
-VALUES (?, ?, ?, ?, ?)
-ON CONFLICT(id) DO NOTHING
-`, desktopPreferencesRowID, defaultPreferences.Locale, defaultPreferences.ThemeSource, defaultPreferences.DockIconStyle, unixMs(time.Now().UTC())); err != nil {
-		return preferencesbiz.DesktopPreferences{}, fmt.Errorf("initialize desktop preferences for agent session launch mode patch: %w", err)
-	}
 
 	var raw string
 	if err := tx.QueryRowContext(ctx, `
@@ -347,6 +228,9 @@ SELECT agent_session_launch_modes_by_workspace_json
 FROM desktop_preferences
 WHERE id = ?
 `, desktopPreferencesRowID).Scan(&raw); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return preferencesbiz.DesktopPreferences{}, fmt.Errorf("read agent session launch modes for patch: %w", ErrDesktopPreferencesNotInitialized)
+		}
 		return preferencesbiz.DesktopPreferences{}, fmt.Errorf("read agent session launch modes for patch: %w", err)
 	}
 	modesByWorkspace, err := decodeAgentSessionLaunchModesByWorkspace(raw)
@@ -379,7 +263,7 @@ WHERE id = ?
 		return preferencesbiz.DesktopPreferences{}, fmt.Errorf("count agent session launch mode patch rows: %w", err)
 	}
 	if rows != 1 {
-		return preferencesbiz.DesktopPreferences{}, errors.New("desktop preferences row is not initialized")
+		return preferencesbiz.DesktopPreferences{}, ErrDesktopPreferencesNotInitialized
 	}
 	if err := tx.Commit(); err != nil {
 		return preferencesbiz.DesktopPreferences{}, fmt.Errorf("commit agent session launch mode patch: %w", err)

--- a/services/tuttid/data/workspace/sqlite_preferences_test.go
+++ b/services/tuttid/data/workspace/sqlite_preferences_test.go
@@ -2,8 +2,12 @@ package workspace
 
 import (
 	"context"
+	"errors"
+	"reflect"
+	"runtime"
 	"sync"
 	"testing"
+	"time"
 
 	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
 )
@@ -65,8 +69,8 @@ func TestSQLiteStoreGetDesktopPreferencesDefaultsWhenUnset(t *testing.T) {
 	if preferences.UpdatePolicy != "prompt" {
 		t.Fatalf("GetDesktopPreferences() updatePolicy = %q, want prompt", preferences.UpdatePolicy)
 	}
-	if preferences.UpdateChannel != "rc" {
-		t.Fatalf("GetDesktopPreferences() updateChannel = %q, want rc", preferences.UpdateChannel)
+	if preferences.UpdateChannel != "stable" {
+		t.Fatalf("GetDesktopPreferences() updateChannel = %q, want stable", preferences.UpdateChannel)
 	}
 }
 
@@ -190,6 +194,165 @@ func TestSQLiteStorePutDesktopPreferencesPersistsValue(t *testing.T) {
 		codexDefaults.PermissionModeID != "full-access" ||
 		codexDefaults.ReasoningEffort != "high" {
 		t.Fatalf("GetDesktopPreferences() codex composer defaults = %#v, want gpt-5/full-access/high", codexDefaults)
+	}
+}
+
+func TestSQLiteStoreInitializeDesktopPreferencesCreatesMissingRow(t *testing.T) {
+	t.Parallel()
+
+	store := openTestSQLiteStore(t)
+	candidate := preferencesbiz.DefaultDesktopPreferences()
+	candidate.Locale = "zh-CN"
+
+	stored, created, err := store.InitializeDesktopPreferences(context.Background(), candidate)
+	if err != nil {
+		t.Fatalf("InitializeDesktopPreferences() error = %v", err)
+	}
+	if !created {
+		t.Fatal("InitializeDesktopPreferences() created = false, want true")
+	}
+	if !stored.Initialized || stored.Locale != "zh-CN" {
+		t.Fatalf("stored preferences = %#v", stored)
+	}
+	if !stored.FeatureFlags[preferencesbiz.DesktopStandaloneAgentModeFeatureFlag] {
+		t.Fatalf("stored feature flags = %#v, want standalone Agent mode enabled", stored.FeatureFlags)
+	}
+}
+
+func TestSQLiteStoreInitializeDesktopPreferencesPreservesExistingLegacyRow(t *testing.T) {
+	t.Parallel()
+
+	store := openTestSQLiteStore(t)
+	ctx := context.Background()
+	existing := preferencesbiz.DefaultDesktopPreferences()
+	existing.FeatureFlags = map[string]bool{}
+	existing.Locale = "en"
+	existing.ThemeSource = "light"
+	if _, err := store.PutDesktopPreferences(ctx, existing); err != nil {
+		t.Fatalf("PutDesktopPreferences() error = %v", err)
+	}
+	candidate := preferencesbiz.DefaultDesktopPreferences()
+	candidate.Locale = "zh-CN"
+	candidate.ThemeSource = "dark"
+
+	stored, created, err := store.InitializeDesktopPreferences(ctx, candidate)
+	if err != nil {
+		t.Fatalf("InitializeDesktopPreferences() error = %v", err)
+	}
+	if created {
+		t.Fatal("InitializeDesktopPreferences() created = true, want false")
+	}
+	if stored.Locale != "en" || stored.ThemeSource != "light" {
+		t.Fatalf("stored locale/theme = %q/%q, want en/light", stored.Locale, stored.ThemeSource)
+	}
+	if len(stored.FeatureFlags) != 0 {
+		t.Fatalf("stored feature flags = %#v, want legacy empty flags", stored.FeatureFlags)
+	}
+}
+
+func TestSQLiteStoreInitializeDesktopPreferencesCommitsExactlyOneCompleteCandidateUnderConcurrentWriters(t *testing.T) {
+	t.Parallel()
+
+	store := openTestSQLiteStore(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	writerGate, err := store.writeDB.Conn(ctx)
+	if err != nil {
+		t.Fatalf("hold SQLite writer connection: %v", err)
+	}
+	gateReleased := false
+	releaseGate := func() {
+		if gateReleased {
+			return
+		}
+		gateReleased = true
+		if err := writerGate.Close(); err != nil {
+			t.Errorf("release SQLite writer connection: %v", err)
+		}
+	}
+	defer releaseGate()
+
+	candidateA := preferencesbiz.DefaultDesktopPreferences()
+	candidateA.Initialized = true
+	candidateA.Locale = "zh-CN"
+	candidateA.ThemeSource = "dark"
+	candidateA.FeatureFlags = map[string]bool{
+		preferencesbiz.DesktopStandaloneAgentModeFeatureFlag: true,
+		"test.candidate-a": true,
+	}
+	candidateB := preferencesbiz.DefaultDesktopPreferences()
+	candidateB.Initialized = true
+	candidateB.DockPlacement = "left"
+	candidateB.Locale = "en"
+	candidateB.ThemeSource = "light"
+	candidateB.FeatureFlags = map[string]bool{
+		preferencesbiz.DesktopStandaloneAgentModeFeatureFlag: false,
+		"test.candidate-b": true,
+	}
+	candidates := []preferencesbiz.DesktopPreferences{candidateA, candidateB}
+
+	type initializationResult struct {
+		created     bool
+		err         error
+		preferences preferencesbiz.DesktopPreferences
+	}
+	results := make(chan initializationResult, len(candidates))
+	var writers sync.WaitGroup
+	baselineWaitCount := store.writeDB.Stats().WaitCount
+	for _, candidate := range candidates {
+		candidate := candidate
+		writers.Add(1)
+		go func() {
+			defer writers.Done()
+			stored, created, err := store.InitializeDesktopPreferences(ctx, candidate)
+			results <- initializationResult{
+				created:     created,
+				err:         err,
+				preferences: stored,
+			}
+		}()
+	}
+
+	wantWaitCount := baselineWaitCount + int64(len(candidates))
+	for store.writeDB.Stats().WaitCount < wantWaitCount && ctx.Err() == nil {
+		runtime.Gosched()
+	}
+	queuedWaitCount := store.writeDB.Stats().WaitCount
+	releaseGate()
+	writers.Wait()
+	close(results)
+	if queuedWaitCount < wantWaitCount {
+		t.Fatalf("SQLite writer wait count = %d, want at least %d before gate release: %v", queuedWaitCount, wantWaitCount, ctx.Err())
+	}
+
+	createdCount := 0
+	var returned []preferencesbiz.DesktopPreferences
+	for result := range results {
+		if result.err != nil {
+			t.Fatalf("InitializeDesktopPreferences() error = %v", result.err)
+		}
+		if result.created {
+			createdCount++
+		}
+		returned = append(returned, result.preferences)
+	}
+	if createdCount != 1 {
+		t.Fatalf("created results = %d, want exactly 1", createdCount)
+	}
+	if len(returned) != len(candidates) || !reflect.DeepEqual(returned[0], returned[1]) {
+		t.Fatalf("returned preferences = %#v, want both writers to observe one canonical row", returned)
+	}
+
+	final, err := store.GetDesktopPreferences(context.Background())
+	if err != nil {
+		t.Fatalf("GetDesktopPreferences() error = %v", err)
+	}
+	if !reflect.DeepEqual(returned[0], final) {
+		t.Fatalf("returned preferences = %#v, final = %#v", returned[0], final)
+	}
+	if !reflect.DeepEqual(final, candidateA) && !reflect.DeepEqual(final, candidateB) {
+		t.Fatalf("final preferences = %#v, want one complete candidate without merging", final)
 	}
 }
 
@@ -428,28 +591,32 @@ func TestSQLiteStorePatchAgentComposerDefaultsForTargetMergesLatestFieldsAndPres
 	}
 }
 
-func TestSQLiteStorePatchAgentComposerDefaultsForTargetInitializesMissingPreferencesRow(t *testing.T) {
+func TestSQLiteStorePatchAgentComposerDefaultsForTargetRejectsMissingPreferencesRow(t *testing.T) {
 	t.Parallel()
 
 	store := openTestSQLiteStore(t)
 	model := "gpt-5"
-	if _, err := store.PatchAgentComposerDefaultsForTarget(context.Background(), "local:codex", preferencesbiz.AgentComposerDefaultsPatch{
+	_, err := store.PatchAgentComposerDefaultsForTarget(context.Background(), "local:codex", preferencesbiz.AgentComposerDefaultsPatch{
 		preferencesbiz.AgentComposerDefaultsFieldModel: &model,
-	}); err != nil {
-		t.Fatalf("PatchAgentComposerDefaultsForTarget() error = %v", err)
+	})
+	if !errors.Is(err, ErrDesktopPreferencesNotInitialized) {
+		t.Fatalf("PatchAgentComposerDefaultsForTarget() error = %v, want %v", err, ErrDesktopPreferencesNotInitialized)
 	}
-	got, err := store.GetDesktopPreferences(context.Background())
-	if err != nil {
-		t.Fatalf("GetDesktopPreferences() error = %v", err)
+	var rows int
+	if err := store.readDB.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM desktop_preferences`).Scan(&rows); err != nil {
+		t.Fatalf("count desktop preferences rows: %v", err)
 	}
-	if !got.Initialized || got.AgentComposerDefaultsByAgentTarget["local:codex"].Model != model {
-		t.Fatalf("preferences = %#v", got)
+	if rows != 0 {
+		t.Fatalf("desktop preferences rows = %d, want 0", rows)
 	}
 }
 
 func TestSQLiteStorePatchAgentComposerDefaultsForTargetPersistsCodexSaverMode(t *testing.T) {
 	t.Parallel()
 	store := openTestSQLiteStore(t)
+	if _, err := store.PutDesktopPreferences(context.Background(), preferencesbiz.DefaultDesktopPreferences()); err != nil {
+		t.Fatalf("PutDesktopPreferences() error = %v", err)
+	}
 	if _, err := store.PatchAgentComposerDefaultsForTarget(context.Background(), "local:codex", preferencesbiz.AgentComposerDefaultsPatch{
 		preferencesbiz.AgentComposerDefaultsFieldCodexSaverMode: true,
 	}); err != nil {
@@ -480,6 +647,9 @@ func TestSQLiteStorePatchAgentComposerDefaultsForTargetSerializesConcurrentField
 	t.Parallel()
 
 	store := openTestSQLiteStore(t)
+	if _, err := store.PutDesktopPreferences(context.Background(), preferencesbiz.DefaultDesktopPreferences()); err != nil {
+		t.Fatalf("PutDesktopPreferences() error = %v", err)
+	}
 	permission := "full-access"
 	model := "gpt-5"
 	patches := []preferencesbiz.AgentComposerDefaultsPatch{
@@ -569,6 +739,28 @@ func TestSQLiteStorePatchAgentSessionLaunchModeSerializesConcurrentProjectsAndRe
 	}
 	if got.Locale != "zh-CN" {
 		t.Fatalf("locale = %q, want zh-CN", got.Locale)
+	}
+}
+
+func TestSQLiteStorePatchAgentSessionLaunchModeRejectsMissingPreferencesRow(t *testing.T) {
+	t.Parallel()
+
+	store := openTestSQLiteStore(t)
+	_, err := store.PatchAgentSessionLaunchMode(
+		context.Background(),
+		"workspace-a",
+		"project:/alpha",
+		"worktree",
+	)
+	if !errors.Is(err, ErrDesktopPreferencesNotInitialized) {
+		t.Fatalf("PatchAgentSessionLaunchMode() error = %v, want %v", err, ErrDesktopPreferencesNotInitialized)
+	}
+	var rows int
+	if err := store.readDB.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM desktop_preferences`).Scan(&rows); err != nil {
+		t.Fatalf("count desktop preferences rows: %v", err)
+	}
+	if rows != 0 {
+		t.Fatalf("desktop preferences rows = %d, want 0", rows)
 	}
 }
 

--- a/services/tuttid/data/workspace/sqlite_preferences_write.go
+++ b/services/tuttid/data/workspace/sqlite_preferences_write.go
@@ -1,0 +1,222 @@
+package workspace
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
+)
+
+const desktopPreferencesInsertSQL = `
+INSERT INTO desktop_preferences (
+  id,
+  agent_cli_update_check_enabled,
+  default_agent_provider,
+  agent_conversation_detail_mode,
+  agent_dock_layout,
+  dock_icon_style,
+  dock_placement,
+  deleted_agent_conversation_retention_days,
+  locale,
+  theme_source,
+  sleep_prevention_mode,
+  update_channel,
+  update_policy,
+  agent_composer_defaults_by_provider_json,
+  agent_composer_defaults_by_agent_target_json,
+  agent_gui_conversation_rail_collapsed_by_provider_json,
+  agent_session_launch_modes_by_workspace_json,
+  file_default_openers_by_extension_json,
+  app_catalog_channel,
+  browser_use_connection_mode,
+  minimize_animation,
+  show_app_developer_sources,
+  workbench_window_snapping_enabled,
+  workbench_window_snapping_shortcut_preset,
+  feature_flags_json,
+  workbench_shortcuts_json,
+  updated_at_unix_ms
+)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+`
+
+const desktopPreferencesReplaceOnConflictSQL = `
+ON CONFLICT(id) DO UPDATE SET
+  agent_cli_update_check_enabled = excluded.agent_cli_update_check_enabled,
+  default_agent_provider = excluded.default_agent_provider,
+  agent_conversation_detail_mode = excluded.agent_conversation_detail_mode,
+  agent_dock_layout = excluded.agent_dock_layout,
+  dock_icon_style = excluded.dock_icon_style,
+  dock_placement = excluded.dock_placement,
+  deleted_agent_conversation_retention_days = excluded.deleted_agent_conversation_retention_days,
+  locale = excluded.locale,
+  theme_source = excluded.theme_source,
+  sleep_prevention_mode = excluded.sleep_prevention_mode,
+  update_channel = excluded.update_channel,
+  update_policy = excluded.update_policy,
+  agent_composer_defaults_by_provider_json = excluded.agent_composer_defaults_by_provider_json,
+  agent_gui_conversation_rail_collapsed_by_provider_json = excluded.agent_gui_conversation_rail_collapsed_by_provider_json,
+  file_default_openers_by_extension_json = excluded.file_default_openers_by_extension_json,
+  app_catalog_channel = excluded.app_catalog_channel,
+  browser_use_connection_mode = excluded.browser_use_connection_mode,
+  minimize_animation = excluded.minimize_animation,
+  show_app_developer_sources = excluded.show_app_developer_sources,
+  workbench_window_snapping_enabled = excluded.workbench_window_snapping_enabled,
+  workbench_window_snapping_shortcut_preset = excluded.workbench_window_snapping_shortcut_preset,
+  feature_flags_json = excluded.feature_flags_json,
+  workbench_shortcuts_json = excluded.workbench_shortcuts_json,
+  updated_at_unix_ms = excluded.updated_at_unix_ms
+`
+
+type desktopPreferencesExecer interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
+
+type encodedDesktopPreferences struct {
+	agentComposerDefaultsJSON              string
+	agentComposerDefaultsByAgentTargetJSON string
+	agentGUIConversationRailCollapsedJSON  string
+	agentSessionLaunchModesJSON            string
+	featureFlagsJSON                       string
+	fileDefaultOpenersJSON                 string
+	workbenchShortcutsJSON                 string
+}
+
+func (s *SQLiteStore) PutDesktopPreferences(ctx context.Context, preferences preferencesbiz.DesktopPreferences) (preferencesbiz.DesktopPreferences, error) {
+	if s == nil || s.writeDB == nil {
+		return preferencesbiz.DesktopPreferences{}, errors.New("workspace database is not initialized")
+	}
+
+	if _, err := writeDesktopPreferences(ctx, s.writeDB, preferences, desktopPreferencesReplaceOnConflictSQL); err != nil {
+		return preferencesbiz.DesktopPreferences{}, fmt.Errorf("put desktop preferences: %w", err)
+	}
+
+	// Re-read after the write because the dedicated target-defaults or launch-mode
+	// patch may have committed between a full preferences caller's read and this
+	// update. The conflict clause deliberately preserves those columns, so
+	// returning the input object here would publish a stale snapshot.
+	return s.GetDesktopPreferences(ctx)
+}
+
+func (s *SQLiteStore) InitializeDesktopPreferences(
+	ctx context.Context,
+	preferences preferencesbiz.DesktopPreferences,
+) (preferencesbiz.DesktopPreferences, bool, error) {
+	if s == nil || s.writeDB == nil {
+		return preferencesbiz.DesktopPreferences{}, false, errors.New("workspace database is not initialized")
+	}
+
+	tx, err := s.writeDB.BeginTx(ctx, nil)
+	if err != nil {
+		return preferencesbiz.DesktopPreferences{}, false, fmt.Errorf("begin desktop preferences initialization: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	created, err := insertDesktopPreferencesIfAbsent(ctx, tx, preferences)
+	if err != nil {
+		return preferencesbiz.DesktopPreferences{}, false, fmt.Errorf("initialize desktop preferences: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return preferencesbiz.DesktopPreferences{}, false, fmt.Errorf("commit desktop preferences initialization: %w", err)
+	}
+	stored, err := s.GetDesktopPreferences(ctx)
+	if err != nil {
+		return preferencesbiz.DesktopPreferences{}, false, fmt.Errorf("read initialized desktop preferences: %w", err)
+	}
+	return stored, created, nil
+}
+
+func insertDesktopPreferencesIfAbsent(
+	ctx context.Context,
+	execer desktopPreferencesExecer,
+	preferences preferencesbiz.DesktopPreferences,
+) (bool, error) {
+	result, err := writeDesktopPreferences(ctx, execer, preferences, "ON CONFLICT(id) DO NOTHING")
+	if err != nil {
+		return false, err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("count initialized desktop preferences rows: %w", err)
+	}
+	return rows == 1, nil
+}
+
+func writeDesktopPreferences(
+	ctx context.Context,
+	execer desktopPreferencesExecer,
+	preferences preferencesbiz.DesktopPreferences,
+	conflictSQL string,
+) (sql.Result, error) {
+	encoded, err := encodeDesktopPreferences(preferences)
+	if err != nil {
+		return nil, err
+	}
+	return execer.ExecContext(
+		ctx,
+		desktopPreferencesInsertSQL+conflictSQL,
+		desktopPreferencesRowID,
+		preferences.AgentCLIUpdateCheckEnabled,
+		preferences.DefaultAgentProvider,
+		preferencesbiz.NormalizeDesktopAgentConversationDetailMode(preferences.AgentConversationDetailMode),
+		preferencesbiz.NormalizeDesktopAgentDockLayout(preferences.AgentDockLayout),
+		preferences.DockIconStyle,
+		preferences.DockPlacement,
+		preferencesbiz.NormalizeDeletedAgentConversationRetentionDays(preferences.DeletedAgentConversationRetentionDays),
+		preferences.Locale,
+		preferences.ThemeSource,
+		preferences.SleepPreventionMode,
+		preferences.UpdateChannel,
+		preferences.UpdatePolicy,
+		encoded.agentComposerDefaultsJSON,
+		encoded.agentComposerDefaultsByAgentTargetJSON,
+		encoded.agentGUIConversationRailCollapsedJSON,
+		encoded.agentSessionLaunchModesJSON,
+		encoded.fileDefaultOpenersJSON,
+		preferences.AppCatalogChannel,
+		preferences.BrowserUseConnectionMode,
+		preferences.MinimizeAnimation,
+		preferences.ShowAppDeveloperSources,
+		preferences.WindowSnappingEnabled,
+		preferences.WindowSnappingShortcutPreset,
+		encoded.featureFlagsJSON,
+		encoded.workbenchShortcutsJSON,
+		unixMs(time.Now().UTC()),
+	)
+}
+
+func encodeDesktopPreferences(preferences preferencesbiz.DesktopPreferences) (encodedDesktopPreferences, error) {
+	var encoded encodedDesktopPreferences
+	var err error
+	encoded.agentComposerDefaultsJSON, err = encodeAgentComposerDefaultsByProvider(preferences.AgentComposerDefaultsByProvider)
+	if err != nil {
+		return encoded, fmt.Errorf("encode desktop preferences agent composer defaults: %w", err)
+	}
+	encoded.agentComposerDefaultsByAgentTargetJSON, err = encodeAgentComposerDefaultsByProvider(preferences.AgentComposerDefaultsByAgentTarget)
+	if err != nil {
+		return encoded, fmt.Errorf("encode desktop preferences agent composer defaults by agent target: %w", err)
+	}
+	encoded.agentGUIConversationRailCollapsedJSON, err = encodeAgentGUIConversationRailCollapsedByProvider(preferences.AgentGUIConversationRailCollapsedByProvider)
+	if err != nil {
+		return encoded, fmt.Errorf("encode desktop preferences agent gui conversation rail: %w", err)
+	}
+	encoded.agentSessionLaunchModesJSON, err = encodeAgentSessionLaunchModesByWorkspace(preferences.AgentSessionLaunchModesByWorkspace)
+	if err != nil {
+		return encoded, fmt.Errorf("encode desktop preferences Agent Session launch modes: %w", err)
+	}
+	encoded.fileDefaultOpenersJSON, err = encodeFileDefaultOpenersByExtension(preferences.FileDefaultOpenersByExtension)
+	if err != nil {
+		return encoded, fmt.Errorf("encode desktop preferences file default openers: %w", err)
+	}
+	encoded.featureFlagsJSON, err = encodeFeatureFlags(preferences.FeatureFlags)
+	if err != nil {
+		return encoded, fmt.Errorf("encode desktop preferences feature flags: %w", err)
+	}
+	encoded.workbenchShortcutsJSON, err = encodeWorkbenchShortcuts(preferences.WorkbenchShortcuts)
+	if err != nil {
+		return encoded, fmt.Errorf("encode desktop preferences workbench shortcuts: %w", err)
+	}
+	return encoded, nil
+}

--- a/services/tuttid/data/workspace/store.go
+++ b/services/tuttid/data/workspace/store.go
@@ -23,6 +23,7 @@ import (
 )
 
 var ErrWorkspaceNotFound = errors.New("workspace not found")
+var ErrDesktopPreferencesNotInitialized = errors.New("desktop preferences are not initialized")
 var ErrWorkbenchSnapshotNotFound = errors.New("workspace workbench snapshot not found")
 var ErrWorkspaceAppNotFound = errors.New("workspace app not found")
 var ErrWorkspaceAppFactoryJobNotFound = errors.New("workspace app factory job not found")
@@ -112,6 +113,10 @@ type AgentQuickPromptStore interface {
 type PreferencesStore interface {
 	GetDesktopPreferences(context.Context) (preferencesbiz.DesktopPreferences, error)
 	PutDesktopPreferences(context.Context, preferencesbiz.DesktopPreferences) (preferencesbiz.DesktopPreferences, error)
+}
+
+type DesktopPreferencesInitializer interface {
+	InitializeDesktopPreferences(context.Context, preferencesbiz.DesktopPreferences) (preferencesbiz.DesktopPreferences, bool, error)
 }
 
 // AgentProviderRuntimeSelectionStore persists an explicit local runtime choice.

--- a/services/tuttid/integration/desktop_preferences_initialization_test.go
+++ b/services/tuttid/integration/desktop_preferences_initialization_test.go
@@ -1,0 +1,112 @@
+package integration_test
+
+import (
+	"net/http"
+	"testing"
+
+	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
+)
+
+const standaloneAgentModeFeatureFlag = "workspace.standaloneAgentMode"
+
+func TestDesktopPreferencesInitializeIfAbsentAppliesDaemonFreshModeDefault(t *testing.T) {
+	testCases := []struct {
+		featureFlags tuttigenerated.DesktopFeatureFlags
+		name         string
+	}{
+		{name: "missing mode flag", featureFlags: tuttigenerated.DesktopFeatureFlags{}},
+		{name: "explicit false mode flag", featureFlags: tuttigenerated.DesktopFeatureFlags{standaloneAgentModeFeatureFlag: false}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			daemon := startTestDaemon(t)
+			initial := mustRequestJSON[tuttigenerated.DesktopPreferencesStateResponse](
+				t,
+				daemon,
+				http.MethodGet,
+				"/v1/preferences/desktop",
+				nil,
+				http.StatusOK,
+			)
+			if initial.Initialized {
+				t.Fatal("initial desktop preferences initialized = true, want false")
+			}
+
+			initial.Preferences.FeatureFlags = testCase.featureFlags
+			writeMode := tuttigenerated.DesktopPreferencesWriteModeInitializeIfAbsent
+			initialized := mustRequestJSON[tuttigenerated.DesktopPreferencesStateResponse](
+				t,
+				daemon,
+				http.MethodPut,
+				"/v1/preferences/desktop",
+				tuttigenerated.PutDesktopPreferencesRequest{
+					Preferences: initial.Preferences,
+					WriteMode:   &writeMode,
+				},
+				http.StatusOK,
+			)
+			if !initialized.Initialized {
+				t.Fatal("initialized desktop preferences initialized = false, want true")
+			}
+			if !initialized.Preferences.FeatureFlags[standaloneAgentModeFeatureFlag] {
+				t.Fatalf("initialized feature flags = %#v, want Agent mode", initialized.Preferences.FeatureFlags)
+			}
+
+			stored := mustRequestJSON[tuttigenerated.DesktopPreferencesStateResponse](
+				t,
+				daemon,
+				http.MethodGet,
+				"/v1/preferences/desktop",
+				nil,
+				http.StatusOK,
+			)
+			if !stored.Preferences.FeatureFlags[standaloneAgentModeFeatureFlag] {
+				t.Fatalf("stored feature flags = %#v, want Agent mode", stored.Preferences.FeatureFlags)
+			}
+		})
+	}
+}
+
+func TestDesktopPreferencesInitializeIfAbsentPreservesExistingOSMode(t *testing.T) {
+	daemon := startTestDaemon(t)
+	initial := mustRequestJSON[tuttigenerated.DesktopPreferencesStateResponse](
+		t,
+		daemon,
+		http.MethodGet,
+		"/v1/preferences/desktop",
+		nil,
+		http.StatusOK,
+	)
+	initial.Preferences.FeatureFlags = tuttigenerated.DesktopFeatureFlags{
+		standaloneAgentModeFeatureFlag: false,
+	}
+	mustRequestJSON[tuttigenerated.DesktopPreferencesStateResponse](
+		t,
+		daemon,
+		http.MethodPut,
+		"/v1/preferences/desktop",
+		tuttigenerated.PutDesktopPreferencesRequest{Preferences: initial.Preferences},
+		http.StatusOK,
+	)
+
+	candidate := initial.Preferences
+	candidate.FeatureFlags = tuttigenerated.DesktopFeatureFlags{
+		standaloneAgentModeFeatureFlag: true,
+	}
+	writeMode := tuttigenerated.DesktopPreferencesWriteModeInitializeIfAbsent
+	stored := mustRequestJSON[tuttigenerated.DesktopPreferencesStateResponse](
+		t,
+		daemon,
+		http.MethodPut,
+		"/v1/preferences/desktop",
+		tuttigenerated.PutDesktopPreferencesRequest{
+			Preferences: candidate,
+			WriteMode:   &writeMode,
+		},
+		http.StatusOK,
+	)
+	if stored.Preferences.FeatureFlags[standaloneAgentModeFeatureFlag] {
+		t.Fatalf("stored feature flags = %#v, want existing OS mode", stored.Preferences.FeatureFlags)
+	}
+}

--- a/services/tuttid/service/preferences/service.go
+++ b/services/tuttid/service/preferences/service.go
@@ -8,6 +8,8 @@ import (
 	agentproviderbiz "github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
 	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
+	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
+	reporterevents "github.com/tutti-os/tutti/services/tuttid/service/reporter/events"
 )
 
 type DesktopPreferencesPublisher interface {
@@ -33,6 +35,7 @@ type Service struct {
 	Publisher                      DesktopPreferencesPublisher
 	AgentComposerDefaultsPublisher AgentComposerDefaultsPublisher
 	AgentComposerDefaultsValidator AgentComposerDefaultsPatchValidator
+	AnalyticsReporter              reporterservice.Reporter
 	changeObservers                []ChangeObserver
 }
 
@@ -55,7 +58,16 @@ type PatchAgentSessionLaunchModeInput struct {
 	Mode              string
 }
 
+type DesktopPreferencesWriteMode string
+
+const (
+	DesktopPreferencesWriteModeReplace            DesktopPreferencesWriteMode = "replace"
+	DesktopPreferencesWriteModeInitializeIfAbsent DesktopPreferencesWriteMode = "initializeIfAbsent"
+)
+
 type PutInput struct {
+	WriteMode DesktopPreferencesWriteMode
+
 	AgentCLIUpdateCheckEnabled bool
 	// AgentComposerDefaultsByProvider is accepted for wire compatibility but
 	// ignored on write: the legacy provider-keyed defaults are frozen after
@@ -194,13 +206,21 @@ func (s Service) Put(ctx context.Context, input PutInput) (preferencesbiz.Deskto
 		return preferencesbiz.DesktopPreferences{}, errors.New("desktop preferences store is not configured")
 	}
 
+	writeMode := input.WriteMode
+	if writeMode == "" {
+		writeMode = DesktopPreferencesWriteModeReplace
+	}
+	if writeMode != DesktopPreferencesWriteModeReplace && writeMode != DesktopPreferencesWriteModeInitializeIfAbsent {
+		return preferencesbiz.DesktopPreferences{}, errors.New("desktop preferences write mode is unsupported")
+	}
+
 	stored, err := s.Store.GetDesktopPreferences(ctx)
 	if err != nil {
 		return preferencesbiz.DesktopPreferences{}, err
 	}
 
 	windowSnapping := resolveWindowSnapping(stored, input.WindowSnapping)
-	preferences, err := s.Store.PutDesktopPreferences(ctx, preferencesbiz.DesktopPreferences{
+	candidate := preferencesbiz.DesktopPreferences{
 		AgentCLIUpdateCheckEnabled: input.AgentCLIUpdateCheckEnabled,
 		// The legacy provider-keyed defaults are frozen: client input is
 		// ignored so nothing writes the old field anymore; the stored value
@@ -235,7 +255,36 @@ func (s Service) Put(ctx context.Context, input PutInput) (preferencesbiz.Deskto
 		UpdatePolicy:                          strings.TrimSpace(input.UpdatePolicy),
 		WindowSnappingEnabled:                 windowSnapping.Enabled,
 		WindowSnappingShortcutPreset:          windowSnapping.ShortcutPreset,
-	})
+	}
+
+	var preferences preferencesbiz.DesktopPreferences
+	if writeMode == DesktopPreferencesWriteModeInitializeIfAbsent {
+		// Callers provide the complete candidate row, but tuttid owns the
+		// workspace-mode policy for a freshly created profile.
+		freshDefaults := preferencesbiz.DefaultDesktopPreferences()
+		candidate.FeatureFlags[preferencesbiz.DesktopStandaloneAgentModeFeatureFlag] =
+			freshDefaults.FeatureFlags[preferencesbiz.DesktopStandaloneAgentModeFeatureFlag]
+		initializer, ok := s.Store.(workspacedata.DesktopPreferencesInitializer)
+		if !ok {
+			return preferencesbiz.DesktopPreferences{}, errors.New("desktop preferences initializer is not configured")
+		}
+		var created bool
+		preferences, created, err = initializer.InitializeDesktopPreferences(ctx, candidate)
+		if err != nil {
+			return preferencesbiz.DesktopPreferences{}, err
+		}
+		if !created {
+			return preferences, nil
+		}
+		// Every fresh-profile row is created through this branch (the field
+		// patch writers refuse to materialize a missing row), so this is the
+		// single spot that can attribute the assigned initial workspace mode.
+		reporterevents.Track(ctx, s.AnalyticsReporter, "settings.workspace_ui_mode_initialized", map[string]any{
+			"workspace_ui_mode": workspaceUiModeAnalyticsValue(preferences),
+		})
+	} else {
+		preferences, err = s.Store.PutDesktopPreferences(ctx, candidate)
+	}
 	if err != nil {
 		return preferencesbiz.DesktopPreferences{}, err
 	}
@@ -246,6 +295,13 @@ func (s Service) Put(ctx context.Context, input PutInput) (preferencesbiz.Deskto
 		_ = s.Publisher.PublishDesktopPreferencesUpdated(ctx, preferences)
 	}
 	return preferences, nil
+}
+
+func workspaceUiModeAnalyticsValue(preferences preferencesbiz.DesktopPreferences) string {
+	if preferences.FeatureFlags[preferencesbiz.DesktopStandaloneAgentModeFeatureFlag] {
+		return "agent"
+	}
+	return "os"
 }
 
 func normalizeAgentComposerDefaultsPatch(

--- a/services/tuttid/service/preferences/service_test.go
+++ b/services/tuttid/service/preferences/service_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
+	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
+	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
 )
 
 type preferencesStoreStub struct {
@@ -13,17 +15,33 @@ type preferencesStoreStub struct {
 	patchAgentTarget             string
 	patchInput                   preferencesbiz.AgentComposerDefaultsPatch
 	patchResult                  preferencesbiz.AgentComposerDefaults
+	patchErr                     error
 	patchLaunchWorkspaceID       string
 	patchLaunchProjectSectionKey string
 	patchLaunchMode              string
 	patchLaunchResult            preferencesbiz.DesktopPreferences
+	patchLaunchErr               error
 	putInput                     preferencesbiz.DesktopPreferences
+	initializeInput              preferencesbiz.DesktopPreferences
+	initializeResult             preferencesbiz.DesktopPreferences
+	initializeCreated            bool
+	initializeErr                error
 }
 
 type preferencesPublisherStub struct {
 	published []preferencesbiz.DesktopPreferences
 	err       error
 }
+
+type analyticsReporterStub struct {
+	events []reporterservice.Event
+}
+
+func (s *analyticsReporterStub) Track(_ context.Context, events ...reporterservice.Event) {
+	s.events = append(s.events, events...)
+}
+
+func (*analyticsReporterStub) Close() error { return nil }
 
 func (s preferencesStoreStub) GetDesktopPreferences(context.Context) (preferencesbiz.DesktopPreferences, error) {
 	return s.getResult, nil
@@ -34,17 +52,22 @@ func (s *preferencesStoreStub) PutDesktopPreferences(_ context.Context, preferen
 	return preferences, nil
 }
 
+func (s *preferencesStoreStub) InitializeDesktopPreferences(_ context.Context, preferences preferencesbiz.DesktopPreferences) (preferencesbiz.DesktopPreferences, bool, error) {
+	s.initializeInput = preferences
+	return s.initializeResult, s.initializeCreated, s.initializeErr
+}
+
 func (s *preferencesStoreStub) PatchAgentComposerDefaultsForTarget(_ context.Context, agentTargetID string, patch preferencesbiz.AgentComposerDefaultsPatch) (preferencesbiz.AgentComposerDefaults, error) {
 	s.patchAgentTarget = agentTargetID
 	s.patchInput = patch
-	return s.patchResult, nil
+	return s.patchResult, s.patchErr
 }
 
 func (s *preferencesStoreStub) PatchAgentSessionLaunchMode(_ context.Context, workspaceID string, projectSectionKey string, mode string) (preferencesbiz.DesktopPreferences, error) {
 	s.patchLaunchWorkspaceID = workspaceID
 	s.patchLaunchProjectSectionKey = projectSectionKey
 	s.patchLaunchMode = mode
-	return s.patchLaunchResult, nil
+	return s.patchLaunchResult, s.patchLaunchErr
 }
 
 type agentComposerDefaultsValidatorStub struct {
@@ -165,6 +188,177 @@ func TestServicePutNotifiesChangeObserversWithPreviousAndCurrentPreferences(t *t
 	}
 }
 
+func TestServicePutInitializeIfAbsentPublishesOnlyCreatedInitialization(t *testing.T) {
+	stored := preferencesbiz.DefaultDesktopPreferences()
+	initialized := stored
+	initialized.Initialized = true
+	store := &preferencesStoreStub{
+		getResult:         stored,
+		initializeResult:  initialized,
+		initializeCreated: true,
+	}
+	publisher := &preferencesPublisherStub{}
+	service := Service{Store: store, Publisher: publisher}
+	observed := 0
+	service.RegisterChangeObserver(func(_ context.Context, before, after preferencesbiz.DesktopPreferences) {
+		observed++
+		if before.Initialized {
+			t.Fatal("observer previous preferences initialized = true, want false")
+		}
+		if !after.Initialized {
+			t.Fatal("observer current preferences initialized = false, want true")
+		}
+	})
+
+	preferences, err := service.Put(context.Background(), PutInput{
+		WriteMode: DesktopPreferencesWriteModeInitializeIfAbsent,
+		FeatureFlags: map[string]bool{
+			preferencesbiz.DesktopStandaloneAgentModeFeatureFlag: false,
+			"agent.extension.gemini":                             true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	if !preferences.Initialized {
+		t.Fatal("Put() initialized = false, want true")
+	}
+	if !store.initializeInput.Initialized {
+		t.Fatal("InitializeDesktopPreferences() candidate initialized = false, want true")
+	}
+	if !store.initializeInput.FeatureFlags[preferencesbiz.DesktopStandaloneAgentModeFeatureFlag] {
+		t.Fatalf("InitializeDesktopPreferences() feature flags = %#v, want Agent mode", store.initializeInput.FeatureFlags)
+	}
+	if !store.initializeInput.FeatureFlags["agent.extension.gemini"] {
+		t.Fatalf("InitializeDesktopPreferences() feature flags = %#v, want unrelated flags preserved", store.initializeInput.FeatureFlags)
+	}
+	if store.putInput.Initialized {
+		t.Fatal("PutDesktopPreferences() was called for initialize-if-absent write")
+	}
+	if observed != 1 {
+		t.Fatalf("observer calls = %d, want 1", observed)
+	}
+	if len(publisher.published) != 1 {
+		t.Fatalf("published preferences = %d, want 1", len(publisher.published))
+	}
+}
+
+func TestServicePutInitializeIfAbsentReturnsExistingPreferencesWithoutPublishing(t *testing.T) {
+	existing := preferencesbiz.DefaultDesktopPreferences()
+	existing.Initialized = true
+	existing.FeatureFlags = map[string]bool{preferencesbiz.DesktopStandaloneAgentModeFeatureFlag: false}
+	store := &preferencesStoreStub{
+		getResult:         preferencesbiz.DefaultDesktopPreferences(),
+		initializeResult:  existing,
+		initializeCreated: false,
+	}
+	publisher := &preferencesPublisherStub{}
+	service := Service{Store: store, Publisher: publisher}
+	observed := 0
+	service.RegisterChangeObserver(func(context.Context, preferencesbiz.DesktopPreferences, preferencesbiz.DesktopPreferences) {
+		observed++
+	})
+
+	preferences, err := service.Put(context.Background(), PutInput{
+		WriteMode:    DesktopPreferencesWriteModeInitializeIfAbsent,
+		FeatureFlags: map[string]bool{preferencesbiz.DesktopStandaloneAgentModeFeatureFlag: true},
+	})
+	if err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	if preferences.FeatureFlags[preferencesbiz.DesktopStandaloneAgentModeFeatureFlag] {
+		t.Fatalf("Put() feature flags = %#v, want existing OS mode", preferences.FeatureFlags)
+	}
+	if observed != 0 {
+		t.Fatalf("observer calls = %d, want 0", observed)
+	}
+	if len(publisher.published) != 0 {
+		t.Fatalf("published preferences = %d, want 0", len(publisher.published))
+	}
+}
+
+func TestServicePutReportsWorkspaceUiModeInitializedOnlyOnCreation(t *testing.T) {
+	t.Parallel()
+
+	initialized := preferencesbiz.DefaultDesktopPreferences()
+	initialized.Initialized = true
+
+	t.Run("created initialization reports the assigned mode once", func(t *testing.T) {
+		t.Parallel()
+		store := &preferencesStoreStub{
+			getResult:         preferencesbiz.DefaultDesktopPreferences(),
+			initializeResult:  initialized,
+			initializeCreated: true,
+		}
+		reporter := &analyticsReporterStub{}
+		service := Service{Store: store, AnalyticsReporter: reporter}
+		if _, err := service.Put(context.Background(), PutInput{
+			WriteMode: DesktopPreferencesWriteModeInitializeIfAbsent,
+			FeatureFlags: map[string]bool{
+				preferencesbiz.DesktopStandaloneAgentModeFeatureFlag: false,
+			},
+		}); err != nil {
+			t.Fatalf("Put() error = %v", err)
+		}
+		if len(reporter.events) != 1 {
+			t.Fatalf("tracked events = %d, want 1", len(reporter.events))
+		}
+		event := reporter.events[0]
+		if event.Name != "settings.workspace_ui_mode_initialized" {
+			t.Fatalf("event name = %q, want settings.workspace_ui_mode_initialized", event.Name)
+		}
+		// The mode derives from the authoritative stored row, not the caller
+		// input: daemon policy owns the fresh default.
+		if got := event.Params["workspace_ui_mode"]; got != "agent" {
+			t.Fatalf("workspace_ui_mode = %v, want agent", got)
+		}
+	})
+
+	t.Run("existing row initialization reports nothing", func(t *testing.T) {
+		t.Parallel()
+		store := &preferencesStoreStub{
+			getResult:         initialized,
+			initializeResult:  initialized,
+			initializeCreated: false,
+		}
+		reporter := &analyticsReporterStub{}
+		service := Service{Store: store, AnalyticsReporter: reporter}
+		if _, err := service.Put(context.Background(), PutInput{
+			WriteMode: DesktopPreferencesWriteModeInitializeIfAbsent,
+		}); err != nil {
+			t.Fatalf("Put() error = %v", err)
+		}
+		if len(reporter.events) != 0 {
+			t.Fatalf("tracked events = %d, want 0", len(reporter.events))
+		}
+	})
+
+	t.Run("replace write reports nothing", func(t *testing.T) {
+		t.Parallel()
+		store := &preferencesStoreStub{getResult: initialized}
+		reporter := &analyticsReporterStub{}
+		service := Service{Store: store, AnalyticsReporter: reporter}
+		if _, err := service.Put(context.Background(), PutInput{
+			WriteMode: DesktopPreferencesWriteModeReplace,
+		}); err != nil {
+			t.Fatalf("Put() error = %v", err)
+		}
+		if len(reporter.events) != 0 {
+			t.Fatalf("tracked events = %d, want 0", len(reporter.events))
+		}
+	})
+}
+
+func TestServicePutRejectsUnsupportedWriteMode(t *testing.T) {
+	t.Parallel()
+
+	service := Service{Store: &preferencesStoreStub{}}
+	_, err := service.Put(context.Background(), PutInput{WriteMode: "merge"})
+	if err == nil {
+		t.Fatal("Put() error = nil, want unsupported write mode error")
+	}
+}
+
 func TestServicePutPreservesAgentSessionLaunchModesWhenFieldIsOmitted(t *testing.T) {
 	t.Parallel()
 
@@ -231,6 +425,30 @@ func TestServicePatchAgentSessionLaunchModeUsesDedicatedStoreAndPublishes(t *tes
 	}
 	if len(publisher.published) != 1 || publisher.published[0].AgentSessionLaunchModesByWorkspace["workspace-a"]["project:/alpha"] != "worktree" {
 		t.Fatalf("published preferences = %#v", publisher.published)
+	}
+}
+
+func TestServicePatchAgentSessionLaunchModeDoesNotPublishOrObserveStoreFailure(t *testing.T) {
+	t.Parallel()
+
+	store := &preferencesStoreStub{patchLaunchErr: workspacedata.ErrDesktopPreferencesNotInitialized}
+	publisher := &preferencesPublisherStub{}
+	observed := 0
+	service := Service{Store: store, Publisher: publisher}
+	service.RegisterChangeObserver(func(context.Context, preferencesbiz.DesktopPreferences, preferencesbiz.DesktopPreferences) {
+		observed++
+	})
+
+	_, err := service.PatchAgentSessionLaunchMode(context.Background(), PatchAgentSessionLaunchModeInput{
+		WorkspaceID:       "workspace-a",
+		ProjectSectionKey: "project:/alpha",
+		Mode:              "worktree",
+	})
+	if !errors.Is(err, workspacedata.ErrDesktopPreferencesNotInitialized) {
+		t.Fatalf("PatchAgentSessionLaunchMode() error = %v, want %v", err, workspacedata.ErrDesktopPreferencesNotInitialized)
+	}
+	if len(publisher.published) != 0 || observed != 0 {
+		t.Fatalf("side effects published=%d observed=%d, want none", len(publisher.published), observed)
 	}
 }
 
@@ -673,6 +891,33 @@ func TestServicePatchAgentComposerDefaultsForTargetValidatesStoresAndInvalidates
 	}
 	if len(publisher.agentTargetIDs) != 1 || publisher.agentTargetIDs[0] != "local:codex" {
 		t.Fatalf("invalidations = %#v", publisher.agentTargetIDs)
+	}
+}
+
+func TestServicePatchAgentComposerDefaultsForTargetDoesNotPublishStoreFailure(t *testing.T) {
+	t.Parallel()
+
+	store := &preferencesStoreStub{patchErr: workspacedata.ErrDesktopPreferencesNotInitialized}
+	validator := &agentComposerDefaultsValidatorStub{}
+	publisher := &agentComposerDefaultsPublisherStub{}
+	service := Service{
+		Store:                          store,
+		AgentComposerDefaultsValidator: validator,
+		AgentComposerDefaultsPublisher: publisher,
+	}
+	model := "gpt-5"
+
+	_, err := service.PatchAgentComposerDefaultsForTarget(context.Background(), PatchAgentComposerDefaultsForTargetInput{
+		AgentTargetID: "local:codex",
+		Patch: preferencesbiz.AgentComposerDefaultsPatch{
+			preferencesbiz.AgentComposerDefaultsFieldModel: &model,
+		},
+	})
+	if !errors.Is(err, workspacedata.ErrDesktopPreferencesNotInitialized) {
+		t.Fatalf("PatchAgentComposerDefaultsForTarget() error = %v, want %v", err, workspacedata.ErrDesktopPreferencesNotInitialized)
+	}
+	if len(publisher.agentTargetIDs) != 0 {
+		t.Fatalf("invalidations = %#v, want none", publisher.agentTargetIDs)
 	}
 }
 

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -679,6 +679,9 @@ func attachAnalyticsReporter(api *tuttiapi.DaemonAPI, analyticsReporter reporter
 	if service, ok := api.AccountService.(*accountservice.Service); ok {
 		service.SetAnalyticsReporter(analyticsReporter)
 	}
+	if service, ok := api.PreferencesService.(*preferencesservice.Service); ok {
+		service.AnalyticsReporter = analyticsReporter
+	}
 }
 
 func openWorkspaceStore(ctx context.Context) (*workspacedata.SQLiteStore, error) {


### PR DESCRIPTION
## Summary

- cherry-pick #2457 onto `release/0818`
- preserve the original workspace UI mode initialization, persistence, analytics, generated API, and documentation changes
- retain source commit provenance in the backport commit

## Source

- Source PR: #2457
- Source merge commit: `7dc392ec203779222d7718fdc2b408333fc4a9b1`
- Target base before backport: `443ae0f6fa78ec0a601d8bc79273c1a5060bbe46`

## Validation

- `corepack pnpm@10.11.0 check:changed` (17 lanes passed)
- `corepack pnpm@10.11.0 check:changed -- --push-ready` (19 lanes passed twice, including pre-push)
- `git diff --check origin/release/0818...HEAD`

## Platform impact

- No new platform-specific branch, path, shell, or process behavior is introduced by the backport
- Shared desktop preference persistence and startup behavior remain subject to the existing native Windows startup acceptance gates documented by #2457
