### PR TITLE
fix(connector): hide delisted catalog entries

### DIFF
--- a/docs/architecture/connector.md
+++ b/docs/architecture/connector.md
@@ -44,6 +44,15 @@ schema versions belong to different APIs and do not imply compatibility.
 The renderer never calls the remote market. The local daemon is authoritative
 for every state rendered by the desktop application.
 
+An authoritative catalog refresh treats a missing Connector as delisted. A
+not-installed Connector with no active lifecycle operation is deleted
+immediately. Installed Connectors and Connectors with active operations retain
+their private durable installation and cleanup evidence, but the daemon marks
+them `removed_from_catalog` and omits the Connector and its operations from
+public snapshots, single-Connector reads, and catalog-page projections. Public
+validation runs only after that filter, so an obsolete manifest retained solely
+for cleanup cannot make the visible catalog unavailable.
+
 Category identifiers are opaque routing values. The Connector adapter sends
 the exact server `categoryId` back as `sectionId` and never rewrites legacy or
 new IDs. The daemon projects both `displayNameZh` and `displayNameEn` through

--- a/packages/connector/daemon/core/application.go
+++ b/packages/connector/daemon/core/application.go
@@ -169,19 +169,36 @@ func (application *Application) SnapshotForScope(ctx context.Context, scope Oper
 }
 
 func publicSnapshot(snapshot Snapshot, scope OperationScope) (Snapshot, error) {
+	visibleConnectorKeys := make(map[string]struct{}, len(snapshot.Connectors))
+	connectors := snapshot.Connectors[:0]
 	for _, connector := range snapshot.Connectors {
+		if connectorRemovedFromCatalog(connector) {
+			continue
+		}
 		if err := ValidateReleaseShape(connector.Release); err != nil {
 			return Snapshot{}, fmt.Errorf("validate connector %q release: %w", connector.Key, err)
 		}
+		visibleConnectorKeys[connector.Key] = struct{}{}
+		connectors = append(connectors, connector)
 	}
+	snapshot.Connectors = connectors
 	operations := snapshot.Operations[:0]
 	for _, operation := range snapshot.Operations {
+		if operation.ConnectorKey != "" {
+			if _, visible := visibleConnectorKeys[operation.ConnectorKey]; !visible {
+				continue
+			}
+		}
 		if OperationVisibleToScope(operation, scope) {
 			operations = append(operations, operation)
 		}
 	}
 	snapshot.Operations = operations
 	return snapshot, nil
+}
+
+func connectorRemovedFromCatalog(connector Connector) bool {
+	return connector.Compatibility.Reason == compatibilityReasonRemovedFromCatalog
 }
 
 func (application *Application) ListCatalogCategories(ctx context.Context) ([]CatalogCategory, error) {
@@ -348,6 +365,9 @@ func (application *Application) projectCatalogSourcePage(
 		if err != nil {
 			return CatalogPage{}, err
 		}
+		if connectorRemovedFromCatalog(connector) {
+			continue
+		}
 		result.Items = append(result.Items, CatalogListing{CategoryID: entry.CategoryID, Featured: entry.Featured, Connector: connector})
 	}
 	return result, nil
@@ -399,6 +419,9 @@ func (application *Application) GetConnector(
 	connector, err := application.config.Repository.Connector(ctx, connectorKey)
 	if err != nil {
 		return Connector{}, err
+	}
+	if connectorRemovedFromCatalog(connector) {
+		return Connector{}, ErrNotFound
 	}
 	if err := ValidateReleaseShape(connector.Release); err != nil {
 		return Connector{}, fmt.Errorf("validate connector %q release: %w", connector.Key, err)

--- a/packages/connector/daemon/core/application_catalog_freshness_test.go
+++ b/packages/connector/daemon/core/application_catalog_freshness_test.go
@@ -71,3 +71,57 @@ func TestCatalogFetchFenceDropsSlowOlderPage(t *testing.T) {
 		t.Fatalf("slow old page replaced newer catalog state: %#v", stored.Release)
 	}
 }
+
+func TestCatalogFetchFenceDoesNotProjectDelistedConnectorFromSlowOlderPage(t *testing.T) {
+	connector := installedTestConnector("github")
+	source := &outOfOrderCatalogSource{
+		oldRelease: connector.Release, newRelease: connector.Release,
+		firstStarted: make(chan struct{}), releaseFirst: make(chan struct{}),
+	}
+	t.Cleanup(func() {
+		select {
+		case <-source.releaseFirst:
+		default:
+			close(source.releaseFirst)
+		}
+	})
+	repository := newMemoryRepository(connector)
+	application := newTestApplication(t, repository, &memoryScheduler{}, &memoryInstallRuntime{}, CatalogSnapshot{})
+	application.config.CatalogSource = source
+	query := CatalogPageQuery{SectionID: "featured", PageSize: 20}
+	type pageResult struct {
+		page CatalogPage
+		err  error
+	}
+	firstDone := make(chan pageResult, 1)
+	go func() {
+		page, err := application.ListCatalogPage(context.Background(), query)
+		firstDone <- pageResult{page: page, err: err}
+	}()
+
+	<-source.firstStarted
+	accepted, err := application.RefreshCatalog(context.Background(), Mutation{
+		ClientRequestID: "refresh-without-github", ExpectedRevision: repository.revision,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := application.ExecuteOperation(context.Background(), accepted.Operation.OperationID); err != nil {
+		t.Fatal(err)
+	}
+	close(source.releaseFirst)
+	result := <-firstDone
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if len(result.page.Items) != 0 {
+		t.Fatalf("slow page projected delisted connector: %#v", result.page.Items)
+	}
+	stored, err := repository.Connector(context.Background(), connector.Key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !connectorRemovedFromCatalog(stored) {
+		t.Fatalf("stored connector compatibility = %#v", stored.Compatibility)
+	}
+}

--- a/packages/connector/daemon/core/application_execution.go
+++ b/packages/connector/daemon/core/application_execution.go
@@ -9,6 +9,8 @@ import (
 
 const authorizationSessionTTL = 10 * time.Minute
 
+const compatibilityReasonRemovedFromCatalog = "removed_from_catalog"
+
 func (application *Application) executeRefresh(ctx context.Context, operation Operation) error {
 	if _, err := application.updateOperationStage(ctx, operation.OperationID, OperationStageRefreshing, nil); err != nil {
 		return err
@@ -78,7 +80,7 @@ func (application *Application) executeRefresh(ctx context.Context, operation Op
 				}
 				connector.Compatibility = Compatibility{
 					State:  CompatibilityStateUnsupportedVersion,
-					Reason: "removed_from_catalog",
+					Reason: compatibilityReasonRemovedFromCatalog,
 				}
 				connector.Revision = revision
 				if err := tx.SaveConnector(connector); err != nil {

--- a/packages/connector/daemon/core/application_test.go
+++ b/packages/connector/daemon/core/application_test.go
@@ -48,6 +48,73 @@ func TestApplicationPublicReadsRejectObsoleteConnectorIcon(t *testing.T) {
 	}
 }
 
+func TestApplicationPublicReadsHideRemovedCatalogConnectorBeforeValidation(t *testing.T) {
+	removed := testConnector("removed")
+	removed.Installation = Installation{
+		State:                  InstallationStateInstalled,
+		InstalledVersion:       removed.Release.Version,
+		InstalledReleaseID:     removed.Release.ReleaseID,
+		InstalledReleaseDigest: removed.Release.ReleaseDigest,
+	}
+	removed.Compatibility = Compatibility{
+		State:  CompatibilityStateUnsupportedVersion,
+		Reason: compatibilityReasonRemovedFromCatalog,
+	}
+	// Delisted releases may retain an obsolete manifest solely as uninstall
+	// evidence. Public reads must filter them before validating visible data.
+	removed.Release.Manifest.IconURL = "data:image/png;base64,iVBORw0KGgo="
+	visible := testConnector("visible")
+	repository := newMemoryRepository(removed, visible)
+	repository.operations["removed-install"] = Operation{
+		OperationID: "removed-install", ClientRequestID: "removed-install",
+		ConnectorKey: removed.Key, Kind: OperationKindInstall,
+		State: OperationStateCompleted, Stage: OperationStageCompleted,
+		Scope: OperationScope{AccountID: "account-1"}, OwnerAccountID: "account-1",
+		Visibility: OperationVisibilityAccount,
+	}
+	application := newTestApplication(
+		t,
+		repository,
+		&memoryScheduler{},
+		&memoryInstallRuntime{},
+		CatalogSnapshot{},
+	)
+
+	for _, read := range []struct {
+		name string
+		load func() (Snapshot, error)
+	}{
+		{name: "snapshot", load: func() (Snapshot, error) {
+			return application.Snapshot(context.Background())
+		}},
+		{name: "scoped snapshot", load: func() (Snapshot, error) {
+			return application.SnapshotForScope(context.Background(), OperationScope{AccountID: "account-1"})
+		}},
+	} {
+		t.Run(read.name, func(t *testing.T) {
+			snapshot, err := read.load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(snapshot.Connectors) != 1 || snapshot.Connectors[0].Key != visible.Key {
+				t.Fatalf("public connectors = %#v", snapshot.Connectors)
+			}
+			for _, operation := range snapshot.Operations {
+				if operation.ConnectorKey == removed.Key {
+					t.Fatalf("removed connector operation was public: %#v", operation)
+				}
+			}
+		})
+	}
+
+	if _, err := application.GetConnector(context.Background(), removed.Key); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetConnector() error = %v, want not found", err)
+	}
+	if _, err := repository.Connector(context.Background(), removed.Key); err != nil {
+		t.Fatalf("removed connector durable evidence was deleted: %v", err)
+	}
+}
+
 func TestApplicationInstallIsDurableAndIdempotent(t *testing.T) {
 	repository := newMemoryRepository(testConnector("github"))
 	scheduler := &memoryScheduler{}


### PR DESCRIPTION
## Root cause

Authoritative catalog refreshes already marked retained installed or in-flight Connectors as `removed_from_catalog`, but public snapshots and item reads still validated and projected those durable cleanup records. Delisted Connectors therefore remained visible, and an obsolete retained manifest could make the entire visible catalog fail validation.

## Changes

- filter `removed_from_catalog` Connectors and their operations at the shared Core public snapshot boundary
- return not found for delisted single-Connector reads
- prevent a superseded slow catalog page from projecting a Connector removed by a newer authoritative refresh
- preserve internal installation, runtime, and uninstall evidence
- document the public projection and validation order

## Verification

- `GOWORK=off go test -race ./...` in `packages/connector/daemon/core`
- `pnpm check:connector-boundaries`
- `pnpm check:changed -- --push-ready`
- `pnpm exec prettier --check docs/architecture/connector.md`
- `git diff --check`

## Platform impact

No platform-specific behavior changes; filtering is host-neutral Core projection logic.