### PR TITLE
fix(agent-activity): preserve slash policy across capability refreshes

### DIFF
--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -896,7 +896,11 @@ capability catalog.
 The activity snapshot also exposes the composer-options request lifecycle per
 opaque target key and per independent section. `core` contains model,
 reasoning, speed, permission, and effective-settings data; `capabilities`
-contains skills, commands, and capability-catalog data. Desktop requests
+contains skills, commands, and capability-catalog data. The provider's typed
+slash-command policy belongs to `core`; a `capabilities` response that omits it
+or projects it as null must not erase the last successful core value. Every
+section merge updates only the fields owned by that section and preserves
+fields owned by the other sections. Desktop requests
 `core` for the model/reasoning/speed consumer and requests `capabilities` only
 when a capability surface is opened or used; neither capability discovery nor
 its eight-second provider timeout blocks the model controls. `full` remains the

--- a/packages/agent/activity-core/src/engine/composerOptions.reducer.ts
+++ b/packages/agent/activity-core/src/engine/composerOptions.reducer.ts
@@ -284,7 +284,7 @@ function mergeSectionOptions(
     commands: incoming.commands,
     skills: incoming.skills,
     capabilityCatalog: incoming.capabilityCatalog,
-    slashCommandPolicy: incoming.slashCommandPolicy,
+    slashCommandPolicy: existing.slashCommandPolicy,
     loadedAtUnixMs: incoming.loadedAtUnixMs
   });
 }

--- a/packages/agent/activity-core/src/engine/composerOptions.semantic.test.ts
+++ b/packages/agent/activity-core/src/engine/composerOptions.semantic.test.ts
@@ -71,7 +71,7 @@ function loadInput(overrides: { cwd?: string; force?: boolean } = {}) {
   };
 }
 
-test("core settles before capabilities and section requests do not share in-flight state", async () => {
+test("core settles before capabilities without losing core-owned options", async () => {
   const harness = createHarness();
   const core = harness.engine.loadComposerOptions({
     ...loadInput(),
@@ -90,15 +90,25 @@ test("core settles before capabilities and section requests do not share in-flig
 
   harness.succeed(
     harness.commands[0]!.commandId,
-    composerOptions("core-model")
+    composerOptions("core-model", {
+      slashCommandPolicy: {
+        fallbackCommands: ["compact", "help"],
+        commandEffects: []
+      }
+    })
   );
   const coreOptions = await core;
   assert.equal(coreOptions.models[0]?.value, "core-model");
+  assert.deepEqual(coreOptions.slashCommandPolicy?.fallbackCommands, [
+    "compact",
+    "help"
+  ]);
   assert.equal(harness.commands.length, 2);
 
   harness.succeed(
     harness.commands[1]!.commandId,
     composerOptions("capability-response", {
+      slashCommandPolicy: null,
       skills: [
         {
           name: "search",
@@ -111,6 +121,10 @@ test("core settles before capabilities and section requests do not share in-flig
   const merged = await capabilities;
   assert.equal(merged.models[0]?.value, "core-model");
   assert.equal(merged.skills[0]?.name, "search");
+  assert.deepEqual(merged.slashCommandPolicy?.fallbackCommands, [
+    "compact",
+    "help"
+  ]);
 });
 
 test("connector section replaces only connector capabilities", async () => {


### PR DESCRIPTION
## Summary

- preserve the `core` section's typed slash-command policy when a later `capabilities` section settles
- cover the exact core-then-capabilities ordering that removed Codex slash commands in consumers
- document composer-option section ownership

## Root cause

`mergeSectionOptions` treated `slashCommandPolicy` as capabilities-owned. Consumers that project an omitted capabilities policy as `null` therefore erased the valid policy returned by the earlier core request.

## Validation

- negative control: the new semantic test failed before the reducer change because `fallbackCommands` became `undefined`
- `pnpm --dir packages/agent/activity-core exec node --test --experimental-strip-types src/engine/composerOptions.semantic.test.ts` (8 passed)
- `pnpm check:changed` (11 lanes passed)
- pre-push `pnpm check:changed -- --push-ready` (12 lanes passed)

## Review impact

- Architecture/consumer: section ownership is explicit; capabilities refreshes cannot mutate core-owned slash policy
- Performance: one existing property assignment changes its source; no added work or render path
- Windows: platform-neutral TypeScript state reduction; no OS-specific path, process, or transport behavior
- Self-evolution/docs: the durable ownership rule is recorded in `agent-activity-packages.md`
