### PR TITLE
fix(desktop): stop publishing release notes pointers

### DIFF
--- a/.github/workflows/desktop-release-promote.yml
+++ b/.github/workflows/desktop-release-promote.yml
@@ -562,7 +562,6 @@ jobs:
         env:
           RELEASE_CHANNEL: ${{ env.TUTTI_DESKTOP_RELEASE_CHANNEL }}
           RELEASE_GIT_SHA: ${{ env.TUTTI_DESKTOP_RELEASE_TARGET }}
-          RELEASE_NOTES_URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
           RELEASE_SOURCE_REF: ${{ needs.resolve.outputs.source_ref }}
           RELEASE_TAG: ${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
         run: |

--- a/apps/desktop/scripts/build-release-latest.mjs
+++ b/apps/desktop/scripts/build-release-latest.mjs
@@ -168,7 +168,6 @@ async function buildDesktopReleaseLatest(options) {
   );
   const gitSha = String(options.gitSha ?? "").trim();
   const sourceRef = String(options.sourceRef ?? "").trim();
-  const releaseNotesUrl = String(options.releaseNotesUrl ?? "").trim();
   const releasedAt =
     options.releasedAt instanceof Date
       ? options.releasedAt.toISOString()
@@ -204,7 +203,6 @@ async function buildDesktopReleaseLatest(options) {
     releasedAt,
     gitSha: gitSha || null,
     sourceRef: sourceRef || null,
-    releaseNotesUrl: releaseNotesUrl || null,
     baseUrl,
     preferredDownloads: {
       macosUniversalDmg,
@@ -222,7 +220,6 @@ async function main() {
     gitSha: process.env.RELEASE_GIT_SHA,
     releaseAssetBaseUrl: process.env.RELEASE_ASSET_BASE_URL,
     releaseTag: process.env.RELEASE_TAG,
-    releaseNotesUrl: process.env.RELEASE_NOTES_URL,
     releasedAt: process.env.RELEASED_AT,
     sourceRef: process.env.RELEASE_SOURCE_REF
   });

--- a/apps/desktop/src/main/update/appUpdateService.test.ts
+++ b/apps/desktop/src/main/update/appUpdateService.test.ts
@@ -180,7 +180,6 @@ test("createAppUpdateService configures the static RC feed before checking", asy
         return {
           feedUrl: "https://updates.example.test/v0.0.1-rc.17",
           releasedAt: "2026-06-15T00:00:00.000Z",
-          releaseNotesUrl: null,
           tag: "v0.0.1-rc.17",
           updaterChannel: "rc",
           version: "0.0.1-rc.17"
@@ -204,10 +203,8 @@ test("createAppUpdateService configures the static RC feed before checking", asy
   }
 });
 
-test("createAppUpdateService exposes release notes for the resolved update", async () => {
+test("createAppUpdateService keeps release notes unset for the resolved update", async () => {
   let notifyAvailable: ((info: UpdateInfo) => void) | null = null;
-  const releaseNotesUrl =
-    "https://github.com/tutti-os/tutti/releases/tag/v1.2.3";
   const driver = createFakeDriver({
     async checkForUpdates() {
       notifyAvailable?.(createUpdateInfoFixture("1.2.3"));
@@ -222,7 +219,6 @@ test("createAppUpdateService exposes release notes for the resolved update", asy
     releaseFeedResolver: async () => ({
       feedUrl: "https://updates.example.test/v1.2.3",
       releasedAt: "2026-08-17T00:00:00.000Z",
-      releaseNotesUrl,
       tag: "v1.2.3",
       updaterChannel: "latest",
       version: "1.2.3"
@@ -236,7 +232,7 @@ test("createAppUpdateService exposes release notes for the resolved update", asy
       () => service.getState().status === "available",
       "update did not become available"
     );
-    assert.equal(service.getState().releaseNotesUrl, releaseNotesUrl);
+    assert.equal(service.getState().releaseNotesUrl, null);
   } finally {
     service.dispose();
   }
@@ -328,7 +324,6 @@ test("createAppUpdateService shares static feed resolution across concurrent che
   const deferredFeed = createDeferred<{
     feedUrl: string;
     releasedAt: string;
-    releaseNotesUrl: string | null;
     tag: string;
     updaterChannel: "latest" | "rc";
     version: string;
@@ -351,7 +346,6 @@ test("createAppUpdateService shares static feed resolution across concurrent che
     deferredFeed.resolve({
       feedUrl: "https://updates.example.test/v0.0.1-rc.17",
       releasedAt: "2026-06-15T00:00:00.000Z",
-      releaseNotesUrl: null,
       tag: "v0.0.1-rc.17",
       updaterChannel: "rc",
       version: "0.0.1-rc.17"

--- a/apps/desktop/src/main/update/appUpdateService.ts
+++ b/apps/desktop/src/main/update/appUpdateService.ts
@@ -31,7 +31,6 @@ import {
 } from "./macosUpdaterSupport.ts";
 import {
   createDesktopReleaseFeedResolver,
-  type DesktopReleaseFeed,
   type DesktopReleaseFeedResolver
 } from "./desktopReleaseFeed.ts";
 
@@ -351,7 +350,6 @@ export function createAppUpdateService(
   let activeDownloadPromise: Promise<void> | null = null;
   let preserveAvailableStateDuringCheck = false;
   let quitAndInstallPending = false;
-  let activeReleaseFeed: DesktopReleaseFeed | null = null;
   const stateChangedListeners = new Set<
     (state: AppUpdateState, previousState: AppUpdateState) => void
   >();
@@ -496,11 +494,7 @@ export function createAppUpdateService(
         checkedAt: new Date().toISOString(),
         latestVersion: info.version ?? null,
         releaseDate: normalizeReleaseDate(info.releaseDate),
-        releaseName: info.releaseName ?? null,
-        releaseNotesUrl:
-          activeReleaseFeed?.version === info.version
-            ? activeReleaseFeed.releaseNotesUrl
-            : null
+        releaseName: info.releaseName ?? null
       });
     }),
     resolvedDriver.onUpdateNotAvailable(() => {
@@ -758,7 +752,6 @@ export function createAppUpdateService(
     try {
       if (releaseFeedResolver) {
         const feed = await releaseFeedResolver({ channel: state.channel });
-        activeReleaseFeed = feed;
         resolvedDriver.setFeedUrl(feed.feedUrl);
         getDesktopLogger().info("application updater static feed configured", {
           channel: state.channel,

--- a/apps/desktop/src/main/update/desktopReleaseFeed.test.ts
+++ b/apps/desktop/src/main/update/desktopReleaseFeed.test.ts
@@ -25,7 +25,6 @@ test("desktop release feed resolves the stable pointer to its immutable feed", a
   assert.deepEqual(feed, {
     feedUrl: `${baseUrl}/v1.2.3`,
     releasedAt: "2026-07-13T10:00:00.000Z",
-    releaseNotesUrl: null,
     tag: "v1.2.3",
     updaterChannel: "latest",
     version: "1.2.3"
@@ -61,18 +60,20 @@ test("desktop release feed rejects malformed pointer JSON", async () => {
   await assert.rejects(resolver({ channel: "stable" }), /not valid JSON/);
 });
 
-test("desktop release feed exposes a validated release notes URL", async () => {
-  const releaseNotesUrl =
-    "https://github.com/tutti-os/tutti/releases/tag/v1.2.3";
+test("desktop release feed ignores legacy release notes metadata", async () => {
   const resolver = createDesktopReleaseFeedResolver({
     baseUrl,
-    fetch: async () => jsonResponse(createPointerDocument({ releaseNotesUrl }))
+    fetch: async () =>
+      jsonResponse(
+        createPointerDocument({
+          releaseNotesUrl:
+            "https://github.com/tutti-os/tutti/releases/tag/v1.2.3"
+        })
+      )
   });
 
-  assert.equal(
-    (await resolver({ channel: "stable" })).releaseNotesUrl,
-    releaseNotesUrl
-  );
+  const feed = await resolver({ channel: "stable" });
+  assert.equal("releaseNotesUrl" in feed, false);
 });
 
 test("desktop release feed rejects an unsupported schema, origin, channel, and tag", async (t) => {

--- a/apps/desktop/src/main/update/desktopReleaseFeed.ts
+++ b/apps/desktop/src/main/update/desktopReleaseFeed.ts
@@ -10,7 +10,6 @@ export const desktopReleaseFeedBaseUrl =
 export interface DesktopReleaseFeed {
   feedUrl: string;
   releasedAt: string;
-  releaseNotesUrl: string | null;
   tag: string;
   updaterChannel: "latest" | "rc";
   version: string;
@@ -30,7 +29,6 @@ interface DesktopReleaseLatestDocument {
   channel: string;
   prerelease: boolean;
   releasedAt: string;
-  releaseNotesUrl: string | null;
   schemaVersion: string;
   tag: string;
   version: string;
@@ -64,7 +62,6 @@ export function createDesktopReleaseFeedResolver(
     return {
       feedUrl: `${baseUrl}/${encodeURIComponent(document.tag)}`,
       releasedAt: document.releasedAt,
-      releaseNotesUrl: document.releaseNotesUrl,
       tag: document.tag,
       updaterChannel: channel === "rc" ? "rc" : "latest",
       version: document.version
@@ -113,7 +110,6 @@ function parseDesktopReleaseLatestDocument(
     channel: readRequiredString(parsed, "channel"),
     prerelease: readBoolean(parsed, "prerelease"),
     releasedAt: readRequiredString(parsed, "releasedAt"),
-    releaseNotesUrl: readOptionalHttpsUrl(parsed, "releaseNotesUrl"),
     schemaVersion: readRequiredString(parsed, "schemaVersion"),
     tag: readRequiredString(parsed, "tag"),
     version: readRequiredString(parsed, "version")
@@ -198,24 +194,6 @@ function readBoolean(value: Record<string, unknown>, key: string): boolean {
     throw new Error(`Desktop update pointer ${key} must be a boolean`);
   }
   return candidate;
-}
-
-function readOptionalHttpsUrl(
-  value: Record<string, unknown>,
-  key: string
-): string | null {
-  const candidate = value[key];
-  if (candidate === undefined || candidate === null) {
-    return null;
-  }
-  if (typeof candidate !== "string") {
-    throw new Error(`Desktop update pointer ${key} must be an HTTPS URL`);
-  }
-  const parsed = new URL(candidate.trim());
-  if (parsed.protocol !== "https:" || parsed.username || parsed.password) {
-    throw new Error(`Desktop update pointer ${key} must be an HTTPS URL`);
-  }
-  return parsed.href;
 }
 
 function releaseVersionFromTag(tag: string): string | null {

--- a/apps/desktop/src/renderer/src/features/app-update/ui/AppUpdateStatus.tsx
+++ b/apps/desktop/src/renderer/src/features/app-update/ui/AppUpdateStatus.tsx
@@ -12,7 +12,10 @@ import {
 import { useTranslation } from "@renderer/i18n";
 import { cn } from "@renderer/lib/format";
 import { useAppUpdateService } from "./useAppUpdateService";
-import { resolveStandaloneAppUpdateStatusPresentation } from "./appUpdateStatusPresentation";
+import {
+  resolveStandaloneAppUpdateStatusPresentation,
+  shouldShowReleaseNotesAction
+} from "./appUpdateStatusPresentation";
 
 const updateIconUrl = new URL("../assets/update.png", import.meta.url).href;
 const tuttiIconUrl = new URL("../assets/tutti.png", import.meta.url).href;
@@ -35,6 +38,10 @@ export function AppUpdateStatus({
         isActing={state.isActing}
         openReleaseNotes={() => service.openReleaseNotes()}
         runPrimaryAction={() => service.runPrimaryAction()}
+        showReleaseNotes={shouldShowReleaseNotesAction(
+          state.updateState?.channel,
+          view.action
+        )}
         view={view}
       />
     );
@@ -46,8 +53,10 @@ export function AppUpdateStatus({
 
   const label = t(view.titleKey, view.titleParams);
   const compact = density === "compact";
-  const showReleaseNotesAction =
-    view.action === "download" || view.action === "install";
+  const showReleaseNotesAction = shouldShowReleaseNotesAction(
+    state.updateState?.channel,
+    view.action
+  );
 
   return (
     <div
@@ -111,11 +120,13 @@ function StandaloneAppUpdateStatus({
   isActing,
   openReleaseNotes,
   runPrimaryAction,
+  showReleaseNotes,
   view
 }: {
   isActing: boolean;
   openReleaseNotes(): Promise<void>;
   runPrimaryAction(): Promise<void>;
+  showReleaseNotes: boolean;
   view: ReturnType<typeof useAppUpdateService>["state"]["view"];
 }) {
   const { t } = useTranslation();
@@ -186,19 +197,21 @@ function StandaloneAppUpdateStatus({
           </p>
         </div>
         <div className="flex items-center justify-end gap-1.5">
-          <PopoverClose asChild>
-            <Button
-              disabled={isActing}
-              onClick={() => {
-                void openReleaseNotes();
-              }}
-              size="sm"
-              type="button"
-              variant="ghost"
-            >
-              {releaseNotesLabel}
-            </Button>
-          </PopoverClose>
+          {showReleaseNotes ? (
+            <PopoverClose asChild>
+              <Button
+                disabled={isActing}
+                onClick={() => {
+                  void openReleaseNotes();
+                }}
+                size="sm"
+                type="button"
+                variant="ghost"
+              >
+                {releaseNotesLabel}
+              </Button>
+            </PopoverClose>
+          ) : null}
           <PopoverClose asChild>
             <Button
               disabled={isActing}

--- a/apps/desktop/src/renderer/src/features/app-update/ui/appUpdateStatusPresentation.test.ts
+++ b/apps/desktop/src/renderer/src/features/app-update/ui/appUpdateStatusPresentation.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { shouldShowReleaseNotesAction } from "./appUpdateStatusPresentation.ts";
+
+test("release notes are available for stable download and install actions", () => {
+  assert.equal(shouldShowReleaseNotesAction("stable", "download"), true);
+  assert.equal(shouldShowReleaseNotesAction("stable", "install"), true);
+  assert.equal(shouldShowReleaseNotesAction("stable", "retry"), false);
+});
+
+test("release notes are hidden for RC and missing update states", () => {
+  assert.equal(shouldShowReleaseNotesAction("rc", "download"), false);
+  assert.equal(shouldShowReleaseNotesAction("rc", "install"), false);
+  assert.equal(shouldShowReleaseNotesAction(null, "download"), false);
+});

--- a/apps/desktop/src/renderer/src/features/app-update/ui/appUpdateStatusPresentation.ts
+++ b/apps/desktop/src/renderer/src/features/app-update/ui/appUpdateStatusPresentation.ts
@@ -1,3 +1,4 @@
+import type { AppUpdateState } from "@shared/contracts/ipc";
 import type { AppUpdateViewState } from "../services/appUpdateTypes";
 
 export type StandaloneAppUpdateStatusPresentation =
@@ -34,4 +35,13 @@ export function resolveStandaloneAppUpdateStatusPresentation(
     titleKey: view.titleKey,
     titleParams: view.titleParams
   };
+}
+
+export function shouldShowReleaseNotesAction(
+  channel: AppUpdateState["channel"] | null | undefined,
+  action: AppUpdateViewState["action"]
+): boolean {
+  return (
+    channel === "stable" && (action === "download" || action === "install")
+  );
 }

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -466,12 +466,12 @@ The Stage job adds the generated summary before checksums and seeds a clearly ma
 - enrich the Feishu release card with the Chinese summary when Feishu notification is enabled
 - update `changelog.json` for stable releases
 
-The desktop updater keeps `releaseNotesUrl` as the published-release pointer so
-the update action remains available only when a release has public notes. The
-renderer opens the official localized changelog landing page instead of a
-GitHub Release: `https://tutti.sh/zh/changelog` for `zh-CN`, and
+The desktop release pointer does not contain a release-notes URL. The renderer
+opens the official localized changelog landing page instead of a GitHub
+Release: `https://tutti.sh/zh/changelog` for `zh-CN`, and
 `https://tutti.sh/en/changelog` for English. It never appends a version or
-anchor, so the website owns the release-history presentation.
+anchor, so the website owns the release-history presentation. Older pointers
+may still contain `releaseNotesUrl`; desktop clients ignore that legacy field.
 
 Before staging the Draft Release, generate GitHub's detailed release notes with
 an explicit comparison tag. RC and beta notes compare against the newest tag in

--- a/tools/scripts/desktop-release-latest.test.mjs
+++ b/tools/scripts/desktop-release-latest.test.mjs
@@ -34,10 +34,7 @@ test("desktop release latest metadata exposes CloudFront URLs for every asset", 
     assert.equal(latest.releasedAt, "2026-07-04T12:00:00.000Z");
     assert.equal(latest.gitSha, "537327a1");
     assert.equal(latest.sourceRef, "main");
-    assert.equal(
-      latest.releaseNotesUrl,
-      "https://github.com/tutti-os/tutti/releases/tag/v1.2.3"
-    );
+    assert.equal("releaseNotesUrl" in latest, false);
     assert.equal(
       latest.baseUrl,
       "https://d111111abcdef8.cloudfront.net/desktop-release-assets"


### PR DESCRIPTION
## Summary

- stop publishing `releaseNotesUrl` in desktop `latest.json` metadata and remove the promote workflow input
- stop parsing/propagating the legacy pointer field while continuing to ignore it safely
- keep the renderer's localized official changelog URL and hide the release-notes action for RC updates
- update release documentation and regression coverage

## Validation

- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm --filter @tutti-os/desktop build`
  - renderer: 8,084 modules transformed
  - renderer CSS contracts: 3 assets passed
- desktop release metadata tests: 5/5
- desktop release feed tests: 10/10
- desktop update service tests: 19/19
- release-notes presentation tests: 2/2
- independent read-only review: no blocking findings

The full desktop suite was also attempted (1,773 tests); 1,755 passed and 13 pre-existing Windows/POSIX environment-dependent tests failed around Claude credential fixtures, POSIX path expectations, Unix shims, symlink permissions, and fixed test paths. None were in the changed update/metadata tests.