### PR TITLE
fix(agent-gui): restore composer trigger palettes

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailSideConversation.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailSideConversation.spec.ts
@@ -63,6 +63,23 @@ describe("appendAgentSidePromptToDraft", () => {
 });
 
 describe("useAgentGUIDetailSideConversation lifecycle", () => {
+  it("does not focus the main composer when no Side conversation is active", () => {
+    const rendered = renderHook(() =>
+      useAgentGUIDetailSideConversation({
+        enabled: false,
+        workspaceId: "workspace-1",
+        sourceAgentSessionId: "source-1",
+        provider: "codex",
+        cwd: null,
+        availableCommands: [],
+        clearMainDraft: vi.fn(),
+        submitPrompt: vi.fn()
+      })
+    );
+
+    expect(rendered.result.current.focused).toBe(false);
+  });
+
   it("leaves /side as ordinary main input when the developer flag is off", () => {
     const submitPrompt = vi.fn();
     const rendered = renderHook(() =>

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailSideConversation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailSideConversation.ts
@@ -95,7 +95,9 @@ export function useAgentGUIDetailSideConversation({
   const [focusedSideAgentSessionId, setFocusedSideAgentSessionId] = useState<
     string | null
   >(null);
-  const focused = activeSideAgentSessionId === focusedSideAgentSessionId;
+  const focused =
+    activeSideAgentSessionId !== null &&
+    activeSideAgentSessionId === focusedSideAgentSessionId;
   const emptyDraft = useMemo(emptyAgentComposerDraft, [
     activeSideAgentSessionId
   ]);


### PR DESCRIPTION
## Summary
- Fixes the AgentGUI composer focus state when no Side conversation is active.
- Restores `/` slash-command and `@` file-mention palettes in the main composer.
- Adds a regression test covering the no-active-Side state.

## Tests
- `pnpm --filter @tutti-os/agent-gui exec vitest run agent-gui/agentGuiNode/view/useAgentGUIDetailSideConversation.spec.ts agent-gui/agentGuiNode/AgentSlashCommandPalette.spec.tsx`
- `pnpm check:changed -- --failed-only`
- `pnpm check:changed -- --push-ready`

## Notes
- The fix is platform-neutral; no Windows-specific behavior is affected.