### PR TITLE
fix(desktop): hide release notes action on release builds

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -401,6 +401,7 @@ jobs:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           NODE_OPTIONS: --max-old-space-size=4096
+          VITE_TUTTI_DESKTOP_RELEASE_NOTES_ENABLED: ${{ github.ref_name == 'main' && 'true' || 'false' }}
         run: |
           if [[ "${TUTTI_DESKTOP_DRY_RUN}" == "true" ]]; then
             unset CSC_LINK CSC_KEY_PASSWORD APPLE_API_KEY APPLE_API_KEY_ID APPLE_API_ISSUER
@@ -491,6 +492,7 @@ jobs:
         shell: pwsh
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: "false"
+          VITE_TUTTI_DESKTOP_RELEASE_NOTES_ENABLED: ${{ github.ref_name == 'main' && 'true' || 'false' }}
         run: pnpm --filter @tutti-os/desktop build:win
 
       - name: Verify Windows release metadata

--- a/.github/workflows/desktop-store-submit.yml
+++ b/.github/workflows/desktop-store-submit.yml
@@ -158,6 +158,7 @@ jobs:
         shell: pwsh
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: "false"
+          VITE_TUTTI_DESKTOP_RELEASE_NOTES_ENABLED: "false"
         run: pnpm --filter @tutti-os/desktop build:win:store
 
       - id: package

--- a/apps/desktop/src/renderer/src/features/app-update/ui/AppUpdateStatus.tsx
+++ b/apps/desktop/src/renderer/src/features/app-update/ui/AppUpdateStatus.tsx
@@ -19,6 +19,8 @@ import {
 
 const updateIconUrl = new URL("../assets/update.png", import.meta.url).href;
 const tuttiIconUrl = new URL("../assets/tutti.png", import.meta.url).href;
+const releaseNotesActionEnabled =
+  import.meta.env.VITE_TUTTI_DESKTOP_RELEASE_NOTES_ENABLED !== "false";
 
 export function AppUpdateStatus({
   density = "default",
@@ -39,8 +41,8 @@ export function AppUpdateStatus({
         openReleaseNotes={() => service.openReleaseNotes()}
         runPrimaryAction={() => service.runPrimaryAction()}
         showReleaseNotes={shouldShowReleaseNotesAction(
-          state.updateState?.channel,
-          view.action
+          view.action,
+          releaseNotesActionEnabled
         )}
         view={view}
       />
@@ -54,8 +56,8 @@ export function AppUpdateStatus({
   const label = t(view.titleKey, view.titleParams);
   const compact = density === "compact";
   const showReleaseNotesAction = shouldShowReleaseNotesAction(
-    state.updateState?.channel,
-    view.action
+    view.action,
+    releaseNotesActionEnabled
   );
 
   return (

--- a/apps/desktop/src/renderer/src/features/app-update/ui/appUpdateStatusPresentation.test.ts
+++ b/apps/desktop/src/renderer/src/features/app-update/ui/appUpdateStatusPresentation.test.ts
@@ -2,14 +2,13 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { shouldShowReleaseNotesAction } from "./appUpdateStatusPresentation.ts";
 
-test("release notes are available for stable download and install actions", () => {
-  assert.equal(shouldShowReleaseNotesAction("stable", "download"), true);
-  assert.equal(shouldShowReleaseNotesAction("stable", "install"), true);
-  assert.equal(shouldShowReleaseNotesAction("stable", "retry"), false);
+test("release notes follow the build flag for download and install actions", () => {
+  assert.equal(shouldShowReleaseNotesAction("download", true), true);
+  assert.equal(shouldShowReleaseNotesAction("install", true), true);
+  assert.equal(shouldShowReleaseNotesAction("retry", true), false);
 });
 
-test("release notes are hidden for RC and missing update states", () => {
-  assert.equal(shouldShowReleaseNotesAction("rc", "download"), false);
-  assert.equal(shouldShowReleaseNotesAction("rc", "install"), false);
-  assert.equal(shouldShowReleaseNotesAction(null, "download"), false);
+test("release builds hide release notes for every update channel", () => {
+  assert.equal(shouldShowReleaseNotesAction("download", false), false);
+  assert.equal(shouldShowReleaseNotesAction("install", false), false);
 });

--- a/apps/desktop/src/renderer/src/features/app-update/ui/appUpdateStatusPresentation.ts
+++ b/apps/desktop/src/renderer/src/features/app-update/ui/appUpdateStatusPresentation.ts
@@ -1,4 +1,3 @@
-import type { AppUpdateState } from "@shared/contracts/ipc";
 import type { AppUpdateViewState } from "../services/appUpdateTypes";
 
 export type StandaloneAppUpdateStatusPresentation =
@@ -38,10 +37,10 @@ export function resolveStandaloneAppUpdateStatusPresentation(
 }
 
 export function shouldShowReleaseNotesAction(
-  channel: AppUpdateState["channel"] | null | undefined,
-  action: AppUpdateViewState["action"]
+  action: AppUpdateViewState["action"],
+  releaseNotesActionEnabled: boolean
 ): boolean {
   return (
-    channel === "stable" && (action === "download" || action === "install")
+    releaseNotesActionEnabled && (action === "download" || action === "install")
   );
 }

--- a/apps/desktop/src/renderer/src/global.d.ts
+++ b/apps/desktop/src/renderer/src/global.d.ts
@@ -12,6 +12,7 @@ declare global {
     readonly VITE_TUTTID_ACCESS_TOKEN?: string;
     readonly VITE_TUTTID_BASE_URL?: string;
     readonly VITE_TUTTI_REACT_PROFILER?: string;
+    readonly VITE_TUTTI_DESKTOP_RELEASE_NOTES_ENABLED?: string;
     readonly VITE_TUTTI_WHY_DID_YOU_RENDER?: string;
     readonly VITE_TUTTI_WEB_DEV?: string;
     readonly VITE_TUTTI_WEB_WORKSPACE_ID?: string;


### PR DESCRIPTION
## What changed

- Gate the desktop `更新内容` / `What's new` action with a build-time flag.
- Keep the action enabled for builds triggered from `main`.
- Disable it for `release/*` and tag builds on macOS, Windows, and Microsoft Store packages.
- Keep local development enabled by default.

## Why

Release-branch packages should not expose the release-notes entry, while `main` RC/validation builds should keep it available.

## Validation

- Targeted app-update presentation tests: 2 passed.
- Desktop typecheck: passed.
- Prettier and diff checks: passed.
- Desktop renderer build with the release flag disabled: passed; 8,086 modules transformed and renderer CSS contracts passed.
- Verified the compiled renderer contains `releaseNotesActionEnabled = false` under the release build flag.
- Independent review completed; Store workflow omission was fixed before updating this MR.

## Note

The local pre-commit/pre-push hooks also report a pre-existing stale renderer-token state in `origin/main`; no token files are included in this change.