### PR TITLE
feat(connector-renderer): add access selection panel

### DIFF
--- a/.changeset/connector-access-selection-panel.md
+++ b/.changeset/connector-access-selection-panel.md
@@ -1,0 +1,7 @@
+---
+"@tutti-os/connector-renderer": minor
+---
+
+Export a host-neutral Connector access-selection panel with controlled catalog,
+selection, localized-label, disabled, and busy-state contracts from
+`@tutti-os/connector-renderer/ui`.

--- a/docs/architecture/connector.md
+++ b/docs/architecture/connector.md
@@ -601,6 +601,15 @@ requiring those connectors to be selected in the current draft; draft selection
 continues to control only structured prompt content. Selecting “more” remains
 host navigation because settings/workbench location is product-owned.
 
+Connector access-policy editors reuse `ConnectorAccessSelectionPanel` from the
+same shared UI entrypoint. The controlled panel accepts only loading/error/ready
+state, neutral Connector items, selected keys, caller-localized labels, and
+semantic callbacks. It owns the Connector-specific loading, empty, error,
+selection, disabled, and busy presentation. The host retains authorization and
+sharing policy, selected-key normalization, persistence, navigation, and
+catalog projection; the panel imports no AgentGUI draft/store, Desktop global,
+or daemon client.
+
 Every renderer window mounts exactly one `ConnectorMarketDialogHost` alongside
 its other window-level panel hosts. Composer entries and catalog cards never
 mount their own dialog host. This keeps dialog identity and mutual exclusion in

--- a/packages/connector/renderer/README.md
+++ b/packages/connector/renderer/README.md
@@ -10,6 +10,11 @@ import {
   IConnectorMarketModule
 } from "@tutti-os/connector-renderer/application";
 import {
+  ConnectorAccessSelectionPanel,
+  type ConnectorAccessSelectionItem,
+  type ConnectorAccessSelectionPanelLabels,
+  type ConnectorAccessSelectionPanelProps,
+  type ConnectorAccessSelectionState,
   ConnectorComposerMenu,
   ConnectorMarketDialogHost,
   ConnectorMarketPanel,
@@ -29,9 +34,10 @@ ports, Root/Lifecycle/StartupJob services, state, View projection, dialog
 intents, and declarative authorization mapping.
 
 `src/ui` is the only owner of Connector-specific React, including Catalog,
-dialogs, authorization rendering, Composer controls, selection chips, Palette
-items, icons, toolbar, and default i18n resources. It uses the repository UI
-System and accepts neutral Connector models and semantic callbacks.
+dialogs, authorization rendering, access selection, Composer controls,
+selection chips, Palette items, icons, toolbar, and default i18n resources. It
+uses the repository UI System and accepts neutral Connector models,
+caller-localized labels, and semantic callbacks.
 
 Desktop supplies generated-client, account, event, and navigation adapters.
 AgentGUI owns Agent draft and prompt semantics, then projects those models into
@@ -39,6 +45,18 @@ the neutral Renderer UI contracts. Neither host is imported by this package.
 
 Wire authorization schemas and the OpenAPI fragment are published by
 `@tutti-os/connector-contracts`.
+
+Hosts that compile Tailwind utilities from published packages must include the
+Renderer build output as a source, for example:
+
+```css
+@source "../../node_modules/@tutti-os/connector-renderer/dist";
+```
+
+`ConnectorAccessSelectionPanel` is controlled: the host owns catalog loading,
+selected-key ordering, policy persistence, localized labels, and semantic
+callbacks. The package owns the Connector-specific loading, error, empty,
+selection, disabled, and busy presentation.
 
 ## Validation
 

--- a/packages/connector/renderer/src/ui/access/ConnectorAccessSelectionPanel.spec.tsx
+++ b/packages/connector/renderer/src/ui/access/ConnectorAccessSelectionPanel.spec.tsx
@@ -1,0 +1,196 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ConnectorAccessSelectionPanel,
+  type ConnectorAccessSelectionPanelProps,
+  type ConnectorAccessSelectionState
+} from "./ConnectorAccessSelectionPanel";
+
+afterEach(cleanup);
+
+const labels = {
+  back: "Back",
+  cancel: "Cancel",
+  confirm: "Confirm access",
+  description: "Choose which connectors this consumer may use",
+  empty: "No connectors are available",
+  error: "Connectors could not be loaded",
+  loading: "Loading connectors",
+  title: "Connector access"
+};
+
+const readyState: ConnectorAccessSelectionState = {
+  status: "ready",
+  items: [
+    {
+      connectorKey: "github",
+      description: "Connected",
+      iconUrl: "/github.png",
+      name: "GitHub"
+    },
+    {
+      connectorKey: "notion",
+      description: "Installed",
+      name: "Notion"
+    }
+  ]
+};
+
+function createProps(
+  overrides: Partial<ConnectorAccessSelectionPanelProps> = {}
+): ConnectorAccessSelectionPanelProps {
+  return {
+    labels,
+    onBack: vi.fn(),
+    onCancel: vi.fn(),
+    onSelectionChange: vi.fn(),
+    onSubmit: vi.fn(),
+    selectedConnectorKeys: ["notion"],
+    state: readyState,
+    ...overrides
+  };
+}
+
+describe("ConnectorAccessSelectionPanel", () => {
+  it("presents loading without claiming the catalog is empty", () => {
+    render(
+      <ConnectorAccessSelectionPanel
+        {...createProps({ state: { status: "loading" } })}
+      />
+    );
+
+    expect(
+      screen.getByRole("status", { name: "Loading connectors" })
+    ).toBeInTheDocument();
+    expect(screen.queryByText(labels.empty)).not.toBeInTheDocument();
+    expect(screen.queryByText(labels.error)).not.toBeInTheDocument();
+  });
+
+  it("presents an explicit catalog error", () => {
+    render(
+      <ConnectorAccessSelectionPanel
+        {...createProps({ state: { status: "error" } })}
+      />
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent(labels.error);
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+  });
+
+  it("presents an authoritative empty ready catalog", () => {
+    render(
+      <ConnectorAccessSelectionPanel
+        {...createProps({ state: { items: [], status: "ready" } })}
+      />
+    );
+
+    expect(screen.getByText(labels.empty)).toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("renders ready items and their controlled selection", () => {
+    render(<ConnectorAccessSelectionPanel {...createProps()} />);
+
+    expect(screen.getByText("Connected")).toBeInTheDocument();
+    expect(screen.getByText("Installed")).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "GitHub" })).not.toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Notion" })).toBeChecked();
+  });
+
+  it("emits the complete controlled selection without imposing host ordering", () => {
+    const onSelectionChange = vi.fn();
+    const props = createProps({ onSelectionChange });
+    const rendered = render(<ConnectorAccessSelectionPanel {...props} />);
+
+    fireEvent.click(screen.getByText("GitHub"));
+    expect(onSelectionChange).toHaveBeenLastCalledWith(["notion", "github"]);
+
+    rendered.rerender(
+      <ConnectorAccessSelectionPanel
+        {...props}
+        selectedConnectorKeys={["github", "notion"]}
+      />
+    );
+    fireEvent.click(screen.getByText("Notion"));
+    expect(onSelectionChange).toHaveBeenLastCalledWith(["github"]);
+  });
+
+  it("keeps an individually disabled item visible and inert", () => {
+    const onSelectionChange = vi.fn();
+    render(
+      <ConnectorAccessSelectionPanel
+        {...createProps({
+          onSelectionChange,
+          state: {
+            items: [
+              {
+                connectorKey: "github",
+                description: "Unavailable for this consumer",
+                disabled: true,
+                name: "GitHub"
+              }
+            ],
+            status: "ready"
+          }
+        })}
+      />
+    );
+
+    const checkbox = screen.getByRole("checkbox", { name: "GitHub" });
+    expect(checkbox).toBeDisabled();
+    fireEvent.click(checkbox);
+    expect(onSelectionChange).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: labels.confirm })).toBeEnabled();
+  });
+
+  it("blocks every interaction when the panel is disabled", () => {
+    const props = createProps({ disabled: true });
+    render(<ConnectorAccessSelectionPanel {...props} />);
+
+    const controls = [
+      screen.getByRole("button", { name: labels.back }),
+      screen.getByRole("checkbox", { name: "GitHub" }),
+      screen.getByRole("button", { name: labels.cancel }),
+      screen.getByRole("button", { name: labels.confirm })
+    ];
+    for (const control of controls) {
+      expect(control).toBeDisabled();
+      fireEvent.click(control);
+    }
+
+    expect(props.onBack).not.toHaveBeenCalled();
+    expect(props.onCancel).not.toHaveBeenCalled();
+    expect(props.onSelectionChange).not.toHaveBeenCalled();
+    expect(props.onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("locks the panel and shows submit progress while busy", () => {
+    const props = createProps({ busy: true });
+    render(<ConnectorAccessSelectionPanel {...props} />);
+
+    const panel = screen.getByRole("region", { name: labels.title });
+    const submit = screen.getByRole("button", { name: labels.confirm });
+    expect(panel).toHaveAttribute("aria-busy", "true");
+    expect(submit).toBeDisabled();
+    expect(submit).toHaveAttribute("aria-busy", "true");
+    expect(submit.querySelector('[data-slot="spinner"]')).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: labels.back })).toBeDisabled();
+    expect(screen.getByRole("checkbox", { name: "GitHub" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: labels.cancel })).toBeDisabled();
+  });
+
+  it("dispatches navigation, cancellation, and submission independently", () => {
+    const props = createProps();
+    render(<ConnectorAccessSelectionPanel {...props} />);
+
+    fireEvent.click(screen.getByRole("button", { name: labels.back }));
+    fireEvent.click(screen.getByRole("button", { name: labels.cancel }));
+    fireEvent.click(screen.getByRole("button", { name: labels.confirm }));
+
+    expect(props.onBack).toHaveBeenCalledOnce();
+    expect(props.onCancel).toHaveBeenCalledOnce();
+    expect(props.onSubmit).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/connector/renderer/src/ui/access/ConnectorAccessSelectionPanel.tsx
+++ b/packages/connector/renderer/src/ui/access/ConnectorAccessSelectionPanel.tsx
@@ -1,0 +1,201 @@
+import type { JSX } from "react";
+import {
+  ArrowLeftIcon,
+  Avatar,
+  Button,
+  Checkbox,
+  Spinner,
+  cn
+} from "@tutti-os/ui-system";
+
+export interface ConnectorAccessSelectionItem {
+  connectorKey: string;
+  description?: string;
+  disabled?: boolean;
+  iconUrl?: string;
+  name: string;
+}
+
+export type ConnectorAccessSelectionState =
+  | { status: "loading" }
+  | { status: "error" }
+  | {
+      items: readonly ConnectorAccessSelectionItem[];
+      status: "ready";
+    };
+
+export interface ConnectorAccessSelectionPanelLabels {
+  back: string;
+  cancel: string;
+  confirm: string;
+  description: string;
+  empty: string;
+  error: string;
+  loading: string;
+  title: string;
+}
+
+export interface ConnectorAccessSelectionPanelProps {
+  busy?: boolean;
+  disabled?: boolean;
+  labels: ConnectorAccessSelectionPanelLabels;
+  onBack(): void;
+  onCancel(): void;
+  onSelectionChange(connectorKeys: string[]): void;
+  onSubmit(): void;
+  selectedConnectorKeys: readonly string[];
+  state: ConnectorAccessSelectionState;
+}
+
+/**
+ * Host-neutral controlled selector for choosing Connector access. The host
+ * retains catalog, authorization, admission, persistence, and copy ownership.
+ */
+export function ConnectorAccessSelectionPanel({
+  busy = false,
+  disabled = false,
+  labels,
+  onBack,
+  onCancel,
+  onSelectionChange,
+  onSubmit,
+  selectedConnectorKeys,
+  state
+}: ConnectorAccessSelectionPanelProps): JSX.Element {
+  const selectedConnectorKeySet = new Set(selectedConnectorKeys);
+  const interactionsDisabled = disabled || busy;
+
+  const changeSelection = (connectorKey: string, selected: boolean): void => {
+    const nextSelection = new Set(selectedConnectorKeys);
+    if (selected) {
+      nextSelection.add(connectorKey);
+    } else {
+      nextSelection.delete(connectorKey);
+    }
+    onSelectionChange(Array.from(nextSelection));
+  };
+
+  return (
+    <section
+      aria-busy={busy}
+      aria-disabled={disabled || undefined}
+      aria-label={labels.title}
+      className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)_auto]"
+    >
+      <header className="pb-3">
+        <div className="flex items-center gap-1">
+          <Button
+            aria-label={labels.back}
+            disabled={interactionsDisabled}
+            onClick={onBack}
+            size="icon-sm"
+            type="button"
+            variant="ghost"
+          >
+            <ArrowLeftIcon aria-hidden className="size-4" />
+          </Button>
+          <h2 className="m-0 min-w-0 truncate text-sm font-semibold leading-5 text-[var(--text-primary)]">
+            {labels.title}
+          </h2>
+        </div>
+        <p className="mb-0 mt-1 text-[11px] leading-[1.4] text-[var(--text-secondary)]">
+          {labels.description}
+        </p>
+      </header>
+
+      <div className="min-h-0 overflow-y-auto">
+        {state.status === "loading" ? (
+          <div
+            aria-label={labels.loading}
+            className="flex min-h-20 items-center justify-center"
+            role="status"
+          >
+            <Spinner size={16} />
+          </div>
+        ) : state.status === "error" ? (
+          <div
+            className="rounded-md border border-dashed border-[var(--border-1)] px-3 py-4 text-xs text-[var(--text-secondary)]"
+            role="alert"
+          >
+            {labels.error}
+          </div>
+        ) : state.items.length === 0 ? (
+          <div className="rounded-md border border-dashed border-[var(--border-1)] px-3 py-4 text-xs text-[var(--text-secondary)]">
+            {labels.empty}
+          </div>
+        ) : (
+          <div className="flex flex-col gap-1">
+            {state.items.map((item) => {
+              const checked = selectedConnectorKeySet.has(item.connectorKey);
+              const itemDisabled =
+                interactionsDisabled || item.disabled === true;
+
+              return (
+                <label
+                  aria-disabled={itemDisabled || undefined}
+                  className={cn(
+                    "flex min-h-10 w-full items-center gap-2.5 rounded-md px-1.5 py-1 text-left",
+                    itemDisabled
+                      ? "cursor-not-allowed opacity-60"
+                      : "cursor-pointer hover:bg-[var(--transparency-hover)]"
+                  )}
+                  key={item.connectorKey}
+                >
+                  <Avatar
+                    aria-hidden="true"
+                    className="text-[10px]"
+                    label={item.name}
+                    size={28}
+                    src={item.iconUrl}
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-[13px] font-medium text-[var(--text-primary)]">
+                      {item.name}
+                    </span>
+                    {item.description ? (
+                      <span className="block truncate text-[11px] text-[var(--text-secondary)]">
+                        {item.description}
+                      </span>
+                    ) : null}
+                  </span>
+                  <Checkbox
+                    aria-label={item.name}
+                    checked={checked}
+                    disabled={itemDisabled}
+                    onCheckedChange={(nextChecked) =>
+                      changeSelection(item.connectorKey, nextChecked === true)
+                    }
+                  />
+                </label>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      <footer className="pt-3">
+        <div className="flex justify-end gap-2">
+          <Button
+            disabled={interactionsDisabled}
+            onClick={onCancel}
+            size="dialog"
+            type="button"
+            variant="ghost"
+          >
+            {labels.cancel}
+          </Button>
+          <Button
+            aria-busy={busy}
+            disabled={interactionsDisabled}
+            onClick={onSubmit}
+            size="dialog"
+            type="button"
+          >
+            {busy ? <Spinner size={14} /> : null}
+            {labels.confirm}
+          </Button>
+        </div>
+      </footer>
+    </section>
+  );
+}

--- a/packages/connector/renderer/src/ui/index.ts
+++ b/packages/connector/renderer/src/ui/index.ts
@@ -19,6 +19,13 @@ export {
   type ConnectorComposerMenuProps
 } from "./composer/ConnectorComposerMenu.tsx";
 export {
+  ConnectorAccessSelectionPanel,
+  type ConnectorAccessSelectionItem,
+  type ConnectorAccessSelectionPanelLabels,
+  type ConnectorAccessSelectionPanelProps,
+  type ConnectorAccessSelectionState
+} from "./access/ConnectorAccessSelectionPanel.tsx";
+export {
   ConnectorSelectionList,
   type ConnectorSelectionItem,
   type ConnectorSelectionListProps


### PR DESCRIPTION
## Summary

- export a controlled, host-neutral Connector access-selection panel from @tutti-os/connector-renderer/ui
- cover loading, error, empty, ready, disabled, busy, selection, navigation, and submit behavior
- document the Renderer ownership boundary and external Tailwind source contract

## Motivation

TSH needs to edit Shared Agent Connector allowlists without owning a second Connector-specific visual implementation. The host continues to own sharing policy, catalog projection, localized labels, selected-key normalization, persistence, and navigation. Renderer owns only the shared Connector presentation and semantic callbacks. No AgentGUI, Desktop, daemon client, or product type crosses into the package.

## Public contract

The new controlled API accepts loading/error/ready state, neutral Connector items, selected keys, caller-localized labels, disabled/busy flags, and onBack/onCancel/onSelectionChange/onSubmit callbacks. It does not change OpenAPI, Connector events, authorization, persistence, runtime, MCP, or CLI protocols.

## Validation

- renderer focused component tests: 9 passed
- renderer package tests: 95 passed
- renderer typecheck: passed
- package pack check for @tutti-os/connector-renderer: passed; built JS and declarations contain the new export
- pnpm check:changed -- --push-ready: 11 lanes passed

## Windows impact

None. This is a controlled React UI component with no filesystem, process, path, shell, native dependency, or OS-specific behavior.

## Documentation impact

Updated the Connector architecture and renderer README. No new subpath, repository rule, runtime configuration, or troubleshooting contract was introduced.