### PR TITLE
fix(connector): allow runtime switches to turn off

### DIFF
--- a/packages/connector/renderer/src/ui/composer/ConnectorComposerMenu.spec.tsx
+++ b/packages/connector/renderer/src/ui/composer/ConnectorComposerMenu.spec.tsx
@@ -302,14 +302,26 @@ describe("ConnectorComposerMenu", () => {
     const toggle = await screen.findByTestId(
       "connector-market-composer-status-github"
     );
+    const menuItem = screen.getByTestId(
+      "connector-market-composer-item-github"
+    );
+    expect(menuItem).not.toContainElement(toggle);
+    fireEvent.pointerDown(toggle, {
+      button: 0,
+      ctrlKey: false,
+      pointerType: "mouse"
+    });
+    fireEvent.pointerUp(toggle, {
+      button: 0,
+      ctrlKey: false,
+      pointerType: "mouse"
+    });
     fireEvent.click(toggle);
 
     expect(onRuntimeEnabledChange).toHaveBeenCalledWith("github", false);
     expect(onSelectConnector).not.toHaveBeenCalled();
     expect(toggle).not.toBeChecked();
-    expect(
-      screen.getByTestId("connector-market-composer-item-github")
-    ).toBeInTheDocument();
+    expect(menuItem).toBeInTheDocument();
     expect(screen.getByRole("menu")).toHaveClass("w-[240px]");
   });
 

--- a/packages/connector/renderer/src/ui/composer/ConnectorComposerMenu.tsx
+++ b/packages/connector/renderer/src/ui/composer/ConnectorComposerMenu.tsx
@@ -179,49 +179,56 @@ export function ConnectorComposerMenu({
                 ? labels.authorize
                 : labels.connect;
             return (
-              <DropdownMenuItem
-                key={item.connectorKey}
-                className="min-h-9 gap-2.5 px-2.5"
-                data-testid={`connector-market-composer-item-${item.connectorKey}`}
-                data-selected={selected ? "true" : undefined}
-                disabled={
-                  readOnly ||
-                  (connected ? !onSelectConnector : !onOpenConnector)
-                }
-                onPointerDown={(event) => {
-                  if (event.button !== 0 || event.ctrlKey) {
-                    return;
+              <div key={item.connectorKey} className="relative" role="none">
+                <DropdownMenuItem
+                  className={cn("min-h-9 gap-2.5 px-2.5", installed && "pr-14")}
+                  data-testid={`connector-market-composer-item-${item.connectorKey}`}
+                  data-selected={selected ? "true" : undefined}
+                  disabled={
+                    readOnly ||
+                    (connected ? !onSelectConnector : !onOpenConnector)
                   }
-                  event.preventDefault();
-                  closeAndRun(() => {
-                    if (connected) {
-                      onSelectConnector?.(item.connectorKey, !selected);
+                  onPointerDown={(event) => {
+                    if (event.button !== 0 || event.ctrlKey) {
                       return;
                     }
-                    onOpenConnector?.(item.connectorKey);
-                  });
-                }}
-                onSelect={(event) => {
-                  event.preventDefault();
-                  closeAndRun(() => {
-                    if (connected) {
-                      onSelectConnector?.(item.connectorKey, !selected);
-                      return;
-                    }
-                    onOpenConnector?.(item.connectorKey);
-                  });
-                }}
-              >
-                <ConnectorComposerIcon
-                  iconUrl={item.iconUrl}
-                  label={item.name}
-                />
-                <span className="min-w-0 flex-1 truncate">{item.name}</span>
+                    event.preventDefault();
+                    closeAndRun(() => {
+                      if (connected) {
+                        onSelectConnector?.(item.connectorKey, !selected);
+                        return;
+                      }
+                      onOpenConnector?.(item.connectorKey);
+                    });
+                  }}
+                  onSelect={(event) => {
+                    event.preventDefault();
+                    closeAndRun(() => {
+                      if (connected) {
+                        onSelectConnector?.(item.connectorKey, !selected);
+                        return;
+                      }
+                      onOpenConnector?.(item.connectorKey);
+                    });
+                  }}
+                >
+                  <ConnectorComposerIcon
+                    iconUrl={item.iconUrl}
+                    label={item.name}
+                  />
+                  <span className="min-w-0 flex-1 truncate">{item.name}</span>
+                  {!installed && !readOnly ? (
+                    <div className="ml-auto inline-flex shrink-0 items-center gap-1 pl-3 text-xs text-[var(--text-primary)]">
+                      <LinkIcon aria-hidden className="size-4" />
+                      {actionLabel}
+                    </div>
+                  ) : null}
+                </DropdownMenuItem>
                 {installed ? (
                   <Switch
                     aria-label={item.name}
                     checked={runtimeEnabled}
-                    className="ml-auto shrink-0"
+                    className="absolute top-1/2 right-2.5 z-10 -translate-y-1/2"
                     data-testid={`connector-market-composer-status-${item.connectorKey}`}
                     disabled={
                       readOnly ||
@@ -271,13 +278,8 @@ export function ConnectorComposerMenu({
                       );
                     }}
                   />
-                ) : !readOnly ? (
-                  <div className="ml-auto inline-flex shrink-0 items-center gap-1 pl-3 text-xs text-[var(--text-primary)]">
-                    <LinkIcon aria-hidden className="size-4" />
-                    {actionLabel}
-                  </div>
                 ) : null}
-              </DropdownMenuItem>
+              </div>
             );
           })
         ) : loading ? (


### PR DESCRIPTION
## Summary

Installed connector switches could not be turned off in the desktop composer because each interactive `Switch` was nested inside a Radix `DropdownMenuItem`. The parent menu item absorbed the real pointer interaction, so the UI did not reliably dispatch the runtime-disable intent.

This change renders the connector row and runtime switch as sibling controls inside a presentation wrapper. The switch now owns its pointer interaction, while clicking the row keeps the existing connector-selection behavior. The row reserves space for the overlaid switch so connector names remain aligned.

## Verification

- Added a regression scenario that drives the full mouse `pointerdown` → `pointerup` → `click` sequence and verifies the runtime callback receives `false`, the switch becomes unchecked, the connector is not selected, and the menu remains open.
- `pnpm --filter @tutti-os/connector-renderer test` — 79 service tests and 19 component tests passed.
- `pnpm --filter @tutti-os/connector-renderer typecheck` — passed.
- `pnpm lint:ts` — passed.
- Push-ready changed-surface checks — 11 lanes passed.

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter. (Not applicable.)
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed. (Not applicable.)
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. (Not applicable.)
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
