### PR TITLE
fix(connector): isolate catalog refresh operation lane

### DIFF
--- a/docs/architecture/connector.md
+++ b/docs/architecture/connector.md
@@ -457,6 +457,11 @@ global `expectedRevision` remains in the wire contract for old clients and is
 used when the Connector fence is absent. Catalog refresh retains its global
 revision fence. Internal level-triggered repair reads current durable state
 inside its transaction.
+Active-operation exclusion follows the same ownership boundary through exact
+scheduling lanes. The empty lane is reserved for catalog refresh; each
+Connector key is its own device lifecycle lane. A catalog refresh and a
+Connector operation may therefore coexist, while a second refresh or a second
+operation for the same Connector is rejected atomically by the durable store.
 An in-flight reconcile may have resolved its binding before a newer Projection
 was persisted. Its Observed compare-and-swap is rejected after Desired advances;
 the scanner then applies the newer generation before receipt resolution.

--- a/packages/connector/daemon/adapters/sqlite/store.go
+++ b/packages/connector/daemon/adapters/sqlite/store.go
@@ -587,17 +587,12 @@ WHERE owner_account_id = ? AND client_request_id = ?`,
 	return &operation, err
 }
 
-func (transaction *transaction) ActiveOperation(connectorKey string) (*market.Operation, error) {
+func (transaction *transaction) ActiveOperationInLane(connectorKey string) (*market.Operation, error) {
 	var payload string
-	query := `
+	if err := transaction.tx.QueryRowContext(transaction.ctx, `
 SELECT operation_json FROM connector_market_operations
-WHERE connector_key IN ('', ?) AND state IN ('accepted', 'running') LIMIT 1`
-	arguments := []any{connectorKey}
-	if strings.TrimSpace(connectorKey) == "" {
-		query = `SELECT operation_json FROM connector_market_operations WHERE state IN ('accepted', 'running') LIMIT 1`
-		arguments = nil
-	}
-	if err := transaction.tx.QueryRowContext(transaction.ctx, query, arguments...).Scan(&payload); err != nil {
+WHERE connector_key = ? AND state IN ('accepted', 'running') LIMIT 1`,
+		strings.TrimSpace(connectorKey)).Scan(&payload); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}

--- a/packages/connector/daemon/adapters/sqlite/store_test.go
+++ b/packages/connector/daemon/adapters/sqlite/store_test.go
@@ -311,6 +311,62 @@ func TestStoreKeepsActiveConnectorLifecycleUniqueAcrossAccounts(t *testing.T) {
 	}
 }
 
+func TestStoreScopesActiveOperationsToExactLane(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(ctx, filepath.Join(t.TempDir(), "tuttid.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	now := time.Unix(1, 0).UTC()
+	operations := []market.Operation{
+		{
+			OperationID: "refresh", ClientRequestID: "refresh", ConnectorKey: "",
+			Kind: market.OperationKindRefreshCatalog, State: market.OperationStateRunning,
+			CreatedAt: now, UpdatedAt: now,
+		},
+		{
+			OperationID: "authorization", ClientRequestID: "authorization", ConnectorKey: "google-sheets",
+			Kind: market.OperationKindStartAuthorization, State: market.OperationStateAccepted,
+			Scope: market.OperationScope{AccountID: "account-a"}, CreatedAt: now, UpdatedAt: now,
+		},
+	}
+	for _, operation := range operations {
+		operation := operation
+		if err := store.Transaction(ctx, func(tx market.Transaction) error { return tx.SaveOperation(operation) }); err != nil {
+			t.Fatalf("save %s operation: %v", operation.OperationID, err)
+		}
+	}
+	if err := store.Transaction(ctx, func(tx market.Transaction) error {
+		catalog, err := tx.ActiveOperationInLane("")
+		if err != nil {
+			return err
+		}
+		connector, err := tx.ActiveOperationInLane("google-sheets")
+		if err != nil {
+			return err
+		}
+		if catalog == nil || catalog.OperationID != "refresh" {
+			return fmt.Errorf("catalog lane operation = %#v", catalog)
+		}
+		if connector == nil || connector.OperationID != "authorization" {
+			return fmt.Errorf("connector lane operation = %#v", connector)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	secondRefresh := market.Operation{
+		OperationID: "refresh-2", ClientRequestID: "refresh-2", ConnectorKey: "",
+		Kind: market.OperationKindRefreshCatalog, State: market.OperationStateAccepted,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := store.Transaction(ctx, func(tx market.Transaction) error { return tx.SaveOperation(secondRefresh) }); err == nil {
+		t.Fatal("second active catalog refresh unexpectedly entered the catalog lane")
+	}
+}
+
 func TestStorePrivateOperationEventDoesNotExposeOperationID(t *testing.T) {
 	ctx := context.Background()
 	store, err := Open(ctx, filepath.Join(t.TempDir(), "tuttid.db"))

--- a/packages/connector/daemon/core/application.go
+++ b/packages/connector/daemon/core/application.go
@@ -1551,7 +1551,7 @@ func verifyIdempotentOperation(operation Operation, kind OperationKind, connecto
 }
 
 func rejectActiveOperation(tx Transaction, connectorKey string) error {
-	active, err := tx.ActiveOperation(connectorKey)
+	active, err := tx.ActiveOperationInLane(connectorKey)
 	if err != nil {
 		return err
 	}

--- a/packages/connector/daemon/core/application_execution.go
+++ b/packages/connector/daemon/core/application_execution.go
@@ -65,10 +65,16 @@ func (application *Application) executeRefresh(ctx context.Context, operation Op
 					continue
 				}
 				if connector.Installation.State == InstallationStateNotInstalled {
-					if err := tx.DeleteConnector(connector.Key); err != nil {
+					active, err := tx.ActiveOperationInLane(connector.Key)
+					if err != nil {
 						return err
 					}
-					continue
+					if active == nil {
+						if err := tx.DeleteConnector(connector.Key); err != nil {
+							return err
+						}
+						continue
+					}
 				}
 				connector.Compatibility = Compatibility{
 					State:  CompatibilityStateUnsupportedVersion,

--- a/packages/connector/daemon/core/application_scoped_runtime.go
+++ b/packages/connector/daemon/core/application_scoped_runtime.go
@@ -33,7 +33,7 @@ func (application *Application) EnsureRuntimeReconcile(
 	var result MutationResult
 	created := false
 	err := application.config.Repository.Transaction(ctx, func(tx Transaction) error {
-		active, err := tx.ActiveOperation(connectorKey)
+		active, err := tx.ActiveOperationInLane(connectorKey)
 		if err != nil {
 			return err
 		}

--- a/packages/connector/daemon/core/application_test.go
+++ b/packages/connector/daemon/core/application_test.go
@@ -75,6 +75,50 @@ func TestApplicationConnectorRevisionFenceAllowsIndependentConcurrentCommands(t 
 	}
 }
 
+func TestApplicationCatalogRefreshDoesNotBlockConnectorAuthorization(t *testing.T) {
+	connector := testManagedAuthorizedConnector("google-sheets")
+	connector.Authorization = Authorization{State: AuthorizationStateDisconnected}
+	repository := newMemoryRepository(connector)
+	repository.operations["refresh-running"] = Operation{
+		OperationID: "refresh-running", ClientRequestID: "refresh-running", ConnectorKey: "",
+		Kind: OperationKindRefreshCatalog, State: OperationStateRunning, Stage: OperationStageRefreshing,
+	}
+	application := newTestApplication(t, repository, &memoryScheduler{}, &memoryInstallRuntime{}, CatalogSnapshot{})
+
+	result, err := application.BeginAuthorization(context.Background(), ConnectorMutation{
+		Mutation:     Mutation{ClientRequestID: "authorize-google-sheets"},
+		ConnectorKey: connector.Key,
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Operation.ConnectorKey != connector.Key || result.Operation.Kind != OperationKindStartAuthorization {
+		t.Fatalf("authorization operation = %#v", result.Operation)
+	}
+	if active := repository.operations["refresh-running"]; active.State != OperationStateRunning {
+		t.Fatalf("catalog refresh operation = %#v", active)
+	}
+}
+
+func TestApplicationConnectorOperationDoesNotBlockCatalogRefresh(t *testing.T) {
+	repository := newMemoryRepository(testConnector("google-sheets"))
+	repository.operations["install-running"] = Operation{
+		OperationID: "install-running", ClientRequestID: "install-running", ConnectorKey: "google-sheets",
+		Kind: OperationKindInstall, State: OperationStateRunning, Stage: OperationStageInstalling,
+	}
+	application := newTestApplication(t, repository, &memoryScheduler{}, &memoryInstallRuntime{}, CatalogSnapshot{})
+
+	result, err := application.RefreshCatalog(context.Background(), Mutation{
+		ClientRequestID: "refresh-catalog", ExpectedRevision: repository.revision,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Operation.ConnectorKey != "" || result.Operation.Kind != OperationKindRefreshCatalog {
+		t.Fatalf("catalog refresh operation = %#v", result.Operation)
+	}
+}
+
 func TestApplicationRepairInstallClearsInvalidInstalledEvidence(t *testing.T) {
 	for _, failureCode := range []string{
 		InstallationFailureCodePhysicallyAbsent,
@@ -1779,6 +1823,52 @@ func TestApplicationRefreshRejectsUnknownImplementation(t *testing.T) {
 	}
 }
 
+func TestApplicationRefreshRetainsRemovedUninstalledConnectorWithActiveOperation(t *testing.T) {
+	connector := testConnector("google-sheets")
+	repository := newMemoryRepository(connector)
+	repository.operations["authorization-running"] = Operation{
+		OperationID: "authorization-running", ClientRequestID: "authorization-running", ConnectorKey: connector.Key,
+		Kind: OperationKindStartAuthorization, State: OperationStateRunning, Stage: OperationStageAuthorizing,
+	}
+	application := newTestApplication(t, repository, &memoryScheduler{}, &memoryInstallRuntime{}, CatalogSnapshot{
+		SourceRevision: "catalog-without-google-sheets",
+	})
+
+	accepted, err := application.RefreshCatalog(context.Background(), Mutation{
+		ClientRequestID: "refresh-catalog", ExpectedRevision: repository.revision,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := application.ExecuteOperation(context.Background(), accepted.Operation.OperationID); err != nil {
+		t.Fatal(err)
+	}
+	retained, err := repository.Connector(context.Background(), connector.Key)
+	if err != nil {
+		t.Fatalf("connector with an active operation was deleted: %v", err)
+	}
+	if retained.Compatibility.State != CompatibilityStateUnsupportedVersion || retained.Compatibility.Reason != "removed_from_catalog" {
+		t.Fatalf("retained connector compatibility = %#v", retained.Compatibility)
+	}
+
+	authorization := repository.operations["authorization-running"]
+	authorization.State = OperationStateCompleted
+	authorization.Stage = OperationStageCompleted
+	repository.operations[authorization.OperationID] = authorization
+	next, err := application.RefreshCatalog(context.Background(), Mutation{
+		ClientRequestID: "refresh-catalog-again", ExpectedRevision: repository.revision,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := application.ExecuteOperation(context.Background(), next.Operation.OperationID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repository.Connector(context.Background(), connector.Key); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("connector remained after its active operation completed: %v", err)
+	}
+}
+
 func TestApplicationRejectsStaleRevisionBeforeMutation(t *testing.T) {
 	repository := newMemoryRepository(testConnector("github"))
 	repository.revision = 4
@@ -3046,9 +3136,9 @@ func (transaction *memoryTransaction) OperationByClientRequestID(ownerAccountID,
 	return nil, nil
 }
 
-func (transaction *memoryTransaction) ActiveOperation(connectorKey string) (*Operation, error) {
+func (transaction *memoryTransaction) ActiveOperationInLane(connectorKey string) (*Operation, error) {
 	for _, operation := range transaction.operations {
-		if (connectorKey == "" || operation.ConnectorKey == "" || operation.ConnectorKey == connectorKey) &&
+		if operation.ConnectorKey == connectorKey &&
 			(operation.State == OperationStateAccepted || operation.State == OperationStateRunning) {
 			copy := operation
 			return &copy, nil

--- a/packages/connector/daemon/core/ports.go
+++ b/packages/connector/daemon/core/ports.go
@@ -107,7 +107,10 @@ type Transaction interface {
 	Connector(connectorKey string) (Connector, error)
 	Operation(operationID string) (Operation, error)
 	OperationByClientRequestID(ownerAccountID, clientRequestID string) (*Operation, error)
-	ActiveOperation(connectorKey string) (*Operation, error)
+	// ActiveOperationInLane returns the active operation for exactly one
+	// scheduling lane. The empty lane is reserved for catalog refreshes; it is
+	// not a wildcard for connector-scoped operations.
+	ActiveOperationInLane(connectorKey string) (*Operation, error)
 	SaveCatalogRevision(sourceRevision string) error
 	SetCatalogState(state CatalogState) error
 	SaveConnector(Connector) error


### PR DESCRIPTION
## Summary

- make active-operation lookup exact by scheduling lane so catalog refresh no longer blocks connector authorization
- preserve removed, not-installed connectors while a connector-scoped operation is active
- document the lane invariant and add core/SQLite concurrency regressions

## Verification

- `go test ./... -count=1` in connector daemon core, SQLite adapter, control-plane adapter, and application modules
- `go vet ./...` in the same four modules
- `git diff --check`
- desktop dev app launched with the rebuilt `tuttid`

The normal pre-push hook could not write its check logs because the local disk had only about 140 MiB free (`ENOSPC`). The relevant local checks above passed before push; GitHub CI remains the merge gate.

## Fallback Three Questions

- Source: catalog refresh can remove a not-installed connector while an independently accepted connector operation still needs its durable record.
- Why can it not be fixed at that source? Exact catalog and connector lanes intentionally permit this concurrency, so refresh must retain the record until the connector operation is terminal.
- Removal condition: this guard can be removed only if connector operations no longer depend on the connector record or deletion becomes an operation-aware durable tombstone transition.

## Checklist

- [x] This does not change agent lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior changed.
- [x] No README or CONTRIBUTING language source changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] The commit is signed off with DCO.