### PR TITLE
fix(agent-gui): backport Tutti mode controls to release/0819

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -91,7 +91,8 @@ import {
   isFeatureEnabled,
   LAB_AGENT_SIDE_CONVERSATION_FLAG,
   LAB_CODEX_SAVER_MODE_FLAG,
-  LAB_CONNECTORS_FLAG
+  LAB_CONNECTORS_FLAG,
+  LAB_TUTTI_MODE_FLAG
 } from "../../../../../shared/featureFlags/catalog.ts";
 
 const EMPTY_AGENT_SESSION_LAUNCH_MODES_BY_PROJECT_SECTION_KEY: Readonly<
@@ -570,7 +571,7 @@ function DesktopAgentGUISurfaceImpl({
         enabled: isFeatureEnabled(featureFlags, LAB_CONNECTORS_FLAG)
       },
       tuttiMode: {
-        enabled: true
+        enabled: isFeatureEnabled(featureFlags, LAB_TUTTI_MODE_FLAG)
       }
     };
   }, [

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceLabFeatureGateRows.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceLabFeatureGateRows.tsx
@@ -5,12 +5,18 @@ import {
   LAB_AUTOMATION_RULES_FLAG,
   LAB_CONNECTORS_FLAG,
   LAB_CONVERSATION_ACTIVITY_VIEW_FLAG,
+  LAB_TUTTI_MODE_FLAG,
   LAB_WORKBENCH_SHORTCUTS_FLAG,
   isFeatureEnabled
 } from "../../../../../shared/featureFlags/catalog.ts";
 import type { DesktopFeatureFlags } from "../../../../../shared/preferences/index.ts";
 
 const featureGateRows = [
+  {
+    key: LAB_TUTTI_MODE_FLAG,
+    labelKey: "workspace.settings.lab.tuttiModeLabel" as const,
+    descriptionKey: "workspace.settings.lab.tuttiModeDescription" as const
+  },
   {
     key: LAB_AUTOMATION_RULES_FLAG,
     labelKey: "workspace.settings.lab.automationRulesLabel" as const,

--- a/apps/desktop/src/shared/featureFlags/catalog.test.ts
+++ b/apps/desktop/src/shared/featureFlags/catalog.test.ts
@@ -17,6 +17,7 @@ import {
   LAB_AUTOMATION_RULES_FLAG,
   LAB_CONNECTORS_FLAG,
   LAB_CONVERSATION_ACTIVITY_VIEW_FLAG,
+  LAB_TUTTI_MODE_FLAG,
   MOBILE_REMOTE_ACCESS_SETTINGS_FLAG,
   isStableAgentExtensionTarget,
   resolveDesktopWorkspaceUiMode,
@@ -92,7 +93,8 @@ test("experimental Agent features require independent Lab opt-ins", () => {
   const flags = [
     LAB_AUTOMATION_RULES_FLAG,
     LAB_CONNECTORS_FLAG,
-    LAB_CONVERSATION_ACTIVITY_VIEW_FLAG
+    LAB_CONVERSATION_ACTIVITY_VIEW_FLAG,
+    LAB_TUTTI_MODE_FLAG
   ];
 
   for (const flag of flags) {
@@ -122,7 +124,6 @@ test("graduated Agent features are not registered as Lab flags", () => {
   const definitions = labFeatureDefinitions();
   for (const retiredKey of [
     "lab.agentInputHistory",
-    "lab.tuttiMode",
     "lab.modelPlans",
     "lab.workspaceAgents"
   ]) {

--- a/apps/desktop/src/shared/featureFlags/catalog.ts
+++ b/apps/desktop/src/shared/featureFlags/catalog.ts
@@ -7,6 +7,7 @@ import {
 export const LAB_ENABLED_FLAG = "lab.enabled";
 export const BROWSER_CHROME_COOKIE_IMPORT_FLAG = "browser.chromeCookieImport";
 export const LAB_AUTOMATION_RULES_FLAG = "lab.automationRules";
+export const LAB_TUTTI_MODE_FLAG = "lab.tuttiMode";
 export const LAB_CONNECTORS_FLAG = "lab.connectors";
 export const LAB_WORKBENCH_SHORTCUTS_FLAG = "lab.workbenchShortcuts";
 export const LAB_CONVERSATION_ACTIVITY_VIEW_FLAG =
@@ -157,6 +158,13 @@ export const FEATURE_FLAG_DEFINITIONS: readonly FeatureFlagDefinition[] = [
     group: "lab",
     labelKey: "workspace.settings.lab.automationRulesLabel",
     descriptionKey: "workspace.settings.lab.automationRulesDescription"
+  },
+  {
+    key: LAB_TUTTI_MODE_FLAG,
+    default: false,
+    group: "lab",
+    labelKey: "workspace.settings.lab.tuttiModeLabel",
+    descriptionKey: "workspace.settings.lab.tuttiModeDescription"
   },
   {
     key: LAB_CONNECTORS_FLAG,

--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -1375,6 +1375,9 @@ export const en = {
           "Show agent integrations that Tutti is still testing and validating.",
         previewAgentsLabel: "Early access agent integrations",
         shortcutUnbound: "Unbound",
+        tuttiModeDescription:
+          "Shows the Tutti Mode switch and /tutti command in Agent conversations.",
+        tuttiModeLabel: "Tutti Mode",
         workbenchShortcutsDescription:
           "Enables configurable workbench shortcut actions.",
         workbenchShortcutsLabel: "Workbench shortcuts",

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -1287,6 +1287,9 @@ export const zhCN = {
         previewAgentsDescription: "显示仍在 Tutti 中测试和验证的 Agent 集成",
         previewAgentsLabel: "抢先体验 Agent 集成",
         shortcutUnbound: "未绑定",
+        tuttiModeDescription:
+          "在 Agent 对话中显示 Tutti Mode 开关与 /tutti 命令",
+        tuttiModeLabel: "Tutti Mode",
         workbenchShortcutsDescription: "启用可配置的工作台快捷键操作",
         workbenchShortcutsLabel: "工作台快捷键",
         workbenchShortcutsManageLabel: "配置键盘快捷键"

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2002,12 +2002,14 @@ converge on the next canonical read without exposing stale entries. The flag
 does not uninstall connectors, stop their runtimes, or reject an already
 structured connector prompt.
 
-Desktop also projects the flag through AgentGUI's existing host-owned
-capability-menu state. The primary footer capability slot renders the
-Connectors menu only when `lab.connectors` is on; otherwise it is omitted.
-Tutti Mode remains available through the slash-command surface, but has no
-dedicated footer entry. The same footer serves both the home hero and
-existing-session dock, so the two AgentGUI contexts cannot drift.
+Desktop also projects these flags through AgentGUI's existing host-owned
+capability-menu state. The footer renders the Connectors menu only when
+`lab.connectors` is on. The independent `lab.tuttiMode` flag defaults off; when
+enabled, the same footer renders the Tutti Mode activation switch and the slash
+palette exposes `/tutti`, including when Connectors are also enabled. When the
+flag is off, both Tutti Mode entry points are omitted. The same footer serves
+both the home hero and existing-session dock, so the two AgentGUI contexts
+cannot drift.
 The menu, selection-chip, and Palette-item implementations plus their neutral
 item contracts belong to `@tutti-os/connector-renderer/ui`. AgentGUI owns only
 the React-free capability projection under `integrations/connector`, Composer
@@ -2327,8 +2329,10 @@ remains a separate adjacent action, and all controls stay disabled while an
 activation update is unresolved. The Desktop command host and HTTP adapter must
 preserve the optimistic CAS revision and both optional preferences; dropping
 any field turns a valid UI intent into a stale or semantically mismatched
-response. Tutti Desktop always advertises the Tutti Mode host capability;
-historical `lab.tuttiMode` preference values do not hide or disable it.
+response. Tutti Desktop advertises the Tutti Mode host capability only while
+the default-off `lab.tuttiMode` preference is enabled. Toggling the preference
+changes presentation without mutating an existing session's durable activation
+or workflow state.
 
 The preference popup uses two independent 0-100 sliders. `effect` raises the
 minimum model capability and task-verification breadth. `speed` asks the

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2263,6 +2263,18 @@ plan panel starts with the plan title and body; it does not repeat mode,
 review-kind, or pending-state badges already communicated by the workflow
 banner.
 
+The reviewed document's effect and speed are immutable plan inputs, while the
+Composer preferences remain mutable for the next Turn. A change is proven only
+when the document carries both explicit frozen values and either differs from
+the current Composer value; legacy documents with a missing pair never infer a
+change from reasoning or orchestration fields. With a proven change, the empty
+Composer shows `Request changes` beside `Accept`; without one, it shows only
+`Accept`. Accept always targets the checkpoint bound to the currently projected
+revision and therefore executes exactly the visible plan. The daemon rejects a
+checkpoint that is no longer bound to the workflow's current revision, so a
+stale render cannot execute replacement content. Typed feedback continues to
+request changes and includes the current preferences when they diverge.
+
 Task-assignment directories and target option catalogs are workspace query
 projections, not Plan, Session, or Turn state. The Desktop assignment source
 retains them in the shared bounded workspace query cache: directories are keyed

--- a/docs/architecture/workspace-workflows.md
+++ b/docs/architecture/workspace-workflows.md
@@ -123,10 +123,14 @@ require the same caller session as the workflow's `sourceSessionId`; a mismatch
 is deliberately reported as not found. This is a local capability boundary,
 not a claim that an environment variable is a malicious-client authentication
 credential. The daemon host is responsible for constructing the CLI runtime
-context. Until it exposes a trusted current Turn/tool-call seam, CLI proposal
-creation leaves `sourceTurnId` and `sourceToolCallId` empty. In particular,
-App CLI `ParentCommandID` is nested-command context and must never be recorded
-as an Agent tool-call ID.
+context. Agent plan proposal and revision commands require the exact active
+Turn ID from that context and fail closed when it is unavailable. The plan
+service resolves that Turn through the activation service and verifies the
+document's explicit `execution.effect` and `execution.speed` equal its frozen
+snapshot before writing an immutable revision or workflow mutation. It never
+substitutes the mutable current Session preferences. `sourceToolCallId` remains
+empty until a trusted tool-call seam exists; App CLI `ParentCommandID` is
+nested-command context and must never be recorded as an Agent tool-call ID.
 
 The same caller authority applies after Issue materialization. Generic Issue
 Manager mutations cannot modify a `tutti_mode_plan` graph; they return
@@ -269,6 +273,10 @@ The frontmatter owns:
   compiles the explicit speed preference into a 1-4 upper parallel target while
   the durable scheduler still enforces dependency, isolation, budget, and
   workspace-capacity limits;
+- explicit effect and speed values copied from the producing Turn's immutable
+  activation snapshot; both fields are required for Agent CLI proposals and
+  revisions, and either a missing snapshot or an unequal value rejects the
+  mutation before revision-file persistence;
 - auto or fixed token budget and quota waterline (the token limit is dormant
   and no longer surfaced in UI);
 - task IDs, content, priority, assignment (agent target, model plan, model,
@@ -295,6 +303,7 @@ directly.
 ```text
 Agent: tutti plan propose --file <plan.md> --request-id <stable-id>
   (plan.md = complete narrative + full task graph in one document)
+  -> daemon validates effect/speed against the exact producing Turn snapshot
   -> daemon commits workflow + revision + the single pending task review
   -> daemon publishes workspace.workflow.updated
   -> AgentGUI pulls the authoritative session-scoped pending snapshot
@@ -312,6 +321,7 @@ review rejected ("request changes")
      checkpoint-scoped clientSubmitId and linked back as a feedback turn
      (best-effort; the committed rejection never depends on dispatch)
   -> Agent appends a complete replacement plan with tutti plan revise
+  -> daemon validates the replacement against that revision Turn's snapshot
   -> revision append atomically completes that exact pending operation
   -> the panel refreshes onto the new pending review
 

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -58,6 +58,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - [AgentGUI turn actions return plain-text route 404s](./agent-session-lifecycle.md#agentgui-turn-actions-return-plain-text-route-404s)
 - [One hung provider startup blocks unrelated Agent sessions](./agent-session-lifecycle.md#one-hung-provider-startup-blocks-unrelated-agent-sessions)
 - [Existing Session shows Tutti active but the Agent reports Default mode](./agent-session-lifecycle.md#existing-session-shows-tutti-active-but-the-agent-reports-default-mode)
+- [Tutti Mode review only offers request changes after preference drift](./agent-session-lifecycle.md#tutti-mode-review-only-offers-request-changes-after-preference-drift)
 - [Many stopped Tutti Mode conversations start again when the app opens](./agent-session-lifecycle.md#many-stopped-tutti-mode-conversations-start-again-when-the-app-opens)
 - [A new Tutti conversation briefly reports session not found after submit](./agent-session-lifecycle.md#a-new-tutti-conversation-briefly-reports-session-not-found-after-submit)
 - [AgentGUI rail shows a failed Turn but the detail has no error](./agent-session-lifecycle.md#agentgui-rail-shows-a-failed-turn-but-the-detail-has-no-error)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -463,6 +463,44 @@ detailHydrated:false`.
   [tutti_mode_host_context.go](../../../packages/agent/daemon/runtime/tutti_mode_host_context.go),
   [tutti_mode_host_context_test.go](../../../packages/agent/daemon/runtime/tutti_mode_host_context_test.go)
 
+### Tutti Mode review only offers request changes after preference drift
+
+- **Symptom:** A pending plan review shows only a request-changes action, or
+  accepting an existing plan is silently converted into a rejection after the
+  Composer effect or speed changes. The plan may also contain values that never
+  matched the Turn that produced it.
+- **Quick checks:** Compare three distinct values: the producing Turn's
+  `TuttiModeTurnSnapshot`, the current revision's explicit
+  `execution.effect`/`execution.speed`, and the Session's current Composer
+  preferences. If the first two differ, inspect the `plan propose` or
+  `plan revise` response for `tutti_mode_preference_snapshot_mismatch`. If only
+  the current Composer preferences differ, the drift happened legitimately
+  after proposal and both review decisions must remain available.
+- **Root cause:** Range validation alone allowed an Agent to persist plausible
+  but invented preference values. A hardcoded Host Context example could teach
+  the Agent different values than the frozen Turn snapshot. AgentGUI then
+  treated every post-proposal preference difference as implicit rejection, so
+  the user lost a direct way to accept the already-reviewed document.
+- **Fix:** Render Host Context examples from the exact Turn snapshot. Require
+  Agent CLI proposals and revisions to carry that active Turn ID, and have the
+  plan service validate both explicit values through the activation-service
+  snapshot reader before allocating IDs, writing revision content, or mutating
+  workflow state. In AgentGUI, expose `Request changes` beside `Accept` only
+  when both frozen values prove a real preference change; otherwise expose only
+  `Accept`. Accept must keep the visible checkpoint identity and never convert
+  into request-changes feedback.
+- **Validation:** Prove mismatched, missing-value, and missing-snapshot
+  documents leave revision content and workflow state untouched; prove a
+  matching document succeeds. In the UI, verify the divergent state exposes
+  both actions, request-changes rejects with current-preference feedback,
+  explicit accept records `accepted`, and matching empty-send still accepts.
+- **References:**
+  [workspace-workflows.md](../../architecture/workspace-workflows.md),
+  [agent-gui-node.md](../../architecture/agent-gui-node.md),
+  [service.go](../../../services/tuttid/service/tuttimodeplan/service.go),
+  [tutti_mode_host_context.go](../../../packages/agent/daemon/runtime/tutti_mode_host_context.go),
+  [useAgentGUITuttiWorkflow.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUITuttiWorkflow.ts)
+
 ### Tutti Mode Plan stops loading after a task-graph revision
 
 - **Symptom:** The configuration review panel works and `tutti plan revise`

--- a/packages/agent/daemon/runtime/tutti_mode_host_context.go
+++ b/packages/agent/daemon/runtime/tutti_mode_host_context.go
@@ -135,7 +135,11 @@ func renderTuttiModeHostContextForCLI(snapshot *TuttiModeTurnSnapshot, cliName s
 			"Copy effect and speed into the optional execution.effect and execution.speed preference snapshots. Keep the existing execution.reasoningIntensity and execution.orchestrationIntensity meanings unchanged: reasoningIntensity is the Issue/provider reasoning strength, while orchestrationIntensity is decomposition, dependency, review, and retry strength and must never represent speed. For every task, state concrete validation expectations scaled by effect: low means one focused check, balanced means relevant tests plus integration checks when applicable, and high means broad relevant tests, edge/variant coverage, and an explicit final review. Do not invent tasks merely to fill parallelTarget; actual concurrency is limited by real dependency and ownership boundaries, safe isolation, budget, ready work, and workspace capacity. " +
 			"Read-only investigation (for example reading files or listing directories) is allowed when needed to write an accurate plan, but do not start making changes or produce final deliverables. " +
 			"Use this Tutti plan workflow for the turn; do not substitute a provider-native planning mode for it."
-		workflowGuide = renderTuttiModeWorkflowGuide(cliName)
+		workflowGuide = renderTuttiModeWorkflowGuide(
+			cliName,
+			normalized.Effect,
+			normalized.Speed,
+		)
 	}
 	return `<tutti-host-context schemaVersion="1">` + "\n" +
 		string(facts) + "\n" +
@@ -150,7 +154,7 @@ func renderTuttiModeHostContextForCLI(snapshot *TuttiModeTurnSnapshot, cliName s
 // Providers repeatedly misread the bare directive as referring to a built-in
 // tool they lack and fall back to provider planning surfaces, so each step
 // carries the concrete shell command and document shape it expects.
-func renderTuttiModeWorkflowGuide(cliName string) string {
+func renderTuttiModeWorkflowGuide(cliName string, effect int, speed int) string {
 	return fmt.Sprintf("Workflow examples. `%[1]s` is the Tutti CLI executable on PATH in your shell; every plan command below is a shell command, not a built-in tool. Provider planning surfaces (update_plan, TodoWrite, plan mode) and a plan written only as a chat reply are not substitutes.\n"+
 		"Step 1 example, only when something material is unknown, ask and stop: \"Should the FAQ target end users or contributors, and where in the README should it live?\"\n"+
 		"Step 2 example, first discover launch options (read-only), then write the plan file, then run propose:\n"+
@@ -170,9 +174,9 @@ func renderTuttiModeWorkflowGuide(cliName string) string {
 		"topicId: default\n"+
 		"execution:\n"+
 		"  mode: sequential\n"+
-		"  effect: 80\n"+
-		"  speed: 60\n"+
-		"  reasoningIntensity: 80\n"+
+		"  effect: %[2]d\n"+
+		"  speed: %[3]d\n"+
+		"  reasoningIntensity: %[2]d\n"+
 		"  orchestrationIntensity: 50\n"+
 		"tasks:\n"+
 		"  - id: task-1\n"+
@@ -214,7 +218,7 @@ func renderTuttiModeWorkflowGuide(cliName string) string {
 		"Step 3, end the turn as soon as propose returns a workflowId (nextAction \"stop\") — there is no wait command, and polling with plan get wastes the turn. The user reviews the plan in their own time; their decision reaches you as a new user message. "+
 		"If that message requests changes, update the plan document, run `%[1]s plan revise --workflow-id <workflowId> --file <absolute path> --request-id <new id>`, and end the turn again. If the user accepts, Tutti materializes an inert Issue plus an initial execution checkpoint, and this conversation becomes the plan's orchestrator. Inspect the checkpoint and board state, choose no more than parallelTarget exact ready task IDs to run, then invoke `%[1]s plan issue schedule --issue-id <issueId> --checkpoint-id <checkpointId> --expected-graph-revision <revision> --task-ids-json '[\"task-1\"]' --request-id <stable-id>`; the command must schedule exactly the task IDs you selected. After every task settles this conversation is woken again to review evidence and explicitly decide the next graph command; it never executes the child tasks' work itself. The user can steer you with messages at any time, and stopping this conversation stops every running task. A dispatch-paused Issue must stay quiet; when the user explicitly asks to continue, the original source conversation can run `%[1]s plan issue resume --issue-id <issueId> --json` before using the unchanged active checkpoint. When all tasks becoming terminal starts Goal Review, review whether the user's goal is actually satisfied and never infer completion from task counts. Add and schedule more work when needed; otherwise finish only with `%[1]s plan issue complete --issue-id <issueId> --checkpoint-id <checkpointId> --expected-graph-revision <revision> --decision goal_satisfied --request-id <stable-id>`. An independent reviewer verdict is advisory evidence; a negative or inconclusive verdict requires an audited disagreement reason before completion.\n"+
 		"A Tutti plan exists only after plan propose returns a workflowId; a plan that was only shown in chat was never submitted.\n",
-		cliName)
+		cliName, effect, speed)
 }
 
 func appendTuttiModeHostContextPrompt(content []map[string]any, snapshot *TuttiModeTurnSnapshot) []map[string]any {

--- a/packages/agent/daemon/runtime/tutti_mode_host_context_test.go
+++ b/packages/agent/daemon/runtime/tutti_mode_host_context_test.go
@@ -107,7 +107,7 @@ func TestRenderTuttiModeHostContextCarriesWorkedWorkflowExamples(t *testing.T) {
 		"schema: tutti-mode-plan/v1",
 		"topicId: default",
 		"effect: 80",
-		"speed: 60",
+		"speed: 70",
 		"reasoningIntensity: 80",
 		"dependsOn: [task-1]",
 		"permissionModeId: bypassPermissions",

--- a/packages/agent/gui/agent-gui/agentGuiNode/TuttiWorkflowDock.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/TuttiWorkflowDock.spec.tsx
@@ -391,7 +391,7 @@ describe("TuttiWorkflowDock", () => {
     );
   });
 
-  it("changes the review hint when either preference diverges", () => {
+  it("changes the review hint without creating a duplicate decision surface", () => {
     renderDock({
       kind: "review",
       panel: plan,
@@ -407,5 +407,11 @@ describe("TuttiWorkflowDock", () => {
     expect(
       screen.getByTestId("agent-gui-tutti-workflow-intensity")
     ).toHaveTextContent("80 · 90");
+    expect(
+      screen.queryByRole("button", { name: "Send to re-plan" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Send to accept" })
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
@@ -453,8 +453,7 @@ export interface AgentComposerProps {
   onSubmitEmpty?: () => void;
   /**
    * Overrides the empty-draft send button copy while the empty-send override
-   * is active (e.g. plan review with a diverged intensity reads "Request
-   * changes" instead of "Accept plan"). Falls back to labels.sendAccept.
+   * is active. Falls back to labels.sendAccept.
    */
   emptySubmitLabel?: string;
   onSubmitGuidance?: (

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
@@ -635,6 +635,11 @@ export function AgentComposerView(
             showComposerAction={showComposerActionInFooter}
             isGoalModeActive={input.isGoalModeActive}
             isPlanModeActive={input.isPlanModeActive}
+            isTuttiModeActive={input.isTuttiModeActive}
+            isTuttiModeUpdating={input.isTuttiModeUpdating}
+            tuttiModeSupported={
+              input.props.capabilityMenuState?.tuttiMode?.enabled === true
+            }
             connectorsVisible={
               input.props.capabilityMenuState?.connectors?.enabled !== false
             }
@@ -646,6 +651,7 @@ export function AgentComposerView(
               input.props.capabilityMenuState?.connectors?.showViewMore !==
               false
             }
+            onTuttiModeChange={input.props.onTuttiModeChange}
             onClearPlanMode={input.onClearPlanMode}
             composerAction={composerActionNode}
             projectControl={

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerFooter.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerFooter.tsx
@@ -51,9 +51,13 @@ interface Props {
   showComposerAction: boolean;
   isGoalModeActive: boolean;
   isPlanModeActive: boolean;
+  isTuttiModeActive: boolean;
+  isTuttiModeUpdating: boolean;
+  tuttiModeSupported: boolean;
   connectorsVisible: boolean;
   connectorsReadOnly?: boolean;
   showConnectorViewMore?: boolean;
+  onTuttiModeChange?: (active: boolean) => void;
   composerAction: ReactNode;
   projectControl?: ReactNode;
   quickPromptControl?: ReactNode;
@@ -106,9 +110,13 @@ export function ComposerFooter({
   showComposerAction,
   isGoalModeActive,
   isPlanModeActive,
+  isTuttiModeActive,
+  isTuttiModeUpdating,
+  tuttiModeSupported,
   connectorsVisible,
   connectorsReadOnly = false,
   showConnectorViewMore = true,
+  onTuttiModeChange,
   composerAction,
   projectControl,
   quickPromptControl,
@@ -222,13 +230,17 @@ export function ComposerFooter({
             connectorsVisible={connectorsVisible}
             connectorsReadOnly={connectorsReadOnly}
             disabled={composerControlsHardDisabled}
+            isTuttiModeActive={isTuttiModeActive}
+            isTuttiModeUpdating={isTuttiModeUpdating}
             labels={labels}
             loading={composerSettings.isConnectorOptionsLoading === true}
             onRetryComposerOptions={onRetryComposerOptions}
             onCapabilitySettingsRequest={onCapabilitySettingsRequest}
             onConnectorSelected={onConnectorSelected}
+            onTuttiModeChange={onTuttiModeChange}
             selectedConnectorKeys={selectedConnectorKeys}
             showConnectorViewMore={showConnectorViewMore}
+            tuttiModeSupported={tuttiModeSupported}
           />
           {showHandoffSelect ? (
             <AgentHandoffMenu

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerPrimaryCapabilityControl.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerPrimaryCapabilityControl.spec.tsx
@@ -17,42 +17,68 @@ const labels = {
   tuttiModeLabel: "Tutti Mode"
 } as AgentComposerProps["labels"];
 
+function renderControl(
+  overrides: Partial<
+    Parameters<typeof ComposerPrimaryCapabilityControl>[0]
+  > = {}
+) {
+  return render(
+    <ComposerPrimaryCapabilityControl
+      availableSkills={[]}
+      connectorsVisible={false}
+      disabled={false}
+      isTuttiModeActive={false}
+      isTuttiModeUpdating={false}
+      labels={labels}
+      loading={false}
+      onCapabilitySettingsRequest={vi.fn()}
+      onConnectorSelected={vi.fn()}
+      onTuttiModeChange={vi.fn()}
+      selectedConnectorKeys={[]}
+      tuttiModeSupported={false}
+      {...overrides}
+    />
+  );
+}
+
 describe("ComposerPrimaryCapabilityControl", () => {
-  it("hides the capability slot when connectors are disabled", () => {
-    const { container } = render(
-      <ComposerPrimaryCapabilityControl
-        availableSkills={[]}
-        connectorsVisible={false}
-        disabled={false}
-        labels={labels}
-        loading={false}
-        onCapabilitySettingsRequest={vi.fn()}
-        onConnectorSelected={vi.fn()}
-        selectedConnectorKeys={[]}
-      />
-    );
+  it("hides every Tutti entry point when its host gate is off", () => {
+    const { container } = renderControl();
 
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("shows only connectors when connectors are enabled", () => {
-    const onRetryComposerOptions = vi.fn();
-    render(
-      <ComposerPrimaryCapabilityControl
-        availableSkills={[]}
-        connectorsVisible
-        disabled={false}
-        labels={labels}
-        loading
-        onRetryComposerOptions={onRetryComposerOptions}
-        onCapabilitySettingsRequest={vi.fn()}
-        onConnectorSelected={vi.fn()}
-        selectedConnectorKeys={[]}
-      />
+  it("shows the Tutti switch and routes activation when its host gate is on", () => {
+    const onTuttiModeChange = vi.fn();
+    renderControl({ onTuttiModeChange, tuttiModeSupported: true });
+
+    expect(
+      screen.getByTestId("agent-gui-composer-tutti-mode-toggle")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("connector-market-composer-trigger")
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByTestId("agent-gui-composer-tutti-mode-toggle-switch")
     );
+    expect(onTuttiModeChange).toHaveBeenCalledWith(true);
+  });
+
+  it("shows the Tutti switch alongside connectors when both gates are on", () => {
+    const onRetryComposerOptions = vi.fn();
+    renderControl({
+      connectorsVisible: true,
+      loading: true,
+      onRetryComposerOptions,
+      tuttiModeSupported: true
+    });
 
     expect(
       screen.getByTestId("connector-market-composer-trigger")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("agent-gui-composer-tutti-mode-toggle")
     ).toBeInTheDocument();
     fireEvent.pointerDown(
       screen.getByTestId("connector-market-composer-trigger"),
@@ -69,30 +95,24 @@ describe("ComposerPrimaryCapabilityControl", () => {
   it("keeps a shared connector catalog inspectable without mutation or management actions", () => {
     const onCapabilitySettingsRequest = vi.fn();
     const onConnectorSelected = vi.fn();
-    render(
-      <ComposerPrimaryCapabilityControl
-        availableSkills={[
-          {
-            connectorKey: "github",
-            description: "Authorization required on the owner device.",
-            kind: "connector",
-            name: "GitHub",
-            sourceKind: "connector",
-            status: "authRequired",
-            trigger: "/github"
-          }
-        ]}
-        connectorsReadOnly
-        connectorsVisible
-        disabled={false}
-        labels={labels}
-        loading={false}
-        onCapabilitySettingsRequest={onCapabilitySettingsRequest}
-        onConnectorSelected={onConnectorSelected}
-        selectedConnectorKeys={[]}
-        showConnectorViewMore={false}
-      />
-    );
+    renderControl({
+      availableSkills: [
+        {
+          connectorKey: "github",
+          description: "Authorization required on the owner device.",
+          kind: "connector",
+          name: "GitHub",
+          sourceKind: "connector",
+          status: "authRequired",
+          trigger: "/github"
+        }
+      ],
+      connectorsReadOnly: true,
+      connectorsVisible: true,
+      onCapabilitySettingsRequest,
+      onConnectorSelected,
+      showConnectorViewMore: false
+    });
 
     fireEvent.pointerDown(
       screen.getByTestId("connector-market-composer-trigger"),

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerPrimaryCapabilityControl.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerPrimaryCapabilityControl.tsx
@@ -2,6 +2,7 @@ import { ConnectorComposerMenu } from "@tutti-os/connector-renderer/ui";
 import { openWorkspaceSettingsPanel } from "../../../shared/workspaceSettingsPanel/workspaceSettingsPanelStore";
 import { projectConnectorComposerItems } from "../integrations/connector/model/connectorPresentation";
 import type { AgentComposerProps } from "./AgentComposer.types";
+import { ComposerTuttiModeChip } from "./ComposerTuttiModeChip";
 
 interface Props {
   availableSkills: AgentComposerProps["availableSkills"];
@@ -9,80 +10,107 @@ interface Props {
   connectorsReadOnly?: boolean;
   showConnectorViewMore?: boolean;
   disabled: boolean;
+  isTuttiModeActive: boolean;
+  isTuttiModeUpdating: boolean;
   labels: AgentComposerProps["labels"];
   loading: boolean;
   onRetryComposerOptions?: AgentComposerProps["onRetryComposerOptions"];
   onCapabilitySettingsRequest: AgentComposerProps["onCapabilitySettingsRequest"];
   onConnectorSelected: (connectorKey: string, selected: boolean) => void;
+  onTuttiModeChange?: (active: boolean) => void;
   selectedConnectorKeys: readonly string[];
+  tuttiModeSupported: boolean;
 }
 
 /**
- * Owns the single primary capability slot between the mention and handoff
- * controls. Connector visibility is host-owned; when it is off, the slot is
- * omitted. Tutti Mode remains available through slash commands.
+ * Owns the host-gated capability controls between the mention and handoff
+ * controls. Tutti Mode and Connectors are independent capabilities, so either
+ * may render alone and both remain visible when both host gates are enabled.
  */
 export function ComposerPrimaryCapabilityControl({
   availableSkills,
   connectorsVisible,
   connectorsReadOnly = false,
   disabled,
+  isTuttiModeActive,
+  isTuttiModeUpdating,
   labels,
   loading,
   onRetryComposerOptions,
   onCapabilitySettingsRequest,
   onConnectorSelected,
+  onTuttiModeChange,
   selectedConnectorKeys,
-  showConnectorViewMore = true
+  showConnectorViewMore = true,
+  tuttiModeSupported
 }: Props): React.JSX.Element | null {
   if (!connectorsVisible) {
-    return null;
+    return (
+      <ComposerTuttiModeChip
+        active={isTuttiModeActive}
+        updating={isTuttiModeUpdating}
+        label={labels.tuttiModeLabel}
+        description={labels.tuttiModeDescription}
+        tuttiModeSupported={tuttiModeSupported}
+        onTuttiModeChange={onTuttiModeChange}
+      />
+    );
   }
 
   return (
-    <ConnectorComposerMenu
-      disabled={disabled}
-      items={projectConnectorComposerItems(
-        availableSkills ?? [],
-        connectorsReadOnly ? [] : selectedConnectorKeys
-      )}
-      labels={{
-        authorize: labels.addContentConnectorAuthorize,
-        connect: labels.addContentConnectorConnect,
-        connected: labels.addContentConnectorConnected,
-        connectors: labels.addContentConnectors,
-        empty: labels.addContentConnectorEmpty,
-        loading: labels.addContentConnectorLoading,
-        more: labels.addContentConnectorMore,
-        selected: labels.addContentConnectorSelected
-      }}
-      loading={loading}
-      onOpenChange={(open) => {
-        if (open) {
-          onRetryComposerOptions?.({ section: "connectors" });
+    <>
+      <ComposerTuttiModeChip
+        active={isTuttiModeActive}
+        updating={isTuttiModeUpdating}
+        label={labels.tuttiModeLabel}
+        description={labels.tuttiModeDescription}
+        tuttiModeSupported={tuttiModeSupported}
+        onTuttiModeChange={onTuttiModeChange}
+      />
+      <ConnectorComposerMenu
+        disabled={disabled}
+        items={projectConnectorComposerItems(
+          availableSkills ?? [],
+          connectorsReadOnly ? [] : selectedConnectorKeys
+        )}
+        labels={{
+          authorize: labels.addContentConnectorAuthorize,
+          connect: labels.addContentConnectorConnect,
+          connected: labels.addContentConnectorConnected,
+          connectors: labels.addContentConnectors,
+          empty: labels.addContentConnectorEmpty,
+          loading: labels.addContentConnectorLoading,
+          more: labels.addContentConnectorMore,
+          selected: labels.addContentConnectorSelected
+        }}
+        loading={loading}
+        onOpenChange={(open) => {
+          if (open) {
+            onRetryComposerOptions?.({ section: "connectors" });
+          }
+        }}
+        onOpenConnector={
+          connectorsReadOnly
+            ? undefined
+            : (connectorKey) =>
+                onCapabilitySettingsRequest?.({
+                  kind: "connector",
+                  connectorKey,
+                  action: "open"
+                })
         }
-      }}
-      onOpenConnector={
-        connectorsReadOnly
-          ? undefined
-          : (connectorKey) =>
-              onCapabilitySettingsRequest?.({
-                kind: "connector",
-                connectorKey,
-                action: "open"
-              })
-      }
-      onOpenMarket={
-        !showConnectorViewMore
-          ? undefined
-          : () =>
-              openWorkspaceSettingsPanel({
-                section: "agent",
-                pane: "connectors"
-              })
-      }
-      onSelectConnector={connectorsReadOnly ? undefined : onConnectorSelected}
-      readOnly={connectorsReadOnly}
-    />
+        onOpenMarket={
+          !showConnectorViewMore
+            ? undefined
+            : () =>
+                openWorkspaceSettingsPanel({
+                  section: "agent",
+                  pane: "connectors"
+                })
+        }
+        onSelectConnector={connectorsReadOnly ? undefined : onConnectorSelected}
+        readOnly={connectorsReadOnly}
+      />
+    </>
   );
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerTuttiModeChip.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerTuttiModeChip.tsx
@@ -1,0 +1,131 @@
+import { useId, useState } from "react";
+import {
+  Switch,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger
+} from "@tutti-os/ui-system";
+import { cn } from "../../../app/renderer/lib/utils";
+import tuttiModeLinedIconUrl from "../../../app/renderer/assets/icons/tutti-mode-lined.svg";
+import tuttiSnapStarsLightUrl from "../../../app/renderer/assets/animations/tutti-snap-stars-light.png";
+import tuttiSnapStarsLightActiveUrl from "../../../app/renderer/assets/animations/tutti-snap-stars-light-active.png";
+import tuttiSnapStarsDarkUrl from "../../../app/renderer/assets/animations/tutti-snap-stars-dark.png";
+import tuttiSnapStarsDarkActiveUrl from "../../../app/renderer/assets/animations/tutti-snap-stars-dark-active.png";
+import styles from "../AgentGUINode.styles";
+
+/**
+ * Compact Tutti Mode activation switch in the composer footer. It drives the
+ * same activation path as /tutti and disappears under the same host gate.
+ */
+export function ComposerTuttiModeChip({
+  active,
+  updating,
+  label,
+  description,
+  tuttiModeSupported,
+  onTuttiModeChange
+}: {
+  active: boolean;
+  updating: boolean;
+  label: string;
+  description?: string;
+  tuttiModeSupported: boolean;
+  onTuttiModeChange?: (active: boolean) => void;
+}): React.JSX.Element | null {
+  const switchId = useId();
+  const [hovered, setHovered] = useState(false);
+  const shouldPlaySnap = hovered && !updating;
+
+  if (!onTuttiModeChange || !tuttiModeSupported) {
+    return null;
+  }
+
+  return (
+    <TooltipProvider delayDuration={120}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <label
+            htmlFor={switchId}
+            data-testid="agent-gui-composer-tutti-mode-toggle"
+            data-agent-tutti-mode-active={active ? "true" : undefined}
+            className={cn(
+              styles.composerMenuTrigger,
+              "group w-auto !gap-1.5",
+              updating ? "cursor-wait" : "cursor-pointer"
+            )}
+            onMouseEnter={() => setHovered(true)}
+            onMouseLeave={() => setHovered(false)}
+          >
+            <span
+              aria-hidden
+              className={styles.composerTuttiModeIcon}
+              data-snap-active={shouldPlaySnap ? "true" : undefined}
+            >
+              <span
+                className={styles.composerTuttiModeIconStatic}
+                style={{
+                  WebkitMaskImage: `url("${tuttiModeLinedIconUrl}")`,
+                  WebkitMaskPosition: "center",
+                  WebkitMaskRepeat: "no-repeat",
+                  WebkitMaskSize: "contain",
+                  maskImage: `url("${tuttiModeLinedIconUrl}")`,
+                  maskPosition: "center",
+                  maskRepeat: "no-repeat",
+                  maskSize: "contain"
+                }}
+              />
+              {shouldPlaySnap ? (
+                <ComposerTuttiModeSnapAnimation active={active} />
+              ) : null}
+            </span>
+            <span className="min-w-0 truncate">{label}</span>
+            <Switch
+              id={switchId}
+              size="sm"
+              checked={active}
+              disabled={updating}
+              aria-label={label}
+              className="ml-0.5"
+              data-testid="agent-gui-composer-tutti-mode-toggle-switch"
+              onCheckedChange={(checked) => onTuttiModeChange(checked)}
+            />
+          </label>
+        </TooltipTrigger>
+        <TooltipContent side="top">{description ?? label}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+const SNAP_STARS_URLS = {
+  light: { idle: tuttiSnapStarsLightUrl, active: tuttiSnapStarsLightActiveUrl },
+  dark: { idle: tuttiSnapStarsDarkUrl, active: tuttiSnapStarsDarkActiveUrl }
+} as const;
+
+function ComposerTuttiModeSnapAnimation({
+  active
+}: {
+  active: boolean;
+}): React.JSX.Element {
+  const isDark =
+    typeof document !== "undefined" &&
+    document.documentElement.getAttribute("data-theme") === "dark";
+  const src =
+    SNAP_STARS_URLS[isDark ? "dark" : "light"][active ? "active" : "idle"];
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  return (
+    <img
+      alt=""
+      aria-hidden="true"
+      className={styles.composerTuttiModeIconAnimated}
+      data-active={isLoaded ? "true" : undefined}
+      decoding="async"
+      draggable={false}
+      src={src}
+      key={src}
+      onLoad={() => setIsLoaded(true)}
+    />
+  );
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerPaletteCatalog.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerPaletteCatalog.spec.tsx
@@ -171,4 +171,54 @@ describe("useComposerPaletteCatalog", () => {
         .map((entry) => entry.label)
     ).toEqual(["review"]);
   });
+
+  it("shows /tutti only while the host Tutti Mode gate is enabled", () => {
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useComposerPaletteCatalog({
+          provider: "codex",
+          isGoalModeActive: false,
+          goalSupported: false,
+          paletteDraftPrompt: "/",
+          availableCommands: [],
+          availableSkills: [],
+          hasCompactableContext: false,
+          compactSupported: false,
+          composerSettings: {
+            supportsPlanMode: false,
+            supportsBrowser: false,
+            supportsComputerUse: false,
+            slashCommandPolicy: {
+              fallbackCommands: [],
+              commandEffects: [],
+              commandCatalogAuthoritative: true
+            }
+          } as unknown as AgentGUIComposerSettingsVM,
+          capabilityMenuState: { tuttiMode: { enabled } },
+          capabilityControlsReadOnly: false,
+          labels: {
+            tuttiModeDescription: "Coordinate work",
+            tuttiModeLabel: "Tutti Mode"
+          } as AgentComposerProps["labels"],
+          uiLanguage: "en",
+          editorHandleRef: { current: null }
+        }),
+      { initialProps: { enabled: false } }
+    );
+
+    const tuttiEntry = () =>
+      result.current.slashPaletteEntries.find(
+        (entry) => entry.key === "capability:tutti"
+      );
+
+    expect(tuttiEntry()).toBeUndefined();
+    rerender({ enabled: true });
+    expect(tuttiEntry()).toMatchObject({
+      capability: { capability: "tutti", name: "tutti" },
+      label: "Tutti Mode",
+      type: "capability"
+    });
+    rerender({ enabled: false });
+    expect(tuttiEntry()).toBeUndefined();
+  });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
@@ -32,6 +32,7 @@ import { useAgentGUIDetailScroll } from "./useAgentGUIDetailScroll";
 import { useAgentGUIDetailModel } from "./useAgentGUIDetailModel";
 import { useAgentGUIComposerInputHistoryProps } from "./useAgentGUIComposerInputHistoryProps";
 import { useAgentGUITuttiWorkflow } from "./useAgentGUITuttiWorkflow";
+import { AgentGUITuttiPlanReviewActionSlot } from "./AgentGUITuttiPlanReviewAction";
 import type { AgentGUIDetailPaneProps } from "./AgentGUIDetailPane.types";
 import { useAgentGUIDetailEditRetry } from "./useAgentGUIDetailEditRetry";
 import { useAgentGUIDetailSideConversation } from "./useAgentGUIDetailSideConversation";
@@ -497,14 +498,15 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
           : undefined,
       onPlanIssueBudgetPresetChange: updatePlanIssueBudgetPreset,
       onSubmit: sideConversation.submitMain,
+      composerActionAccessory: (
+        <AgentGUITuttiPlanReviewActionSlot
+          controller={tuttiWorkflowComposer}
+          label={labels.tuttiModePlanSendRequestChanges}
+        />
+      ),
       onSubmitEmpty: tuttiWorkflowComposer.planReviewSendActive
         ? tuttiWorkflowComposer.acceptPendingPlan
         : undefined,
-      emptySubmitLabel:
-        tuttiWorkflowComposer.planReviewSendActive &&
-        tuttiWorkflowComposer.planReviewPreferencesDiverged
-          ? labels.tuttiModePlanSendRequestChanges
-          : undefined,
       onSubmitGuidance: submitGuidancePromptAndScrollToBottom,
       onPromptImagesUnsupported: showPromptImagesUnsupported,
       onSendQueuedPromptNext: sendQueuedPromptNext,
@@ -571,15 +573,15 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       setTuttiModeEffect,
       setTuttiModeSpeed,
       submitInteractivePrompt,
-      tuttiWorkflowComposer.submitPromptOrDecidePlan,
       sideConversation.submitMain,
       tuttiWorkflowComposer.planReviewSendActive,
       tuttiWorkflowComposer.tuttiExecutionActive,
       tuttiWorkflowComposer.tuttiExecutionStopping,
+      tuttiWorkflowComposer.planReviewDraftHasContent,
       tuttiWorkflowComposer.planReviewPreferencesDiverged,
       tuttiWorkflowDock.phase?.kind,
-      labels.tuttiModePlanSendRequestChanges,
       tuttiWorkflowComposer.acceptPendingPlan,
+      tuttiWorkflowComposer.requestPendingPlanChanges,
       submitGuidancePromptAndScrollToBottom,
       uiLanguage,
       stableLinkAction,
@@ -592,7 +594,6 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       updateDraftContent,
       updateSelectedProjectPath,
       viewModel.rail.activeConversationId,
-      viewModel.composer.availableCommands,
       sideConversation.commands,
       viewModel.composer.availableSkills,
       viewModel.composer.compactSupported,

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUITuttiPlanReviewAction.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUITuttiPlanReviewAction.spec.tsx
@@ -1,0 +1,72 @@
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  AgentGUITuttiPlanReviewAction,
+  AgentGUITuttiPlanReviewActionSlot
+} from "./AgentGUITuttiPlanReviewAction";
+
+describe("AgentGUITuttiPlanReviewAction", () => {
+  it("renders the localized request-changes action and dispatches it explicitly", () => {
+    const onRequestChanges = vi.fn();
+    render(
+      <AgentGUITuttiPlanReviewAction
+        label="请求修改"
+        onRequestChanges={onRequestChanges}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "请求修改" }));
+
+    expect(onRequestChanges).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the request-changes action only for a divergent empty plan review", () => {
+    const onRequestChanges = vi.fn();
+    const controller = {
+      planReviewDraftHasContent: false,
+      planReviewPreferencesDiverged: true,
+      planReviewSendActive: true,
+      requestPendingPlanChanges: onRequestChanges
+    };
+    const { rerender } = render(
+      <AgentGUITuttiPlanReviewActionSlot
+        controller={controller}
+        label="请求修改"
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "请求修改" }));
+    expect(onRequestChanges).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <AgentGUITuttiPlanReviewActionSlot
+        controller={{ ...controller, planReviewPreferencesDiverged: false }}
+        label="请求修改"
+      />
+    );
+    expect(
+      screen.queryByRole("button", { name: "请求修改" })
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <AgentGUITuttiPlanReviewActionSlot
+        controller={{ ...controller, planReviewSendActive: false }}
+        label="请求修改"
+      />
+    );
+    expect(
+      screen.queryByRole("button", { name: "请求修改" })
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <AgentGUITuttiPlanReviewActionSlot
+        controller={{ ...controller, planReviewDraftHasContent: true }}
+        label="请求修改"
+      />
+    );
+    expect(
+      screen.queryByRole("button", { name: "请求修改" })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUITuttiPlanReviewAction.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUITuttiPlanReviewAction.tsx
@@ -1,0 +1,51 @@
+import { Button } from "@tutti-os/ui-system";
+
+interface AgentGUITuttiPlanReviewActionSlotController {
+  planReviewDraftHasContent: boolean;
+  planReviewPreferencesDiverged: boolean;
+  planReviewSendActive: boolean;
+  requestPendingPlanChanges(): void;
+}
+
+export function AgentGUITuttiPlanReviewActionSlot({
+  controller,
+  label
+}: {
+  controller: AgentGUITuttiPlanReviewActionSlotController;
+  label: string;
+}): React.JSX.Element | null {
+  if (
+    !controller.planReviewSendActive ||
+    !controller.planReviewPreferencesDiverged ||
+    controller.planReviewDraftHasContent
+  ) {
+    return null;
+  }
+  return (
+    <AgentGUITuttiPlanReviewAction
+      label={label}
+      onRequestChanges={controller.requestPendingPlanChanges}
+    />
+  );
+}
+
+export function AgentGUITuttiPlanReviewAction({
+  label,
+  onRequestChanges
+}: {
+  label: string;
+  onRequestChanges(): void;
+}): React.JSX.Element {
+  return (
+    <Button
+      type="button"
+      variant="secondary"
+      size="sm"
+      className="rounded-full"
+      data-testid="agent-gui-plan-request-changes"
+      onClick={onRequestChanges}
+    >
+      {label}
+    </Button>
+  );
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUITuttiWorkflow.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUITuttiWorkflow.spec.tsx
@@ -238,7 +238,8 @@ function emptyProjection(): PlanPanelsProjection {
 }
 
 describe("useAgentGUITuttiWorkflow materialization bridge", () => {
-  it("uses the legacy intensity as effect only when preference snapshots are absent", () => {
+  it("only reports a real preference change when the plan carries both frozen values", () => {
+    decide.mockClear();
     const legacyPanel = panel();
     legacyPanel.execution = {
       ...legacyPanel.execution,
@@ -246,8 +247,10 @@ describe("useAgentGUITuttiWorkflow materialization bridge", () => {
     };
     const legacy = renderWorkflow(reviewProjection(legacyPanel));
     expect(legacy.result.current.composer.planReviewPreferencesDiverged).toBe(
-      true
+      false
     );
+    act(() => legacy.result.current.composer.requestPendingPlanChanges());
+    expect(decide).not.toHaveBeenCalled();
     legacy.unmount();
 
     const currentPanel = panel();
@@ -260,6 +263,107 @@ describe("useAgentGUITuttiWorkflow materialization bridge", () => {
     const current = renderWorkflow(reviewProjection(currentPanel));
     expect(current.result.current.composer.planReviewPreferencesDiverged).toBe(
       false
+    );
+  });
+
+  it("accepts the reviewed plan explicitly even when current preferences diverge", () => {
+    decide.mockClear();
+    const divergentPanel = panel();
+    divergentPanel.execution = {
+      ...divergentPanel.execution,
+      effect: 90,
+      speed: 55
+    };
+    const rendered = renderWorkflow(reviewProjection(divergentPanel));
+
+    act(() => rendered.result.current.composer.acceptPendingPlan());
+
+    expect(decide).toHaveBeenCalledTimes(1);
+    expect(decide).toHaveBeenCalledWith(
+      expect.objectContaining({ decision: "accepted" })
+    );
+  });
+
+  it("requests a replacement plan only through the explicit current-preferences action", () => {
+    decide.mockClear();
+    const divergentPanel = panel();
+    divergentPanel.execution = {
+      ...divergentPanel.execution,
+      effect: 90,
+      speed: 55
+    };
+    const rendered = renderWorkflow(reviewProjection(divergentPanel));
+
+    act(() => rendered.result.current.composer.requestPendingPlanChanges());
+
+    expect(decide).toHaveBeenCalledTimes(1);
+    expect(decide).toHaveBeenCalledWith(
+      expect.objectContaining({ decision: "rejected", reason: "Re-plan" })
+    );
+  });
+
+  it("uses the empty composer action to accept the visible plan regardless of preference changes", () => {
+    decide.mockClear();
+    const divergentPanel = panel();
+    divergentPanel.execution = {
+      ...divergentPanel.execution,
+      effect: 90,
+      speed: 55
+    };
+    const divergent = renderWorkflow(reviewProjection(divergentPanel));
+
+    act(() => divergent.result.current.composer.acceptPendingPlan());
+
+    expect(decide).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        checkpointId: "checkpoint-a",
+        decision: "accepted",
+        workflowId: "workflow-a"
+      })
+    );
+    divergent.unmount();
+
+    decide.mockClear();
+    const matching = renderWorkflow(reviewProjection());
+
+    act(() => matching.result.current.composer.acceptPendingPlan());
+
+    expect(decide).toHaveBeenLastCalledWith(
+      expect.objectContaining({ decision: "accepted" })
+    );
+  });
+
+  it("accepts the checkpoint belonging to the latest visible plan revision", () => {
+    decide.mockClear();
+    const rendered = renderWorkflow(reviewProjection());
+    const revisedPanel = panel("checkpoint-b");
+    revisedPanel.revision = {
+      ...revisedPanel.revision,
+      id: "revision-b",
+      sequence: 2,
+      sha256: "b".repeat(64)
+    };
+    revisedPanel.title = "Latest visible plan";
+
+    rendered.setProjection(reviewProjection(revisedPanel));
+    rendered.rerender({ activeConversationId: "session-a" });
+    expect(rendered.result.current.workflowDock.phase).toMatchObject({
+      kind: "review",
+      panel: {
+        checkpoint: { id: "checkpoint-b" },
+        revision: { id: "revision-b" },
+        title: "Latest visible plan"
+      }
+    });
+
+    act(() => rendered.result.current.composer.acceptPendingPlan());
+
+    expect(decide).toHaveBeenCalledWith(
+      expect.objectContaining({
+        checkpointId: "checkpoint-b",
+        decision: "accepted",
+        workflowId: "workflow-a"
+      })
     );
   });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUITuttiWorkflow.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUITuttiWorkflow.ts
@@ -12,6 +12,7 @@ import {
   type TuttiPlanIssueTaskAction
 } from "../../../workspaceWorkflow";
 import {
+  agentComposerDraftHasContent,
   agentPromptContentDisplayText,
   updateAgentComposerDraft
 } from "../model/agentComposerDraft";
@@ -28,8 +29,10 @@ export interface AgentGUITuttiWorkflowComposerController {
   planReviewSendActive: boolean;
   tuttiExecutionActive: boolean;
   tuttiExecutionStopping: boolean;
+  planReviewDraftHasContent: boolean;
   planReviewPreferencesDiverged: boolean;
   acceptPendingPlan: () => void;
+  requestPendingPlanChanges: () => void;
   setTuttiModeActiveAndSettleReview: (active: boolean) => void;
   stopTuttiExecution: () => Promise<void>;
   submitPromptOrDecidePlan: (
@@ -72,7 +75,8 @@ interface MaterializingPlan {
 /**
  * Everything the detail pane needs for the Tutti plan review flow and the
  * materialized plan Issue embed: composer-integrated review decisions (empty
- * send accepts, typed send requests changes, preference divergence re-plans),
+ * send accepts, typed send requests changes, and a proven preference change
+ * exposes an additional request-changes action),
  * per-task assignment drafts, the embedded issue panel data plus its inline
  * acceptance decisions, and the single bottom-dock workflow projection.
  */
@@ -148,16 +152,20 @@ export function useAgentGUITuttiWorkflow(input: {
   );
   const planReviewSendActive =
     pendingPlanPanel !== null && !pendingPlanSubmitting;
-  // Current v1 documents carry explicit preference snapshots. Documents from
-  // the legacy single-axis window use orchestrationIntensity as effect and the
-  // balanced speed default without changing that field's execution meaning.
-  const pendingPlanEffect =
-    pendingPlanPanel?.execution.effect ??
-    pendingPlanPanel?.execution.orchestrationIntensity ??
-    50;
-  const pendingPlanSpeed = pendingPlanPanel?.execution.speed ?? 50;
+  const planReviewDraftHasContent = agentComposerDraftHasContent(
+    viewModel.composer.draftContent
+  );
+  // A preference change is real only when the reviewed document carries both
+  // explicit frozen values. Legacy documents without that pair remain
+  // acceptable, but the UI must not invent a comparison from unrelated fields.
+  const pendingPlanEffect = pendingPlanPanel?.execution.effect;
+  const pendingPlanSpeed = pendingPlanPanel?.execution.speed;
+  const pendingPlanHasPreferenceSnapshot =
+    typeof pendingPlanEffect === "number" &&
+    typeof pendingPlanSpeed === "number";
   const planReviewPreferencesDiverged =
     pendingPlanPanel !== null &&
+    pendingPlanHasPreferenceSnapshot &&
     (viewModel.composer.tuttiModeEffect !== pendingPlanEffect ||
       viewModel.composer.tuttiModeSpeed !== pendingPlanSpeed);
   const decidePendingPlan = useStableEventCallback(
@@ -183,18 +191,6 @@ export function useAgentGUITuttiWorkflow(input: {
     }
   );
   const acceptPendingPlan = useStableEventCallback((): void => {
-    if (planReviewPreferencesDiverged && pendingPlanPanel) {
-      decidePendingPlan(
-        "rejected",
-        labels.tuttiModePlanReplanFeedback(
-          String(pendingPlanEffect),
-          String(pendingPlanSpeed),
-          String(viewModel.composer.tuttiModeEffect),
-          String(viewModel.composer.tuttiModeSpeed)
-        )
-      );
-      return;
-    }
     if (pendingPlanPanel && viewModel.rail.activeConversationId) {
       setMaterializingPlan({
         checkpointId: pendingPlanPanel.checkpoint.id,
@@ -205,6 +201,20 @@ export function useAgentGUITuttiWorkflow(input: {
     }
     decidePendingPlan("accepted");
   });
+  const replanPendingPlanWithCurrentPreferences = useStableEventCallback(
+    (): void => {
+      if (!pendingPlanPanel || !pendingPlanHasPreferenceSnapshot) return;
+      decidePendingPlan(
+        "rejected",
+        labels.tuttiModePlanReplanFeedback(
+          String(pendingPlanEffect),
+          String(pendingPlanSpeed),
+          String(viewModel.composer.tuttiModeEffect),
+          String(viewModel.composer.tuttiModeSpeed)
+        )
+      );
+    }
+  );
   const cancelPendingPlan = useStableEventCallback((): void => {
     decidePendingPlan("canceled");
   });
@@ -222,8 +232,8 @@ export function useAgentGUITuttiWorkflow(input: {
   );
   // While a plan review is pending the composer doubles as the decision
   // surface: typed text becomes request-changes feedback (the daemon relays
-  // it to the agent), an empty send accepts. Normal sends resume once the
-  // checkpoint settles.
+  // it to the agent), while an empty send always accepts the exact visible
+  // checkpoint. Normal sends resume once the checkpoint settles.
   const submitPromptOrDecidePlan = useStableEventCallback(
     (
       ...args: Parameters<AgentGUINodeViewProps["actions"]["submitPrompt"]>
@@ -415,8 +425,10 @@ export function useAgentGUITuttiWorkflow(input: {
   return {
     composer: {
       acceptPendingPlan,
+      planReviewDraftHasContent,
       planReviewPreferencesDiverged,
       planReviewSendActive,
+      requestPendingPlanChanges: replanPendingPlanWithCurrentPreferences,
       setTuttiModeActiveAndSettleReview,
       stopTuttiExecution: cancelPlanIssueExecution,
       tuttiExecutionActive,

--- a/packages/agent/gui/app/renderer/i18n/locales/en.tuttiModePlan.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.tuttiModePlan.ts
@@ -1,9 +1,8 @@
 export const enTuttiModePlan = {
   taskReview: "Plan review",
   cancel: "Cancel plan",
-  reviewHint: "Send to accept · type feedback to request changes",
-  reviewHintReplan:
-    "Effect or speed changed · send to re-plan with the new preferences",
+  reviewHint: "Awaiting review",
+  reviewHintReplan: "Preferences changed",
   materializingTitle: "Creating tasks",
   switchToSelfReview: "Switch to self review",
   switchingToSelfReview: "Switching to self review",
@@ -13,7 +12,7 @@ export const enTuttiModePlan = {
   errorTitle: "Workflow unavailable",
   expand: "Expand workflow",
   collapse: "Collapse workflow",
-  sendAccept: "Accept plan",
+  sendAccept: "Accept",
   sendRequestChanges: "Request changes",
   replanFeedback:
     "Preferences changed from effect {{fromEffect}} / speed {{fromSpeed}} to effect {{toEffect}} / speed {{toSpeed}}. Re-plan the model choices and effect-scaled task verification.",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.tuttiModePlan.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.tuttiModePlan.ts
@@ -1,8 +1,8 @@
 export const zhCNTuttiModePlan = {
   taskReview: "计划确认",
   cancel: "取消计划",
-  reviewHint: "直接发送即接受 · 输入反馈后发送即请求修改",
-  reviewHintReplan: "效果或速度已调整 · 发送即按新偏好重新规划",
+  reviewHint: "等待确认",
+  reviewHintReplan: "偏好有变",
   materializingTitle: "正在创建任务",
   switchToSelfReview: "切换为自主审核",
   switchingToSelfReview: "正在切换为自主审核",
@@ -12,7 +12,7 @@ export const zhCNTuttiModePlan = {
   errorTitle: "工作流暂不可用",
   expand: "展开工作流",
   collapse: "收起工作流",
-  sendAccept: "接受计划",
+  sendAccept: "接受",
   sendRequestChanges: "请求修改",
   replanFeedback:
     "偏好已从效果 {{fromEffect}} / 速度 {{fromSpeed}} 调整为效果 {{toEffect}} / 速度 {{toSpeed}}。请重新规划模型选择和随效果变化的任务验证",
@@ -57,5 +57,5 @@ export const zhCNTuttiModePlan = {
   issueStripFailed: "{{count}} 失败",
   issueStripDone: "{{done}}/{{total}} 已完成",
   issueCreateFailed:
-    "已核准的计划未能创建 Issue：{{message}}。请让 Agent 修订计划。"
+    "已核准的计划未能创建 Issue：{{message}}。请让 Agent 修订计划"
 } as const;

--- a/services/tuttid/service/cli/providers/tuttimodeplan/commands.go
+++ b/services/tuttid/service/cli/providers/tuttimodeplan/commands.go
@@ -230,6 +230,10 @@ func (p Provider) runPropose(ctx context.Context, invoke framework.InvokeContext
 	if err := p.requireTuttiModeActive(ctx, invoke.WorkspaceID, sessionID); err != nil {
 		return nil, err
 	}
+	turnID, err := p.callerActiveTurnID(ctx, invoke.WorkspaceID, sessionID)
+	if err != nil {
+		return nil, err
+	}
 	markdown, err := readPlanFile(input.File)
 	if err != nil {
 		return nil, err
@@ -237,7 +241,7 @@ func (p Provider) runPropose(ctx context.Context, invoke framework.InvokeContext
 	result, err := p.plans.Propose(ctx, tuttimodeplanservice.ProposeInput{
 		WorkspaceID:     invoke.WorkspaceID,
 		SourceSessionID: sessionID,
-		SourceTurnID:    p.callerActiveTurnID(ctx, invoke.WorkspaceID, sessionID),
+		SourceTurnID:    turnID,
 		RequestID:       input.RequestID,
 		Markdown:        markdown,
 	})
@@ -258,16 +262,21 @@ func (p Provider) runRevise(ctx context.Context, invoke framework.InvokeContext,
 	if err := p.requireTuttiModeActive(ctx, invoke.WorkspaceID, sessionID); err != nil {
 		return nil, err
 	}
+	turnID, err := p.callerActiveTurnID(ctx, invoke.WorkspaceID, sessionID)
+	if err != nil {
+		return nil, err
+	}
 	markdown, err := readPlanFile(input.File)
 	if err != nil {
 		return nil, err
 	}
 	result, err := p.plans.ReviseFromAgent(ctx, tuttimodeplanservice.AgentReviseInput{
-		WorkspaceID:    invoke.WorkspaceID,
-		WorkflowID:     input.WorkflowID,
-		AgentSessionID: sessionID,
-		RequestID:      input.RequestID,
-		Markdown:       markdown,
+		WorkspaceID:      invoke.WorkspaceID,
+		WorkflowID:       input.WorkflowID,
+		AgentSessionID:   sessionID,
+		ProducedByTurnID: turnID,
+		RequestID:        input.RequestID,
+		Markdown:         markdown,
 	})
 	if err != nil {
 		return nil, agentPlanError(err)
@@ -462,18 +471,33 @@ func (p Provider) runIssueStop(
 	}, nil
 }
 
-// callerActiveTurnID is best-effort decoration: the timeline anchors the plan
-// panel on this turn when present, and a missing pointer (unwired store, read
-// race) degrades the panel to the timeline tail rather than failing propose.
-func (p Provider) callerActiveTurnID(ctx context.Context, workspaceID string, sessionID string) string {
+// callerActiveTurnID is the authority for the immutable preference snapshot
+// that a new proposal or revision must copy. Agent-authored plan mutations fail
+// closed when the exact active Turn cannot be proven; otherwise omitting the
+// provenance would also bypass preference consistency validation.
+func (p Provider) callerActiveTurnID(ctx context.Context, workspaceID string, sessionID string) (string, error) {
 	if p.turns == nil {
-		return ""
+		return "", cliservice.ServiceUnavailableError(
+			"Tutti Mode source Turn resolver is unavailable",
+			nil,
+		)
 	}
 	turnID, err := p.turns.PersistedActiveTurnID(ctx, workspaceID, sessionID)
 	if err != nil {
-		return ""
+		return "", cliservice.ServiceUnavailableError(
+			"Tutti Mode source Turn is unavailable",
+			err,
+		)
 	}
-	return strings.TrimSpace(turnID)
+	turnID = strings.TrimSpace(turnID)
+	if turnID == "" {
+		return "", cliservice.InvalidInputReasonError(
+			"tutti_mode_source_turn_unavailable",
+			"Tutti Mode plan mutations must run inside the active Agent Turn so its exact effect and speed snapshot can be verified. Start a new Tutti Mode Turn and retry.",
+			nil,
+		)
+	}
+	return turnID, nil
 }
 
 func callerAgentSessionID(invoke framework.InvokeContext) (string, error) {

--- a/services/tuttid/service/cli/providers/tuttimodeplan/execution_errors.go
+++ b/services/tuttid/service/cli/providers/tuttimodeplan/execution_errors.go
@@ -2,6 +2,7 @@ package tuttimodeplan
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	workspaceissues "github.com/tutti-os/tutti/packages/workspace/issues"
@@ -12,6 +13,25 @@ import (
 )
 
 func agentPlanError(err error) error {
+	var preferenceMismatch *tuttimodeplanservice.PreferenceSnapshotMismatchError
+	if errors.As(err, &preferenceMismatch) {
+		return cliservice.InvalidInputReasonError(
+			"tutti_mode_preference_snapshot_mismatch",
+			fmt.Sprintf(
+				"Plan preferences do not match this Turn. Set execution.effect to %d and execution.speed to %d exactly, then retry the plan command.",
+				preferenceMismatch.ExpectedEffect,
+				preferenceMismatch.ExpectedSpeed,
+			),
+			nil,
+		)
+	}
+	if errors.Is(err, tuttimodeplanservice.ErrTurnSnapshotUnavailable) {
+		return cliservice.InvalidInputReasonError(
+			"tutti_mode_source_turn_unavailable",
+			"The exact Tutti Mode source Turn snapshot is unavailable. Stop and retry from a new active Tutti Mode Turn.",
+			nil,
+		)
+	}
 	if errors.Is(err, workflowdata.ErrWorkspaceWorkflowNotFound) {
 		return cliservice.InvalidInputReasonError(
 			string(executionbiz.RejectionExecutionNotFound),

--- a/services/tuttid/service/cli/providers/tuttimodeplan/provider.go
+++ b/services/tuttid/service/cli/providers/tuttimodeplan/provider.go
@@ -23,8 +23,9 @@ type Plans interface {
 	GetViewForAgent(context.Context, tuttimodeplanservice.AgentGetInput) (tuttimodeplanservice.SnapshotView, error)
 }
 
-// ActiveTurns resolves the caller session's persisted active turn pointer so
-// propose can stamp the workflow with the turn it was created in.
+// ActiveTurns resolves the caller session's persisted active Turn. The plan
+// service uses that identity to read the immutable effect/speed snapshot and
+// rejects any proposal or revision that does not copy it exactly.
 type ActiveTurns interface {
 	PersistedActiveTurnID(ctx context.Context, workspaceID string, agentSessionID string) (string, error)
 }

--- a/services/tuttid/service/cli/providers/tuttimodeplan/provider_test.go
+++ b/services/tuttid/service/cli/providers/tuttimodeplan/provider_test.go
@@ -827,6 +827,28 @@ func TestIssueAcknowledgeConflictAndRejectedFenceMapToInvalidInput(t *testing.T)
 	}
 }
 
+func TestAgentPlanPreferenceMismatchMapsToActionableInvalidInput(t *testing.T) {
+	actualEffect := 90
+	actualSpeed := 55
+	err := agentPlanError(&tuttimodeplanservice.PreferenceSnapshotMismatchError{
+		ExpectedEffect: 50,
+		ExpectedSpeed:  50,
+		ActualEffect:   &actualEffect,
+		ActualSpeed:    &actualSpeed,
+	})
+	if !errors.Is(err, cliservice.ErrInvalidInput) {
+		t.Fatalf("preference mismatch mapped to %v, want invalid input", err)
+	}
+	if got := cliservice.InvokeErrorReason(err); got != "tutti_mode_preference_snapshot_mismatch" {
+		t.Fatalf("preference mismatch reason = %q", got)
+	}
+	for _, expected := range []string{"execution.effect to 50", "execution.speed to 50"} {
+		if !strings.Contains(err.Error(), expected) {
+			t.Fatalf("preference mismatch error = %v, want %q", err, expected)
+		}
+	}
+}
+
 func TestRunIssueAcknowledgeMapsMissingExecutionWithoutScheduleCopy(t *testing.T) {
 	_, err := (Provider{
 		acknowledgements: &recordingIssueAcknowledger{
@@ -1201,7 +1223,7 @@ func TestRunProposeUsesAgentSessionWithoutInventingToolCallProvenance(t *testing
 		t.Fatalf("write proposal: %v", err)
 	}
 	plans := &recordingPlans{}
-	result, err := NewProvider(nil, plans, nil).runPropose(context.Background(), framework.InvokeContext{
+	result, err := NewProvider(nil, plans, &stubActiveTurns{turnID: "turn-1"}).runPropose(context.Background(), framework.InvokeContext{
 		WorkspaceID: "workspace-1",
 		Request: cliservice.InvokeRequest{Context: cliservice.InvokeContext{
 			AgentSessionID:  "session-1",
@@ -1235,18 +1257,28 @@ func (turns *stubActiveTurns) PersistedActiveTurnID(_ context.Context, workspace
 	return turns.turnID, turns.err
 }
 
-func TestRunProposeStampsCallerActiveTurnBestEffort(t *testing.T) {
+func TestRunProposeRequiresAndStampsCallerActiveTurn(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "proposal.md")
 	if err := os.WriteFile(path, configurationMarkdownFixture(), 0o600); err != nil {
 		t.Fatalf("write proposal: %v", err)
 	}
 	for name, testCase := range map[string]struct {
-		turns *stubActiveTurns
-		want  string
+		turns   *stubActiveTurns
+		want    string
+		wantErr bool
 	}{
-		"stamps the persisted active turn": {turns: &stubActiveTurns{turnID: " turn-9 "}, want: "turn-9"},
-		// Anchoring is decoration; a pointer read failure must not fail propose.
-		"resolver failure degrades to no anchor": {turns: &stubActiveTurns{err: errors.New("pointer read failed")}, want: ""},
+		"stamps the persisted active turn": {
+			turns: &stubActiveTurns{turnID: " turn-9 "},
+			want:  "turn-9",
+		},
+		"resolver failure fails closed": {
+			turns:   &stubActiveTurns{err: errors.New("pointer read failed")},
+			wantErr: true,
+		},
+		"missing pointer fails closed": {
+			turns:   &stubActiveTurns{},
+			wantErr: true,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			plans := &recordingPlans{}
@@ -1254,6 +1286,15 @@ func TestRunProposeStampsCallerActiveTurnBestEffort(t *testing.T) {
 				WorkspaceID: "workspace-1",
 				Request:     cliservice.InvokeRequest{Context: cliservice.InvokeContext{AgentSessionID: "session-1"}},
 			}, proposeInput{File: path, RequestID: "proposal-request-1"})
+			if testCase.wantErr {
+				if err == nil {
+					t.Fatal("runPropose() error = nil, want missing source Turn error")
+				}
+				if plans.proposeInput.RequestID != "" {
+					t.Fatalf("plan service was called without exact source Turn: %#v", plans.proposeInput)
+				}
+				return
+			}
 			if err != nil {
 				t.Fatalf("runPropose() error = %v", err)
 			}
@@ -1293,7 +1334,7 @@ func TestAgentPlanCommandsRequireAndPropagateCallerSession(t *testing.T) {
 	}
 
 	plans := &recordingPlans{}
-	provider = NewProvider(nil, plans, nil)
+	provider = NewProvider(nil, plans, &stubActiveTurns{turnID: "turn-9"})
 	invoke := framework.InvokeContext{
 		WorkspaceID: "workspace-1",
 		Request:     cliservice.InvokeRequest{Context: cliservice.InvokeContext{AgentSessionID: " session-1 "}},
@@ -1306,6 +1347,9 @@ func TestAgentPlanCommandsRequireAndPropagateCallerSession(t *testing.T) {
 	}
 	if plans.reviseInput.AgentSessionID != "session-1" || plans.reviseInput.RequestID != "revision-request-1" || plans.getInput.AgentSessionID != "session-1" {
 		t.Fatalf("caller session was not propagated: revise=%#v get=%#v", plans.reviseInput, plans.getInput)
+	}
+	if plans.reviseInput.ProducedByTurnID != "turn-9" {
+		t.Fatalf("revision source turn = %q, want turn-9", plans.reviseInput.ProducedByTurnID)
 	}
 }
 
@@ -1376,7 +1420,7 @@ func TestTuttiModeGateRejectsInactiveSessionsAndAllowsActive(t *testing.T) {
 
 	// An active session proceeds to the plan service.
 	activePlans := &recordingPlans{}
-	_, err = NewProvider(nil, activePlans, nil).
+	_, err = NewProvider(nil, activePlans, &stubActiveTurns{turnID: "turn-1"}).
 		WithTuttiModeActivations(&stubActivationReader{activation: activeActivation()}).
 		runPropose(context.Background(), invoke, proposeInput{File: path, RequestID: "request-2"})
 	if err != nil {
@@ -1388,7 +1432,7 @@ func TestTuttiModeGateRejectsInactiveSessionsAndAllowsActive(t *testing.T) {
 
 	// An unwired reader leaves the gate open (best-effort semantics).
 	openPlans := &recordingPlans{}
-	if _, err := NewProvider(nil, openPlans, nil).
+	if _, err := NewProvider(nil, openPlans, &stubActiveTurns{turnID: "turn-1"}).
 		runPropose(context.Background(), invoke, proposeInput{File: path, RequestID: "request-3"}); err != nil {
 		t.Fatalf("unwired gate error = %v", err)
 	}

--- a/services/tuttid/service/tuttimodeplan/service.go
+++ b/services/tuttid/service/tuttimodeplan/service.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	activationbiz "github.com/tutti-os/tutti/services/tuttid/biz/tuttimodeactivation"
 	workflowbiz "github.com/tutti-os/tutti/services/tuttid/biz/workspaceworkflow"
 	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
 )
@@ -18,14 +19,47 @@ import (
 const defaultWaitInterval = 100 * time.Millisecond
 
 var (
-	ErrInvalidInput       = errors.New("invalid Tutti Mode Plan input")
-	ErrInvalidTransition  = errors.New("invalid Tutti Mode Plan transition")
-	ErrInvalidDecision    = errors.New("invalid Tutti Mode Plan decision")
-	ErrDecisionConflict   = errors.New("tutti mode plan checkpoint decision conflicts with durable state")
-	ErrMutationConflict   = errors.New("tutti mode plan request id conflicts with a prior mutation")
-	ErrCheckpointMissing  = errors.New("tutti mode plan checkpoint was not found")
-	ErrServiceUnavailable = errors.New("tutti mode plan service is unavailable")
+	ErrInvalidInput            = errors.New("invalid Tutti Mode Plan input")
+	ErrInvalidTransition       = errors.New("invalid Tutti Mode Plan transition")
+	ErrInvalidDecision         = errors.New("invalid Tutti Mode Plan decision")
+	ErrDecisionConflict        = errors.New("tutti mode plan checkpoint decision conflicts with durable state")
+	ErrMutationConflict        = errors.New("tutti mode plan request id conflicts with a prior mutation")
+	ErrCheckpointMissing       = errors.New("tutti mode plan checkpoint was not found")
+	ErrServiceUnavailable      = errors.New("tutti mode plan service is unavailable")
+	ErrTurnSnapshotUnavailable = fmt.Errorf(
+		"%w: the exact source turn preference snapshot is unavailable",
+		ErrInvalidInput,
+	)
+	ErrPreferenceSnapshotMismatch = fmt.Errorf(
+		"%w: plan preferences do not match the exact source turn snapshot",
+		ErrInvalidInput,
+	)
 )
+
+// PreferenceSnapshotMismatchError keeps the exact, non-sensitive values the
+// planning Agent needs to repair its document while preserving a typed error
+// for the CLI boundary.
+type PreferenceSnapshotMismatchError struct {
+	ExpectedEffect int
+	ExpectedSpeed  int
+	ActualEffect   *int
+	ActualSpeed    *int
+}
+
+func (e *PreferenceSnapshotMismatchError) Error() string {
+	return fmt.Sprintf(
+		"%v: expected effect %d and speed %d, got effect %s and speed %s",
+		ErrPreferenceSnapshotMismatch,
+		e.ExpectedEffect,
+		e.ExpectedSpeed,
+		optionalPreferenceString(e.ActualEffect),
+		optionalPreferenceString(e.ActualSpeed),
+	)
+}
+
+func (*PreferenceSnapshotMismatchError) Unwrap() error {
+	return ErrPreferenceSnapshotMismatch
+}
 
 // Store is the durable workflow surface owned by the workspace data layer.
 type Store interface {
@@ -42,6 +76,13 @@ type Store interface {
 	CompleteWorkspaceWorkflowOperation(context.Context, workspacedata.CompleteWorkspaceWorkflowOperationInput) (workflowbiz.WorkflowOperation, bool, error)
 	ListRecoverableCreateIssueOperations(context.Context) ([]workspacedata.RecoverableCreateIssueOperation, error)
 	ListPendingConfigurationReviewCheckpoints(context.Context) ([]workspacedata.PendingConfigurationReviewCheckpoint, error)
+}
+
+// TurnSnapshotReader is the narrow activation-service capability required to
+// bind a plan revision to the immutable preferences of its producing Turn.
+// The plan service must not infer those values from mutable session state.
+type TurnSnapshotReader interface {
+	ExistingTurnSnapshot(context.Context, string, string, string) (activationbiz.TurnSnapshot, error)
 }
 
 type Publisher interface {
@@ -95,6 +136,7 @@ type PlanRevisionFeedbackInput struct {
 
 type Service struct {
 	Store              Store
+	TurnSnapshots      TurnSnapshotReader
 	Revisions          RevisionContentStore
 	Publisher          Publisher
 	IssueMaterializer  IssueMaterializer
@@ -250,6 +292,15 @@ func (s *Service) Propose(ctx context.Context, input ProposeInput) (ProposalResu
 	if err := ValidatePlanExecutionIsolation(document); err != nil {
 		return ProposalResult{}, err
 	}
+	if err := s.validateTurnPreferenceSnapshot(
+		ctx,
+		input.WorkspaceID,
+		input.SourceSessionID,
+		input.SourceTurnID,
+		document,
+	); err != nil {
+		return ProposalResult{}, err
+	}
 
 	now := s.now()
 	workflowID := s.newID()
@@ -392,6 +443,15 @@ func (s *Service) revise(ctx context.Context, input ReviseInput, expectedSourceS
 	if err := validateRevisionPhase(current, document.Phase); err != nil {
 		return RevisionResult{}, err
 	}
+	if err := s.validateTurnPreferenceSnapshot(
+		ctx,
+		input.WorkspaceID,
+		snapshot.Workflow.SourceSessionID,
+		input.ProducedByTurnID,
+		document,
+	); err != nil {
+		return RevisionResult{}, err
+	}
 	completion, err := s.revisionOperationCompletion(ctx, input.WorkspaceID, snapshot, current)
 	if err != nil {
 		return RevisionResult{}, err
@@ -482,6 +542,67 @@ func (s *Service) revise(ctx context.Context, input ReviseInput, expectedSourceS
 		ChangeKind:      workflowbiz.ChangeKindRevisionCreated,
 	})
 	return s.revisionResultFromMutation(ctx, committedMutation, false)
+}
+
+func (s *Service) validateTurnPreferenceSnapshot(
+	ctx context.Context,
+	workspaceID string,
+	sourceSessionID string,
+	turnID string,
+	document PlanDocument,
+) error {
+	turnID = strings.TrimSpace(turnID)
+	if turnID == "" {
+		// Historical and daemon-internal callers may lack Turn provenance. The
+		// Agent CLI boundary requires it for all new proposals and revisions;
+		// stored legacy documents remain readable.
+		return nil
+	}
+	if s.TurnSnapshots == nil {
+		return fmt.Errorf("%w: turn %q", ErrTurnSnapshotUnavailable, turnID)
+	}
+	snapshot, err := s.TurnSnapshots.ExistingTurnSnapshot(
+		ctx,
+		workspaceID,
+		sourceSessionID,
+		turnID,
+	)
+	if err != nil {
+		return fmt.Errorf("%w: read turn %q: %v", ErrTurnSnapshotUnavailable, turnID, err)
+	}
+	normalized, err := activationbiz.NormalizeTurnSnapshot(snapshot)
+	if err != nil {
+		return fmt.Errorf("%w: turn %q is invalid: %v", ErrTurnSnapshotUnavailable, turnID, err)
+	}
+	if normalized.State != activationbiz.StateActive {
+		return fmt.Errorf("%w: turn %q is not active", ErrTurnSnapshotUnavailable, turnID)
+	}
+	if document.Execution.Effect == nil || document.Execution.Speed == nil ||
+		*document.Execution.Effect != normalized.Effect ||
+		*document.Execution.Speed != normalized.Speed {
+		return &PreferenceSnapshotMismatchError{
+			ExpectedEffect: normalized.Effect,
+			ExpectedSpeed:  normalized.Speed,
+			ActualEffect:   cloneOptionalPreference(document.Execution.Effect),
+			ActualSpeed:    cloneOptionalPreference(document.Execution.Speed),
+		}
+	}
+	return nil
+}
+
+func cloneOptionalPreference(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func optionalPreferenceString(value *int) string {
+	if value == nil {
+		return "missing"
+	}
+	return fmt.Sprint(*value)
 }
 
 func (s *Service) Decide(ctx context.Context, input DecideInput) (DecisionResult, error) {

--- a/services/tuttid/service/tuttimodeplan/service_test.go
+++ b/services/tuttid/service/tuttimodeplan/service_test.go
@@ -3,11 +3,13 @@ package tuttimodeplan
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	activationbiz "github.com/tutti-os/tutti/services/tuttid/biz/tuttimodeactivation"
 	workflowbiz "github.com/tutti-os/tutti/services/tuttid/biz/workspaceworkflow"
 	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
 )
@@ -55,6 +57,88 @@ func TestServiceProposePersistsPlanRevisionAndSingleTaskReviewCheckpoint(t *test
 	}
 	if !result.Snapshot.Workflow.CreatedAt.Equal(now) || !result.Snapshot.Checkpoints[0].CreatedAt.Equal(now) {
 		t.Fatalf("timestamps do not use service clock: %#v", result.Snapshot)
+	}
+}
+
+func TestServiceProposeRejectsTurnPreferenceSnapshotMismatchBeforePersistence(t *testing.T) {
+	t.Parallel()
+
+	for name, markdown := range map[string][]byte{
+		"mismatched values": taskGraphMarkdownWithPreferences("Mismatched proposal", 90, 55),
+		"missing values":    taskGraphMarkdownWithoutPreferences("Missing preference snapshot"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			store := newMemoryWorkflowStore()
+			store.turnSnapshots[turnSnapshotStoreKey("workspace-1", "session-1", "turn-1")] = activationbiz.TurnSnapshot{
+				ActivationID: "activation-1",
+				RevisionID:   "activation-revision-1",
+				Revision:     1,
+				State:        activationbiz.StateActive,
+				Source:       activationbiz.SourceSlashCommand,
+				Effect:       50,
+				Speed:        50,
+			}
+			service := newTestService(
+				t,
+				store,
+				time.UnixMilli(1_700_000_000_000).UTC(),
+				"workflow-1",
+				"revision-1",
+				"checkpoint-1",
+			)
+
+			_, err := service.Propose(context.Background(), ProposeInput{
+				WorkspaceID:     "workspace-1",
+				SourceSessionID: "session-1",
+				SourceTurnID:    "turn-1",
+				RequestID:       "request-1",
+				Markdown:        markdown,
+			})
+			if !errors.Is(err, ErrPreferenceSnapshotMismatch) || !errors.Is(err, ErrInvalidInput) {
+				t.Fatalf("Propose() error = %v, want typed preference snapshot mismatch", err)
+			}
+			if len(store.snapshots) != 0 || len(store.mutations) != 0 {
+				t.Fatalf(
+					"preference mismatch persisted workflow state: snapshots=%#v mutations=%#v",
+					store.snapshots,
+					store.mutations,
+				)
+			}
+		})
+	}
+}
+
+func TestServiceProposeRejectsMissingSourceTurnSnapshotBeforePersistence(t *testing.T) {
+	t.Parallel()
+
+	store := newMemoryWorkflowStore()
+	service := newTestService(
+		t,
+		store,
+		time.UnixMilli(1_700_000_000_000).UTC(),
+		"workflow-1",
+		"revision-1",
+		"checkpoint-1",
+	)
+	delete(store.turnSnapshots, turnSnapshotStoreKey("workspace-1", "session-1", "turn-1"))
+
+	_, err := service.Propose(context.Background(), ProposeInput{
+		WorkspaceID:     "workspace-1",
+		SourceSessionID: "session-1",
+		SourceTurnID:    "turn-1",
+		RequestID:       "request-1",
+		Markdown:        taskGraphMarkdown("Missing Turn snapshot"),
+	})
+	if !errors.Is(err, ErrTurnSnapshotUnavailable) || !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("Propose() error = %v, want typed unavailable Turn snapshot", err)
+	}
+	if len(store.snapshots) != 0 || len(store.mutations) != 0 {
+		t.Fatalf(
+			"missing Turn snapshot persisted workflow state: snapshots=%#v mutations=%#v",
+			store.snapshots,
+			store.mutations,
+		)
 	}
 }
 
@@ -526,6 +610,56 @@ func TestServiceReviseEnforcesPhaseStateMachine(t *testing.T) {
 	}
 }
 
+func TestServiceReviseRejectsTurnPreferenceSnapshotMismatchBeforeRevisionWrite(t *testing.T) {
+	t.Parallel()
+
+	now := time.UnixMilli(1_700_000_000_000).UTC()
+	store := newMemoryWorkflowStore()
+	store.snapshots[workflowStoreKey("workspace-1", "workflow-1")] = workflowSnapshotFixture(
+		workflowbiz.CheckpointKindTaskReview,
+		workflowbiz.CheckpointStatusRejected,
+		workflowbiz.WorkflowStatusInProgress,
+		now,
+	)
+	service := newTestService(t, store, now.Add(time.Minute), "revision-2", "checkpoint-2")
+	durableRevisions := service.Revisions
+	documentPath, digest, err := durableRevisions.Write(
+		"workflow-1",
+		taskGraphMarkdown("Current plan"),
+	)
+	if err != nil {
+		t.Fatalf("seed current revision: %v", err)
+	}
+	current := store.snapshots[workflowStoreKey("workspace-1", "workflow-1")]
+	current.Revisions[0].DocumentPath = documentPath
+	current.Revisions[0].SHA256 = digest
+	store.snapshots[workflowStoreKey("workspace-1", "workflow-1")] = current
+	countingRevisions := &countingRevisionContentStore{delegate: durableRevisions}
+	service.Revisions = countingRevisions
+
+	_, err = service.Revise(context.Background(), ReviseInput{
+		WorkspaceID:      "workspace-1",
+		WorkflowID:       "workflow-1",
+		ProducedByTurnID: "turn-2",
+		RequestID:        "request-2",
+		Markdown:         taskGraphMarkdownWithPreferences("Mismatched revision", 90, 55),
+	})
+	if !errors.Is(err, ErrPreferenceSnapshotMismatch) {
+		t.Fatalf("Revise() error = %v, want preference snapshot mismatch", err)
+	}
+	if countingRevisions.writes != 0 {
+		t.Fatalf("mismatched revision file writes = %d, want 0", countingRevisions.writes)
+	}
+	persisted := store.snapshots[workflowStoreKey("workspace-1", "workflow-1")]
+	if len(persisted.Revisions) != 1 || len(store.mutations) != 0 {
+		t.Fatalf(
+			"preference mismatch persisted revision state: revisions=%#v mutations=%#v",
+			persisted.Revisions,
+			store.mutations,
+		)
+	}
+}
+
 func TestServiceReviseRetriesAfterMetadataCommitFailureWithoutRevisionFileConflict(t *testing.T) {
 	t.Parallel()
 
@@ -724,6 +858,61 @@ func TestServiceDecideMapsCheckpointDecisionToWorkflowAndOperation(t *testing.T)
 	}
 }
 
+func TestServiceDecideRejectsAStaleRenderedCheckpointBeforeMaterialization(t *testing.T) {
+	t.Parallel()
+
+	now := time.UnixMilli(1_700_000_000_000).UTC()
+	store := newMemoryWorkflowStore()
+	snapshot := workflowSnapshotFixture(
+		workflowbiz.CheckpointKindTaskReview,
+		workflowbiz.CheckpointStatusPending,
+		workflowbiz.WorkflowStatusPendingReview,
+		now,
+	)
+	snapshot.Workflow.CurrentRevisionID = "revision-2"
+	snapshot.Revisions = append(snapshot.Revisions, workflowbiz.PlanRevision{
+		ID:               "revision-2",
+		WorkflowID:       "workflow-1",
+		Sequence:         2,
+		SchemaVersion:    SchemaV1,
+		DocumentPath:     "tutti-mode-plans/workflow-1/revisions/" + strings.Repeat("b", 64) + ".md",
+		SHA256:           strings.Repeat("b", 64),
+		ProducedByTurnID: "turn-2",
+		CreatedAt:        now.Add(time.Minute),
+	})
+	snapshot.Checkpoints = append(snapshot.Checkpoints, workflowbiz.WorkflowCheckpoint{
+		ID:         "checkpoint-2",
+		WorkflowID: "workflow-1",
+		Kind:       workflowbiz.CheckpointKindTaskReview,
+		RevisionID: "revision-2",
+		Status:     workflowbiz.CheckpointStatusPending,
+		CreatedAt:  now.Add(time.Minute),
+		UpdatedAt:  now.Add(time.Minute),
+	})
+	store.snapshots[workflowStoreKey("workspace-1", "workflow-1")] = snapshot
+	service := newTestService(t, store, now.Add(2*time.Minute))
+	materializer := &recordingIssueMaterializer{issueID: "must-not-exist"}
+	service.IssueMaterializer = materializer
+
+	_, err := service.Decide(context.Background(), DecideInput{
+		WorkspaceID:  "workspace-1",
+		WorkflowID:   "workflow-1",
+		CheckpointID: "checkpoint-1",
+		Decision:     workflowbiz.CheckpointStatusAccepted,
+		DecidedBy:    "user-1",
+	})
+	if !errors.Is(err, ErrCheckpointMissing) {
+		t.Fatalf("Decide(stale visible checkpoint) error = %v, want ErrCheckpointMissing", err)
+	}
+	if len(materializer.inputs) != 0 {
+		t.Fatalf("stale visible checkpoint materialized inputs = %#v", materializer.inputs)
+	}
+	persisted := store.snapshots[workflowStoreKey("workspace-1", "workflow-1")]
+	if persisted.Checkpoints[0].Status != workflowbiz.CheckpointStatusPending || len(persisted.Operations) != 0 {
+		t.Fatalf("stale visible checkpoint mutated workflow = %#v", persisted)
+	}
+}
+
 func TestServiceRevisionCompletesDecisionOperationLifecycle(t *testing.T) {
 	t.Parallel()
 
@@ -837,7 +1026,12 @@ func TestServiceAcceptTaskGraphMaterializesActionableItemsAndCompletesOperation(
 	if len(materializer.inputs) != 1 || len(materializer.inputs[0].ActionableItems) != 1 {
 		t.Fatalf("materializer inputs = %#v", materializer.inputs)
 	}
-	if materializer.inputs[0].ActionableItems[0].Task.ID != "task-1" || materializer.inputs[0].SourceSessionID != "session-1" {
+	if materializer.inputs[0].Title != "Executable plan" ||
+		materializer.inputs[0].Content != "Task graph narrative\n" ||
+		materializer.inputs[0].Execution.Effect == nil || *materializer.inputs[0].Execution.Effect != 50 ||
+		materializer.inputs[0].Execution.Speed == nil || *materializer.inputs[0].Execution.Speed != 50 ||
+		materializer.inputs[0].ActionableItems[0].Task.ID != "task-1" ||
+		materializer.inputs[0].SourceSessionID != "session-1" {
 		t.Fatalf("materializer input = %#v", materializer.inputs[0])
 	}
 	replayed, err := service.Decide(context.Background(), DecideInput{
@@ -1382,11 +1576,26 @@ func TestServiceWaitRepairsMissingFollowUpOperationAfterDecisionCrashGap(t *test
 
 func newTestService(t *testing.T, store *memoryWorkflowStore, now time.Time, ids ...string) *Service {
 	t.Helper()
+	for _, turnID := range []string{"turn-1", "turn-2"} {
+		key := turnSnapshotStoreKey("workspace-1", "session-1", turnID)
+		if _, found := store.turnSnapshots[key]; !found {
+			store.turnSnapshots[key] = activationbiz.TurnSnapshot{
+				ActivationID: "activation-1",
+				RevisionID:   "activation-revision-1",
+				Revision:     1,
+				State:        activationbiz.StateActive,
+				Source:       activationbiz.SourceSlashCommand,
+				Effect:       50,
+				Speed:        50,
+			}
+		}
+	}
 	index := 0
 	return &Service{
-		Store:     store,
-		Revisions: workspacedata.WorkflowRevisionFiles{StateDir: t.TempDir()},
-		Now:       func() time.Time { return now },
+		Store:         store,
+		TurnSnapshots: store,
+		Revisions:     workspacedata.WorkflowRevisionFiles{StateDir: t.TempDir()},
+		Now:           func() time.Time { return now },
 		NewID: func() string {
 			if index >= len(ids) {
 				t.Fatalf("unexpected id allocation after %d ids", len(ids))
@@ -1403,11 +1612,24 @@ func configurationMarkdown(title string) []byte {
 }
 
 func planMarkdownWithoutPhase(title string) []byte {
-	return []byte("---\nschema: tutti-mode-plan/v1\ntitle: " + title + "\ntopicId: topic-1\nexecution:\n  mode: sequential\n  reasoningIntensity: 50\n  orchestrationIntensity: 50\nbudget:\n  mode: auto\n  tokenLimit: 0\n  quotaWaterlinePercent: 0\ntasks:\n  - id: task-1\n    title: Implement task\n    priority: medium\n---\nPlan narrative with tasks\n")
+	return []byte("---\nschema: tutti-mode-plan/v1\ntitle: " + title + "\ntopicId: topic-1\nexecution:\n  mode: sequential\n  effect: 50\n  speed: 50\n  reasoningIntensity: 50\n  orchestrationIntensity: 50\nbudget:\n  mode: auto\n  tokenLimit: 0\n  quotaWaterlinePercent: 0\ntasks:\n  - id: task-1\n    title: Implement task\n    priority: medium\n---\nPlan narrative with tasks\n")
 }
 
 func taskGraphMarkdown(title string) []byte {
+	return taskGraphMarkdownWithPreferences(title, 50, 50)
+}
+
+func taskGraphMarkdownWithoutPreferences(title string) []byte {
 	return []byte("---\nschema: tutti-mode-plan/v1\nphase: task_graph\ntitle: " + title + "\ntopicId: topic-1\nexecution:\n  mode: sequential\n  reasoningIntensity: 50\n  orchestrationIntensity: 50\nbudget:\n  mode: auto\n  tokenLimit: 0\n  quotaWaterlinePercent: 0\ntasks:\n  - id: task-1\n    title: Implement task\n    priority: medium\n---\nTask graph narrative\n")
+}
+
+func taskGraphMarkdownWithPreferences(title string, effect int, speed int) []byte {
+	return []byte(
+		"---\nschema: tutti-mode-plan/v1\nphase: task_graph\ntitle: " + title +
+			"\ntopicId: topic-1\nexecution:\n  mode: sequential\n  effect: " +
+			fmt.Sprint(effect) + "\n  speed: " + fmt.Sprint(speed) +
+			"\n  reasoningIntensity: 50\n  orchestrationIntensity: 50\nbudget:\n  mode: auto\n  tokenLimit: 0\n  quotaWaterlinePercent: 0\ntasks:\n  - id: task-1\n    title: Implement task\n    priority: medium\n---\nTask graph narrative\n",
+	)
 }
 
 func workflowSnapshotFixture(kind workflowbiz.CheckpointKind, checkpointStatus workflowbiz.CheckpointStatus, workflowStatus workflowbiz.WorkflowStatus, now time.Time) workflowbiz.Snapshot {
@@ -1483,6 +1705,7 @@ type memoryWorkflowStore struct {
 	mu               sync.Mutex
 	snapshots        map[string]workflowbiz.Snapshot
 	mutations        map[string]workflowbiz.WorkflowMutation
+	turnSnapshots    map[string]activationbiz.TurnSnapshot
 	getCount         int
 	appendFailures   int
 	completeFailures int
@@ -1492,6 +1715,20 @@ type recordingWorkflowPublisher struct {
 	updates []workflowbiz.Update
 }
 
+type countingRevisionContentStore struct {
+	delegate RevisionContentStore
+	writes   int
+}
+
+func (store *countingRevisionContentStore) Write(workflowID string, raw []byte) (string, string, error) {
+	store.writes++
+	return store.delegate.Write(workflowID, raw)
+}
+
+func (store *countingRevisionContentStore) Read(workflowID string, documentPath string, expectedSHA256 string) ([]byte, error) {
+	return store.delegate.Read(workflowID, documentPath, expectedSHA256)
+}
+
 func (publisher *recordingWorkflowPublisher) PublishWorkspaceWorkflowUpdated(_ context.Context, update workflowbiz.Update) error {
 	publisher.updates = append(publisher.updates, update)
 	return nil
@@ -1499,9 +1736,29 @@ func (publisher *recordingWorkflowPublisher) PublishWorkspaceWorkflowUpdated(_ c
 
 func newMemoryWorkflowStore() *memoryWorkflowStore {
 	return &memoryWorkflowStore{
-		snapshots: make(map[string]workflowbiz.Snapshot),
-		mutations: make(map[string]workflowbiz.WorkflowMutation),
+		snapshots:     make(map[string]workflowbiz.Snapshot),
+		mutations:     make(map[string]workflowbiz.WorkflowMutation),
+		turnSnapshots: make(map[string]activationbiz.TurnSnapshot),
 	}
+}
+
+func turnSnapshotStoreKey(workspaceID string, sessionID string, turnID string) string {
+	return strings.Join([]string{workspaceID, sessionID, turnID}, "\x00")
+}
+
+func (store *memoryWorkflowStore) ExistingTurnSnapshot(
+	_ context.Context,
+	workspaceID string,
+	agentSessionID string,
+	turnID string,
+) (activationbiz.TurnSnapshot, error) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	snapshot, found := store.turnSnapshots[turnSnapshotStoreKey(workspaceID, agentSessionID, turnID)]
+	if !found {
+		return activationbiz.TurnSnapshot{}, fmt.Errorf("turn snapshot not found")
+	}
+	return snapshot, nil
 }
 
 func workflowStoreKey(workspaceID string, workflowID string) string {

--- a/services/tuttid/wiring_daemon_api.go
+++ b/services/tuttid/wiring_daemon_api.go
@@ -568,6 +568,7 @@ func buildDaemonAPI(
 	}
 	tuttiModePlans := &tuttimodeplanservice.Service{
 		Store:             workflowStore,
+		TurnSnapshots:     tuttiModeActivations,
 		Revisions:         workspacedata.WorkflowRevisionFiles{StateDir: tuttitypes.DefaultStateDir()},
 		Publisher:         eventstreamservice.WorkspaceWorkflowPublisher{Service: events},
 		IssueMaterializer: tuttimodeplanservice.WorkspaceIssueMaterializer{Issues: &issueService},


### PR DESCRIPTION
## What changed

- Backport the Tutti plan review consistency fixes from #2403 onto `release/0819`.
- Restore the Tutti Mode feature gate, defaulting it to off.
- Show both the Tutti Mode composer switch and the `/tutti` slash-command entry only when the gate is enabled; hide both when disabled.
- Preserve the release branch's Connector composer API while resolving the backport conflicts.

## Why

The release branch needs the corrected request-changes/decision flow and the opt-in Tutti Mode controls without pulling in unrelated `main` history.

## Validation

- `@tutti-os/agent-gui:typecheck` passed.
- `@tutti-os/agent-gui:test` passed.
- `@tutti-os/desktop:typecheck` passed.
- `@tutti-os/desktop:test` passed (1,753 tests; 1,751 passed and 2 skipped).
- `go test . ./service/tuttimodeplan ./service/cli/providers/tuttimodeplan` passed.
- `lint:go (packages/agent/daemon)` and `test:go (packages/agent/daemon)` passed.
- `git diff --check` passed.

The broad release-vs-main `check:changed` run passed 63/64 lanes. Its remaining `test:go (services/tuttid)` lane contains existing release/host-sensitive failures outside this diff, including an OpenCode slash-command expectation that already disagrees with the `release/0819` provider registry.

## Backport commits

- `c8e8b860b` — keep Tutti plan review consistent
- `1aeecb0d5` — restore gated Tutti Mode controls
