### PR TITLE
fix(agent): unblock later prompts after hidden send failure

### DIFF
--- a/packages/agent/activity-core/src/engine/promptQueue.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.reducer.test.ts
@@ -551,6 +551,69 @@ test("send failure stays blocked until send-now retry clears it", () => {
   assert.equal(retried.commands[0]?.type, "queue/sendPrompt");
 });
 
+test("failed auto submit is removed before a later independent submit", () => {
+  const available = canonicalLifecycle("settled", 1);
+  const first = reduce(
+    createInitialPromptQueueState(),
+    submit("prompt-1"),
+    available
+  );
+  const failed = reduce(
+    first.state,
+    commandResult(commandId(first.commands[0]), "queue/sendPrompt", "failed", {
+      errorMessage: "boom"
+    }),
+    available
+  );
+
+  assert.equal(failed.state.recordsBySessionId["session-1"], undefined);
+
+  const second = reduce(failed.state, submit("prompt-2"), available);
+  assert.equal(send(second.commands[0]).clientSubmitId, "prompt-2");
+});
+
+test("failed hidden head does not block a later queued prompt", () => {
+  const available = canonicalLifecycle("settled", 1);
+  const first = reduce(
+    createInitialPromptQueueState(),
+    submit("prompt-1"),
+    available
+  );
+  const later = reduce(first.state, submit("prompt-2"), available);
+  const failed = reduce(
+    later.state,
+    commandResult(commandId(first.commands[0]), "queue/sendPrompt", "failed", {
+      errorMessage: "boom"
+    }),
+    available
+  );
+
+  assert.equal(failed.commands[0]?.type, "queue/sendPrompt");
+  assert.equal(send(failed.commands[0]).clientSubmitId, "prompt-2");
+});
+
+test("pre-turn failure removes a hidden auto submit before a later submit", () => {
+  const available = canonicalLifecycle("settled", 1);
+  const first = reduce(
+    createInitialPromptQueueState(),
+    submit("prompt-1"),
+    available
+  );
+  const failed = reduce(
+    first.state,
+    commandResult(commandId(first.commands[0]), "queue/sendPrompt", "failed", {
+      errorCode: "agent.process_cleanup_pending"
+    }),
+    available
+  );
+
+  assert.equal(failed.state.recordsBySessionId["session-1"], undefined);
+  assert.equal(failed.commands[0]?.type, "session/reconcile");
+
+  const second = reduce(failed.state, submit("prompt-2"), available);
+  assert.equal(send(second.commands[0]).clientSubmitId, "prompt-2");
+});
+
 test("no-active-turn send failure reconciles before retrying queued prompt", () => {
   const available = canonicalLifecycle("settled", 1);
   const sending = reduce(

--- a/packages/agent/activity-core/src/engine/promptQueue.reducer.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.reducer.ts
@@ -447,17 +447,40 @@ function settleQueueCommand(
     };
   }
   if (isPreTurnSendFailure(intent)) {
+    const nextState =
+      current.prompts.find((prompt) => prompt.id === inFlight.promptId)
+        ?.visibleInQueue === false
+        ? removeHiddenFailedPrompt(
+            state,
+            agentSessionId,
+            current,
+            inFlight.promptId
+          )
+        : replaceRecord(state, agentSessionId, {
+            ...current,
+            failedPromptId: null,
+            failureMessage: null,
+            inFlight: null
+          });
     return {
       commands: [
         queueOwnedReconcileCommand(agentSessionId, current.workspaceId, intent)
       ],
-      state: replaceRecord(state, agentSessionId, {
-        ...current,
-        failedPromptId: null,
-        failureMessage: null,
-        inFlight: null
-      })
+      state: nextState
     };
+  }
+  if (
+    current.prompts.find((prompt) => prompt.id === inFlight.promptId)
+      ?.visibleInQueue === false
+  ) {
+    return result(
+      removeHiddenFailedPrompt(
+        state,
+        agentSessionId,
+        current,
+        inFlight.promptId
+      )
+    );
   }
   return result(
     replaceRecord(state, agentSessionId, {
@@ -467,6 +490,26 @@ function settleQueueCommand(
       inFlight: null
     })
   );
+}
+
+function removeHiddenFailedPrompt(
+  state: PromptQueueState,
+  agentSessionId: string,
+  current: PromptQueueRecord,
+  promptId: string
+): PromptQueueState {
+  const record = compactQueueRecord({
+    ...current,
+    failedPromptId:
+      current.failedPromptId === promptId ? null : current.failedPromptId,
+    failureMessage:
+      current.failedPromptId === promptId ? null : current.failureMessage,
+    inFlight: null,
+    prompts: current.prompts.filter((prompt) => prompt.id !== promptId)
+  });
+  return record
+    ? replaceRecord(state, agentSessionId, record)
+    : deleteRecord(state, agentSessionId);
 }
 
 function isPreTurnSendFailure(intent: EngineIntent): boolean {


### PR DESCRIPTION
## Summary
- Remove failed prompts that were returned to the composer from the active send queue.
- Allow later independent prompts to drain instead of being blocked by `failed_head`.
- Preserve visible queued-prompt failures for explicit retry/remove behavior.
- Cover ordinary and `agent.process_cleanup_pending` failures with queue regression tests.

## Tests
- `pnpm --filter @tutti-os/agent-activity-core test`
- `pnpm --filter @tutti-os/agent-activity-core typecheck`
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm --filter @tutti-os/agent-gui test -- src/agent-gui/agentGuiNode/controller/AgentGUIEngineSettlementController.spec.ts`
- `pnpm check:changed -- --push-ready`

## Notes
- Follow-up to #2480.
- No unrelated worktree changes are included.