### PR TITLE
fix(agent): recover from missing provider sessions

### DIFF
--- a/packages/agent/activity-core/src/engine/promptQueue.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.reducer.test.ts
@@ -611,6 +611,33 @@ test("session no-active-turn app error reconciles before retrying queued prompt"
   assert.equal(failed.state.recordsBySessionId["session-1"]?.inFlight, null);
 });
 
+test("process cleanup failure reconciles before retrying queued prompt", () => {
+  const available = canonicalLifecycle("settled", 1);
+  const sending = reduce(
+    createInitialPromptQueueState(),
+    enqueue("prompt-1"),
+    available
+  );
+  const failed = reduce(
+    sending.state,
+    commandResult(
+      commandId(sending.commands[0]),
+      "queue/sendPrompt",
+      "failed",
+      { errorCode: "agent.process_cleanup_pending" }
+    ),
+    available
+  );
+
+  assert.equal(failed.commands.length, 1);
+  assert.equal(failed.commands[0]?.type, "session/reconcile");
+  assert.equal(
+    failed.state.recordsBySessionId["session-1"]?.failedPromptId,
+    null
+  );
+  assert.equal(failed.state.recordsBySessionId["session-1"]?.inFlight, null);
+});
+
 test("timeout confirmation waits for its exact canonical turn to settle", () => {
   const available = canonicalLifecycle("settled", 1, "turn-0");
   const first = reduce(

--- a/packages/agent/activity-core/src/engine/promptQueue.reducer.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.reducer.ts
@@ -83,7 +83,7 @@ export function promptQueueReducer(
   if (intent.type === "submit/requested" && intent.routing === "immediate") {
     return reduced;
   }
-  if (isNoActiveTurnSendFailure(intent)) {
+  if (isPreTurnSendFailure(intent)) {
     return reduced;
   }
   return drainAffectedSessions(
@@ -446,7 +446,7 @@ function settleQueueCommand(
       state: replaceRecord(state, agentSessionId, record)
     };
   }
-  if (isNoActiveTurnSendFailure(intent)) {
+  if (isPreTurnSendFailure(intent)) {
     return {
       commands: [
         queueOwnedReconcileCommand(agentSessionId, current.workspaceId, intent)
@@ -469,7 +469,7 @@ function settleQueueCommand(
   );
 }
 
-function isNoActiveTurnSendFailure(intent: EngineIntent): boolean {
+function isPreTurnSendFailure(intent: EngineIntent): boolean {
   if (
     intent.type !== "engine/commandResult" ||
     intent.commandType !== "queue/sendPrompt" ||
@@ -483,7 +483,9 @@ function isNoActiveTurnSendFailure(intent: EngineIntent): boolean {
     errorReason === "agent.no_active_turn" ||
     errorCode === "agent.no_active_turn" ||
     errorReason === "agent.session_no_active_turn" ||
-    errorCode === "agent.session_no_active_turn"
+    errorCode === "agent.session_no_active_turn" ||
+    errorReason === "agent.process_cleanup_pending" ||
+    errorCode === "agent.process_cleanup_pending"
   );
 }
 

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.cancel.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.cancel.ts
@@ -186,6 +186,23 @@ export function cancelCommand(
   };
 }
 
+export function clearCancel(
+  state: SessionLifecycleState,
+  id: string
+): EngineReducerResult<SessionLifecycleState> {
+  const operation = state.operationBySessionId[id];
+  if (!operation || operation.cancel.status === "idle") return unchanged(state);
+  const nextState = state.sessionsById[id]
+    ? setCancel(state, id, initialCancel())
+    : removeDetachedOperation(state, id);
+  return {
+    commands: operation.cancel.expiryId
+      ? [{ type: "engine/cancelExpiry", expiryId: operation.cancel.expiryId }]
+      : NO_COMMANDS,
+    state: nextState
+  };
+}
+
 export function sessionVersion(session: {
   updatedAtUnixMs?: number;
   lastEventUnixMs?: number;
@@ -213,4 +230,13 @@ function unchanged(
   state: SessionLifecycleState
 ): EngineReducerResult<SessionLifecycleState> {
   return { commands: NO_COMMANDS, state };
+}
+
+function removeDetachedOperation(
+  state: SessionLifecycleState,
+  id: string
+): SessionLifecycleState {
+  const operationBySessionId = { ...state.operationBySessionId };
+  delete operationBySessionId[id];
+  return { ...state, operationBySessionId };
 }

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.test.ts
@@ -1791,6 +1791,45 @@ test("authoritative settled state clears a cancel timeout failure", () => {
   );
 });
 
+test("process cleanup failure abandons its awaiting-turn cancel", () => {
+  let state = reduce(createInitialSessionLifecycleState(), {
+    type: "session/snapshotReceived",
+    sessions: [session(null, 1)]
+  }).state;
+  state = reduce(state, {
+    agentSessionId: "session-1",
+    awaitingTurnExpiresAtUnixMs: 30_000,
+    clientSubmitId: "submit-1",
+    commandId: "submit:cancel:submit-1",
+    type: "session/cancelRequested",
+    workspaceId: "workspace-1"
+  }).state;
+  assert.equal(
+    state.operationBySessionId["session-1"]?.cancel.status,
+    "awaitingTurn"
+  );
+
+  const failed = reduce(state, {
+    commandId: "submit:send:submit-1",
+    commandType: "queue/sendPrompt",
+    correlationId: "submit-1",
+    errorCode: "agent.process_cleanup_pending",
+    outcome: "failed",
+    type: "engine/commandResult"
+  });
+
+  assert.equal(
+    failed.state.operationBySessionId["session-1"]?.cancel.status,
+    "idle"
+  );
+  assert.deepEqual(failed.commands, [
+    {
+      expiryId: "cancel:awaiting-turn:submit:cancel:submit-1",
+      type: "engine/cancelExpiry"
+    }
+  ]);
+});
+
 test("cancel result for another session cannot enter canonical turn state", () => {
   let state = reduce(createInitialSessionLifecycleState(), {
     type: "session/snapshotReceived",

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.ts
@@ -41,6 +41,7 @@ import {
 } from "./sessionLifecycle.state.ts";
 import {
   cancelCommand,
+  clearCancel,
   reconcilePendingCancelForSubmit,
   reconcilePendingCancelFromMessages,
   reconcilePendingCancels,
@@ -183,6 +184,7 @@ export function sessionLifecycleReducer(
             commandId: `submit:cancel:${intent.clientSubmitId}`,
             awaitingTurnExpiresAtUnixMs:
               intent.requestedAtUnixMs + TURN_CANCEL_TIMEOUT_MS,
+            clientSubmitId: intent.clientSubmitId,
             timeoutMs: TURN_CANCEL_TIMEOUT_MS,
             workspaceId: intent.workspaceId
           })
@@ -243,6 +245,12 @@ export function sessionLifecycleReducer(
         );
       if (
         intent.commandType === "queue/sendPrompt" &&
+        isPreTurnSendFailure(intent)
+      ) {
+        return abandonPendingSubmitCancel(state, intent);
+      }
+      if (
+        intent.commandType === "queue/sendPrompt" &&
         context.sendResultValidation?.kind === "valid"
       ) {
         const sendResult = context.sendResultValidation.result;
@@ -267,6 +275,41 @@ export function sessionLifecycleReducer(
     default:
       return unchanged(state);
   }
+}
+
+function isPreTurnSendFailure(intent: EngineIntent): boolean {
+  if (
+    intent.type !== "engine/commandResult" ||
+    intent.commandType !== "queue/sendPrompt" ||
+    intent.outcome !== "failed"
+  ) {
+    return false;
+  }
+  const errorReason = intent.errorReason?.trim();
+  const errorCode = intent.errorCode?.trim();
+  return (
+    errorReason === "agent.no_active_turn" ||
+    errorCode === "agent.no_active_turn" ||
+    errorReason === "agent.session_no_active_turn" ||
+    errorCode === "agent.session_no_active_turn" ||
+    errorReason === "agent.process_cleanup_pending" ||
+    errorCode === "agent.process_cleanup_pending"
+  );
+}
+
+function abandonPendingSubmitCancel(
+  state: SessionLifecycleState,
+  intent: Extract<EngineIntent, { type: "engine/commandResult" }>
+): EngineReducerResult<SessionLifecycleState> {
+  const clientSubmitId = intent.correlationId?.trim() ?? "";
+  if (!clientSubmitId) return unchanged(state);
+  const entry = Object.entries(state.operationBySessionId).find(
+    ([, operation]) =>
+      operation.cancel.status === "awaitingTurn" &&
+      (operation.cancel.targetClientSubmitId === clientSubmitId ||
+        operation.cancel.commandId === `submit:cancel:${clientSubmitId}`)
+  );
+  return entry ? clearCancel(state, entry[0]) : unchanged(state);
 }
 
 function changeRuntimeActivity(
@@ -551,7 +594,11 @@ function requestCancel(
   const turn = activeTurnId
     ? state.turnsById[canonicalTurnKey(id, activeTurnId)]
     : null;
-  if (turn && turn.phase !== "settled" && !targetClientSubmitId) {
+  if (
+    turn &&
+    turn.phase !== "settled" &&
+    (!targetClientSubmitId || intent.commandId.startsWith("submit:cancel:"))
+  ) {
     const next = setCancel(
       nextState,
       id,
@@ -726,32 +773,6 @@ function expireCancel(
     ([, value]) => value.cancel.expiryId === expiryId
   );
   return entry ? clearCancel(state, entry[0]) : unchanged(state);
-}
-
-function clearCancel(
-  state: SessionLifecycleState,
-  id: string
-): EngineReducerResult<SessionLifecycleState> {
-  const operation = state.operationBySessionId[id];
-  if (!operation || operation.cancel.status === "idle") return unchanged(state);
-  const nextState = state.sessionsById[id]
-    ? setCancel(state, id, initialCancel())
-    : removeDetachedOperation(state, id);
-  return {
-    commands: operation.cancel.expiryId
-      ? [{ type: "engine/cancelExpiry", expiryId: operation.cancel.expiryId }]
-      : NO_COMMANDS,
-    state: nextState
-  };
-}
-
-function removeDetachedOperation(
-  state: SessionLifecycleState,
-  id: string
-): SessionLifecycleState {
-  const operationBySessionId = { ...state.operationBySessionId };
-  delete operationBySessionId[id];
-  return { ...state, operationBySessionId };
 }
 
 function updateOperation(

--- a/packages/agent/daemon/runtime/codex_appserver_lifecycle_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_lifecycle_test.go
@@ -489,6 +489,115 @@ func TestCodexAppServerClientCloseIsIdempotent(t *testing.T) {
 	}
 }
 
+type sequencedCloseErrorConnection struct {
+	ProcessConnection
+	mu     sync.Mutex
+	errors []error
+}
+
+func (c *sequencedCloseErrorConnection) Close() error {
+	c.mu.Lock()
+	var err error
+	if len(c.errors) > 0 {
+		err = c.errors[0]
+		c.errors = c.errors[1:]
+	}
+	c.mu.Unlock()
+	if err == nil {
+		return c.ProcessConnection.Close()
+	}
+	if errors.Is(err, ErrSessionNotFound) {
+		// The sentinel represents a connection whose provider session has
+		// already disappeared. Close the scripted transport for test cleanup,
+		// while preserving the provider error returned to the adapter.
+		_ = c.ProcessConnection.Close()
+	}
+	return err
+}
+
+type sequencedCloseErrorTransport struct {
+	mu          sync.Mutex
+	starts      int
+	closeErrors []error
+}
+
+func (t *sequencedCloseErrorTransport) Start(_ context.Context, _ ProcessSpec) (ProcessConnection, error) {
+	conn, _ := newScriptedAppServerHarness()
+	t.mu.Lock()
+	start := t.starts
+	t.starts++
+	closeErrors := append([]error(nil), t.closeErrors...)
+	t.mu.Unlock()
+	if start == 0 {
+		return &sequencedCloseErrorConnection{
+			ProcessConnection: conn,
+			errors:            closeErrors,
+		}, nil
+	}
+	return conn, nil
+}
+
+func TestAppServerAlreadyGoneRetiredHandleDoesNotBackpressureReplacement(t *testing.T) {
+	t.Parallel()
+
+	transport := &sequencedCloseErrorTransport{
+		closeErrors: []error{
+			errors.New("injected first close failure"),
+			errors.New("injected second close failure"),
+			ErrSessionNotFound,
+		},
+	}
+	adapter := NewCodexAppServerAdapter(transport)
+	session := testAppServerSession()
+	if _, err := adapter.Start(t.Context(), session); err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	if _, err := adapter.Start(t.Context(), session); err != nil {
+		t.Fatalf("replacement Start: %v", err)
+	}
+
+	session.ProviderSessionID = "codex-thread-1"
+	if err := adapter.Resume(t.Context(), session); err != nil {
+		t.Fatalf("Resume after provider session disappeared: %v", err)
+	}
+	if !adapter.HasLiveSession(session) {
+		t.Fatal("replacement app-server session is not usable")
+	}
+	cleanup := adapter.CleanupLiveSessionResources(t.Context(), 1)
+	if cleanup.Attempted != 0 || cleanup.Cleaned != 0 || cleanup.Failed != 0 {
+		t.Fatalf("cleanup=%#v, want no retained session", cleanup)
+	}
+	if err := adapter.ReleaseLiveSession(t.Context(), session); err != nil {
+		t.Fatalf("release replacement: %v", err)
+	}
+}
+
+func TestAppServerCloseTreatsMissingSessionAsSuccess(t *testing.T) {
+	t.Parallel()
+
+	connection, _ := newScriptedAppServerHarness()
+	client := newCodexAppServerClient(&sequencedCloseErrorConnection{
+		ProcessConnection: connection,
+		errors:            []error{ErrSessionNotFound},
+	})
+	adapter := NewCodexAppServerAdapter(&multiProcAppServerTransport{})
+	session := testAppServerSession()
+	adapter.storeSession(session.AgentSessionID, &codexAppServerSession{
+		client:          client,
+		pendingRequests: make(map[string]*pendingInteractiveRequest),
+	})
+
+	if err := adapter.ReleaseLiveSession(t.Context(), session); err != nil {
+		t.Fatalf("ReleaseLiveSession: %v", err)
+	}
+	if adapter.getSession(session.AgentSessionID) != nil {
+		t.Fatal("missing provider session remained owned as current")
+	}
+	if adapter.hasRetiredCodexSessions(session.AgentSessionID) {
+		t.Fatal("missing provider session was retained for cleanup")
+	}
+}
+
 func TestAppServerCloseFailureRetainsUnusableHandleAndBackpressuresReplacement(t *testing.T) {
 	for _, provider := range []string{ProviderCodex, ProviderTuttiAgent} {
 		provider := provider

--- a/packages/agent/daemon/runtime/codex_appserver_registry.go
+++ b/packages/agent/daemon/runtime/codex_appserver_registry.go
@@ -105,7 +105,7 @@ func (a *CodexAppServerAdapter) invalidateSessionClient(
 	for _, request := range pending {
 		request.supersede(errPermissionRequestCanceled)
 	}
-	if err := expectedClient.Close(); err != nil {
+	if err := expectedClient.Close(); err != nil && !codexSessionAlreadyGone(err) {
 		a.retainRetiredCodexSession(key, appSession)
 	}
 	return true

--- a/packages/agent/daemon/runtime/codex_appserver_resource_ownership.go
+++ b/packages/agent/daemon/runtime/codex_appserver_resource_ownership.go
@@ -19,6 +19,13 @@ func codexProcessCleanupPendingError(cause error) error {
 	}
 }
 
+// A provider process can disappear before its owner gets to close the local
+// connection. Once the provider reports that the session is already gone,
+// there is no resource left for the ownership registry to retain or retry.
+func codexSessionAlreadyGone(err error) bool {
+	return errors.Is(err, ErrSessionNotFound)
+}
+
 func (a *CodexAppServerAdapter) retainRetiredCodexSession(agentSessionID string, session *codexAppServerSession) {
 	if a == nil || session == nil || session.client == nil {
 		return
@@ -46,6 +53,9 @@ func (a *CodexAppServerAdapter) closeOrRetainCodexSession(agentSessionID string,
 	}
 	session.client.SetMessageHandler(nil)
 	if err := session.client.Close(); err != nil {
+		if codexSessionAlreadyGone(err) {
+			return
+		}
 		a.retainRetiredCodexSession(agentSessionID, session)
 	}
 }
@@ -112,6 +122,14 @@ func (a *CodexAppServerAdapter) retryOneCodexSessionLocked(agentSessionID string
 		current.client.SetMessageHandler(nil)
 		a.mu.Unlock()
 		if err := current.client.Close(); err != nil {
+			if codexSessionAlreadyGone(err) {
+				a.mu.Lock()
+				if a.sessions[agentSessionID] == current {
+					delete(a.sessions, agentSessionID)
+				}
+				a.mu.Unlock()
+				return true, nil
+			}
 			a.mu.Lock()
 			if a.sessions[agentSessionID] == current {
 				current.releasing = false
@@ -142,6 +160,10 @@ func (a *CodexAppServerAdapter) retryOneCodexSessionLocked(agentSessionID string
 	target.client.SetMessageHandler(nil)
 	a.mu.Unlock()
 	if err := target.client.Close(); err != nil {
+		if codexSessionAlreadyGone(err) {
+			a.removeRetiredCodexSession(agentSessionID, target)
+			return true, nil
+		}
 		a.mu.Lock()
 		target.releasing = false
 		a.mu.Unlock()

--- a/packages/agent/daemon/runtime/codex_appserver_session.go
+++ b/packages/agent/daemon/runtime/codex_appserver_session.go
@@ -452,6 +452,14 @@ func (a *CodexAppServerAdapter) closeLiveSession(agentSessionID string) error {
 	a.mu.Unlock()
 	if appSession != nil && appSession.client != nil {
 		if err := appSession.client.Close(); err != nil {
+			if codexSessionAlreadyGone(err) {
+				a.mu.Lock()
+				if a.sessions[agentSessionID] == appSession {
+					delete(a.sessions, agentSessionID)
+				}
+				a.mu.Unlock()
+				return nil
+			}
 			a.mu.Lock()
 			if a.sessions[agentSessionID] == appSession {
 				appSession.releasing = false


### PR DESCRIPTION
## Summary
- Treat `ErrSessionNotFound` as an idempotent provider cleanup result.
- Recover local prompt queue and pending cancel state after pre-turn cleanup failure.
- Add Go and activity-core regression coverage.

## Tests
- `pnpm check:changed -- --push-ready`

## Notes
- Unrelated worktree changes were excluded from the commit.