### PR TITLE
fix(agent): route standalone tools through sidebar adapters

### DIFF
--- a/apps/desktop/src/main/ipc/browser.ts
+++ b/apps/desktop/src/main/ipc/browser.ts
@@ -58,6 +58,7 @@ type BrowserInvokeChannel = Exclude<
   | typeof desktopIpcChannels.browser.automationHostReady
   | typeof desktopIpcChannels.browser.automationRequest
   | typeof desktopIpcChannels.browser.automationResponse
+  | typeof desktopIpcChannels.browser.automationTurnClaim
   | typeof desktopIpcChannels.browser.event
 >;
 

--- a/apps/desktop/src/main/ipc/browserAutomationCoordinator.test.ts
+++ b/apps/desktop/src/main/ipc/browserAutomationCoordinator.test.ts
@@ -77,6 +77,21 @@ function createHarness() {
     );
   };
 
+  const claimTurn = (
+    host: FakeHost,
+    input: {
+      agentSessionId: string;
+      agentTurnId: string;
+      workspaceId: string;
+    }
+  ) => {
+    ipc.emit(
+      desktopIpcChannels.browser.automationTurnClaim,
+      { sender: sender(host) },
+      input
+    );
+  };
+
   const coordinator = createDesktopBrowserAutomationCoordinator({
     async ensureAgentBrowserHost(input) {
       ensureCalls.push(input);
@@ -119,13 +134,15 @@ function createHarness() {
         const host = hosts.get(id);
         return host ? sender(host) : null;
       }
-    }
+    },
+    turnClaimWaitTimeoutMs: 5
   });
 
   return {
     activatedHostIds,
     addHost,
     announceReady,
+    claimTurn,
     coordinator,
     ensureCalls,
     ensureUserCalls,
@@ -133,18 +150,23 @@ function createHarness() {
   };
 }
 
-test("Agent new_page creates and reveals a full User Browser page", async () => {
+test("Agent new_page uses the ready standalone Agent Browser surface", async () => {
   const harness = createHarness();
-  const workspaceHost = harness.addHost(
+  const agentHost = harness.addHost(
     4,
-    { kind: "workspace", workspaceId: "workspace-a" },
+    { kind: "agent", workspaceId: "workspace-a" },
     (request) => ({
       nodeId: request.action === "create" ? "user-page" : request.nodeId,
       ok: true,
       requestId: request.requestId
     })
   );
-  harness.announceReady(workspaceHost);
+  harness.announceReady(agentHost);
+  harness.claimTurn(agentHost, {
+    agentSessionId: "session-a",
+    agentTurnId: "turn-a",
+    workspaceId: "workspace-a"
+  });
   const nodeId = await harness.coordinator.requestTarget({
     agentSessionId: "session-a",
     agentTurnId: "turn-a",
@@ -155,15 +177,91 @@ test("Agent new_page creates and reveals a full User Browser page", async () => 
   assert.equal(nodeId, "user-page");
   assert.deepEqual(harness.ensureCalls, []);
   assert.deepEqual(harness.activatedHostIds, [4]);
-  assert.equal(workspaceHost.requests[0]?.surfaceRole, "user");
-  assert.equal(workspaceHost.requests[0]?.agentSessionId, "session-a");
-  assert.equal(workspaceHost.requests[0]?.agentTurnId, "turn-a");
-  assert.equal(workspaceHost.requests[0]?.reveal, true);
+  assert.equal(agentHost.requests[0]?.surfaceRole, "agent");
+  assert.equal(agentHost.requests[0]?.agentSessionId, "session-a");
+  assert.equal(agentHost.requests[0]?.agentTurnId, "turn-a");
+  assert.equal(agentHost.requests[0]?.reveal, true);
   harness.coordinator.dispose();
 });
 
-test("Agent new_page opens a workspace Browser host when none is ready", async () => {
+test("Agent new_page creates an Agent Browser host when its originating window is not ready", async () => {
   const harness = createHarness();
+  const agentHost = harness.addHost(
+    4,
+    { kind: "agent", workspaceId: "workspace-a" },
+    () => ({ nodeId: null, ok: true, requestId: "unused" })
+  );
+  harness.claimTurn(agentHost, {
+    agentSessionId: "session-a",
+    agentTurnId: "turn-a",
+    workspaceId: "workspace-a"
+  });
+  const nodeId = await harness.coordinator.requestTarget({
+    agentSessionId: "session-a",
+    agentTurnId: "turn-a",
+    url: "https://example.com",
+    workspaceId: "workspace-a"
+  });
+
+  assert.equal(nodeId, "background-page");
+  assert.deepEqual(harness.ensureCalls, [
+    { agentSessionId: "session-a", workspaceId: "workspace-a" }
+  ]);
+  assert.deepEqual(harness.ensureUserCalls, []);
+  assert.deepEqual(harness.activatedHostIds, [99]);
+  harness.coordinator.dispose();
+});
+
+test("Agent new_page waits for a canonical Turn claim that arrives after the request", async () => {
+  const harness = createHarness();
+  const agentHost = harness.addHost(
+    4,
+    { kind: "agent", workspaceId: "workspace-a" },
+    () => ({ nodeId: null, ok: true, requestId: "unused" })
+  );
+  const pendingNodeId = harness.coordinator.requestTarget({
+    agentSessionId: "session-a",
+    agentTurnId: "turn-a",
+    workspaceId: "workspace-a"
+  });
+
+  harness.claimTurn(agentHost, {
+    agentSessionId: "session-a",
+    agentTurnId: "turn-a",
+    workspaceId: "workspace-a"
+  });
+
+  assert.equal(await pendingNodeId, "background-page");
+  assert.deepEqual(harness.ensureCalls, [
+    { agentSessionId: "session-a", workspaceId: "workspace-a" }
+  ]);
+  assert.deepEqual(harness.ensureUserCalls, []);
+  harness.coordinator.dispose();
+});
+
+test("Workspace-originated Turn stays in Workspace Browser while an Agent host is ready", async () => {
+  const harness = createHarness();
+  const workspaceHost = harness.addHost(
+    3,
+    { kind: "workspace", workspaceId: "workspace-a" },
+    () => ({ nodeId: null, ok: true, requestId: "unused" })
+  );
+  const agentHost = harness.addHost(
+    4,
+    { kind: "agent", workspaceId: "workspace-a" },
+    (request) => ({
+      nodeId: "wrong-agent-page",
+      ok: true,
+      requestId: request.requestId
+    })
+  );
+  harness.announceReady(agentHost);
+  harness.claimTurn(workspaceHost, {
+    agentSessionId: "session-a",
+    agentTurnId: "turn-a",
+    workspaceId: "workspace-a"
+  });
+
   const nodeId = await harness.coordinator.requestTarget({
     agentSessionId: "session-a",
     agentTurnId: "turn-a",
@@ -173,8 +271,20 @@ test("Agent new_page opens a workspace Browser host when none is ready", async (
 
   assert.equal(nodeId, "workspace-page");
   assert.deepEqual(harness.ensureUserCalls, [{ workspaceId: "workspace-a" }]);
-  assert.deepEqual(harness.ensureCalls, []);
-  assert.deepEqual(harness.activatedHostIds, [98]);
+  assert.deepEqual(agentHost.requests, []);
+  harness.coordinator.dispose();
+});
+
+test("unclaimed legacy Turn keeps the Workspace Browser fallback", async () => {
+  const harness = createHarness();
+  const nodeId = await harness.coordinator.requestTarget({
+    agentSessionId: "session-a",
+    agentTurnId: "turn-a",
+    workspaceId: "workspace-a"
+  });
+
+  assert.equal(nodeId, "workspace-page");
+  assert.deepEqual(harness.ensureUserCalls, [{ workspaceId: "workspace-a" }]);
   harness.coordinator.dispose();
 });
 
@@ -300,16 +410,23 @@ test("ready announcements cannot claim another workspace or surface role", async
 
 test("Agent new_page activates the Browser host only once per turn", async () => {
   const harness = createHarness();
-  const workspaceHost = harness.addHost(
+  const agentHost = harness.addHost(
     4,
-    { kind: "workspace", workspaceId: "workspace-a" },
+    { kind: "agent", workspaceId: "workspace-a" },
     (request) => ({
       nodeId: `page-${request.requestId}`,
       ok: true,
       requestId: request.requestId
     })
   );
-  harness.announceReady(workspaceHost);
+  harness.announceReady(agentHost);
+  for (const agentTurnId of ["turn-a", "turn-b"]) {
+    harness.claimTurn(agentHost, {
+      agentSessionId: "session-a",
+      agentTurnId,
+      workspaceId: "workspace-a"
+    });
+  }
 
   await Promise.all(
     ["one", "two", "three"].map((suffix) =>
@@ -327,9 +444,9 @@ test("Agent new_page activates the Browser host only once per turn", async () =>
     workspaceId: "workspace-a"
   });
 
-  assert.equal(workspaceHost.requests.length, 4);
+  assert.equal(agentHost.requests.length, 4);
   assert.deepEqual(
-    workspaceHost.requests.map((request) => request.reveal),
+    agentHost.requests.map((request) => request.reveal),
     [true, false, false, true]
   );
   assert.deepEqual(harness.activatedHostIds, [4, 4]);

--- a/apps/desktop/src/main/ipc/browserAutomationCoordinator.ts
+++ b/apps/desktop/src/main/ipc/browserAutomationCoordinator.ts
@@ -7,11 +7,14 @@ import {
   desktopIpcChannels,
   type DesktopBrowserAutomationHostReady,
   type DesktopBrowserAutomationRequest,
-  type DesktopBrowserAutomationResponse
+  type DesktopBrowserAutomationResponse,
+  type DesktopBrowserAutomationTurnClaim
 } from "../../shared/contracts/ipc.ts";
 
 const requestTimeoutMs = 10_000;
+const defaultTurnClaimWaitTimeoutMs = 1_000;
 const maximumRevealedAgentTurns = 256;
+const maximumTurnSurfaceClaims = 512;
 
 interface PendingRequest {
   reject(error: Error): void;
@@ -36,6 +39,7 @@ export interface DesktopBrowserAutomationCoordinatorOptions {
     workspaceId: string;
   }): Promise<void>;
   ensureUserBrowserHost(input: { workspaceId: string }): Promise<void>;
+  turnClaimWaitTimeoutMs?: number;
   runtime: {
     activateHost(sender: Electron.WebContents): void;
     ipc: Pick<IpcMain, "off" | "on">;
@@ -57,6 +61,11 @@ export function createDesktopBrowserAutomationCoordinator(
   const readyWaiters = new Map<string, Set<() => void>>();
   const targetOwnerIds = new Map<string, number>();
   const revealedAgentTurns = new Map<string, true>();
+  const turnSurfaceRoles = new Map<string, "agent" | "user">();
+  const turnSurfaceWaiters = new Map<
+    string,
+    Set<(surfaceRole: "agent" | "user" | null) => void>
+  >();
 
   const handleHostReady = (
     event: IpcMainEvent,
@@ -115,11 +124,37 @@ export function createDesktopBrowserAutomationCoordinator(
     }
     request.resolve(response.nodeId);
   };
+  const handleTurnClaim = (
+    event: IpcMainEvent,
+    input: DesktopBrowserAutomationTurnClaim
+  ): void => {
+    const workspaceId = input?.workspaceId?.trim() ?? "";
+    const agentSessionId = input?.agentSessionId?.trim() ?? "";
+    const agentTurnId = input?.agentTurnId?.trim() ?? "";
+    if (!workspaceId || !agentSessionId || !agentTurnId) return;
+    const hostContext = runtime.resolveHostContext(event.sender);
+    if (!hostContext || hostContext.workspaceId !== workspaceId) return;
+    const key = turnKey(workspaceId, agentSessionId, agentTurnId);
+    turnSurfaceRoles.set(key, hostContext.kind === "agent" ? "agent" : "user");
+    const surfaceRole = turnSurfaceRoles.get(key) ?? null;
+    for (const resolve of turnSurfaceWaiters.get(key) ?? []) {
+      resolve(surfaceRole);
+    }
+    turnSurfaceWaiters.delete(key);
+    if (turnSurfaceRoles.size > maximumTurnSurfaceClaims) {
+      const oldestKey = turnSurfaceRoles.keys().next().value;
+      if (oldestKey !== undefined) turnSurfaceRoles.delete(oldestKey);
+    }
+  };
   runtime.ipc.on(
     desktopIpcChannels.browser.automationHostReady,
     handleHostReady
   );
   runtime.ipc.on(desktopIpcChannels.browser.automationResponse, handleResponse);
+  runtime.ipc.on(
+    desktopIpcChannels.browser.automationTurnClaim,
+    handleTurnClaim
+  );
 
   const sendToHost = (
     senderId: number,
@@ -241,6 +276,10 @@ export function createDesktopBrowserAutomationCoordinator(
         desktopIpcChannels.browser.automationResponse,
         handleResponse
       );
+      runtime.ipc.off(
+        desktopIpcChannels.browser.automationTurnClaim,
+        handleTurnClaim
+      );
       for (const request of pending.values()) {
         clearTimeout(request.timeout);
         request.reject(new Error("In-app Browser automation stopped"));
@@ -253,14 +292,33 @@ export function createDesktopBrowserAutomationCoordinator(
       readyWaiters.clear();
       targetOwnerIds.clear();
       revealedAgentTurns.clear();
+      turnSurfaceRoles.clear();
+      for (const waiters of turnSurfaceWaiters.values()) {
+        for (const resolve of waiters) resolve(null);
+      }
+      turnSurfaceWaiters.clear();
     },
-    requestTarget(input) {
+    async requestTarget(input) {
+      const agentSessionId = input.agentSessionId?.trim() ?? "";
+      const agentTurnId = input.agentTurnId?.trim() ?? "";
+      const claimedSurfaceRole =
+        agentSessionId && agentTurnId
+          ? await waitForTurnSurfaceRole({
+              agentSessionId,
+              agentTurnId,
+              timeoutMs:
+                options.turnClaimWaitTimeoutMs ?? defaultTurnClaimWaitTimeoutMs,
+              turnSurfaceRoles,
+              turnSurfaceWaiters,
+              workspaceId: input.workspaceId
+            })
+          : undefined;
       const request = {
         action: "create",
         agentSessionId: input.agentSessionId,
         agentTurnId: input.agentTurnId,
         nodeId: input.requestedPageId ?? null,
-        surfaceRole: "user",
+        surfaceRole: claimedSurfaceRole ?? "user",
         url: input.url ?? null,
         workspaceId: input.workspaceId
       } satisfies Omit<DesktopBrowserAutomationRequest, "requestId">;
@@ -313,6 +371,51 @@ function hostKey(workspaceId: string, surfaceRole: "agent" | "user"): string {
 
 function targetKey(workspaceId: string, nodeId: string): string {
   return `${workspaceId}\u0000${nodeId}`;
+}
+
+function turnKey(
+  workspaceId: string,
+  agentSessionId: string,
+  agentTurnId: string
+): string {
+  return `${workspaceId}\u0000${agentSessionId}\u0000${agentTurnId}`;
+}
+
+async function waitForTurnSurfaceRole(input: {
+  agentSessionId: string;
+  agentTurnId: string;
+  timeoutMs: number;
+  turnSurfaceRoles: Map<string, "agent" | "user">;
+  turnSurfaceWaiters: Map<
+    string,
+    Set<(surfaceRole: "agent" | "user" | null) => void>
+  >;
+  workspaceId: string;
+}): Promise<"agent" | "user" | undefined> {
+  const key = turnKey(
+    input.workspaceId,
+    input.agentSessionId,
+    input.agentTurnId
+  );
+  const existing = input.turnSurfaceRoles.get(key);
+  if (existing) return existing;
+  return await new Promise((resolve) => {
+    const waiters = input.turnSurfaceWaiters.get(key) ?? new Set();
+    const handleClaim = (surfaceRole: "agent" | "user" | null) => {
+      clearTimeout(timeout);
+      resolve(surfaceRole ?? undefined);
+    };
+    const timeout = setTimeout(
+      () => {
+        waiters.delete(handleClaim);
+        if (waiters.size === 0) input.turnSurfaceWaiters.delete(key);
+        resolve(undefined);
+      },
+      Math.max(0, input.timeoutMs)
+    );
+    waiters.add(handleClaim);
+    input.turnSurfaceWaiters.set(key, waiters);
+  });
 }
 
 function resolveReadyHostIds(

--- a/apps/desktop/src/preload/api/browser.ts
+++ b/apps/desktop/src/preload/api/browser.ts
@@ -13,6 +13,7 @@ type BrowserInvokeChannel = Exclude<
   | typeof desktopIpcChannels.browser.automationHostReady
   | typeof desktopIpcChannels.browser.automationRequest
   | typeof desktopIpcChannels.browser.automationResponse
+  | typeof desktopIpcChannels.browser.automationTurnClaim
   | typeof desktopIpcChannels.browser.event
 > &
   DesktopInvokeChannel;
@@ -43,6 +44,9 @@ export function createBrowserDesktopApi(): DesktopBrowserApi {
     ...browserApi,
     announceAutomationHostReady(input) {
       ipcRenderer.send(desktopIpcChannels.browser.automationHostReady, input);
+    },
+    claimAutomationTurn(input) {
+      ipcRenderer.send(desktopIpcChannels.browser.automationTurnClaim, input);
     },
     onAutomationRequest(listener) {
       const handleRequest = (

--- a/apps/desktop/src/preload/types.ts
+++ b/apps/desktop/src/preload/types.ts
@@ -68,6 +68,7 @@ import type {
   DesktopArchiveAgentPromptFileResult,
   DesktopBrowserAutomationRequest,
   DesktopBrowserAutomationHostReady,
+  DesktopBrowserAutomationTurnClaim,
   DesktopBrowserAutomationResponse
 } from "../shared/contracts/ipc";
 import type { BrowserNodeHostApi } from "@tutti-os/browser-node";
@@ -323,6 +324,7 @@ export type DesktopBrowserApi = Pick<
   | "updateAutomationTarget"
 > & {
   announceAutomationHostReady?(input: DesktopBrowserAutomationHostReady): void;
+  claimAutomationTurn?(input: DesktopBrowserAutomationTurnClaim): void;
   onAutomationRequest(
     listener: (request: DesktopBrowserAutomationRequest) => void
   ): () => void;

--- a/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
+++ b/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
@@ -259,6 +259,7 @@ export async function createWorkspaceWindowContainer(): Promise<WorkspaceWindowC
   });
   const workspaceAgentServices = registerWorkspaceAgentServices(registry, {
     accountLogin: accountService,
+    browserApi: desktopApi.browser,
     clipboard: {
       writeText: (text) => navigator.clipboard.writeText(text)
     },

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -525,6 +525,57 @@ test("desktop agent activity adapter rejects send responses without a canonical 
   );
 });
 
+test("desktop agent activity adapter claims canonical Turns for the originating renderer", async () => {
+  const claims: unknown[] = [];
+  const adapter = createDesktopAgentActivityAdapter({
+    claimBrowserAutomationTurn: (claim) => claims.push(claim),
+    tuttidClient: createTuttidClient({
+      async createWorkspaceAgentSession(_requestWorkspaceId, request) {
+        return createSession({
+          id: request.agentSessionId,
+          status: "running"
+        });
+      },
+      async sendWorkspaceAgentSessionInput(
+        _requestWorkspaceId,
+        agentSessionId
+      ) {
+        return createSendInputResponse(
+          createSession({ id: agentSessionId, status: "running" })
+        );
+      }
+    }),
+    runtimeApi: createRuntimeApi()
+  });
+
+  await adapter.createSession({
+    agentSessionId: "agent-session-created",
+    agentTargetId: "local:codex",
+    clientSubmitId: "submit-create",
+    initialContent: [{ type: "text", text: "hello" }],
+    workspaceId
+  });
+  await adapter.sendInput({
+    agentSessionId: "agent-session-existing",
+    clientSubmitId: "submit-send",
+    content: [{ type: "text", text: "continue" }],
+    workspaceId
+  });
+
+  assert.deepEqual(claims, [
+    {
+      agentSessionId: "agent-session-created",
+      agentTurnId: "turn-active",
+      workspaceId
+    },
+    {
+      agentSessionId: "agent-session-existing",
+      agentTurnId: "turn-1",
+      workspaceId
+    }
+  ]);
+});
+
 test("desktop agent activity adapter accepts typed goal input without a Turn", async () => {
   const adapter = createDesktopAgentActivityAdapter({
     tuttidClient: createTuttidClient({

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -47,6 +47,11 @@ import { reportAgentSubmitTraceDiagnostic as reportDesktopAgentSubmitTrace } fro
 import { DESKTOP_AGENT_GUI_CURRENT_USER_ID } from "./desktopAgentGuiIdentity.ts";
 
 export interface CreateDesktopAgentActivityAdapterInput {
+  claimBrowserAutomationTurn?(input: {
+    agentSessionId: string;
+    agentTurnId: string;
+    workspaceId: string;
+  }): void;
   composerOptionsRequestTimeoutMs?: number;
   tuttidClient: TuttidClient;
   runtimeApi: Pick<DesktopRuntimeApi, "logTerminalDiagnostic">;
@@ -138,6 +143,7 @@ export function agentActivitySessionDetailFromTuttid(
 }
 
 export function createDesktopAgentActivityAdapter({
+  claimBrowserAutomationTurn,
   composerOptionsRequestTimeoutMs = defaultComposerOptionsRequestTimeoutMs,
   tuttidClient,
   runtimeApi,
@@ -329,6 +335,13 @@ export function createDesktopAgentActivityAdapter({
           workspaceId: input.workspaceId,
           fields: { sessionStatus: workspaceAgentSessionStatus(session) }
         });
+        if (session.activeTurnId) {
+          claimBrowserAutomationTurn?.({
+            agentSessionId: session.id,
+            agentTurnId: session.activeTurnId,
+            workspaceId: input.workspaceId
+          });
+        }
         return agentActivitySessionFromTuttidSession(
           input.workspaceId,
           session
@@ -417,6 +430,11 @@ export function createDesktopAgentActivityAdapter({
           turnId: result.turnId,
           turnPhase: result.turn.phase
         }
+      });
+      claimBrowserAutomationTurn?.({
+        agentSessionId: input.agentSessionId,
+        agentTurnId: result.turnId,
+        workspaceId: input.workspaceId
       });
       return {
         kind: "turn",

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -52,6 +52,7 @@ import {
 } from "../desktopAgentRuntimeSubmitDiagnostics.ts";
 import { reportAgentSessionSettingsChanges } from "./agentSessionSettingsAnalytics.ts";
 import { AgentSessionReplayActivityBridge } from "../../../agent-session-replay/services/agentSessionReplayActivityBridge.ts";
+import type { CreateDesktopAgentActivityAdapterInput } from "../desktopAgentActivityAdapter.ts";
 
 function waitForPromiseWithSignal<T>(
   promise: Promise<T>,
@@ -82,6 +83,7 @@ function waitForPromiseWithSignal<T>(
 }
 
 export interface WorkspaceAgentActivityServiceDependencies {
+  claimBrowserAutomationTurn?: CreateDesktopAgentActivityAdapterInput["claimBrowserAutomationTurn"];
   eventStreamClient?: TuttidEventStreamClient;
   hostFilesApi?: Pick<
     DesktopHostFilesApi,
@@ -1042,6 +1044,7 @@ export class WorkspaceAgentActivityService
 
   protected createEntry(workspaceId: string): WorkspaceAgentActivityEntry {
     return createWorkspaceAgentSessionEngineHost({
+      claimBrowserAutomationTurn: this.dependencies.claimBrowserAutomationTurn,
       ...(this.dependencies.sessionReplayEnabled
         ? {
             activityEventObserver:

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.ts
@@ -24,6 +24,7 @@ import type { DesktopWorkspaceUiMode } from "@shared/preferences";
 import type { AgentHostAgentSessionComposerSettings } from "@shared/contracts/dto";
 import {
   createDesktopAgentActivityAdapter,
+  type CreateDesktopAgentActivityAdapterInput,
   type DesktopAgentActivityCommandAdapter
 } from "../desktopAgentActivityAdapter.ts";
 import {
@@ -47,6 +48,7 @@ export interface WorkspaceAgentSessionEngineActivityObserver {
 
 interface CreateWorkspaceAgentSessionEngineHostInput {
   activityEventObserver?: WorkspaceAgentSessionEngineActivityObserver;
+  claimBrowserAutomationTurn?: CreateDesktopAgentActivityAdapterInput["claimBrowserAutomationTurn"];
   executeEngineActivateSession(
     input: AgentActivityRuntimeActivateSessionInput,
     options: EngineEffectOptions
@@ -162,6 +164,7 @@ export function createWorkspaceAgentSessionEngineHost(
   input: CreateWorkspaceAgentSessionEngineHostInput
 ): WorkspaceAgentSessionEngineHost {
   const adapter = createDesktopAgentActivityAdapter({
+    claimBrowserAutomationTurn: input.claimBrowserAutomationTurn,
     tuttidClient: input.tuttidClient,
     runtimeApi: input.runtimeApi,
     uiMode: input.uiMode,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/registerWorkspaceAgentServices.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/registerWorkspaceAgentServices.ts
@@ -5,7 +5,11 @@ import type {
   TuttidEventStreamClient,
   WorkspaceAgentProvider
 } from "@tutti-os/client-tuttid-ts";
-import type { DesktopHostFilesApi, DesktopRuntimeApi } from "@preload/types";
+import type {
+  DesktopBrowserApi,
+  DesktopHostFilesApi,
+  DesktopRuntimeApi
+} from "@preload/types";
 import type { IReporterService } from "../../analytics/services/reporterService.interface.ts";
 import type { IWorkspaceUserProjectService } from "../../workspace-user-project/index.ts";
 import type { IDesktopPreferencesService } from "../../desktop-preferences/services/desktopPreferencesService.interface.ts";
@@ -45,6 +49,7 @@ import {
 export interface WorkspaceAgentServiceRegistrationInput {
   accountLogin: { startLogin(): Promise<unknown> };
   clipboard: { writeText(text: string): Promise<void> };
+  browserApi?: Pick<DesktopBrowserApi, "claimAutomationTurn">;
   desktopPreferencesService: IDesktopPreferencesService;
   eventStreamClient?: TuttidEventStreamClient;
   hostFilesApi: Pick<
@@ -154,6 +159,7 @@ export function registerWorkspaceAgentServices(
     );
   const workspaceAgentActivityService = new WorkspaceAgentActivityService({
     ...input,
+    claimBrowserAutomationTurn: input.browserApi?.claimAutomationTurn,
     forceRefreshAgentProviderStatuses: (providers) =>
       agentProviderStatusService.refreshStatuses(providers),
     resolveAgentTargetProvider: (agentTargetId) =>

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/createAgentProviderTerminalCommandRunner.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/createAgentProviderTerminalCommandRunner.test.ts
@@ -5,6 +5,41 @@ import type { WorkbenchHostHandle } from "@tutti-os/workbench-surface";
 import type { DesktopRuntimeApi } from "@preload/types";
 import { createAgentProviderTerminalCommandRunner } from "./createAgentProviderTerminalCommandRunner.ts";
 import { defaultWorkspaceTerminalWorkbenchTypeId } from "./internal/workspaceTerminalWorkbenchConstants.ts";
+import { registerWorkspaceTerminalLoginLaunchHandler } from "../../workspace-agent/services/workspaceTerminalLoginLaunchCoordinator.ts";
+
+test("agent provider terminal runner prefers the registered workspace presenter", async () => {
+  const requests: unknown[] = [];
+  const closed: string[] = [];
+  const unregister = registerWorkspaceTerminalLoginLaunchHandler(
+    "workspace-presenter",
+    async (request) => {
+      requests.push(request);
+      return {
+        close: () => closed.push("terminal"),
+        startupCompletion: Promise.resolve("not_required")
+      };
+    }
+  );
+  try {
+    const runner = createAgentProviderTerminalCommandRunner(createRuntimeApi());
+    const handle = await runner.runTerminalCommand(
+      createCommand("claude auth login"),
+      { workspaceId: "workspace-presenter" }
+    );
+
+    assert.deepEqual(requests, [
+      {
+        command: "claude auth login",
+        cwd: undefined,
+        workspaceId: "workspace-presenter"
+      }
+    ]);
+    handle?.close();
+    assert.deepEqual(closed, ["terminal"]);
+  } finally {
+    unregister();
+  }
+});
 
 test("agent provider terminal runner opens a terminal with the login command", async () => {
   const launchRequests: unknown[] = [];

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/createAgentProviderTerminalCommandRunner.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/createAgentProviderTerminalCommandRunner.ts
@@ -7,6 +7,7 @@ import type { DesktopRuntimeApi } from "@preload/types";
 import type { WorkbenchHostHandle } from "@tutti-os/workbench-surface";
 import { classifyDesktopErrorCode } from "../../../../../shared/errors/desktopErrors.ts";
 import { defaultWorkspaceTerminalWorkbenchTypeId } from "./internal/workspaceTerminalWorkbenchConstants.ts";
+import { requestWorkspaceTerminalLoginLaunch } from "../../workspace-agent/services/workspaceTerminalLoginLaunchCoordinator.ts";
 
 export function createAgentProviderTerminalCommandRunner(
   runtimeApi: DesktopRuntimeApi
@@ -19,6 +20,24 @@ export function createAgentProviderTerminalCommandRunner(
         event: "agent-provider.terminal-command.start",
         level: "info"
       });
+      const workspaceId = context?.workspaceId?.trim() ?? "";
+      if (workspaceId) {
+        const launchHandle = await requestWorkspaceTerminalLoginLaunch({
+          command: command.input,
+          cwd: command.cwd ?? undefined,
+          workspaceId
+        });
+        if (launchHandle) {
+          logTerminalCommandEvent(runtimeApi, {
+            command,
+            context,
+            event: "agent-provider.terminal-command.complete",
+            extraDetails: { launchRoute: "workspace-handler" },
+            level: "info"
+          });
+          return { close: launchHandle.close };
+        }
+      }
       const host = readWorkbenchHost(context);
       if (!host) {
         logTerminalCommandEvent(runtimeApi, {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceTerminalContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceTerminalContribution.ts
@@ -225,8 +225,10 @@ export function createWorkspaceTerminalContribution(input: {
   };
 
   registerWorkspaceTerminalSurfaceRuntime(resolvedContribution, {
-    createSession: () =>
+    createSession: (request) =>
       feature.launchService.create({
+        cwd: request?.cwd,
+        initialInput: request?.initialInput,
         reason: "intent",
         workspaceId: input.workspaceId
       }),

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentLinkAction.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentLinkAction.test.ts
@@ -3,9 +3,10 @@ import test from "node:test";
 import type { DesktopRendererDiagnosticPayload } from "@shared/contracts/ipc.ts";
 import { runStandaloneAgentLinkAction } from "./standaloneAgentLinkAction.ts";
 
-test("standalone Agent logs external link routing without query data", async () => {
+test("standalone Agent routes ordinary links to the in-app Browser", async () => {
   const diagnostics: DesktopRendererDiagnosticPayload[] = [];
-  const openedUrls: string[] = [];
+  const browserUrls: string[] = [];
+  const externalUrls: string[] = [];
   const url = "https://example.com/private?token=secret";
 
   const handled = await runStandaloneAgentLinkAction(
@@ -15,65 +16,59 @@ test("standalone Agent logs external link routing without query data", async () 
       url
     },
     createDependencies({
+      browserUrls,
       diagnostics,
       openExternalUrl: async (target) => {
-        openedUrls.push(target);
+        externalUrls.push(target);
       }
     })
   );
 
   assert.equal(handled, true);
-  assert.deepEqual(openedUrls, [url]);
+  assert.deepEqual(browserUrls, [url]);
+  assert.deepEqual(externalUrls, []);
   assert.deepEqual(
     diagnostics.map((diagnostic) => diagnostic.event),
     [
       "agent.gui.standalone_link_action.received",
-      "agent.gui.standalone_external_link.open_requested",
-      "agent.gui.standalone_external_link.open_succeeded",
       "agent.gui.standalone_link_action.settled"
     ]
   );
   assert.equal(JSON.stringify(diagnostics).includes("token=secret"), false);
-  assert.deepEqual(diagnostics[1]?.details, {
-    urlHost: "example.com",
-    urlLength: url.length,
-    urlProtocol: "https:"
-  });
 });
 
-test("standalone Agent logs external opener failures and a declined action", async () => {
+test("standalone Agent keeps explicit external actions in the system browser", async () => {
   const diagnostics: DesktopRendererDiagnosticPayload[] = [];
+  const externalUrls: string[] = [];
+  const url = "https://example.com";
 
   const handled = await runStandaloneAgentLinkAction(
     {
-      source: "agent-markdown",
+      source: "agent-external-action",
       type: "open-url",
-      url: "https://example.com"
+      url
     },
     createDependencies({
       diagnostics,
-      openExternalUrl: async () => {
-        throw new Error("native opener unavailable");
+      openExternalUrl: async (target) => {
+        externalUrls.push(target);
       }
     })
   );
 
-  assert.equal(handled, false);
+  assert.equal(handled, true);
+  assert.deepEqual(externalUrls, [url]);
   assert.deepEqual(
     diagnostics.map((diagnostic) => diagnostic.event),
     [
       "agent.gui.standalone_link_action.received",
-      "agent.gui.standalone_external_link.open_requested",
-      "agent.gui.standalone_external_link.open_failed",
       "agent.gui.standalone_link_action.settled"
     ]
   );
-  assert.equal(diagnostics[2]?.details?.error, "native opener unavailable");
-  assert.equal(diagnostics[2]?.level, "warn");
-  assert.equal(diagnostics[3]?.details?.handled, false);
 });
 
 function createDependencies(input: {
+  browserUrls?: string[];
   diagnostics: DesktopRendererDiagnosticPayload[];
   openExternalUrl(url: string): Promise<void>;
 }) {
@@ -82,6 +77,10 @@ function createDependencies(input: {
     launchAgentGui: fail,
     launchWorkspaceIssueManager: fail,
     launchWorkspaceFiles: fail,
+    openBrowserUrl: async ({ url }: { url: string }) => {
+      input.browserUrls?.push(url);
+      return true;
+    },
     openExternalUrl: input.openExternalUrl,
     runtimeApi: {
       async logRendererDiagnostic(payload: DesktopRendererDiagnosticPayload) {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentLinkAction.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentLinkAction.ts
@@ -5,10 +5,7 @@ import {
   type DesktopAgentGUILinkActionDependencies
 } from "../../workspace-agent/services/desktopAgentGUILinkActions.ts";
 
-export interface StandaloneAgentLinkActionDependencies extends Omit<
-  DesktopAgentGUILinkActionDependencies,
-  "openBrowserUrl"
-> {
+export interface StandaloneAgentLinkActionDependencies extends DesktopAgentGUILinkActionDependencies {
   openExternalUrl(url: string): Promise<void>;
   runtimeApi: Pick<DesktopRuntimeApi, "logRendererDiagnostic">;
 }
@@ -26,34 +23,7 @@ export async function runStandaloneAgentLinkAction(
   });
 
   try {
-    const handled = await runDesktopAgentGUILinkAction(action, {
-      ...dependencies,
-      openBrowserUrl: async ({ url }) => {
-        const urlDetails = describeExternalUrl(url);
-        await logStandaloneAgentLinkDiagnostic(dependencies, {
-          details: urlDetails,
-          event: "agent.gui.standalone_external_link.open_requested"
-        });
-        try {
-          await dependencies.openExternalUrl(url);
-          await logStandaloneAgentLinkDiagnostic(dependencies, {
-            details: urlDetails,
-            event: "agent.gui.standalone_external_link.open_succeeded"
-          });
-          return true;
-        } catch (error) {
-          await logStandaloneAgentLinkDiagnostic(dependencies, {
-            details: {
-              ...urlDetails,
-              error: stringifyDiagnosticError(error)
-            },
-            event: "agent.gui.standalone_external_link.open_failed",
-            level: "warn"
-          });
-          return false;
-        }
-      }
-    });
+    const handled = await runDesktopAgentGUILinkAction(action, dependencies);
     await logStandaloneAgentLinkDiagnostic(dependencies, {
       details: {
         actionType: action.type,
@@ -97,23 +67,6 @@ async function logStandaloneAgentLinkDiagnostic(
     });
   } catch {
     // Diagnostic transport must never block the user action it observes.
-  }
-}
-
-function describeExternalUrl(url: string): Record<string, unknown> {
-  try {
-    const parsed = new URL(url);
-    return {
-      urlHost: parsed.host,
-      urlLength: url.length,
-      urlProtocol: parsed.protocol
-    };
-  } catch {
-    return {
-      urlHost: null,
-      urlLength: url.length,
-      urlProtocol: null
-    };
   }
 }
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentTerminalLoginPresenter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentTerminalLoginPresenter.test.ts
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { DesktopRuntimeApi } from "@preload/types";
+import type {
+  TerminalDataEvent,
+  TerminalTransport
+} from "@tutti-os/workspace-terminal/contracts";
+import type { WorkbenchContribution } from "@tutti-os/workbench-surface";
+import { registerWorkspaceTerminalLoginLaunchHandler } from "../../workspace-agent/services/workspaceTerminalLoginLaunchCoordinator.ts";
+import { createAgentProviderTerminalCommandRunner } from "./createAgentProviderTerminalCommandRunner.ts";
+import { createStandaloneAgentTerminalLoginPresenter } from "./standaloneAgentTerminalLoginPresenter.ts";
+import { registerWorkspaceTerminalSurfaceRuntime } from "./workspaceTerminalSurfaceRuntime.ts";
+
+test("provider login reaches a standalone Agent Terminal tab through the shared coordinator", async () => {
+  const contribution = {} as WorkbenchContribution;
+  const createRequests: unknown[] = [];
+  registerWorkspaceTerminalSurfaceRuntime(contribution, {
+    async createSession(input) {
+      createRequests.push(input);
+      return { sessionId: "terminal-e2e-session" } as never;
+    },
+    feature: {
+      launchService: { async terminate() {} },
+      transport: createTransportHarness().transport
+    } as never,
+    getExternalState: () => null,
+    subscribe: () => () => {}
+  });
+  const openedSessionIds: string[] = [];
+  const presenter = createStandaloneAgentTerminalLoginPresenter({
+    closeTab() {},
+    contributions: [contribution],
+    openTab(sessionId) {
+      openedSessionIds.push(sessionId);
+      return "terminal-e2e-tab";
+    },
+    runtimeApi: createRuntimeApi()
+  });
+  const unregister = registerWorkspaceTerminalLoginLaunchHandler(
+    "workspace-e2e",
+    presenter
+  );
+  try {
+    const runner = createAgentProviderTerminalCommandRunner(
+      createRuntimeApi() as DesktopRuntimeApi
+    );
+    const handle = await runner.runTerminalCommand(
+      { input: "claude auth login" },
+      { workspaceId: "workspace-e2e" }
+    );
+
+    assert.deepEqual(createRequests, [
+      { cwd: undefined, initialInput: "claude auth login\n" }
+    ]);
+    assert.deepEqual(openedSessionIds, ["terminal-e2e-session"]);
+    assert.ok(handle);
+  } finally {
+    unregister();
+  }
+});
+
+test("standalone Agent terminal login creates a dedicated tab with the login command", async () => {
+  const contribution = {} as WorkbenchContribution;
+  const transport = createTransportHarness();
+  const createRequests: unknown[] = [];
+  const terminatedSessionIds: string[] = [];
+  registerWorkspaceTerminalSurfaceRuntime(contribution, {
+    async createSession(input) {
+      createRequests.push(input);
+      return { sessionId: "terminal-session-1" } as never;
+    },
+    feature: {
+      launchService: {
+        async terminate({ sessionId }: { sessionId: string }) {
+          terminatedSessionIds.push(sessionId);
+        }
+      },
+      transport: transport.transport
+    } as never,
+    getExternalState: () => null,
+    subscribe: () => () => {}
+  });
+  const openedSessionIds: string[] = [];
+  const closedTabIds: string[] = [];
+  const presenter = createStandaloneAgentTerminalLoginPresenter({
+    closeTab: (tabId) => closedTabIds.push(tabId),
+    contributions: [contribution],
+    openTab: (sessionId) => {
+      openedSessionIds.push(sessionId);
+      return "terminal-tab-1";
+    },
+    runtimeApi: createRuntimeApi()
+  });
+
+  const handle = await presenter({
+    command: "claude auth login",
+    cwd: "/workspace",
+    workspaceId: "workspace-1"
+  });
+
+  assert.ok(handle);
+  assert.deepEqual(createRequests, [
+    { cwd: "/workspace", initialInput: "claude auth login\n" }
+  ]);
+  assert.deepEqual(openedSessionIds, ["terminal-session-1"]);
+  assert.equal(await handle.startupCompletion, "not_required");
+  handle.close();
+  await Promise.resolve();
+  assert.deepEqual(closedTabIds, ["terminal-tab-1"]);
+  assert.deepEqual(terminatedSessionIds, ["terminal-session-1"]);
+});
+
+test("standalone Agent terminal login preserves typed startup actions", async () => {
+  const contribution = {} as WorkbenchContribution;
+  const transport = createTransportHarness();
+  registerWorkspaceTerminalSurfaceRuntime(contribution, {
+    async createSession() {
+      return { sessionId: "terminal-session-2" } as never;
+    },
+    feature: {
+      launchService: { async terminate() {} },
+      transport: transport.transport
+    } as never,
+    getExternalState: () => null,
+    subscribe: () => () => {}
+  });
+  const presenter = createStandaloneAgentTerminalLoginPresenter({
+    closeTab() {},
+    contributions: [contribution],
+    openTab: () => "terminal-tab-2",
+    runtimeApi: createRuntimeApi()
+  });
+
+  const handle = await presenter({
+    command: "/opt/kimi/bin/kimi",
+    startupAction: {
+      commandName: "login",
+      readyText: "Welcome to Kimi Code!",
+      type: "slash_command"
+    },
+    workspaceId: "workspace-1"
+  });
+  assert.ok(handle);
+  transport.emit({
+    data: "Welcome to Kimi Code!",
+    sessionId: "terminal-session-2"
+  });
+  assert.equal(await handle.startupCompletion, "submitted");
+  assert.deepEqual(transport.writes, [
+    {
+      data: "/login\r",
+      encoding: "utf8",
+      provenance: "auto",
+      sessionId: "terminal-session-2"
+    }
+  ]);
+});
+
+function createTransportHarness(): {
+  emit(event: TerminalDataEvent): void;
+  transport: Pick<TerminalTransport, "onData" | "write">;
+  writes: Array<Parameters<TerminalTransport["write"]>[0]>;
+} {
+  const listeners = new Set<(event: TerminalDataEvent) => void>();
+  const writes: Array<Parameters<TerminalTransport["write"]>[0]> = [];
+  return {
+    emit(event) {
+      for (const listener of listeners) listener(event);
+    },
+    transport: {
+      onData(listener) {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+      async write(request) {
+        writes.push(request);
+      }
+    },
+    writes
+  };
+}
+
+function createRuntimeApi(): Pick<DesktopRuntimeApi, "logTerminalDiagnostic"> {
+  return { async logTerminalDiagnostic() {} };
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentTerminalLoginPresenter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentTerminalLoginPresenter.ts
@@ -1,0 +1,83 @@
+import type { DesktopRuntimeApi } from "@preload/types";
+import type {
+  WorkspaceTerminalLoginLaunchHandler,
+  WorkspaceTerminalLoginStartupResult
+} from "@renderer/features/workspace-agent/services/workspaceTerminalLoginLaunchCoordinator.ts";
+import type { WorkbenchContribution } from "@tutti-os/workbench-surface";
+import { createTerminalStartupInputGate } from "./terminalStartupInputGate.ts";
+import { getWorkspaceTerminalSurfaceRuntime } from "./workspaceTerminalSurfaceRuntime.ts";
+
+export function createStandaloneAgentTerminalLoginPresenter(input: {
+  closeTab(tabId: string): void;
+  contributions: readonly WorkbenchContribution[];
+  openTab(sessionId: string): string | null;
+  runtimeApi: Pick<DesktopRuntimeApi, "logTerminalDiagnostic">;
+}): WorkspaceTerminalLoginLaunchHandler {
+  const terminalSurfaceRuntime = input.contributions
+    .map((contribution) => getWorkspaceTerminalSurfaceRuntime(contribution))
+    .find((candidate) => candidate !== null);
+
+  return async (request) => {
+    if (!terminalSurfaceRuntime) {
+      throw new Error("Terminal login is unavailable in this window.");
+    }
+    const startupGate = request.startupAction
+      ? createTerminalStartupInputGate({
+          commandName: request.startupAction.commandName,
+          readyText: request.startupAction.readyText,
+          transport: terminalSurfaceRuntime.feature.transport
+        })
+      : null;
+    let sessionId: string | null = null;
+    try {
+      const session = await terminalSurfaceRuntime.createSession({
+        cwd: request.cwd,
+        initialInput: /[\r\n]$/u.test(request.command)
+          ? request.command
+          : `${request.command}\n`
+      });
+      sessionId = session.sessionId;
+      const tabId = input.openTab(session.sessionId);
+      if (!tabId) {
+        throw new Error("Terminal login did not open the Agent tool panel.");
+      }
+
+      let startupCompletion: Promise<WorkspaceTerminalLoginStartupResult>;
+      if (startupGate) {
+        startupCompletion = startupGate.arm(session.sessionId);
+        void startupCompletion.then((result) =>
+          input.runtimeApi
+            .logTerminalDiagnostic({
+              details: { result },
+              event: "agent.gui.terminal-login.startup-input",
+              level: result === "submitted" ? "info" : "warn",
+              nodeId: tabId,
+              workspaceId: request.workspaceId
+            })
+            .catch(() => undefined)
+        );
+      } else {
+        startupCompletion = Promise.resolve("not_required");
+      }
+
+      return {
+        close: () => {
+          startupGate?.cancel();
+          input.closeTab(tabId);
+          void terminalSurfaceRuntime.feature.launchService
+            .terminate({ sessionId: session.sessionId })
+            .catch(() => undefined);
+        },
+        startupCompletion
+      };
+    } catch (error) {
+      startupGate?.cancel();
+      if (sessionId) {
+        void terminalSurfaceRuntime.feature.launchService
+          .terminate({ sessionId })
+          .catch(() => undefined);
+      }
+      throw error;
+    }
+  };
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentWorkspaceFilePreviewPresenter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentWorkspaceFilePreviewPresenter.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createStandaloneAgentWorkspaceFilePreviewPresenter } from "./standaloneAgentWorkspaceFilePreviewPresenter.ts";
+
+test("standalone Agent file previews stay in the right-side Files tool", async () => {
+  const openedPaths: string[] = [];
+  const presenter = createStandaloneAgentWorkspaceFilePreviewPresenter({
+    openFile(path) {
+      openedPaths.push(path);
+      return true;
+    }
+  });
+
+  const presented = await presenter.present({
+    name: "README.md",
+    path: "/workspace/README.md",
+    previewKind: "markdown"
+  });
+
+  assert.equal(presented, true);
+  assert.deepEqual(openedPaths, ["/workspace/README.md"]);
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentWorkspaceFilePreviewPresenter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentWorkspaceFilePreviewPresenter.ts
@@ -1,14 +1,11 @@
-import type { DesktopHostFilesApi } from "@preload/types";
 import type { WorkspaceFilePreviewSurfacePresenter } from "@renderer/features/workspace-file-preview";
 
 export function createStandaloneAgentWorkspaceFilePreviewPresenter(input: {
-  hostFilesApi: Pick<DesktopHostFilesApi, "openFile">;
-  workspaceId: string;
+  openFile(path: string): Promise<boolean> | boolean;
 }): WorkspaceFilePreviewSurfacePresenter {
   return {
     async present(target) {
-      await input.hostFilesApi.openFile(input.workspaceId, target.path);
-      return true;
+      return input.openFile(target.path);
     },
     unsupportedFallbackNotification: "suppress"
   };

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceTerminalSurfaceRuntime.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceTerminalSurfaceRuntime.ts
@@ -6,7 +6,10 @@ import type {
 import type { WorkbenchContribution } from "@tutti-os/workbench-surface";
 
 export interface WorkspaceTerminalSurfaceRuntime {
-  createSession(): Promise<TerminalSessionDescriptor>;
+  createSession(input?: {
+    cwd?: string | null;
+    initialInput?: string | null;
+  }): Promise<TerminalSessionDescriptor>;
   feature: TerminalNodeFeature;
   getExternalState(sessionId: string | null): TerminalNodeExternalState | null;
   subscribe(listener: () => void): () => void;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentTerminalPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentTerminalPanel.tsx
@@ -24,6 +24,7 @@ const terminalCloseGuardDescriptionI18nKey: TerminalNodeI18nKey =
 export function StandaloneAgentTerminalPanel({
   contributions,
   instanceId,
+  initialSessionId,
   loadingLabel,
   open,
   setToolHost,
@@ -31,6 +32,7 @@ export function StandaloneAgentTerminalPanel({
 }: {
   contributions: readonly WorkbenchContribution[] | undefined;
   instanceId: string;
+  initialSessionId?: string | null;
   loadingLabel: string;
   open: boolean;
   setToolHost: (instanceId: string, host: WorkbenchHostHandle | null) => void;
@@ -62,7 +64,9 @@ export function StandaloneAgentTerminalPanel({
     };
   }, [runtime]);
   const [nodeId] = useState(createStandaloneAgentTerminalNodeId);
-  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [sessionId, setSessionId] = useState<string | null>(
+    initialSessionId?.trim() || null
+  );
   const [launchError, setLaunchError] = useState(false);
   const launchPromiseRef = useRef<Promise<void> | null>(null);
   const directHost = useMemo(createStandaloneAgentDirectToolHost, []);

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebar.tsx
@@ -25,7 +25,9 @@ import type {
   WorkbenchHostHandle
 } from "@tutti-os/workbench-surface";
 import type { DesktopBrowserApi } from "@preload/types";
+import type { DesktopRuntimeApi } from "@preload/types";
 import type { WorkspaceAgentActivityService } from "@renderer/features/workspace-agent";
+import { registerWorkspaceTerminalLoginLaunchHandler } from "@renderer/features/workspace-agent/services/workspaceTerminalLoginLaunchCoordinator.ts";
 import {
   resolveWorkspaceAppDisplayName,
   useWorkspaceAppCenterService
@@ -39,6 +41,8 @@ import {
 } from "./StandaloneAgentToolSidebarPanel.tsx";
 import { StandaloneAgentToolLoadingState } from "./StandaloneAgentToolLoadingState.tsx";
 import { createStandaloneAgentToolHostGroup } from "./standaloneAgentToolWorkbench.ts";
+import { createStandaloneAgentTerminalLoginPresenter } from "../services/standaloneAgentTerminalLoginPresenter.ts";
+import { registerWorkspaceBrowserLaunchHandler } from "../services/workspaceBrowserLaunchCoordinator.ts";
 import { useExternalStoreValue } from "./useExternalStoreValue.ts";
 
 export type { StandaloneAgentFileOpenRequest } from "./StandaloneAgentToolSidebarPanel.tsx";
@@ -47,7 +51,6 @@ const browserControllerReadyTimeoutMs = 8_000;
 
 interface StandaloneAgentToolSidebarProps {
   activityService: WorkspaceAgentActivityService;
-  agentSessionId: string | null;
   appOpenId?: string | null;
   appI18n: I18nRuntime<string>;
   browserApi?: DesktopBrowserApi;
@@ -70,12 +73,12 @@ interface StandaloneAgentToolSidebarProps {
     width: number,
     animate?: boolean
   ) => Promise<{ width: number }>;
+  runtimeApi: Pick<DesktopRuntimeApi, "logTerminalDiagnostic">;
   workspaceId: string;
 }
 
 export function StandaloneAgentToolSidebar({
   activityService,
-  agentSessionId,
   appOpenId = null,
   appI18n,
   browserApi,
@@ -92,6 +95,7 @@ export function StandaloneAgentToolSidebar({
   onLayoutWidthChange,
   onToolHostReady,
   resizeWindowContentWidth,
+  runtimeApi,
   workspaceId
 }: StandaloneAgentToolSidebarProps): ReactNode {
   const { i18n, locale } = useTranslation();
@@ -113,6 +117,12 @@ export function StandaloneAgentToolSidebar({
   const toolHostGroup = useMemo(createStandaloneAgentToolHostGroup, []);
   const browserControllersRef = useRef(
     new Map<string, { controller: AgentToolBrowserController; tabId: string }>()
+  );
+  const browserControllersByTabIdRef = useRef(
+    new Map<string, AgentToolBrowserController>()
+  );
+  const browserTabControllerWaitersRef = useRef(
+    new Map<string, Set<(controller: AgentToolBrowserController) => void>>()
   );
   const browserControllerWaitersRef = useRef(
     new Map<
@@ -209,6 +219,20 @@ export function StandaloneAgentToolSidebar({
       controller: AgentToolBrowserController | null
     ) => {
       const sessionId = browserAgentSessionId?.trim() ?? "";
+      const existingTabController =
+        browserControllersByTabIdRef.current.get(tabId);
+      if (!controller) {
+        if (existingTabController) {
+          browserControllersByTabIdRef.current.delete(tabId);
+        }
+      } else {
+        browserControllersByTabIdRef.current.set(tabId, controller);
+        const tabWaiters = browserTabControllerWaitersRef.current.get(tabId);
+        if (tabWaiters) {
+          browserTabControllerWaitersRef.current.delete(tabId);
+          for (const resolve of tabWaiters) resolve(controller);
+        }
+      }
       if (!sessionId) return;
       const existing = browserControllersRef.current.get(sessionId);
       if (!controller) {
@@ -225,6 +249,67 @@ export function StandaloneAgentToolSidebar({
       for (const resolve of waiters) resolve(entry);
     },
     []
+  );
+
+  const waitForBrowserTabController = useCallback(
+    (tabId: string): Promise<AgentToolBrowserController> => {
+      const existing = browserControllersByTabIdRef.current.get(tabId);
+      if (existing) return Promise.resolve(existing);
+      return new Promise((resolve, reject) => {
+        const waiters =
+          browserTabControllerWaitersRef.current.get(tabId) ?? new Set();
+        const handleReady = (controller: AgentToolBrowserController) => {
+          clearTimeout(timeout);
+          resolve(controller);
+        };
+        const timeout = setTimeout(() => {
+          waiters.delete(handleReady);
+          if (waiters.size === 0) {
+            browserTabControllerWaitersRef.current.delete(tabId);
+          }
+          reject(new Error("Agent Browser surface did not become ready"));
+        }, browserControllerReadyTimeoutMs);
+        waiters.add(handleReady);
+        browserTabControllerWaitersRef.current.set(tabId, waiters);
+      });
+    },
+    []
+  );
+
+  useEffect(
+    () =>
+      registerWorkspaceTerminalLoginLaunchHandler(
+        workspaceId,
+        createStandaloneAgentTerminalLoginPresenter({
+          closeTab: (tabId) => sidebarRef.current?.closeTab(tabId),
+          contributions: contributions ?? [],
+          openTab: (sessionId) =>
+            sidebarRef.current?.addPanel("terminal", sessionId) ?? null,
+          runtimeApi
+        })
+      ),
+    [contributions, runtimeApi, workspaceId]
+  );
+
+  useEffect(
+    () =>
+      registerWorkspaceBrowserLaunchHandler(workspaceId, async (request) => {
+        const tabId = sidebarRef.current?.openPanel("browser") ?? null;
+        if (!tabId) return null;
+        const controller = await waitForBrowserTabController(tabId);
+        if (request.kind === "focus") {
+          if (request.preferredNodeId) {
+            controller.selectPage(request.preferredNodeId);
+          }
+          return controller.surfaceNodeId;
+        }
+        return (
+          (request.reuseIfOpen
+            ? controller.activatePageByUrl(request.url)
+            : null) ?? controller.createPage(request.url)
+        );
+      }),
+    [waitForBrowserTabController, workspaceId]
   );
 
   useEffect(() => {
@@ -272,12 +357,16 @@ export function StandaloneAgentToolSidebar({
           if (!sessionId) {
             throw new Error("Agent Browser request requires an agent session");
           }
-          if (request.action === "create" && request.reveal !== false) {
-            sidebarRef.current?.openPanel("browser", sessionId);
-          }
-          const entry = await waitForController(sessionId);
           if (request.action === "create") {
-            const nodeId = entry.controller.createPage(request.url);
+            const tabId =
+              request.reveal === false
+                ? sidebarRef.current?.ensurePanel("browser", sessionId)
+                : sidebarRef.current?.openPanel("browser", sessionId);
+            if (!tabId) {
+              throw new Error("Agent Browser panel did not open");
+            }
+            const controller = await waitForBrowserTabController(tabId);
+            const nodeId = controller.createPage(request.url);
             browserApi.respondAutomationRequest({
               nodeId,
               ok: true,
@@ -285,6 +374,7 @@ export function StandaloneAgentToolSidebar({
             });
             return;
           }
+          const entry = await waitForController(sessionId);
           const nodeId = request.nodeId?.trim() ?? "";
           if (!nodeId) throw new Error("Browser page id is required");
           if (request.action === "select") {
@@ -322,7 +412,13 @@ export function StandaloneAgentToolSidebar({
       disconnectAutomation();
       onToolHostReady(null);
     };
-  }, [browserApi, onToolHostReady, toolHostGroup, workspaceId]);
+  }, [
+    browserApi,
+    onToolHostReady,
+    toolHostGroup,
+    waitForBrowserTabController,
+    workspaceId
+  ]);
 
   useEffect(() => {
     const appId = appOpenId?.trim() || null;
@@ -471,7 +567,6 @@ export function StandaloneAgentToolSidebar({
         renderPanel={({ active, closeSidebar, tab }) => (
           <StandaloneAgentToolSidebarPanel
             active={active}
-            agentSessionId={agentSessionId}
             appI18n={appI18n}
             activityService={activityService}
             browserApi={browserApi}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebarPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebarPanel.tsx
@@ -10,7 +10,6 @@ import type { WorkspaceAgentActivityService } from "@renderer/features/workspace
 import type { DesktopBrowserApi } from "@preload/types";
 import type { useTranslation } from "@renderer/i18n";
 import type { StandaloneAgentIssueManagerOpenRequest } from "../services/standaloneAgentIssueManagerLaunch.ts";
-import { resolveStandaloneAgentBrowserSessionId } from "../services/standaloneAgentBrowserSession.ts";
 import { StandaloneAgentBrowserToolPanel } from "./StandaloneAgentBrowserToolPanel.tsx";
 import { StandaloneAgentToolLoadingState } from "./StandaloneAgentToolLoadingState.tsx";
 
@@ -63,7 +62,6 @@ export interface StandaloneAgentFileOpenRequest {
 
 export function StandaloneAgentToolSidebarPanel({
   active,
-  agentSessionId,
   appI18n,
   activityService,
   browserApi,
@@ -84,7 +82,6 @@ export function StandaloneAgentToolSidebarPanel({
   workspaceId
 }: {
   active: boolean;
-  agentSessionId: string | null;
   appI18n: I18nRuntime<string>;
   activityService: WorkspaceAgentActivityService;
   browserApi?: DesktopBrowserApi;
@@ -129,7 +126,7 @@ export function StandaloneAgentToolSidebarPanel({
           }}
           revealIntent={fileOpenRequest}
           showInternalOpenWithActions
-          showPreviewPanel={false}
+          showPreviewPanel
           workspaceID={workspaceId}
         />
       </Suspense>
@@ -208,10 +205,7 @@ export function StandaloneAgentToolSidebarPanel({
   if (panel === "browser") {
     return browserApi ? (
       <StandaloneAgentBrowserToolPanel
-        agentSessionId={resolveStandaloneAgentBrowserSessionId({
-          currentAgentSessionId: agentSessionId,
-          resourceAgentSessionId: tab.resourceId
-        })}
+        agentSessionId={tab.resourceId ?? null}
         appI18n={appI18n}
         automationManaged={Boolean(tab.resourceId)}
         browserApi={browserApi}
@@ -239,6 +233,7 @@ export function StandaloneAgentToolSidebarPanel({
       >
         <LazyStandaloneAgentTerminalPanel
           contributions={contributions}
+          initialSessionId={tab.resourceId}
           instanceId={instanceId}
           loadingLabel={i18n.t("common.loading")}
           open={active}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
@@ -3,7 +3,6 @@ import {
   Suspense,
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -101,6 +100,7 @@ import { Toast } from "@renderer/lib/toast";
 import { useStandaloneAgentWindowLayout } from "./useStandaloneAgentWindowLayout.ts";
 import { createStandaloneAgentWorkspaceAppSurfacePresenter } from "../services/standaloneAgentWorkspaceAppSurfacePresenter.ts";
 import { createStandaloneAgentWorkspaceFilePreviewPresenter } from "../services/standaloneAgentWorkspaceFilePreviewPresenter.ts";
+import { registerWorkspaceFilesLaunchHandler } from "../services/workspaceFilesLaunchCoordinator.ts";
 
 const LazyWorkspaceAccountMenu = lazy(() =>
   import("./WorkspaceAccountMenu").then(({ WorkspaceAccountMenu }) => ({
@@ -444,11 +444,17 @@ export function StandaloneAgentWindow({
     return workspaceFilePreviewSurfaceHost.registerPresenter(
       workspaceId,
       createStandaloneAgentWorkspaceFilePreviewPresenter({
-        hostFilesApi: desktopApi.host.files,
-        workspaceId
+        openFile: (path) => openFileInSidebar(path, true)
       })
     );
-  }, [desktopApi.host.files, workspaceFilePreviewSurfaceHost, workspaceId]);
+  }, [openFileInSidebar, workspaceFilePreviewSurfaceHost, workspaceId]);
+  useEffect(
+    () =>
+      registerWorkspaceFilesLaunchHandler(workspaceId, (request) =>
+        openFileInSidebar(request.path, request.validateExists)
+      ),
+    [openFileInSidebar, workspaceId]
+  );
   useEffect(() => {
     return workspaceAppSurfaceHost.registerPresenter(
       createStandaloneAgentWorkspaceAppSurfacePresenter({
@@ -590,9 +596,23 @@ export function StandaloneAgentWindow({
       }),
     []
   );
-  useLayoutEffect(
-    () => agentEnvService.bindWorkbenchHost(host),
-    [agentEnvService, host]
+  const releaseAgentEnvHostRef = useRef<(() => void) | null>(null);
+  const handleToolHostReady = useCallback(
+    (toolHost: WorkbenchHostHandle | null) => {
+      releaseAgentEnvHostRef.current?.();
+      releaseAgentEnvHostRef.current = toolHost
+        ? agentEnvService.bindWorkbenchHost(toolHost)
+        : null;
+      toolWorkbench.onHostReady(toolHost);
+    },
+    [agentEnvService, toolWorkbench]
+  );
+  useEffect(
+    () => () => {
+      releaseAgentEnvHostRef.current?.();
+      releaseAgentEnvHostRef.current = null;
+    },
+    []
   );
   const surface = useMemo<DesktopAgentGUISurfaceContext>(
     () => ({
@@ -783,7 +803,6 @@ export function StandaloneAgentWindow({
       >
         <StandaloneAgentToolSidebar
           activityService={workspaceAgentActivityService}
-          agentSessionId={nodeState.lastActiveAgentSessionId}
           appOpenId={openAppId}
           appI18n={toolWorkbench.appI18n}
           browserApi={desktopApi.browser}
@@ -865,8 +884,9 @@ export function StandaloneAgentWindow({
           onAppsOpen={ensureWorkspaceAppPolling}
           onAppendBrowserElementMention={appendBrowserElementMention}
           onBrowserElementError={Toast.Error}
-          onToolHostReady={toolWorkbench.onHostReady}
+          onToolHostReady={handleToolHostReady}
           resizeWindowContentWidth={resizeStandaloneAgentWindowContentWidth}
+          runtimeApi={desktopApi.runtime}
           workspaceId={workspaceId}
         >
           <StandaloneAgentWindowContentReady

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentToolWorkbench.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentToolWorkbench.test.ts
@@ -31,16 +31,31 @@ test("standalone Agent Files keeps the complete Open With menu", () => {
     standaloneAgentToolSidebarPanelSource,
     /showInternalOpenWithActions=\{false\}/
   );
+  assert.match(
+    standaloneAgentToolSidebarPanelSource,
+    /<LazyWorkspaceFileManagerPane[\s\S]*?showPreviewPanel(?:\s|\/|>)/
+  );
 });
 
-test("standalone Agent browser automation reveals the session Browser panel", () => {
+test("standalone Agent manual Browser tabs do not claim automation sessions", () => {
   assert.match(
-    standaloneAgentToolSidebarSource,
-    /request\.action === "create" &&[\s\S]*?request\.reveal !== false[\s\S]*?openPanel\("browser", sessionId\)/
+    standaloneAgentToolSidebarPanelSource,
+    /<StandaloneAgentBrowserToolPanel[\s\S]*?agentSessionId=\{tab\.resourceId \?\? null\}/
   );
   assert.doesNotMatch(
+    standaloneAgentToolSidebarPanelSource,
+    /resolveStandaloneAgentBrowserSessionId/
+  );
+  assert.match(
     standaloneAgentToolSidebarSource,
-    /request\.action === "create"[\s\S]*?ensurePanel\("browser", sessionId\)/
+    /const controller = await waitForBrowserTabController\(tabId\)[\s\S]*?controller\.createPage\(request\.url\)/
+  );
+});
+
+test("standalone Agent browser automation honors the requested reveal mode", () => {
+  assert.match(
+    standaloneAgentToolSidebarSource,
+    /request\.reveal === false[\s\S]*?ensurePanel\("browser", sessionId\)[\s\S]*?openPanel\("browser", sessionId\)/
   );
 });
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useStandaloneAgentLaunchRouting.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useStandaloneAgentLaunchRouting.ts
@@ -32,6 +32,7 @@ import {
   requestWorkspaceIssueManagerLaunch
 } from "../services/workspaceIssueManagerLaunchCoordinator.ts";
 import { runStandaloneAgentLinkAction } from "../services/standaloneAgentLinkAction.ts";
+import { requestWorkspaceBrowserLaunch } from "../services/workspaceBrowserLaunchCoordinator.ts";
 
 interface StandaloneAgentLaunchRoutingInput {
   agentDirectorySnapshot: DesktopAgentDirectorySnapshot;
@@ -177,6 +178,7 @@ export function useStandaloneAgentLaunchRouting({
           return true;
         },
         launchGroupChat: () => false,
+        openBrowserUrl: requestWorkspaceBrowserLaunch,
         openExternalUrl,
         runtimeApi,
         workspaceId

--- a/apps/desktop/src/shared/contracts/ipc.ts
+++ b/apps/desktop/src/shared/contracts/ipc.ts
@@ -192,6 +192,7 @@ export const desktopIpcChannels = {
     automationHostReady: "browser:automation-host-ready",
     automationRequest: "browser:automation-request",
     automationResponse: "browser:automation-response",
+    automationTurnClaim: "browser:automation-turn-claim",
     capturePreview: "browser:capturePreview",
     chooseDownloadDirectory: "browser:chooseDownloadDirectory",
     clearBrowsingData: "browser:clearBrowsingData",
@@ -1090,6 +1091,12 @@ export interface DesktopBrowserAutomationRequest {
 
 export interface DesktopBrowserAutomationHostReady {
   surfaceRole: "agent" | "user";
+  workspaceId: string;
+}
+
+export interface DesktopBrowserAutomationTurnClaim {
+  agentSessionId: string;
+  agentTurnId: string;
   workspaceId: string;
 }
 

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2550,6 +2550,18 @@ tab state. It also owns the single browser chrome instance for that surface.
 Its controller may activate an existing page by URL inside that one surface;
 the product Host remains responsible for choosing among Browser surfaces and
 focusing the owning top-level node or window.
+Desktop mode adapters register the same semantic Terminal, Browser, and Files
+launch coordinators in each renderer. A Workspace adapter presents through its
+Workbench host; a standalone Agent adapter presents through the right-side tool
+sidebar and waits for the exact mounted controller when necessary. The
+standalone AgentGUI `surface.host` represents the Agent node and must not be
+used as a tool-launch host. After a canonical Turn is created, its originating
+renderer claims the Browser presentation role through Electron main; Browser
+automation then selects or creates that exact Agent or Workspace surface.
+Automation may wait briefly when a provider tool request races ahead of that
+claim. Unclaimed legacy Turns retain the user/Workspace fallback. Host
+readiness must not be used to infer Turn origin. These tools remain Desktop
+chrome and do not enter AgentGUI lifecycle state.
 Hosts compose window controls into the tab strip through `defaultActions`,
 pass draggable-header semantics through `dragHandleProps`, and use
 `navigationActions` for address-row actions. A host must not wrap the panel in

--- a/docs/conventions/troubleshooting/toolchain-browser-terminal.md
+++ b/docs/conventions/troubleshooting/toolchain-browser-terminal.md
@@ -2,6 +2,30 @@
 
 [Back to troubleshooting index](./README.md)
 
+### Standalone Agent provider login reports an internal error
+
+- Symptom:
+  A provider login request fails in a standalone Agent window even though a
+  Workbench host appears to be bound, or an HTTP/file action unexpectedly opens
+  an OS application.
+- Quick checks:
+  Distinguish the AgentGUI `surface.host` from the standalone right-side tool
+  host. Verify that the renderer registered the workspace-scoped Terminal,
+  Browser, and Files presenters before announcing tool-host readiness.
+- Root cause:
+  The AgentGUI surface host owns the Agent node, not Desktop tool nodes. Reusing
+  it as a Workspace Workbench host makes Terminal launch return no node, while
+  standalone-specific link/file shortcuts can bypass the in-app tools.
+- Fix:
+  Keep semantic launch coordinators shared and register Desktop presentation
+  adapters per mode. The standalone adapter creates/selects sidebar tabs and
+  reserves OS navigation for explicit external or reveal actions.
+- Validation:
+  Verify provider login opens a new Terminal tab, ordinary HTTP and file
+  preview stay in right-side tools, explicit Open in Finder remains external,
+  and Browser automation follows the canonical Turn's validated renderer claim
+  (with Workspace fallback only for an unclaimed legacy Turn).
+
 ### Go-only PR skips a repository contract that later fails
 
 - Symptom:

--- a/docs/plans/2026-08-19-standalone-agent-tool-surface-adapter.md
+++ b/docs/plans/2026-08-19-standalone-agent-tool-surface-adapter.md
@@ -1,0 +1,134 @@
+# Standalone Agent Tool Surface Adapter
+
+## Background and goal
+
+Standalone Agent windows render AgentGUI without the Workspace Workbench. The
+provider-login, link, Browser Use, and file-preview paths nevertheless reused
+Workspace launch contracts. Some standalone paths therefore targeted the
+AgentGUI surface host (which is not a tool host) or escaped to an OS app.
+
+The goal is to keep the semantic launch contracts shared while adapting their
+presentation at the Desktop surface boundary:
+
+- provider login opens a new Terminal tab in the right sidebar;
+- ordinary HTTP links and Browser Use open the right-side Browser;
+- file preview opens the right-side Files tool; only explicit reveal/Open in
+  Finder uses the OS;
+- `reveal: false` may mount Browser without expanding the sidebar.
+
+There is one standalone Agent window per workspace workflow. This change does
+not introduce window ownership or multi-Agent-window selection.
+
+## Current architecture and complete paths
+
+Provider login currently follows
+`AgentEnv -> provider terminal command runner -> surface.host.launchNode`. In a
+Workspace window the host is a real Workbench host. In a standalone window the
+AgentGUI host only represents the Agent node, so it cannot launch Terminal.
+
+Ordinary links follow
+`AgentGUI link action -> standalone link adapter -> shell.openExternal`, and
+file preview follows
+`workspace file preview host -> standalone presenter -> host files openFile`.
+Both leave Tutti instead of selecting a sidebar tool.
+
+Browser Use follows
+`tuttid/browser request -> Electron main browser automation coordinator -> user
+Browser host`, even when a ready standalone Agent Browser host exists.
+
+## Target architecture and complete paths
+
+Semantic requests remain surface-neutral and are resolved by a Desktop
+presenter registered for the current renderer:
+
+- login: `AgentEnv -> terminal runner -> workspace terminal-login coordinator
+-> standalone presenter -> create terminal session -> add Terminal tab`;
+- HTTP link: `AgentGUI link action -> workspace Browser launch coordinator ->
+standalone presenter -> open Browser tab -> create/activate page`;
+- file preview: `file preview surface host -> standalone presenter -> Files
+launch coordinator/state -> open Files tab and select path`;
+- Browser Use: `renderer submit result -> Turn surface claim -> browser
+automation coordinator -> originating Agent or Workspace Browser host`. The
+  coordinator briefly waits when automation races ahead of the canonical Turn
+  claim, then creates/waits for the claimed host; unclaimed legacy Turns retain
+  the user/Workspace fallback.
+
+Explicit external-link actions remain system-browser actions. Explicit
+reveal/Open in Finder remains a host-files reveal action.
+
+## Repository and module changes
+
+Only `tutti` changes.
+
+- Desktop main browser automation coordinator: record the validated renderer
+  origin for each canonical Turn, then select/create that surface's Browser;
+  preserve the user-host fallback for unclaimed legacy Turns.
+- provider terminal runner: prefer the workspace-scoped terminal-login
+  coordinator and retain Workbench launch fallback.
+- standalone Terminal presenter/runtime: create the session with command and
+  cwd, create one sidebar tab per request, and retain startup-action gating.
+- standalone Browser sidebar adapter: register the shared Browser launch
+  coordinator, wait for the selected tab controller, and implement reveal vs
+  silent mount.
+- standalone link routing: send ordinary HTTP actions to the Browser
+  coordinator; preserve explicit external actions.
+- standalone file-preview presenter: select Files in the sidebar rather than
+  calling the OS open-file API.
+- standalone Agent environment binding: bind provider launch behavior to the
+  right-side tool host group, not the AgentGUI surface host.
+
+Tasks and Apps already use standalone presenters and sidebar state, so their
+contracts do not change.
+
+## Reuse and Adapter boundary
+
+Shared semantic coordinators, terminal runtime, Browser controller, Files pane,
+and provider startup-input gate are reused. Desktop owns the mode-specific
+presenters and top-level focus/tab behavior. AgentGUI, provider protocol, and
+daemon code do not learn about sidebar tabs, Electron windows, or OS reveal.
+
+## Explicit non-goals
+
+- no multi-Agent-window selection or `windowId` protocol;
+- no new Browser, Terminal, Files, Tasks, or Apps implementation;
+- no AgentGUI lifecycle/state changes for Desktop tool chrome;
+- no change to explicit system-browser or Open in Finder actions;
+- no provider authentication or credential format changes.
+
+## Migration and compatibility
+
+There is no persisted-data migration. Existing Workspace presentation remains
+the fallback when no renderer presenter or Turn claim exists. Existing sessions
+and saved layouts keep their current schema.
+
+## Risks and rollback
+
+The main risks are a presenter-registration race, a missing/forged Turn claim,
+targeting the wrong Browser tab, and leaking a terminal session if tab creation
+fails. Registration happens before the tool host is announced; Electron main
+validates claims against the sender window; Browser launch waits for the exact
+Turn claim and tab controller with bounded timeouts; terminal creation failure
+cleans up the session.
+
+Rollback is a single commit/MR revert. Because no schema or daemon contract is
+changed, rollback needs no data repair.
+
+## Tests and acceptance
+
+- unit: terminal coordinator preference/fallback, new-tab creation, startup
+  action, link routing, file preview routing, Browser host selection and reveal
+  policy;
+- static: Desktop typecheck and changed-file repository checks;
+- build: Desktop production build;
+- integration: exercise provider command through the coordinator/presenter and
+  Browser automation through main host selection and renderer response;
+- manual acceptance: Claude login opens a new right Terminal tab; ordinary HTTP
+  and Browser Use stay in right Browser; file preview stays in Files; Open in
+  Finder uses Finder; `reveal:false` does not expand the sidebar.
+
+## Phased implementation
+
+1. Add the standalone Terminal presenter and bind the real tool host.
+2. Route Browser, HTTP links, and Files through their shared coordinators.
+3. Add contract tests, documentation, typecheck/build, and integration checks.
+4. Obtain independent review, fix findings, then push one MR.


### PR DESCRIPTION
## Summary

- Route standalone provider login, ordinary HTTP links, Browser Use, and file preview through right-side tool adapters.
- Bind Browser Use to the originating canonical Turn with validated Electron claims, exact-tab routing, and bounded race handling.
- Preserve Workspace and system fallbacks, including explicit Open in Finder behavior.

## Validation

- `pnpm check:changed` passed; push-ready hook passed 13 lanes.
- `pnpm --filter @tutti-os/desktop build` passed.
- Focused Desktop integration tests passed: 75 tests; Browser race suite passed: 9 tests.
- Independent subagent review completed; all findings fixed and final result: no blocker.

## Risk

- Unclaimed legacy Browser Turns wait up to 1 second before Workspace fallback.
- Real Claude credential login was not exercised; automated login-chain integration and production build are covered.