### PR TITLE
fix(connector): align runtime status with availability

### DIFF
--- a/docs/architecture/connector.md
+++ b/docs/architecture/connector.md
@@ -588,9 +588,14 @@ synchronizing -> materializing -> ready`; failure is terminal and disposes
 
 Compact composer surfaces reuse `ConnectorComposerMenu` from the shared UI
 entrypoint. The menu consumes only a host-neutral projection of connector key,
-name, icon, and setup state; AgentGUI maps its provider-neutral capability
-options into that projection and retains only placement plus its Tutti Mode
-fallback. Selecting one item emits a semantic connector-open intent. The host
+name, icon, setup state, and the scoped runtime state projected by Connector
+Market. An installed Connector is shown as started only when the current boot
+has observed its latest desired generation as enabled and ready; `starting`,
+`stopped`, and `failed` remain off. Older hosts that omit this optional runtime
+projection retain the legacy authorization-based presentation. AgentGUI maps
+its provider-neutral capability options into that projection and retains only
+placement plus its Tutti Mode fallback. Selecting one item emits a semantic
+connector-open intent. The host
 executes `openConnectorMarketDialog(root, connectorKey)`, which waits for the
 authoritative market view, rejects invalid or unknown keys, and then advances
 the package-owned dialog state machine. Before applying the bounded quick-list

--- a/packages/agent/daemon/composercatalog/connectors.go
+++ b/packages/agent/daemon/composercatalog/connectors.go
@@ -16,6 +16,7 @@ const (
 
 	CapabilityStatusAuthRequired  = "authRequired"
 	CapabilityStatusAvailable     = "available"
+	CapabilityStatusDisabled      = "disabled"
 	CapabilityStatusSetupRequired = "setupRequired"
 	CapabilityStatusUnsupported   = "unsupported"
 )
@@ -94,6 +95,9 @@ func ConnectorStatus(connector connectorhost.Connector) string {
 	}
 	switch connector.Authorization.State {
 	case connectorhost.AuthorizationStateNotRequired, connectorhost.AuthorizationStateConnected:
+		if connector.Runtime != nil && connector.Runtime.State != connectorhost.ConnectorRuntimeStateStarted {
+			return CapabilityStatusDisabled
+		}
 		return CapabilityStatusAvailable
 	default:
 		return CapabilityStatusAuthRequired

--- a/packages/agent/daemon/composercatalog/connectors_test.go
+++ b/packages/agent/daemon/composercatalog/connectors_test.go
@@ -45,6 +45,19 @@ func TestConnectorOptionsPreservesSnapshotReadError(t *testing.T) {
 	}
 }
 
+func TestConnectorStatusRequiresStartedRuntimeWhenProjected(t *testing.T) {
+	connector := connectorFixture("github", "GitHub", connectorhost.InstallationStateInstalled,
+		connectorhost.AuthorizationStateConnected, connectorhost.CompatibilityStateSupported)
+	connector.Runtime = &connectorhost.ConnectorRuntime{State: connectorhost.ConnectorRuntimeStateStopped}
+	if got := ConnectorStatus(connector); got != CapabilityStatusDisabled {
+		t.Fatalf("stopped ConnectorStatus() = %q, want %q", got, CapabilityStatusDisabled)
+	}
+	connector.Runtime.State = connectorhost.ConnectorRuntimeStateStarted
+	if got := ConnectorStatus(connector); got != CapabilityStatusAvailable {
+		t.Fatalf("started ConnectorStatus() = %q, want %q", got, CapabilityStatusAvailable)
+	}
+}
+
 type snapshotStub struct {
 	snapshot connectorhost.Snapshot
 	err      error

--- a/packages/agent/gui/agent-gui/agentGuiNode/integrations/connector/model/connectorPresentation.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/integrations/connector/model/connectorPresentation.spec.ts
@@ -72,4 +72,15 @@ describe("connector presentation projection", () => {
       status: "unsupported"
     });
   });
+
+  it("preserves the stopped runtime state for the composer switch", () => {
+    expect(
+      projectConnectorComposerItems([connector("linear", "disabled")])
+    ).toEqual([
+      expect.objectContaining({
+        connectorKey: "linear",
+        status: "disabled"
+      })
+    ]);
+  });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/integrations/connector/model/connectorPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/integrations/connector/model/connectorPresentation.ts
@@ -41,9 +41,11 @@ export function projectConnectorComposerItems(
       status:
         option.status === "available"
           ? "connected"
-          : option.status === "authRequired"
-            ? "authorization_required"
-            : "setup_required"
+          : option.status === "disabled"
+            ? "disabled"
+            : option.status === "authRequired"
+              ? "authorization_required"
+              : "setup_required"
     });
   }
   return items;

--- a/packages/clients/tuttid-ts/src/generated/index.ts
+++ b/packages/clients/tuttid-ts/src/generated/index.ts
@@ -598,6 +598,7 @@ export type {
   ConnectorMarketPageSize,
   ConnectorMarketPageToken,
   ConnectorMarketRelease,
+  ConnectorMarketRuntime,
   ConnectorMarketSectionId,
   ConnectorMarketSnapshot,
   CopyWorkspaceFileEntryData,

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -4921,6 +4921,7 @@ export type ConnectorMarketConnector = {
   installation: ConnectorMarketInstallation;
   authorization: ConnectorMarketAuthorization;
   compatibility: ConnectorMarketCompatibility;
+  runtime?: ConnectorMarketRuntime;
   revision: number;
 };
 
@@ -4999,6 +5000,11 @@ export type ConnectorMarketAuthorization = {
 export type ConnectorMarketCompatibility = {
   state: ConnectorMarketCompatibilityState;
   reason?: string;
+};
+
+export type ConnectorMarketRuntime = {
+  state: "started" | "starting" | "stopped" | "failed";
+  failureCode?: string;
 };
 
 export type ConnectorMarketOperation = {

--- a/packages/connector/contracts/openapi/connector-market.v1.yaml
+++ b/packages/connector/contracts/openapi/connector-market.v1.yaml
@@ -466,6 +466,8 @@ components:
           $ref: "#/components/schemas/ConnectorMarketAuthorization"
         compatibility:
           $ref: "#/components/schemas/ConnectorMarketCompatibility"
+        runtime:
+          $ref: "#/components/schemas/ConnectorMarketRuntime"
         revision:
           type: integer
           format: int64
@@ -649,6 +651,16 @@ components:
         state:
           $ref: "#/components/schemas/ConnectorMarketCompatibilityState"
         reason:
+          type: string
+    ConnectorMarketRuntime:
+      type: object
+      additionalProperties: false
+      required: [state]
+      properties:
+        state:
+          type: string
+          enum: [started, starting, stopped, failed]
+        failureCode:
           type: string
     ConnectorMarketOperation:
       type: object

--- a/packages/connector/daemon/core/application.go
+++ b/packages/connector/daemon/core/application.go
@@ -119,33 +119,44 @@ func NewApplication(config ApplicationConfig) (*Application, error) {
 
 func (application *Application) Snapshot(ctx context.Context) (Snapshot, error) {
 	snapshot, err := application.config.Repository.Snapshot(ctx)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	snapshot, err = application.projectConnectorRuntimes(ctx, snapshot, OperationScope{})
 	return publicSnapshot(snapshot, OperationScope{}), err
 }
 
 func (application *Application) SnapshotForScope(ctx context.Context, scope OperationScope) (Snapshot, error) {
 	if repository, ok := application.config.Repository.(ScopedSnapshotReader); ok {
 		snapshot, err := repository.SnapshotForScope(ctx, scope)
+		if err != nil {
+			return Snapshot{}, err
+		}
+		snapshot, err = application.projectConnectorRuntimes(ctx, snapshot, scope)
 		return publicSnapshot(snapshot, scope), err
 	}
 	snapshot, err := application.config.Repository.Snapshot(ctx)
-	if err != nil || strings.TrimSpace(scope.AccountID) == "" || application.config.AuthorizationProjections == nil {
-		return publicSnapshot(snapshot, scope), err
+	if err != nil {
+		return Snapshot{}, err
 	}
-	for index := range snapshot.Connectors {
-		projection, projectionErr := application.config.AuthorizationProjections.AuthorizationProjection(
-			ctx, scope.AccountID, snapshot.Connectors[index].Key,
-		)
-		if errors.Is(projectionErr, ErrNotFound) {
-			continue
-		}
-		if projectionErr != nil {
-			return Snapshot{}, projectionErr
-		}
-		snapshot.Connectors[index].Authorization = Authorization{
-			State: projection.State, FailureCode: projection.FailureCode,
+	if strings.TrimSpace(scope.AccountID) != "" && application.config.AuthorizationProjections != nil {
+		for index := range snapshot.Connectors {
+			projection, projectionErr := application.config.AuthorizationProjections.AuthorizationProjection(
+				ctx, scope.AccountID, snapshot.Connectors[index].Key,
+			)
+			if errors.Is(projectionErr, ErrNotFound) {
+				continue
+			}
+			if projectionErr != nil {
+				return Snapshot{}, projectionErr
+			}
+			snapshot.Connectors[index].Authorization = Authorization{
+				State: projection.State, FailureCode: projection.FailureCode,
+			}
 		}
 	}
-	return publicSnapshot(snapshot, scope), nil
+	snapshot, err = application.projectConnectorRuntimes(ctx, snapshot, scope)
+	return publicSnapshot(snapshot, scope), err
 }
 
 func publicSnapshot(snapshot Snapshot, scope OperationScope) Snapshot {

--- a/packages/connector/daemon/core/application_runtime_projection.go
+++ b/packages/connector/daemon/core/application_runtime_projection.go
@@ -1,0 +1,46 @@
+package host
+
+import (
+	"context"
+	"errors"
+)
+
+func (application *Application) projectConnectorRuntimes(
+	ctx context.Context,
+	snapshot Snapshot,
+	scope OperationScope,
+) (Snapshot, error) {
+	for index := range snapshot.Connectors {
+		connector := &snapshot.Connectors[index]
+		if connector.Installation.State != InstallationStateInstalled {
+			connector.Runtime = nil
+			continue
+		}
+		convergence, err := application.config.Repository.RuntimeConvergence(ctx, scope, connector.Key)
+		if errors.Is(err, ErrNotFound) {
+			connector.Runtime = &ConnectorRuntime{State: ConnectorRuntimeStateStopped}
+			continue
+		}
+		if err != nil {
+			return Snapshot{}, err
+		}
+		connector.Runtime = connectorRuntimeProjection(convergence, application.config.BootEpoch)
+	}
+	return snapshot, nil
+}
+
+func connectorRuntimeProjection(convergence RuntimeConvergence, bootEpoch string) *ConnectorRuntime {
+	observedCurrent := convergence.Observed.DesiredGeneration == convergence.Desired.Generation &&
+		convergence.Observed.BootEpoch == bootEpoch
+	if observedCurrent && convergence.Observed.Enabled &&
+		convergence.Observed.Readiness.State == RuntimeReadinessReady {
+		return &ConnectorRuntime{State: ConnectorRuntimeStateStarted}
+	}
+	if !convergence.Desired.Enabled {
+		return &ConnectorRuntime{State: ConnectorRuntimeStateStopped}
+	}
+	if convergence.LastErrorCode != "" {
+		return &ConnectorRuntime{State: ConnectorRuntimeStateFailed, FailureCode: convergence.LastErrorCode}
+	}
+	return &ConnectorRuntime{State: ConnectorRuntimeStateStarting}
+}

--- a/packages/connector/daemon/core/application_runtime_projection_test.go
+++ b/packages/connector/daemon/core/application_runtime_projection_test.go
@@ -1,0 +1,72 @@
+package host
+
+import "testing"
+
+func TestApplicationSnapshotProjectsInstalledRuntime(t *testing.T) {
+	connector := testManagedAuthorizedConnector("github")
+	repository := newMemoryRepository(connector)
+	application := newTestApplication(t, repository, &memoryScheduler{}, &memoryInstallRuntime{}, CatalogSnapshot{})
+	repository.runtimeConvergences[memoryRuntimeConvergenceKey(OperationScope{}, connector.Key)] = RuntimeConvergence{
+		Desired: RuntimeDesired{ConnectorKey: connector.Key, Generation: 2, Enabled: true},
+		Observed: RuntimeObserved{DesiredGeneration: 2, BootEpoch: application.config.BootEpoch, Enabled: true,
+			Readiness: RuntimeReadiness{State: RuntimeReadinessReady}},
+	}
+
+	snapshot, err := application.Snapshot(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.Connectors) != 1 || snapshot.Connectors[0].Runtime == nil ||
+		snapshot.Connectors[0].Runtime.State != ConnectorRuntimeStateStarted {
+		t.Fatalf("runtime projection = %#v, want started", snapshot.Connectors)
+	}
+}
+
+func TestConnectorRuntimeProjectionUsesCurrentObservedReadiness(t *testing.T) {
+	tests := []struct {
+		name        string
+		convergence RuntimeConvergence
+		want        ConnectorRuntimeState
+	}{
+		{
+			name: "started",
+			convergence: RuntimeConvergence{
+				Desired: RuntimeDesired{Generation: 2, Enabled: true},
+				Observed: RuntimeObserved{DesiredGeneration: 2, BootEpoch: "boot-1", Enabled: true,
+					Readiness: RuntimeReadiness{State: RuntimeReadinessReady}},
+			},
+			want: ConnectorRuntimeStateStarted,
+		},
+		{
+			name: "stale observation remains starting",
+			convergence: RuntimeConvergence{
+				Desired:  RuntimeDesired{Generation: 3, Enabled: true},
+				Observed: RuntimeObserved{DesiredGeneration: 2, BootEpoch: "boot-1", Enabled: true},
+			},
+			want: ConnectorRuntimeStateStarting,
+		},
+		{
+			name: "disabled intent is stopped",
+			convergence: RuntimeConvergence{
+				Desired: RuntimeDesired{Generation: 3, Enabled: false},
+			},
+			want: ConnectorRuntimeStateStopped,
+		},
+		{
+			name: "retry debt is failed",
+			convergence: RuntimeConvergence{
+				Desired:       RuntimeDesired{Generation: 3, Enabled: true},
+				LastErrorCode: "runtime_probe_failed",
+			},
+			want: ConnectorRuntimeStateFailed,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			projection := connectorRuntimeProjection(test.convergence, "boot-1")
+			if projection.State != test.want {
+				t.Fatalf("runtime state = %q, want %q", projection.State, test.want)
+			}
+		})
+	}
+}

--- a/packages/connector/daemon/core/types.go
+++ b/packages/connector/daemon/core/types.go
@@ -278,13 +278,31 @@ type Compatibility struct {
 	Reason string             `json:"reason,omitempty"`
 }
 
+type ConnectorRuntimeState string
+
+const (
+	ConnectorRuntimeStateStarted  ConnectorRuntimeState = "started"
+	ConnectorRuntimeStateStarting ConnectorRuntimeState = "starting"
+	ConnectorRuntimeStateStopped  ConnectorRuntimeState = "stopped"
+	ConnectorRuntimeStateFailed   ConnectorRuntimeState = "failed"
+)
+
+// ConnectorRuntime is a public, credential-free projection of the current
+// runtime convergence. It is derived while reading a scoped snapshot and is
+// never the source of capability publication truth.
+type ConnectorRuntime struct {
+	State       ConnectorRuntimeState `json:"state"`
+	FailureCode string                `json:"failureCode,omitempty"`
+}
+
 type Connector struct {
-	Key           string        `json:"key"`
-	Release       Release       `json:"release"`
-	Installation  Installation  `json:"installation"`
-	Authorization Authorization `json:"authorization"`
-	Compatibility Compatibility `json:"compatibility"`
-	Revision      uint64        `json:"revision"`
+	Key           string            `json:"key"`
+	Release       Release           `json:"release"`
+	Installation  Installation      `json:"installation"`
+	Authorization Authorization     `json:"authorization"`
+	Compatibility Compatibility     `json:"compatibility"`
+	Runtime       *ConnectorRuntime `json:"runtime,omitempty"`
+	Revision      uint64            `json:"revision"`
 }
 
 type Operation struct {

--- a/packages/connector/renderer/src/application/contracts/domain.ts
+++ b/packages/connector/renderer/src/application/contracts/domain.ts
@@ -172,12 +172,18 @@ export interface ConnectorCompatibility {
   reason?: string;
 }
 
+export interface ConnectorRuntime {
+  state: "started" | "starting" | "stopped" | "failed";
+  failureCode?: string;
+}
+
 export interface Connector {
   key: string;
   release: ConnectorRelease;
   installation: ConnectorInstallation;
   authorization: ConnectorAuthorization;
   compatibility: ConnectorCompatibility;
+  runtime?: ConnectorRuntime;
   revision: number;
 }
 

--- a/packages/connector/renderer/src/ui/composer/ConnectorComposerMenu.spec.tsx
+++ b/packages/connector/renderer/src/ui/composer/ConnectorComposerMenu.spec.tsx
@@ -112,7 +112,7 @@ describe("ConnectorComposerMenu", () => {
     ).toHaveTextContent("+2");
   });
 
-  it("shows connected versus connect actions and opens the catalog footer", async () => {
+  it("shows runtime state versus setup actions and opens the catalog footer", async () => {
     const onOpenConnector = vi.fn();
     const onOpenMarket = vi.fn();
     const onOpenChange = vi.fn();
@@ -139,10 +139,9 @@ describe("ConnectorComposerMenu", () => {
     const connected = await screen.findByTestId(
       "connector-market-composer-item-github"
     );
-    expect(connected).toHaveTextContent("Authorized");
     expect(
       screen.getByTestId("connector-market-composer-status-github")
-    ).toHaveClass("ml-auto");
+    ).toBeChecked();
     expect(connected).toHaveAttribute("data-disabled");
     expect(
       screen.getByTestId("connector-market-composer-item-notion")
@@ -201,7 +200,9 @@ describe("ConnectorComposerMenu", () => {
     const authorized = await screen.findByTestId(
       "connector-market-composer-item-notion"
     );
-    expect(authorized).toHaveTextContent("Authorized");
+    expect(
+      screen.getByTestId("connector-market-composer-status-notion")
+    ).toBeChecked();
     expect(authorized).not.toHaveAttribute("data-disabled");
     fireEvent.pointerDown(authorized, { button: 0, ctrlKey: false });
     expect(onSelectConnector).toHaveBeenCalledWith("notion", true);
@@ -241,7 +242,7 @@ describe("ConnectorComposerMenu", () => {
     });
     expect(
       await screen.findByTestId("connector-market-composer-status-lark-cli")
-    ).toHaveTextContent("Authorized");
+    ).toBeChecked();
 
     rendered.rerender(
       <ConnectorComposerMenu
@@ -256,6 +257,27 @@ describe("ConnectorComposerMenu", () => {
     expect(
       screen.getByTestId("connector-market-composer-item-lark-cli")
     ).toHaveTextContent("Authorize");
+  });
+
+  it("renders an installed but stopped connector as switched off", async () => {
+    render(
+      <ConnectorComposerMenu
+        items={[connector("linear", "disabled")]}
+        disabled={false}
+        labels={labels}
+        onOpenConnector={vi.fn()}
+        onOpenMarket={vi.fn()}
+      />
+    );
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Connectors" }), {
+      button: 0,
+      ctrlKey: false
+    });
+
+    expect(
+      await screen.findByTestId("connector-market-composer-status-linear")
+    ).not.toBeChecked();
   });
 
   it("limits the quick connector projection to ten catalog entries", async () => {

--- a/packages/connector/renderer/src/ui/composer/ConnectorComposerMenu.tsx
+++ b/packages/connector/renderer/src/ui/composer/ConnectorComposerMenu.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import {
   Badge,
   Button,
-  CheckIcon,
   ConnectorLinedIcon,
   DropdownMenu,
   DropdownMenuContent,
@@ -10,7 +9,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
   LinkIcon,
-  OpenLinkLinedIcon
+  OpenLinkLinedIcon,
+  Switch
 } from "@tutti-os/ui-system";
 import { cn } from "@tutti-os/ui-system/utils";
 
@@ -146,6 +146,7 @@ export function ConnectorComposerMenu({
         {quickItems.length > 0 ? (
           quickItems.map((item) => {
             const connected = item.status === "connected";
+            const installed = connected || item.status === "disabled";
             const selected = connected && item.selected === true;
             const actionLabel =
               item.status === "authorization_required"
@@ -190,16 +191,14 @@ export function ConnectorComposerMenu({
                   label={item.name}
                 />
                 <span className="min-w-0 flex-1 truncate">{item.name}</span>
-                {connected ? (
-                  <div
-                    className="ml-auto inline-flex shrink-0 items-center gap-1 pl-3 text-xs text-[var(--success)]"
+                {installed ? (
+                  <Switch
+                    aria-label={item.name}
+                    checked={connected}
+                    className="pointer-events-none ml-auto shrink-0"
                     data-testid={`connector-market-composer-status-${item.connectorKey}`}
-                  >
-                    <CheckIcon aria-hidden className="size-4" />
-                    {selected
-                      ? (labels.selected ?? labels.connected)
-                      : labels.connected}
-                  </div>
+                    tabIndex={-1}
+                  />
                 ) : !readOnly ? (
                   <div className="ml-auto inline-flex shrink-0 items-center gap-1 pl-3 text-xs text-[var(--text-primary)]">
                     <LinkIcon aria-hidden className="size-4" />

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -1735,6 +1735,30 @@ func (e ConnectorMarketReleaseStatus) Valid() bool {
 	}
 }
 
+// Defines values for ConnectorMarketRuntimeState.
+const (
+	ConnectorMarketRuntimeStateFailed   ConnectorMarketRuntimeState = "failed"
+	ConnectorMarketRuntimeStateStarted  ConnectorMarketRuntimeState = "started"
+	ConnectorMarketRuntimeStateStarting ConnectorMarketRuntimeState = "starting"
+	ConnectorMarketRuntimeStateStopped  ConnectorMarketRuntimeState = "stopped"
+)
+
+// Valid indicates whether the value is a known member of the ConnectorMarketRuntimeState enum.
+func (e ConnectorMarketRuntimeState) Valid() bool {
+	switch e {
+	case ConnectorMarketRuntimeStateFailed:
+		return true
+	case ConnectorMarketRuntimeStateStarted:
+		return true
+	case ConnectorMarketRuntimeStateStarting:
+		return true
+	case ConnectorMarketRuntimeStateStopped:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for CreateIssueManagerImageAttachmentRequestMimeType.
 const (
 	IssueAttachmentMimeTypeJPEG CreateIssueManagerImageAttachmentRequestMimeType = "image/jpeg"
@@ -4656,25 +4680,25 @@ func (e WorkspaceWorkflowOperationKind) Valid() bool {
 
 // Defines values for WorkspaceWorkflowOperationStatus.
 const (
-	WorkspaceWorkflowOperationStatusCanceled  WorkspaceWorkflowOperationStatus = "canceled"
-	WorkspaceWorkflowOperationStatusFailed    WorkspaceWorkflowOperationStatus = "failed"
-	WorkspaceWorkflowOperationStatusPending   WorkspaceWorkflowOperationStatus = "pending"
-	WorkspaceWorkflowOperationStatusRunning   WorkspaceWorkflowOperationStatus = "running"
-	WorkspaceWorkflowOperationStatusSucceeded WorkspaceWorkflowOperationStatus = "succeeded"
+	Canceled  WorkspaceWorkflowOperationStatus = "canceled"
+	Failed    WorkspaceWorkflowOperationStatus = "failed"
+	Pending   WorkspaceWorkflowOperationStatus = "pending"
+	Running   WorkspaceWorkflowOperationStatus = "running"
+	Succeeded WorkspaceWorkflowOperationStatus = "succeeded"
 )
 
 // Valid indicates whether the value is a known member of the WorkspaceWorkflowOperationStatus enum.
 func (e WorkspaceWorkflowOperationStatus) Valid() bool {
 	switch e {
-	case WorkspaceWorkflowOperationStatusCanceled:
+	case Canceled:
 		return true
-	case WorkspaceWorkflowOperationStatusFailed:
+	case Failed:
 		return true
-	case WorkspaceWorkflowOperationStatusPending:
+	case Pending:
 		return true
-	case WorkspaceWorkflowOperationStatusRunning:
+	case Running:
 		return true
-	case WorkspaceWorkflowOperationStatusSucceeded:
+	case Succeeded:
 		return true
 	default:
 		return false
@@ -6377,6 +6401,7 @@ type ConnectorMarketConnector struct {
 	Key           string                       `json:"key"`
 	Release       ConnectorMarketRelease       `json:"release"`
 	Revision      int64                        `json:"revision"`
+	Runtime       *ConnectorMarketRuntime      `json:"runtime,omitempty"`
 }
 
 // ConnectorMarketConnectorResponse defines model for ConnectorMarketConnectorResponse.
@@ -6510,6 +6535,15 @@ type ConnectorMarketReleaseSchemaVersion string
 
 // ConnectorMarketReleaseStatus defines model for ConnectorMarketRelease.Status.
 type ConnectorMarketReleaseStatus string
+
+// ConnectorMarketRuntime defines model for ConnectorMarketRuntime.
+type ConnectorMarketRuntime struct {
+	FailureCode *string                     `json:"failureCode,omitempty"`
+	State       ConnectorMarketRuntimeState `json:"state"`
+}
+
+// ConnectorMarketRuntimeState defines model for ConnectorMarketRuntime.State.
+type ConnectorMarketRuntimeState string
 
 // ConnectorMarketSnapshot defines model for ConnectorMarketSnapshot.
 type ConnectorMarketSnapshot struct {

--- a/services/tuttid/service/connector/market/command_provider_test.go
+++ b/services/tuttid/service/connector/market/command_provider_test.go
@@ -52,3 +52,29 @@ func TestConnectorCommandProviderRejectsMissingRegistry(t *testing.T) {
 		t.Fatalf("error = %v", err)
 	}
 }
+
+func TestConnectorCommandProviderOmitsStoppedRuntime(t *testing.T) {
+	host, registry, connector, generation := testCLIHostWithSetup(t, &connectorProcessStub{}, nil)
+	if _, err := host.Reconcile(context.Background(), market.RuntimeReconcileRequest{
+		OperationID: "op-1", ConnectionID: "workspace-1", Connector: connector, Enabled: true, Generation: generation,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	generation.Generation++
+	if _, err := host.Reconcile(context.Background(), market.RuntimeReconcileRequest{
+		OperationID: "op-2", ConnectionID: "workspace-1", Connector: connector, Enabled: false, Generation: generation,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	available, err := NewConnectorCommandProvider(registry).Invoke(
+		context.Background(), cliservice.InvokeRequest{CommandID: connectorAvailableCommandID},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	connectors, ok := available.Value["connectors"].([]implementationhost.ConnectorSummary)
+	if !ok || len(connectors) != 0 {
+		t.Fatalf("available connectors = %#v, want none after the Connector runtime stops", available.Value["connectors"])
+	}
+}


### PR DESCRIPTION
## Summary

Installed and authorized connectors were projected as available in the composer even when their runtime had not converged to a started, ready state. That allowed the UI to imply that a connector was usable while the CLI correctly omitted it from `connector available` because no route was published.

This change adds a credential-free runtime projection (`started`, `starting`, `stopped`, or `failed`) to scoped connector snapshots, maps non-started connectors to the disabled composer state, and renders installed connector status with the UI System switch. The CLI continues to use published runtime routes as its availability source of truth, with a regression test proving stopped connectors are omitted.

Older hosts that omit the optional runtime projection retain the existing authorization-based presentation for mixed-version compatibility.

## Verification

- `go test ./...` in `packages/connector/daemon/core`: runtime projection states pass.
- `go test ./...` in `packages/agent/daemon/composercatalog`: stopped/started capability mapping passes.
- `go test ./service/connector/market` in `services/tuttid`: stopped runtime is omitted from `connector available`.
- `pnpm --filter @tutti-os/connector-renderer test -- ConnectorComposerMenu.spec.tsx`: 78 Node tests and 18 Vitest tests pass, including on/off runtime switches.
- `pnpm check:api-generated`: generated API clients are consistent.
- Pre-push `pnpm check:changed -- --push-ready`: 26 selected lanes pass.

## Fallback Three Questions

- Source: a mixed-version deployment where an older connector host omits the optional runtime projection.
- Why can it not be fixed at that source? Older released hosts cannot emit a field that did not exist in their contract, so the renderer must remain compatible during rollout.
- Removal condition: remove the authorization-only fallback after the minimum supported host version always emits connector runtime state.

## Checklist

- [x] Agent lifecycle conformance is not applicable; this changes connector runtime presentation and CLI route availability only.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] README/CONTRIBUTING language variants are not applicable because neither source changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
