### PR TITLE
fix(desktop): rename Chinese release notes action

### DIFF
--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -78,7 +78,7 @@ export const zhCN = {
     errorTitle: "无法检查更新",
     restartAction: "重启安装",
     retryAction: "重试",
-    releaseNotesAction: "更新内容",
+    releaseNotesAction: "更新日志",
     storeManaged: "更新由 Microsoft Store 管理"
   },
   desktop: {


### PR DESCRIPTION
## 变更

将桌面更新入口的简体中文文案从“更新内容”调整为“更新日志”。

## 影响

仅影响简体中文界面的按钮文案；更新逻辑、英文文案和其他语言不变。

## 验证

- Desktop typecheck：通过
- app-update 相关测试：15/15 通过
- `git diff --check`：通过
- 独立 subagent review：无 P0/P1/P2 findings

说明：`zh-CN.ts` 的 Prettier 基线检查在 `origin/main` 原文件上也会失败，本 MR 未引入额外格式改动。
