### PR TITLE
feat(connector)!: require published HTTPS icons

### DIFF
--- a/docs/architecture/connector.md
+++ b/docs/architecture/connector.md
@@ -210,10 +210,11 @@ stable CLI shims, and removes every prepared artifact and private Node package
 tree for that Connector. It preserves account authorization, user/workspace
 state, and the shared Node package store and package-manager caches.
 
-Catalog display metadata includes a required, bounded PNG, WebP, or SVG data
-URL. This makes the icon available before installation and removes connector-key
-special cases from the renderer. The data URL is generated from the source
-connector icon during publishing and is limited to 128 KiB after decoding.
+Catalog display metadata includes a required public HTTPS icon URL. Publishing
+stores the source PNG, WebP, or SVG as an immutable versioned object and places
+its CDN URL in the Market manifest. The daemon rejects missing URLs, inline
+`data:` images, non-HTTPS schemes, credentials, surrounding whitespace, and
+URLs longer than 2048 bytes before the release reaches a renderer or runtime.
 
 Manifest permissions use a lowercase stable permission name with an optional
 scope (`permission`, `permission:scope`, or `permission:*`). The daemon keeps

--- a/packages/connector/contracts/openapi/connector-market.v1.yaml
+++ b/packages/connector/contracts/openapi/connector-market.v1.yaml
@@ -570,7 +570,9 @@ components:
           type: string
         iconUrl:
           type: string
-          pattern: "^data:image/(?:png|webp|svg\\+xml);base64,"
+          format: uri
+          maxLength: 2048
+          pattern: "^https://"
         description:
           type: string
         agentRouting:

--- a/packages/connector/daemon/adapters/sqlite/store_test.go
+++ b/packages/connector/daemon/adapters/sqlite/store_test.go
@@ -758,7 +758,7 @@ func testConnector() market.Connector {
 		ReleaseDigest:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		ManifestDigest: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 		Manifest: market.Manifest{
-			IconURL:       "data:image/png;base64,iVBORw0KGgo=",
+			IconURL:       "https://cdn.example.test/tutti/connector-market/github/1.0.0/github-1.0.0-icon.svg",
 			SchemaVersion: "1",
 			DisplayName:   "GitHub",
 			Implementation: market.Implementation{Kind: market.ImplementationKindManagedStdio,

--- a/packages/connector/daemon/application/adapters/catalog/source.go
+++ b/packages/connector/daemon/application/adapters/catalog/source.go
@@ -200,14 +200,10 @@ func (source *CatalogSource) mapItem(item *marketv1.PublicMarketItem) (market.Re
 		return market.Release{}, err
 	}
 	releaseDigest := sha256.Sum256([]byte(item.GetItemKey() + "\x00" + item.GetVersion() + "\x00" + item.GetArtifact().GetSha256()))
-	iconURL := connectorManifest.Display.IconURL
-	if strings.TrimSpace(iconURL) == "" {
-		iconURL = legacyConnectorIconURL
-	}
 	// The server's v2 envelope is the generic, market-neutral publication
 	// contract. V3 selects one target first. Both project into the stable host
 	// manifest contract; these schema versions describe different boundaries.
-	manifest := market.Manifest{SchemaVersion: "1", DisplayName: connectorManifest.Display.Name, IconURL: iconURL,
+	manifest := market.Manifest{SchemaVersion: "1", DisplayName: connectorManifest.Display.Name, IconURL: connectorManifest.Display.IconURL,
 		Description: connectorManifest.Display.Description, AgentRouting: connectorManifest.Payload.AgentRouting,
 		Permissions:          connectorManifest.Payload.Permissions,
 		RequiredCapabilities: connectorManifest.Payload.RequiredCapabilities,
@@ -292,8 +288,6 @@ func (authorization wireConnectorAuthorization) interaction() (json.RawMessage, 
 	}
 	return selected, nil
 }
-
-const legacyConnectorIconURL = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCI+PHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiM2YjcyODAiLz48cGF0aCBkPSJNMTggMjBoMjh2MjRIMTh6IiBmaWxsPSJub25lIiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjQiLz48L3N2Zz4="
 
 func artifactMediaType(key string) string {
 	switch {

--- a/packages/connector/daemon/application/adapters/catalog/source_test.go
+++ b/packages/connector/daemon/application/adapters/catalog/source_test.go
@@ -57,7 +57,7 @@ func TestCatalogSourceMapsPublishedConnectorItemsWithAdditiveFields(t *testing.T
       "itemKey": "github",
       "version": "1.0.0",
       "metadata": {"labels": ["source-control"]},
-      "display": {"name": "GitHub", "description": "GitHub connector", "iconUrl": "data:image/png;base64,iVBORw0KGgo=", "badge": "new"},
+      "display": {"name": "GitHub", "description": "GitHub connector", "iconUrl": "https://cdn.example.test/tutti/connector-market/github/1.0.0/github-1.0.0-icon.svg", "badge": "new"},
       "payload": {
         "permissions": ["network:*"],
         "agentRouting": {"aliases": ["Git Hub", "代码托管"]},
@@ -136,7 +136,7 @@ func TestCatalogSourcePreservesRemoteRequiredCapabilities(t *testing.T) {
   "version": "0.2.0",
   "display": {
     "name": "Tencent Docs",
-    "iconUrl": "data:image/png;base64,iVBORw0KGgo="
+    "iconUrl": "https://cdn.example.test/tutti/connector-market/tencent-docs/0.2.0/tencent-docs-0.2.0-icon.svg"
   },
   "payload": {
     "permissions": [],
@@ -188,6 +188,57 @@ func TestCatalogSourcePreservesRemoteRequiredCapabilities(t *testing.T) {
 	}
 }
 
+func TestCatalogSourceRejectsMissingOrNonHTTPSIcon(t *testing.T) {
+	var manifest map[string]any
+	if err := json.Unmarshal([]byte(`{
+  "schemaVersion": "2",
+  "itemType": "connector",
+  "itemKey": "github",
+  "version": "1.0.0",
+  "display": {
+    "name": "GitHub",
+    "iconUrl": "https://cdn.example.test/tutti/connector-market/github/1.0.0/github-1.0.0-icon.svg"
+  },
+  "payload": {
+    "permissions": [],
+    "packageManifestSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "authorization": {"kind": "none"},
+    "compatibility": {},
+    "implementation": {
+      "kind": "managed_stdio",
+      "managedStdio": {
+        "runtime": {"language": "node", "profile": "connector-node-static", "abi": "node20-darwin-arm64"},
+        "mcp": {"entrypoint": "bin/github.js"}
+      }
+    }
+  }
+}`), &manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	display := manifest["display"].(map[string]any)
+	source := &CatalogSource{executionTarget: "darwin-arm64"}
+	for _, test := range []struct {
+		name    string
+		iconURL string
+	}{
+		{name: "missing"},
+		{name: "data URL", iconURL: "data:image/png;base64,iVBORw0KGgo="},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if test.iconURL == "" {
+				delete(display, "iconUrl")
+			} else {
+				display["iconUrl"] = test.iconURL
+			}
+			_, err := source.mapItem(generatedMarketItem(t, manifest, "github", "1.0.0", "connectors/github/1.0.0.zip"))
+			if err == nil || !strings.Contains(err.Error(), "iconUrl") {
+				t.Fatalf("mapItem() error = %v, want iconUrl rejection", err)
+			}
+		})
+	}
+}
+
 func TestCatalogSourceRejectsLegacyConnectorManifestV1(t *testing.T) {
 	var manifest map[string]any
 	if err := json.Unmarshal([]byte(`{
@@ -195,7 +246,7 @@ func TestCatalogSourceRejectsLegacyConnectorManifestV1(t *testing.T) {
   "itemType": "connector",
   "itemKey": "github",
   "version": "1.0.0",
-  "display": {"name": "GitHub", "iconUrl": "data:image/png;base64,iVBORw0KGgo="},
+  "display": {"name": "GitHub", "iconUrl": "https://cdn.example.test/tutti/connector-market/github/1.0.0/github-1.0.0-icon.svg"},
   "supportedMarkets": ["overseas"],
   "payload": {
     "permissions": [],

--- a/packages/connector/daemon/application/host_test.go
+++ b/packages/connector/daemon/application/host_test.go
@@ -665,7 +665,7 @@ func hostTestRelease() market.Release {
 		Manifest: market.Manifest{
 			SchemaVersion:     "1",
 			DisplayName:       "GitHub",
-			IconURL:           "data:image/png;base64,iVBORw0KGgo=",
+			IconURL:           "https://cdn.example.test/tutti/connector-market/github/1.0.0/github-1.0.0-icon.svg",
 			AuthorizationKind: "none",
 			Implementation: market.Implementation{Kind: market.ImplementationKindManagedStdio,
 				ManagedStdio: &market.ManagedStdioImplementation{

--- a/packages/connector/daemon/core/application.go
+++ b/packages/connector/daemon/core/application.go
@@ -123,7 +123,10 @@ func (application *Application) Snapshot(ctx context.Context) (Snapshot, error) 
 		return Snapshot{}, err
 	}
 	snapshot, err = application.projectConnectorRuntimes(ctx, snapshot, OperationScope{})
-	return publicSnapshot(snapshot, OperationScope{}), err
+	if err != nil {
+		return Snapshot{}, err
+	}
+	return publicSnapshot(snapshot, OperationScope{})
 }
 
 func (application *Application) SnapshotForScope(ctx context.Context, scope OperationScope) (Snapshot, error) {
@@ -133,7 +136,10 @@ func (application *Application) SnapshotForScope(ctx context.Context, scope Oper
 			return Snapshot{}, err
 		}
 		snapshot, err = application.projectConnectorRuntimes(ctx, snapshot, scope)
-		return publicSnapshot(snapshot, scope), err
+		if err != nil {
+			return Snapshot{}, err
+		}
+		return publicSnapshot(snapshot, scope)
 	}
 	snapshot, err := application.config.Repository.Snapshot(ctx)
 	if err != nil {
@@ -156,10 +162,18 @@ func (application *Application) SnapshotForScope(ctx context.Context, scope Oper
 		}
 	}
 	snapshot, err = application.projectConnectorRuntimes(ctx, snapshot, scope)
-	return publicSnapshot(snapshot, scope), err
+	if err != nil {
+		return Snapshot{}, err
+	}
+	return publicSnapshot(snapshot, scope)
 }
 
-func publicSnapshot(snapshot Snapshot, scope OperationScope) Snapshot {
+func publicSnapshot(snapshot Snapshot, scope OperationScope) (Snapshot, error) {
+	for _, connector := range snapshot.Connectors {
+		if err := ValidateReleaseShape(connector.Release); err != nil {
+			return Snapshot{}, fmt.Errorf("validate connector %q release: %w", connector.Key, err)
+		}
+	}
 	operations := snapshot.Operations[:0]
 	for _, operation := range snapshot.Operations {
 		if OperationVisibleToScope(operation, scope) {
@@ -167,7 +181,7 @@ func publicSnapshot(snapshot Snapshot, scope OperationScope) Snapshot {
 		}
 	}
 	snapshot.Operations = operations
-	return snapshot
+	return snapshot, nil
 }
 
 func (application *Application) ListCatalogCategories(ctx context.Context) ([]CatalogCategory, error) {
@@ -382,7 +396,14 @@ func (application *Application) GetConnector(
 	if strings.TrimSpace(connectorKey) == "" {
 		return Connector{}, invalidRequest("connectorKey is required")
 	}
-	return application.config.Repository.Connector(ctx, connectorKey)
+	connector, err := application.config.Repository.Connector(ctx, connectorKey)
+	if err != nil {
+		return Connector{}, err
+	}
+	if err := ValidateReleaseShape(connector.Release); err != nil {
+		return Connector{}, fmt.Errorf("validate connector %q release: %w", connector.Key, err)
+	}
+	return connector, nil
 }
 
 func (application *Application) GetOperation(ctx context.Context, operationID string) (Operation, error) {

--- a/packages/connector/daemon/core/application_test.go
+++ b/packages/connector/daemon/core/application_test.go
@@ -12,6 +12,42 @@ import (
 	"time"
 )
 
+func TestApplicationPublicReadsRejectObsoleteConnectorIcon(t *testing.T) {
+	connector := testConnector("github")
+	connector.Release.Manifest.IconURL = "data:image/png;base64,iVBORw0KGgo="
+	application := newTestApplication(
+		t,
+		newMemoryRepository(connector),
+		&memoryScheduler{},
+		&memoryInstallRuntime{},
+		CatalogSnapshot{},
+	)
+
+	for _, test := range []struct {
+		name string
+		read func() error
+	}{
+		{name: "snapshot", read: func() error {
+			_, err := application.Snapshot(context.Background())
+			return err
+		}},
+		{name: "scoped snapshot", read: func() error {
+			_, err := application.SnapshotForScope(context.Background(), OperationScope{AccountID: "account-1"})
+			return err
+		}},
+		{name: "connector", read: func() error {
+			_, err := application.GetConnector(context.Background(), connector.Key)
+			return err
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.read(); err == nil || !strings.Contains(err.Error(), "iconUrl") {
+				t.Fatalf("public read error = %v, want iconUrl rejection", err)
+			}
+		})
+	}
+}
+
 func TestApplicationInstallIsDurableAndIdempotent(t *testing.T) {
 	repository := newMemoryRepository(testConnector("github"))
 	scheduler := &memoryScheduler{}

--- a/packages/connector/daemon/core/manifest.go
+++ b/packages/connector/daemon/core/manifest.go
@@ -77,18 +77,16 @@ func (registry ImplementationRegistry) Validate(manifest Manifest) error {
 }
 
 func ValidateReleaseShape(release Release) error {
-	return validateReleaseShape(release, true)
+	return validateReleaseShape(release)
 }
 
-// ValidateRuntimeReleaseShape validates the durable execution contract while
-// deliberately excluding icon presentation policy. Installed releases may
-// predate the current icon requirements, but runtime identity, artifact,
-// permission, authorization, and implementation checks must remain strict.
+// ValidateRuntimeReleaseShape applies the same release contract before a
+// persisted release is restored or executed.
 func ValidateRuntimeReleaseShape(release Release) error {
-	return validateReleaseShape(release, false)
+	return ValidateReleaseShape(release)
 }
 
-func validateReleaseShape(release Release, validateIcon bool) error {
+func validateReleaseShape(release Release) error {
 	if release.SchemaVersion != "1" {
 		return invalidManifest("schemaVersion must be 1", nil)
 	}
@@ -121,7 +119,7 @@ func validateReleaseShape(release Release, validateIcon bool) error {
 		strings.TrimSpace(release.Artifact.MediaType) == "" {
 		return invalidManifest("artifact key, lowercase SHA-256, positive sizeBytes, and mediaType are required", nil)
 	}
-	if err := validateManifestShape(release.Manifest, validateIcon); err != nil {
+	if err := ValidateManifestShape(release.Manifest); err != nil {
 		return err
 	}
 	return validateLegacyCredentialBrokerPresentation(release)
@@ -140,18 +138,18 @@ func validateLegacyCredentialBrokerPresentation(release Release) error {
 }
 
 func ValidateManifestShape(manifest Manifest) error {
-	return validateManifestShape(manifest, true)
+	return validateManifestShape(manifest)
 }
 
-func validateManifestShape(manifest Manifest, validateIcon bool) error {
+func validateManifestShape(manifest Manifest) error {
 	if manifest.SchemaVersion != "1" {
 		return invalidManifest("manifest schemaVersion must be 1", nil)
 	}
 	if strings.TrimSpace(manifest.DisplayName) == "" {
 		return invalidManifest("displayName is required", nil)
 	}
-	if validateIcon && !isSafeConnectorIconURL(manifest.IconURL) {
-		return invalidManifest("iconUrl must be a PNG, WebP, or SVG data URL", nil)
+	if !isSafeConnectorIconURL(manifest.IconURL) {
+		return invalidManifest("iconUrl must be a safe HTTPS URL", nil)
 	}
 	if err := validateAgentRouting(manifest.AgentRouting); err != nil {
 		return err
@@ -250,19 +248,11 @@ func safeAgentRoutingAlias(alias string) bool {
 }
 
 func isSafeConnectorIconURL(value string) bool {
-	value = strings.TrimSpace(value)
-	for _, prefix := range []string{"data:image/png;base64,", "data:image/webp;base64,", "data:image/svg+xml;base64,"} {
-		if !strings.HasPrefix(value, prefix) {
-			continue
-		}
-		encoded := strings.TrimPrefix(value, prefix)
-		if encoded == "" || base64.StdEncoding.DecodedLen(len(encoded)) > 128*1024 {
-			return false
-		}
-		decoded, err := base64.StdEncoding.DecodeString(encoded)
-		return err == nil && len(decoded) > 0 && len(decoded) <= 128*1024
+	if value == "" || value != strings.TrimSpace(value) || len(value) > 2048 {
+		return false
 	}
-	return false
+	parsed, err := url.Parse(value)
+	return err == nil && parsed.Scheme == "https" && parsed.Hostname() != "" && parsed.User == nil
 }
 
 func validateManagedStdio(managed ManagedStdioImplementation, authorizationKind string) error {

--- a/packages/connector/daemon/core/manifest_test.go
+++ b/packages/connector/daemon/core/manifest_test.go
@@ -7,7 +7,32 @@ import (
 	"testing"
 )
 
-const testConnectorIconURL = "data:image/png;base64,iVBORw0KGgo="
+const testConnectorIconURL = "https://cdn.example.test/tutti/connector-market/test/1.0.0/test-1.0.0-icon.svg"
+
+func TestValidateManifestShapeRequiresSafePublishedHTTPSIcon(t *testing.T) {
+	manifest := Manifest{
+		SchemaVersion: "1", DisplayName: "Published Connector", AuthorizationKind: "none",
+		Implementation: Implementation{Kind: ImplementationKindBuiltin,
+			Builtin: &BuiltinImplementation{ProviderID: "published-connector", MCP: true}},
+	}
+	manifest.IconURL = testConnectorIconURL
+	if err := ValidateManifestShape(manifest); err != nil {
+		t.Fatalf("ValidateManifestShape(%q) error = %v", manifest.IconURL, err)
+	}
+	for _, iconURL := range []string{
+		"data:image/png;base64,iVBORw0KGgo=",
+		"http://cdn.example.test/icon.svg",
+		" https://cdn.example.test/icon.svg",
+		"https://user:secret@cdn.example.test/icon.svg",
+		"https:///icon.svg",
+		"https://cdn.example.test/" + strings.Repeat("x", 2048),
+	} {
+		manifest.IconURL = iconURL
+		if err := ValidateManifestShape(manifest); err == nil || !strings.Contains(err.Error(), "iconUrl") {
+			t.Fatalf("ValidateManifestShape(%q) error = %v, want iconUrl rejection", iconURL, err)
+		}
+	}
+}
 
 func TestImplementationRegistryValidatesSupportedManifest(t *testing.T) {
 	registry := NewImplementationRegistry(map[string]ImplementationValidator{
@@ -188,17 +213,16 @@ func TestImplementationRegistryRejectsUnknownImplementation(t *testing.T) {
 	}
 }
 
-func TestRuntimeReleaseValidationDoesNotRequirePresentationIcon(t *testing.T) {
+func TestRuntimeReleaseValidationRequiresPublishedHTTPSIcon(t *testing.T) {
 	release := testReleaseWithImplementation("github", "1.0.0", ImplementationKindManagedStdio)
-	release.Manifest.IconURL = ""
-
-	if err := ValidateReleaseShape(release); err == nil || !strings.Contains(err.Error(), "iconUrl") {
-		t.Fatalf("full release validation error = %v, want iconUrl rejection", err)
-	}
-	if err := ValidateRuntimeReleaseShape(release); err != nil {
-		t.Fatalf("runtime release validation rejected presentation-only icon: %v", err)
+	for _, iconURL := range []string{"", "data:image/png;base64,iVBORw0KGgo="} {
+		release.Manifest.IconURL = iconURL
+		if err := ValidateRuntimeReleaseShape(release); err == nil || !strings.Contains(err.Error(), "iconUrl") {
+			t.Fatalf("runtime release validation for %q error = %v, want iconUrl rejection", iconURL, err)
+		}
 	}
 
+	release.Manifest.IconURL = testConnectorIconURL
 	release.Manifest.Permissions = []string{"network:*", "network:*"}
 	if err := ValidateRuntimeReleaseShape(release); err == nil || !strings.Contains(err.Error(), "unique") {
 		t.Fatalf("runtime release validation error = %v, want duplicate permission rejection", err)

--- a/packages/connector/renderer/src/application/services/connectorMarketService.test.ts
+++ b/packages/connector/renderer/src/application/services/connectorMarketService.test.ts
@@ -32,7 +32,7 @@ function connector(key: string, revision: number): Connector {
       manifest: {
         schemaVersion: "1",
         displayName: key,
-        iconUrl: "data:image/png;base64,iVBORw0KGgo=",
+        iconUrl: `https://cdn.example.test/tutti/connector-market/${key}/1.0.0/${key}-1.0.0-icon.svg`,
         permissions: [],
         implementation: {
           kind: "builtin",

--- a/packages/connector/renderer/src/application/services/core/connectorMarketRuntime.test.ts
+++ b/packages/connector/renderer/src/application/services/core/connectorMarketRuntime.test.ts
@@ -228,7 +228,7 @@ function connector(key: string, overrides: Partial<Connector> = {}): Connector {
       manifest: {
         authorizationKind: "none",
         displayName: "GitHub",
-        iconUrl: "data:image/png;base64,iVBORw0KGgo=",
+        iconUrl: `https://cdn.example.test/tutti/connector-market/${key}/1.0.0/${key}-1.0.0-icon.svg`,
         implementation: {
           builtin: { cli: true, mcp: true, providerId: key },
           kind: "builtin"

--- a/packages/connector/renderer/src/application/services/view/connectorMarketViewBuilder.test.ts
+++ b/packages/connector/renderer/src/application/services/view/connectorMarketViewBuilder.test.ts
@@ -550,7 +550,8 @@ function connectorFixture(): Connector {
         authorizationKind: "oauth2",
         description: "Manage repositories and pull requests",
         displayName: "GitHub",
-        iconUrl: "data:image/png;base64,iVBORw0KGgo=",
+        iconUrl:
+          "https://cdn.example.test/tutti/connector-market/github/1.0.0/github-1.0.0-icon.svg",
         implementation: {
           builtin: { cli: true, mcp: true, providerId: "github" },
           kind: "builtin"

--- a/packages/connector/runtime/artifact/preparer_test.go
+++ b/packages/connector/runtime/artifact/preparer_test.go
@@ -65,7 +65,7 @@ func TestPreparerVerifiesPromotesAndReusesLatestArtifact(t *testing.T) {
 	}
 }
 
-func TestResolvePreparedAllowsLegacyReleaseWithoutIcon(t *testing.T) {
+func TestResolvePreparedRejectsReleaseWithoutHTTPSIcon(t *testing.T) {
 	manifest := []byte(`{"schemaVersion":"1","connectorKey":"github"}`)
 	archive := testZIP(t, map[string][]byte{
 		packagedManifestPath: manifest,
@@ -79,7 +79,7 @@ func TestResolvePreparedAllowsLegacyReleaseWithoutIcon(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	prepared, err := preparer.Prepare(context.Background(), market.PrepareArtifactRequest{
+	_, err = preparer.Prepare(context.Background(), market.PrepareArtifactRequest{
 		OperationID: "operation-1",
 		Release:     release,
 	})
@@ -87,20 +87,10 @@ func TestResolvePreparedAllowsLegacyReleaseWithoutIcon(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	legacyRelease := release
-	legacyRelease.Manifest.IconURL = ""
-	resolved, err := preparer.ResolvePrepared(context.Background(), legacyRelease)
-	if err != nil {
-		t.Fatalf("ResolvePrepared() rejected legacy presentation metadata: %v", err)
-	}
-	if resolved.PreparedPath != prepared.PreparedPath {
-		t.Fatalf("resolved path = %q, want %q", resolved.PreparedPath, prepared.PreparedPath)
-	}
-	if _, err := preparer.Prepare(context.Background(), market.PrepareArtifactRequest{
-		OperationID: "operation-2",
-		Release:     legacyRelease,
-	}); err == nil || !strings.Contains(err.Error(), "iconUrl") {
-		t.Fatalf("Prepare() error = %v, want full icon validation", err)
+	invalidRelease := release
+	invalidRelease.Manifest.IconURL = ""
+	if _, err := preparer.ResolvePrepared(context.Background(), invalidRelease); err == nil || !strings.Contains(err.Error(), "iconUrl") {
+		t.Fatalf("ResolvePrepared() error = %v, want iconUrl rejection", err)
 	}
 }
 
@@ -339,7 +329,7 @@ func testRelease(archive, manifest []byte) market.Release {
 		Manifest: market.Manifest{
 			SchemaVersion: "1",
 			DisplayName:   "GitHub",
-			IconURL:       "data:image/png;base64,iVBORw0KGgo=",
+			IconURL:       "https://cdn.example.test/tutti/connector-market/github/1.0.0/github-1.0.0-icon.svg",
 			Implementation: market.Implementation{
 				Kind: market.ImplementationKindManagedStdio,
 				ManagedStdio: &market.ManagedStdioImplementation{

--- a/packages/connector/runtime/node_package_installer_test.go
+++ b/packages/connector/runtime/node_package_installer_test.go
@@ -214,7 +214,7 @@ func testNodePackageRelease(connectorKey, digest string) market.Release {
 			SHA256: strings.Repeat("4", 64), SizeBytes: 1, MediaType: "application/zip"},
 		PublishedAt: time.Unix(1, 0).UTC(), Status: market.ReleaseStatusAvailable,
 		Manifest: market.Manifest{
-			SchemaVersion: "1", DisplayName: "Lark", IconURL: "data:image/png;base64,iVBORw0KGgo=", AuthorizationKind: "none",
+			SchemaVersion: "1", DisplayName: "Lark", IconURL: "https://cdn.example.test/tutti/connector-market/lark/1.0.0/lark-1.0.0-icon.svg", AuthorizationKind: "none",
 			Implementation: market.Implementation{
 				Kind: market.ImplementationKindManagedStdio,
 				ManagedStdio: &market.ManagedStdioImplementation{

--- a/packages/connector/runtime/release_installer.go
+++ b/packages/connector/runtime/release_installer.go
@@ -155,9 +155,9 @@ func (installer *ReleaseInstaller) UninstallRelease(
 	if installer == nil || installer.artifacts == nil {
 		return errors.New("connector release installer is unavailable")
 	}
-	if err := market.ValidateRuntimeReleaseShape(request.Release); err != nil {
-		return err
-	}
+	// Removal is keyed only by connector identity, which each storage boundary
+	// validates before deleting. Do not require obsolete presentation metadata
+	// to clean up an otherwise unsupported local installation.
 	var cleanupErrors []error
 	connectorRemoval := market.RemoveConnectorInstallationRequest{
 		OperationID:  request.OperationID,

--- a/packages/connector/runtime/release_installer_test.go
+++ b/packages/connector/runtime/release_installer_test.go
@@ -88,6 +88,25 @@ func TestReleaseInstallerUninstallRemovesPreparedArtifact(t *testing.T) {
 	}
 }
 
+func TestReleaseInstallerUninstallRemovesReleaseWithObsoleteIcon(t *testing.T) {
+	release := runtimeTestRelease()
+	release.Manifest.IconURL = "data:image/png;base64,iVBORw0KGgo="
+	artifacts := &releaseArtifactStub{}
+	installer, err := NewReleaseInstaller(artifacts, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := installer.UninstallRelease(context.Background(), market.UninstallReleaseRequest{
+		OperationID: "uninstall-obsolete-icon",
+		Release:     release,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if artifacts.connectorRemoves != 1 {
+		t.Fatalf("artifact connector removes = %d, want 1", artifacts.connectorRemoves)
+	}
+}
+
 func TestReleaseInstallerUninstallRemovesEveryConnectorRelease(t *testing.T) {
 	runtimeRoot := t.TempDir()
 	nodePath := filepath.Join(runtimeRoot, "node", "bin", "node")
@@ -224,7 +243,7 @@ func runtimeTestRelease() market.Release {
 		ReleaseDigest:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		ManifestDigest: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 		Manifest: market.Manifest{SchemaVersion: "1", DisplayName: "Example",
-			IconURL: "data:image/png;base64,YQ==", AuthorizationKind: "none",
+			IconURL: "https://cdn.example.test/tutti/connector-market/example/1.0.0/example-1.0.0-icon.svg", AuthorizationKind: "none",
 			Implementation: market.Implementation{Kind: market.ImplementationKindManagedStdio,
 				ManagedStdio: &market.ManagedStdioImplementation{
 					Runtime: market.RuntimeRequirement{Language: "node", Profile: "connector-node-static", ABI: "node24-linux-arm64"},

--- a/services/tuttid/api/daemon_agent_composer_options_test.go
+++ b/services/tuttid/api/daemon_agent_composer_options_test.go
@@ -318,11 +318,11 @@ func TestGeneratedAgentProviderCapabilityOptionsProjectsIconURL(t *testing.T) {
 		Kind:       "connector",
 		Name:       "github",
 		Label:      "GitHub",
-		IconURL:    "data:image/png;base64,Z2l0aHVi",
+		IconURL:    "https://cdn.example.test/tutti/connector-market/github/1.0.0/github-1.0.0-icon.svg",
 		Status:     "available",
 		Invocation: "textTrigger",
 	}})
-	if len(options) != 1 || options[0].IconUrl == nil || *options[0].IconUrl != "data:image/png;base64,Z2l0aHVi" {
+	if len(options) != 1 || options[0].IconUrl == nil || *options[0].IconUrl != "https://cdn.example.test/tutti/connector-market/github/1.0.0/github-1.0.0-icon.svg" {
 		t.Fatalf("options = %#v, want connector icon URL", options)
 	}
 }

--- a/services/tuttid/api/daemon_connector_market_test.go
+++ b/services/tuttid/api/daemon_connector_market_test.go
@@ -513,7 +513,7 @@ func connectorMarketTestConnector() market.Connector {
 			ReleaseDigest:  digest,
 			ManifestDigest: digest,
 			Manifest: market.Manifest{
-				IconURL:       "data:image/png;base64,iVBORw0KGgo=",
+				IconURL:       "https://cdn.example.test/tutti/connector-market/notion/1.0.0/notion-1.0.0-icon.svg",
 				SchemaVersion: "1",
 				DisplayName:   "Notion",
 				AgentRouting:  &market.AgentRouting{Aliases: []string{"Notion", "Notion AI"}},

--- a/services/tuttid/service/connector/market/implementation_host_test.go
+++ b/services/tuttid/service/connector/market/implementation_host_test.go
@@ -166,7 +166,7 @@ func testCLIHostWithSetup(t *testing.T, processes agentruntime.ProcessTransport,
 	t.Cleanup(func() { _ = host.Close() })
 	connector := market.Connector{Key: "github", Installation: market.Installation{State: market.InstallationStateInstalled,
 		InstalledReleaseDigest: implementationHostTestReleaseDigest}, Authorization: market.Authorization{State: market.AuthorizationStateNotRequired}}
-	connector.Release = completeImplementationHostTestRelease(market.Release{Manifest: market.Manifest{AuthorizationKind: "none", IconURL: "data:image/png;base64,iVBORw0KGgo=",
+	connector.Release = completeImplementationHostTestRelease(market.Release{Manifest: market.Manifest{AuthorizationKind: "none", IconURL: "https://cdn.example.test/tutti/connector-market/github/1.0.0/github-1.0.0-icon.svg",
 		Implementation: market.Implementation{Kind: market.ImplementationKindManagedStdio, ManagedStdio: &market.ManagedStdioImplementation{
 			Runtime: market.RuntimeRequirement{Language: "node", Profile: connectorruntime.ConnectorNodeProfile, ABI: "node20-" + runtime.GOOS + "-" + runtime.GOARCH},
 			CLI: &market.ManagedCLIInterface{Entrypoint: "connector.js", Commands: []market.CLICommand{{Name: "status",
@@ -295,7 +295,7 @@ func TestImplementationHostRegistersWorkspaceFencedCLIAndDeactivatesIt(t *testin
 	}
 	connector := market.Connector{Key: "github", Installation: market.Installation{State: market.InstallationStateInstalled,
 		InstalledReleaseDigest: implementationHostTestReleaseDigest}, Authorization: market.Authorization{State: market.AuthorizationStateNotRequired}}
-	connector.Release = completeImplementationHostTestRelease(market.Release{Manifest: market.Manifest{AuthorizationKind: "none", IconURL: "data:image/png;base64,iVBORw0KGgo=",
+	connector.Release = completeImplementationHostTestRelease(market.Release{Manifest: market.Manifest{AuthorizationKind: "none", IconURL: "https://cdn.example.test/tutti/connector-market/github/1.0.0/github-1.0.0-icon.svg",
 		Implementation: market.Implementation{Kind: market.ImplementationKindManagedStdio, ManagedStdio: &market.ManagedStdioImplementation{
 			Runtime: market.RuntimeRequirement{Language: "node", Profile: connectorruntime.ConnectorNodeProfile, ABI: "node20-" + runtime.GOOS + "-" + runtime.GOARCH},
 			CLI: &market.ManagedCLIInterface{Entrypoint: "connector.js", Commands: []market.CLICommand{{Name: "status",
@@ -415,7 +415,7 @@ func TestImplementationHostDiscoversAndInvokesRemoteStreamableHTTPMCP(t *testing
 		State: market.InstallationStateInstalled, InstalledReleaseDigest: implementationHostTestReleaseDigest,
 	}, Authorization: market.Authorization{State: market.AuthorizationStateNotRequired}}
 	connector.Release = completeImplementationHostTestRelease(market.Release{Manifest: market.Manifest{
-		AuthorizationKind: "none", IconURL: "data:image/png;base64,iVBORw0KGgo=",
+		AuthorizationKind: "none", IconURL: "https://cdn.example.test/tutti/connector-market/github/1.0.0/github-1.0.0-icon.svg",
 		RequiredCapabilities: []string{"tools"},
 		Implementation: market.Implementation{Kind: market.ImplementationKindRemoteStreamableHTTP,
 			RemoteStreamableHTTP: &market.RemoteStreamableHTTPImplementation{


### PR DESCRIPTION
## Summary

- replace inline Connector icon data URLs with required public HTTPS URLs in the local Connector contract
- project the Market `display.iconUrl` directly without a legacy fallback
- reject missing, inline `data:`, non-HTTPS, credentialed, whitespace-padded, and oversized icon URLs during catalog ingestion, public reads, runtime restoration, and execution
- keep connector-scoped uninstall available for cleaning obsolete local installations while validating the deletion identity at each storage boundary
- update daemon, runtime, renderer, host fixtures, OpenAPI, and Connector architecture documentation

## Breaking Change

This change intentionally provides no backward compatibility.

Existing catalog or persisted Connector releases with a missing or inline `data:` icon fail validation and cannot be displayed, restored, inspected, or executed. They must be republished and local state must be refreshed with a public HTTPS icon URL.

This requires a coordinated rollout with the matching tsh-server and tutti-connectors PRs below. Old Tutti clients and the new Market icon contract are not mutually compatible.

## Verification

- `corepack pnpm@10.11.0 check:changed` — 22 selected lanes passed
- pre-push `check:changed -- --push-ready` — 24 selected lanes passed
- `corepack pnpm@10.11.0 exec prettier --check --config packages/configs/prettier/base.mjs docs/architecture/connector.md` — passed
- commit-time formatting, lint, and staged boundary checks — passed
- `git diff --check` — passed

Windows impact: none. The change is platform-neutral URL validation and does not alter paths, process handling, filesystem semantics, or platform-specific execution.

## Fallback Three Questions

- Source: an explicit uninstall may encounter a persisted pre-cutover release whose icon metadata is now unsupported.
- Why can it not be fixed at that source? Republishing cannot mutate an already persisted local record, and requiring the obsolete release to pass the new contract would prevent its cleanup.
- Removal condition: this cleanup allowance can be reconsidered once supported local state can no longer contain releases predating the HTTPS icon contract.

## Related

- [tutti-connectors public artifact and icon publishing PR #93](https://github.com/tutti-lab/tutti-connectors/pull/93)
- [tsh-server forward-compatible manifest handling PR #851](https://github.com/tutti-lab/tsh-server/pull/851)

## Checklist

- [x] This PR does not change agent lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] I updated the Connector architecture documentation for the changed contract and data flow.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commit is signed off with DCO.