### PR TITLE
fix(release): refresh candidate review links

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -535,7 +535,7 @@ jobs:
           needs.build-windows.result == 'success' }}
     runs-on: ubuntu-latest
     outputs:
-      release_url: ${{ needs.resolve.outputs.release_candidate == 'true' && steps.stage-candidate-release.outputs.release_url || steps.stage-release.outputs.url }}
+      release_url: ${{ needs.resolve.outputs.release_candidate == 'true' && steps.resolve-candidate-release-url.outputs.release_url || steps.stage-release.outputs.url }}
     env:
       AWS_REGION: ${{ vars.AWS_REGION }}
       TUTTI_ARTIFACTS_AWS_ROLE_ARN: ${{ vars.TUTTI_ARTIFACTS_AWS_ROLE_ARN }}
@@ -702,7 +702,7 @@ jobs:
               done
           fi
           gh release upload "${TUTTI_DESKTOP_RELEASE_CANDIDATE_TAG}" release-assets/*
-          echo "release_url=$(jq -r .html_url staged-release.json)" >> "$GITHUB_OUTPUT"
+          echo "release_id=$(jq -r .id staged-release.json)" >> "$GITHUB_OUTPUT"
 
       - name: Install AWS CLI
         run: |
@@ -785,6 +785,20 @@ jobs:
             release-assets \
             updated-release-body.md
           gh release edit "${github_release_tag}" --notes-file updated-release-body.md
+
+      - id: resolve-candidate-release-url
+        name: Resolve current stable GitHub draft URL
+        if: ${{ needs.resolve.outputs.release_candidate == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_ID: ${{ steps.stage-candidate-release.outputs.release_id }}
+        run: |
+          if [[ -z "${RELEASE_ID}" || "${RELEASE_ID}" == "null" ]]; then
+            echo "Stable GitHub draft release id is missing" >&2
+            exit 1
+          fi
+          release_url="$(gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" --jq .html_url)"
+          echo "release_url=${release_url}" >> "$GITHUB_OUTPUT"
 
   promote:
     name: Promote Release

--- a/apps/desktop/scripts/send-release-feishu-card.mjs
+++ b/apps/desktop/scripts/send-release-feishu-card.mjs
@@ -288,8 +288,36 @@ function buildSummaryElements(summary) {
   ];
 }
 
+function buildCandidatePromotionElements({ branch, promotionUrl, tag }) {
+  if (!promotionUrl) {
+    return [];
+  }
+
+  const branchInstruction = branch
+    ? `- Branch 选择 \`${branch}\``
+    : "- Branch 选择本次候选版本的 release 分支";
+  return [
+    {
+      tag: "div",
+      text: {
+        content: [
+          "**发布审核操作**",
+          "1. 点击下方「打开发布审核流水线」",
+          "2. 点击 `Run workflow`",
+          branchInstruction,
+          `- \`release_tag\` 填写 \`${tag}\``,
+          "3. 启动后在 `Approve Stable Release` 完成审核"
+        ].join("\n"),
+        tag: "lark_md"
+      }
+    },
+    { tag: "hr" }
+  ];
+}
+
 function buildCardPayload({
   actor,
+  branch,
   macUrl,
   winUrl,
   publicationStatus = "published",
@@ -311,7 +339,9 @@ function buildCardPayload({
       label: candidate ? "编辑更新说明" : "查看完整更新日志",
       url: releaseUrl
     },
-    ...(candidate ? [{ label: "提交发布审核", url: promotionUrl }] : []),
+    ...(candidate
+      ? [{ label: "打开发布审核流水线", url: promotionUrl }]
+      : []),
     { label: "查看技术详情", url: runUrl }
   ]
     .filter((action) => action.url)
@@ -335,6 +365,9 @@ function buildCardPayload({
         },
         { tag: "hr" },
         ...buildSummaryElements(summary),
+        ...(candidate
+          ? buildCandidatePromotionElements({ branch, promotionUrl, tag })
+          : []),
         {
           fields: [
             {
@@ -522,6 +555,7 @@ if (
 
 export {
   buildCardPayload,
+  buildCandidatePromotionElements,
   buildSummaryElements,
   findPreferredAssetName,
   loadRelease,

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -472,7 +472,20 @@ test("desktop release workflow passes tsh-aligned Feishu card context", async ()
   );
   assert.match(
     workflow,
-    /release_url:\s*\${{\s*needs\.resolve\.outputs\.release_candidate\s*==\s*'true'[\s\S]*steps\.stage-candidate-release\.outputs\.release_url/
+    /release_url:\s*\${{\s*needs\.resolve\.outputs\.release_candidate\s*==\s*'true'[\s\S]*steps\.resolve-candidate-release-url\.outputs\.release_url/
+  );
+  assert.match(
+    workflow,
+    /RELEASE_ID:\s+\${{\s*steps\.stage-candidate-release\.outputs\.release_id\s*}}/
+  );
+  assert.match(
+    workflow,
+    /gh api "repos\/\${GITHUB_REPOSITORY}\/releases\/\${RELEASE_ID}" --jq \.html_url/
+  );
+  assert.ok(
+    workflow.indexOf("name: Resolve current stable GitHub draft URL") >
+      workflow.indexOf("name: Update release notes with summary and direct downloads"),
+    "the candidate draft URL should be refreshed after release notes are updated"
   );
   assert.match(
     workflow,

--- a/tools/scripts/desktop-release-feishu-card.test.mjs
+++ b/tools/scripts/desktop-release-feishu-card.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   buildCardPayload,
+  buildCandidatePromotionElements,
   buildSummaryElements,
   loadRelease,
   resolveMirroredAssetUrl,
@@ -97,6 +98,35 @@ test("release Feishu card clearly marks candidates without claiming public publi
   assert.equal(extractFieldMap(payload).get("构建类型"), "Stable candidate");
   assert.equal(extractFieldMap(payload).has("Commit"), false);
   assert.equal(extractFieldMap(payload).has("部署分支"), false);
+
+  const promotionInstructions = payload.card.elements.find((element) =>
+    element.text?.content?.includes("发布审核操作")
+  );
+  assert.match(
+    promotionInstructions.text.content,
+    /Branch 选择 `release\/0704`/
+  );
+  assert.match(
+    promotionInstructions.text.content,
+    /`release_tag` 填写 `v1\.12\.20`/
+  );
+
+  const actionLabels = payload.card.elements
+    .find((element) => element.tag === "action")
+    .actions.map((action) => action.text.content);
+  assert.ok(actionLabels.includes("打开发布审核流水线"));
+  assert.ok(!actionLabels.includes("提交发布审核"));
+});
+
+test("release Feishu card omits promotion instructions without a workflow URL", () => {
+  assert.deepEqual(
+    buildCandidatePromotionElements({
+      branch: "release/0704",
+      promotionUrl: "",
+      tag: "v1.12.20"
+    }),
+    []
+  );
 });
 
 test("release Feishu card includes tsh-aligned release context fields", () => {


### PR DESCRIPTION
## Summary
- refresh the draft release URL by release id after assets and notes are updated
- clarify that the Feishu action opens the promotion workflow
- include the exact branch, release tag, and approval steps in candidate cards

## Tests
- node --test tools/scripts/desktop-release-feishu-card.test.mjs tools/scripts/desktop-release-candidate.test.mjs tools/scripts/desktop-release-candidate-e2e.test.mjs
- node --check apps/desktop/scripts/send-release-feishu-card.mjs
- YAML parse and git diff --check