### PR TITLE
fix(agent): retain send-now while capabilities load

### DIFF
--- a/.changeset/agent-send-now-capability-admission.md
+++ b/.changeset/agent-send-now-capability-admission.md
@@ -1,0 +1,6 @@
+---
+"@tutti-os/agent-activity-core": patch
+---
+
+Retain active-turn send-now prompts while Session capabilities are unresolved,
+then route the same intent after the authoritative capability snapshot arrives.

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -882,6 +882,14 @@ publish duplicate deletion events.
 
 Before a session exists, composer options carry the same typed capability
 descriptor. The active session descriptor takes precedence once available.
+For an existing active Turn, a null Session capability snapshot is unresolved
+admission input rather than a negative capability result. Activity Core keeps
+an accepted send-now prompt in its queue and resolves the pending delivery
+decision when the complete Session snapshot arrives. Guidance and interruption
+remain exact capability-driven paths; a complete snapshot supporting neither
+degrades only the delivery mode to ordinary queued send and never drops the
+accepted prompt. Deferred decisions are keyed by prompt and bound to the active
+Turn observed at admission; they never steer or cancel a successor Turn.
 Model composer options keep the selected value and provider-resolved value as
 separate facts. An inherited `default` remains the selected value used for
 future mutations; `effectiveModel` is presentation-only runtime evidence for

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1407,6 +1407,15 @@ The busy-session prompt queue is ephemeral durable-intent coordination in the wo
 - a queued-prompt `Send next` action uses native guidance when the provider
   supports it, even when the provider also supports interruption; guidance
   stays on the same canonical Turn and follows the provider's native semantics
+- when an active-turn `Send now` arrives before the Session has an authoritative
+  capability snapshot, the workspace Engine retains the exact prompt and
+  send-now decision without dispatching guidance or cancellation. A later
+  authoritative snapshot resolves that same intent to native guidance or
+  cancel-then-send. An explicit complete snapshot that supports neither keeps
+  the prompt in the ordinary queue until canonical availability returns; a
+  missing snapshot must never discard the prompt or be treated as unsupported.
+  Each queued prompt owns its deferred decision and exact target Turn; a later
+  Turn must not inherit guidance or cancellation intended for its predecessor
 - Claude SDK guidance acknowledges delivery only after its SDK interrupt has
   succeeded and the guidance prompt has been enqueued; a failed interrupt is a
   failed guidance request and must not allow the old response to keep running.

--- a/packages/agent/activity-core/src/engine/promptQueue.drainDecision.test.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.drainDecision.test.ts
@@ -168,6 +168,7 @@ function emptyRecord(
     failedPromptId: null,
     failureMessage: null,
     inFlight: null,
+    pendingSendNowByPromptId: undefined,
     prompts,
     sendNextPromptId: null,
     suspendReason: null,

--- a/packages/agent/activity-core/src/engine/promptQueue.ownedReconcile.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.ownedReconcile.ts
@@ -8,6 +8,7 @@ import type {
   PromptQueueState
 } from "./promptQueue.types.ts";
 import { compactQueueRecord } from "./promptQueue.record.ts";
+import { setPendingSendNowForPrompt } from "./promptQueue.pendingSendNow.ts";
 
 const NO_COMMANDS: readonly EngineCommand[] = [];
 
@@ -63,6 +64,11 @@ export function settleOwnedQueueReconcile(
           : current.failureMessage,
       prompts: current.prompts.filter(
         (prompt) => prompt.id !== uncertain.promptId
+      ),
+      pendingSendNowByPromptId: setPendingSendNowForPrompt(
+        current.pendingSendNowByPromptId,
+        uncertain.promptId,
+        null
       ),
       sendNextPromptId:
         current.sendNextPromptId === uncertain.promptId

--- a/packages/agent/activity-core/src/engine/promptQueue.pendingSendNow.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.pendingSendNow.ts
@@ -1,0 +1,108 @@
+import type { AgentActivitySessionCapabilities } from "../types.ts";
+import type {
+  PromptQueuePendingSendNow,
+  PromptQueueRecord,
+  PromptQueueSendNowRequestedIntent
+} from "./promptQueue.types.ts";
+import {
+  resolvePromptSendNowStrategy,
+  type PromptQueueSendNowStrategy
+} from "./promptQueue.sendNow.ts";
+import { TURN_CANCEL_TIMEOUT_MS } from "./sessionLifecycle.cancel.ts";
+import type { CanonicalSubmitAvailability } from "./sessionLifecycle.availability.ts";
+import type { EngineIntent } from "./types.ts";
+
+export function pendingSendNowFromSubmit(
+  intent: Extract<EngineIntent, { type: "submit/requested" }>,
+  strategy: PromptQueueSendNowStrategy,
+  targetTurnId: string | null | undefined
+): PromptQueuePendingSendNow | null {
+  const target = targetTurnId?.trim() ?? "";
+  return strategy === "await_capabilities" && target
+    ? {
+        awaitingTurnExpiresAtUnixMs:
+          intent.requestedAtUnixMs + TURN_CANCEL_TIMEOUT_MS,
+        cancelCommandId: `submit:cancel:${intent.clientSubmitId}`,
+        promptId: intent.clientSubmitId,
+        targetTurnId: target,
+        timeoutMs: TURN_CANCEL_TIMEOUT_MS
+      }
+    : null;
+}
+
+export function setPendingSendNowForPrompt(
+  current: PromptQueueRecord["pendingSendNowByPromptId"],
+  promptId: string,
+  pending: PromptQueuePendingSendNow | null
+): PromptQueueRecord["pendingSendNowByPromptId"] {
+  const next = { ...(current ?? {}) };
+  if (pending) {
+    next[promptId] = pending;
+  } else {
+    delete next[promptId];
+  }
+  return Object.keys(next).length > 0 ? next : undefined;
+}
+
+export type PendingSendNowResolution =
+  | { kind: "continue"; record: PromptQueueRecord }
+  | {
+      kind: "request";
+      intent: PromptQueueSendNowRequestedIntent;
+      record: PromptQueueRecord;
+    }
+  | { kind: "waiting" };
+
+export function resolvePendingSendNow(input: {
+  activeTurnId: string | null | undefined;
+  availability: CanonicalSubmitAvailability;
+  capabilities: AgentActivitySessionCapabilities | null | undefined;
+  record: PromptQueueRecord;
+}): PendingSendNowResolution {
+  const head = input.record.prompts[0];
+  const pending = head
+    ? input.record.pendingSendNowByPromptId?.[head.id]
+    : undefined;
+  if (!pending) {
+    return { kind: "continue", record: input.record };
+  }
+  const activeTurnId = input.activeTurnId?.trim() ?? "";
+  const targetsSameTurn =
+    activeTurnId.length > 0 && activeTurnId === pending.targetTurnId;
+  if (
+    targetsSameTurn &&
+    input.availability.state === "blocked" &&
+    input.availability.reason === "active_turn" &&
+    input.capabilities == null
+  ) {
+    return { kind: "waiting" };
+  }
+
+  const strategy = targetsSameTurn
+    ? resolvePromptSendNowStrategy(input.availability, input.capabilities)
+    : null;
+  const record = {
+    ...input.record,
+    pendingSendNowByPromptId: setPendingSendNowForPrompt(
+      input.record.pendingSendNowByPromptId,
+      pending.promptId,
+      null
+    )
+  };
+  if (strategy !== "native_guidance" && strategy !== "cancel_then_send") {
+    return { kind: "continue", record };
+  }
+  return {
+    intent: {
+      agentSessionId: input.record.agentSessionId,
+      awaitingTurnExpiresAtUnixMs: pending.awaitingTurnExpiresAtUnixMs,
+      cancelCommandId: pending.cancelCommandId,
+      promptId: pending.promptId,
+      targetTurnId: pending.targetTurnId,
+      timeoutMs: pending.timeoutMs,
+      type: "queue/sendNowRequested"
+    },
+    kind: "request",
+    record
+  };
+}

--- a/packages/agent/activity-core/src/engine/promptQueue.pendingSendNow.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.pendingSendNow.ts
@@ -59,23 +59,30 @@ export function resolvePendingSendNow(input: {
   capabilities: AgentActivitySessionCapabilities | null | undefined;
   record: PromptQueueRecord;
 }): PendingSendNowResolution {
-  const head = input.record.prompts[0];
-  const pending = head
-    ? input.record.pendingSendNowByPromptId?.[head.id]
-    : undefined;
+  if (
+    input.record.inFlight ||
+    input.record.uncertainDelivery ||
+    input.record.sendNextPromptId ||
+    input.record.prompts[0]?.guidance === true
+  ) {
+    return { kind: "continue", record: input.record };
+  }
+  const pending = input.record.prompts
+    .map((prompt) => input.record.pendingSendNowByPromptId?.[prompt.id])
+    .find((candidate) => candidate != null);
   if (!pending) {
     return { kind: "continue", record: input.record };
   }
   const activeTurnId = input.activeTurnId?.trim() ?? "";
   const targetsSameTurn =
     activeTurnId.length > 0 && activeTurnId === pending.targetTurnId;
-  if (
-    targetsSameTurn &&
-    input.availability.state === "blocked" &&
-    input.availability.reason === "active_turn" &&
-    input.capabilities == null
-  ) {
-    return { kind: "waiting" };
+  if (targetsSameTurn && input.availability.state === "blocked") {
+    if (
+      input.availability.reason !== "active_turn" ||
+      input.capabilities == null
+    ) {
+      return { kind: "waiting" };
+    }
   }
 
   const strategy = targetsSameTurn

--- a/packages/agent/activity-core/src/engine/promptQueue.record.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.record.ts
@@ -10,6 +10,7 @@ export function emptyQueueRecord(
     failedPromptId: null,
     failureMessage: null,
     inFlight: null,
+    pendingSendNowByPromptId: undefined,
     prompts: [],
     sendNextPromptId: null,
     suspendReason: null,

--- a/packages/agent/activity-core/src/engine/promptQueue.reducer.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.reducer.ts
@@ -1,12 +1,12 @@
 import type { AgentActivityMessage } from "../types.ts";
 import type {
   EngineCommand,
-  EngineCommandResultIntent,
   EngineIntent,
   EngineReducerResult
 } from "./types.ts";
 import type {
   PromptQueueIntent,
+  PromptQueuePendingSendNow,
   PromptQueueRecord,
   PromptQueueState
 } from "./promptQueue.types.ts";
@@ -42,15 +42,19 @@ import {
 import { canonicalTurnKey } from "./sessionEntityKeys.ts";
 import { promptVisibleInQueueAdmission } from "./promptQueue.admission.ts";
 import { affectedPromptQueueSessionIds } from "./promptQueue.affectedSessions.ts";
+import {
+  pendingSendNowFromSubmit,
+  resolvePendingSendNow,
+  setPendingSendNowForPrompt
+} from "./promptQueue.pendingSendNow.ts";
 import { queuedPromptFromSubmitIntent } from "./promptQueue.submit.ts";
 import {
   requestPromptExecution,
   settlePromptSettingsPrecondition
 } from "./promptQueue.precondition.ts";
-import {
-  queueOwnedReconcileCommand,
-  settleOwnedQueueReconcile
-} from "./promptQueue.ownedReconcile.ts";
+import { settleOwnedQueueReconcile } from "./promptQueue.ownedReconcile.ts";
+import { isPreTurnSendFailure } from "./promptSendFailure.ts";
+import { settleQueueCommand } from "./promptQueue.settle.ts";
 import type { RootEngineReducerResult } from "./rootReducer.types.ts";
 
 const NO_COMMANDS: readonly EngineCommand[] = [];
@@ -115,13 +119,20 @@ function reduceQueueOwnedState(
       }
       if (intent.routing === "send_now") {
         if (!context.sendNowStrategy) return unchanged(state);
+        const targetTurnId =
+          intent.targetTurnId ??
+          activeTurnIdForSession(context.lifecycle, intent.agentSessionId);
         return requestQueuedPromptSendNow(
           enqueueSubmit(state, intent, context.lifecycle).state,
           intent.agentSessionId,
           intent.clientSubmitId,
           context.sendNowStrategy,
-          intent.targetTurnId ??
-            activeTurnIdForSession(context.lifecycle, intent.agentSessionId)
+          targetTurnId,
+          pendingSendNowFromSubmit(
+            intent,
+            context.sendNowStrategy,
+            targetTurnId
+          )
         );
       }
       return enqueueSubmit(state, intent, context.lifecycle);
@@ -154,12 +165,26 @@ function reduceQueueOwnedState(
       ) {
         return unchanged(state);
       }
+      const activeTurnId = activeTurnIdForSession(
+        context.lifecycle,
+        intent.agentSessionId
+      );
+      const targetTurnId = intent.targetTurnId?.trim() || activeTurnId;
       return requestQueuedPromptSendNow(
         state,
         intent.agentSessionId,
         intent.promptId,
         context.sendNowStrategy,
-        activeTurnIdForSession(context.lifecycle, intent.agentSessionId)
+        targetTurnId,
+        context.sendNowStrategy === "await_capabilities" && targetTurnId
+          ? {
+              awaitingTurnExpiresAtUnixMs: intent.awaitingTurnExpiresAtUnixMs,
+              cancelCommandId: intent.cancelCommandId,
+              promptId: intent.promptId,
+              targetTurnId,
+              timeoutMs: intent.timeoutMs
+            }
+          : null
       );
     case "queue/suspended":
       return suspendQueue(state, intent.agentSessionId, intent.reason);
@@ -307,6 +332,11 @@ function removePrompt(
     failureMessage:
       current.failedPromptId === promptId ? null : current.failureMessage,
     prompts: current.prompts.filter((prompt) => prompt.id !== promptId),
+    pendingSendNowByPromptId: setPendingSendNowForPrompt(
+      current.pendingSendNowByPromptId,
+      promptId,
+      null
+    ),
     sendNextPromptId:
       current.sendNextPromptId === promptId ? null : current.sendNextPromptId
   });
@@ -322,7 +352,8 @@ function requestQueuedPromptSendNow(
   rawAgentSessionId: string,
   rawPromptId: string,
   strategy: PromptQueueSendNowStrategy,
-  targetTurnId?: string
+  targetTurnId?: string,
+  pendingSendNow: PromptQueuePendingSendNow | null = null
 ): EngineReducerResult<PromptQueueState> {
   const agentSessionId = rawAgentSessionId.trim();
   const promptId = rawPromptId.trim();
@@ -353,6 +384,11 @@ function requestQueuedPromptSendNow(
         current.failedPromptId === promptId ? null : current.failedPromptId,
       failureMessage:
         current.failedPromptId === promptId ? null : current.failureMessage,
+      pendingSendNowByPromptId: setPendingSendNowForPrompt(
+        current.pendingSendNowByPromptId,
+        promptId,
+        strategy === "await_capabilities" ? pendingSendNow : null
+      ),
       prompts,
       sendNextPromptId: strategy === "cancel_then_send" ? promptId : null,
       suspendReason: null
@@ -395,143 +431,6 @@ function resumeQueue(
       );
 }
 
-function settleQueueCommand(
-  state: PromptQueueState,
-  intent: EngineCommandResultIntent,
-  validation: SendInputResultValidation | null
-): EngineReducerResult<PromptQueueState> {
-  const entry = Object.entries(state.recordsBySessionId).find(
-    ([, record]) => record.inFlight?.commandId === intent.commandId
-  );
-  if (!entry) return unchanged(state);
-  const [agentSessionId, current] = entry;
-  const inFlight = current.inFlight!;
-  if (intent.outcome === "succeeded" && validation?.kind === "valid") {
-    const deliveryBarrierTurnId =
-      validation.result.kind === "goalControl"
-        ? null
-        : validation.result.turnId;
-    const record = compactQueueRecord({
-      ...current,
-      deliveryBarrierTurnId,
-      failedPromptId: null,
-      failureMessage: null,
-      inFlight: null,
-      prompts: current.prompts.filter(
-        (prompt) => prompt.id !== inFlight.promptId
-      ),
-      sendNextPromptId:
-        current.sendNextPromptId === inFlight.promptId
-          ? null
-          : current.sendNextPromptId
-    });
-    return result(
-      record
-        ? replaceRecord(state, agentSessionId, record)
-        : deleteRecord(state, agentSessionId)
-    );
-  }
-  if (intent.outcome === "timedOut" || intent.outcome === "succeeded") {
-    const record = {
-      ...current,
-      failedPromptId: inFlight.promptId,
-      failureMessage: null,
-      inFlight: null,
-      uncertainDelivery: inFlight
-    };
-    return {
-      commands: [
-        queueOwnedReconcileCommand(agentSessionId, current.workspaceId, intent)
-      ],
-      state: replaceRecord(state, agentSessionId, record)
-    };
-  }
-  if (isPreTurnSendFailure(intent)) {
-    const nextState =
-      current.prompts.find((prompt) => prompt.id === inFlight.promptId)
-        ?.visibleInQueue === false
-        ? removeHiddenFailedPrompt(
-            state,
-            agentSessionId,
-            current,
-            inFlight.promptId
-          )
-        : replaceRecord(state, agentSessionId, {
-            ...current,
-            failedPromptId: null,
-            failureMessage: null,
-            inFlight: null
-          });
-    return {
-      commands: [
-        queueOwnedReconcileCommand(agentSessionId, current.workspaceId, intent)
-      ],
-      state: nextState
-    };
-  }
-  if (
-    current.prompts.find((prompt) => prompt.id === inFlight.promptId)
-      ?.visibleInQueue === false
-  ) {
-    return result(
-      removeHiddenFailedPrompt(
-        state,
-        agentSessionId,
-        current,
-        inFlight.promptId
-      )
-    );
-  }
-  return result(
-    replaceRecord(state, agentSessionId, {
-      ...current,
-      failedPromptId: inFlight.promptId,
-      failureMessage: intent.errorMessage?.trim() || null,
-      inFlight: null
-    })
-  );
-}
-
-function removeHiddenFailedPrompt(
-  state: PromptQueueState,
-  agentSessionId: string,
-  current: PromptQueueRecord,
-  promptId: string
-): PromptQueueState {
-  const record = compactQueueRecord({
-    ...current,
-    failedPromptId:
-      current.failedPromptId === promptId ? null : current.failedPromptId,
-    failureMessage:
-      current.failedPromptId === promptId ? null : current.failureMessage,
-    inFlight: null,
-    prompts: current.prompts.filter((prompt) => prompt.id !== promptId)
-  });
-  return record
-    ? replaceRecord(state, agentSessionId, record)
-    : deleteRecord(state, agentSessionId);
-}
-
-function isPreTurnSendFailure(intent: EngineIntent): boolean {
-  if (
-    intent.type !== "engine/commandResult" ||
-    intent.commandType !== "queue/sendPrompt" ||
-    intent.outcome !== "failed"
-  ) {
-    return false;
-  }
-  const errorReason = intent.errorReason?.trim();
-  const errorCode = intent.errorCode?.trim();
-  return (
-    errorReason === "agent.no_active_turn" ||
-    errorCode === "agent.no_active_turn" ||
-    errorReason === "agent.session_no_active_turn" ||
-    errorCode === "agent.session_no_active_turn" ||
-    errorReason === "agent.process_cleanup_pending" ||
-    errorCode === "agent.process_cleanup_pending"
-  );
-}
-
 function confirmDeliveredPrompts(
   state: PromptQueueState,
   messages: readonly AgentActivityMessage[]
@@ -561,6 +460,11 @@ function confirmDeliveredPrompts(
       inFlight:
         current.inFlight?.promptId === matched.id ? null : current.inFlight,
       prompts: current.prompts.filter((prompt) => prompt.id !== matched.id),
+      pendingSendNowByPromptId: setPendingSendNowForPrompt(
+        current.pendingSendNowByPromptId,
+        matched.id,
+        null
+      ),
       sendNextPromptId:
         current.sendNextPromptId === matched.id
           ? null
@@ -661,6 +565,26 @@ function drainSession(
     lifecycle,
     agentSessionId
   );
+  const pendingResolution = resolvePendingSendNow({
+    activeTurnId: activeTurnIdForSession(lifecycle, agentSessionId),
+    availability,
+    capabilities: lifecycle.sessionsById[agentSessionId]?.capabilities,
+    record
+  });
+  if (pendingResolution.kind === "waiting") {
+    return state === originalState ? unchanged(state) : result(state);
+  }
+  if (pendingResolution.record !== record) {
+    record = pendingResolution.record;
+    state = replaceRecord(state, agentSessionId, record);
+  }
+  if (pendingResolution.kind === "request") {
+    return {
+      commands: NO_COMMANDS,
+      followUpIntents: [pendingResolution.intent],
+      state
+    };
+  }
   // The guidance flag was resolved when the prompt entered the queue; whether
   // it can steer is decided here, against the availability observed at drain
   // time. A prompt queued as guidance behind a turn that has since settled is

--- a/packages/agent/activity-core/src/engine/promptQueue.reducer.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.reducer.ts
@@ -368,15 +368,21 @@ function requestQueuedPromptSendNow(
   const selectedWithoutGuidance = { ...selected! };
   delete selectedWithoutGuidance.guidance;
   delete selectedWithoutGuidance.targetTurnId;
-  prompts.unshift(
-    strategy === "native_guidance"
-      ? {
-          ...selectedWithoutGuidance,
-          guidance: true,
-          ...(targetTurnId?.trim() ? { targetTurnId: targetTurnId.trim() } : {})
-        }
-      : selectedWithoutGuidance
-  );
+  if (strategy === "await_capabilities") {
+    prompts.splice(index, 0, selectedWithoutGuidance);
+  } else {
+    prompts.unshift(
+      strategy === "native_guidance"
+        ? {
+            ...selectedWithoutGuidance,
+            guidance: true,
+            ...(targetTurnId?.trim()
+              ? { targetTurnId: targetTurnId.trim() }
+              : {})
+          }
+        : selectedWithoutGuidance
+    );
+  }
   return result(
     replaceRecord(state, agentSessionId, {
       ...current,

--- a/packages/agent/activity-core/src/engine/promptQueue.sendNow.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.sendNow.ts
@@ -4,7 +4,8 @@ import type { PromptQueueState } from "./promptQueue.types.ts";
 export type PromptQueueSendNowStrategy =
   | "send_available"
   | "native_guidance"
-  | "cancel_then_send";
+  | "cancel_then_send"
+  | "await_capabilities";
 
 interface ActiveTurnDeliveryCapabilities {
   activeTurnGuidance?: boolean;
@@ -38,6 +39,9 @@ export function resolvePromptSendNowStrategy(
     availability.reason !== "active_turn"
   ) {
     return null;
+  }
+  if (capabilities == null) {
+    return "await_capabilities";
   }
   if (capabilities?.activeTurnGuidance === true) {
     return "native_guidance";

--- a/packages/agent/activity-core/src/engine/promptQueue.settle.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.settle.ts
@@ -1,0 +1,180 @@
+import type { SendInputResultValidation } from "./commandResult.validation.ts";
+import { isPreTurnSendFailure } from "./promptSendFailure.ts";
+import { queueOwnedReconcileCommand } from "./promptQueue.ownedReconcile.ts";
+import { setPendingSendNowForPrompt } from "./promptQueue.pendingSendNow.ts";
+import { compactQueueRecord } from "./promptQueue.record.ts";
+import type {
+  PromptQueueRecord,
+  PromptQueueState
+} from "./promptQueue.types.ts";
+import type {
+  EngineCommand,
+  EngineCommandResultIntent,
+  EngineReducerResult
+} from "./types.ts";
+
+const NO_COMMANDS: readonly EngineCommand[] = [];
+
+export function settleQueueCommand(
+  state: PromptQueueState,
+  intent: EngineCommandResultIntent,
+  validation: SendInputResultValidation | null
+): EngineReducerResult<PromptQueueState> {
+  const entry = Object.entries(state.recordsBySessionId).find(
+    ([, record]) => record.inFlight?.commandId === intent.commandId
+  );
+  if (!entry) return unchanged(state);
+  const [agentSessionId, current] = entry;
+  const inFlight = current.inFlight!;
+  if (intent.outcome === "succeeded" && validation?.kind === "valid") {
+    const deliveryBarrierTurnId =
+      validation.result.kind === "goalControl"
+        ? null
+        : validation.result.turnId;
+    const record = compactQueueRecord({
+      ...current,
+      deliveryBarrierTurnId,
+      failedPromptId: null,
+      failureMessage: null,
+      inFlight: null,
+      prompts: current.prompts.filter(
+        (prompt) => prompt.id !== inFlight.promptId
+      ),
+      pendingSendNowByPromptId: setPendingSendNowForPrompt(
+        current.pendingSendNowByPromptId,
+        inFlight.promptId,
+        null
+      ),
+      sendNextPromptId:
+        current.sendNextPromptId === inFlight.promptId
+          ? null
+          : current.sendNextPromptId
+    });
+    return result(
+      record
+        ? replaceRecord(state, agentSessionId, record)
+        : deleteRecord(state, agentSessionId)
+    );
+  }
+  if (intent.outcome === "timedOut" || intent.outcome === "succeeded") {
+    const record = {
+      ...current,
+      failedPromptId: inFlight.promptId,
+      failureMessage: null,
+      inFlight: null,
+      uncertainDelivery: inFlight
+    };
+    return {
+      commands: [
+        queueOwnedReconcileCommand(agentSessionId, current.workspaceId, intent)
+      ],
+      state: replaceRecord(state, agentSessionId, record)
+    };
+  }
+  if (isPreTurnSendFailure(intent)) {
+    const nextState =
+      current.prompts.find((prompt) => prompt.id === inFlight.promptId)
+        ?.visibleInQueue === false
+        ? removeHiddenFailedPrompt(
+            state,
+            agentSessionId,
+            current,
+            inFlight.promptId
+          )
+        : replaceRecord(state, agentSessionId, {
+            ...current,
+            failedPromptId: null,
+            failureMessage: null,
+            inFlight: null
+          });
+    return {
+      commands: [
+        queueOwnedReconcileCommand(agentSessionId, current.workspaceId, intent)
+      ],
+      state: nextState
+    };
+  }
+  if (
+    current.prompts.find((prompt) => prompt.id === inFlight.promptId)
+      ?.visibleInQueue === false
+  ) {
+    return result(
+      removeHiddenFailedPrompt(
+        state,
+        agentSessionId,
+        current,
+        inFlight.promptId
+      )
+    );
+  }
+  return result(
+    replaceRecord(state, agentSessionId, {
+      ...current,
+      failedPromptId: inFlight.promptId,
+      failureMessage: intent.errorMessage?.trim() || null,
+      inFlight: null
+    })
+  );
+}
+
+function removeHiddenFailedPrompt(
+  state: PromptQueueState,
+  agentSessionId: string,
+  current: PromptQueueRecord,
+  promptId: string
+): PromptQueueState {
+  const record = compactQueueRecord({
+    ...current,
+    failedPromptId:
+      current.failedPromptId === promptId ? null : current.failedPromptId,
+    failureMessage:
+      current.failedPromptId === promptId ? null : current.failureMessage,
+    inFlight: null,
+    pendingSendNowByPromptId: setPendingSendNowForPrompt(
+      current.pendingSendNowByPromptId,
+      promptId,
+      null
+    ),
+    prompts: current.prompts.filter((prompt) => prompt.id !== promptId),
+    sendNextPromptId:
+      current.sendNextPromptId === promptId ? null : current.sendNextPromptId
+  });
+  return record
+    ? replaceRecord(state, agentSessionId, record)
+    : deleteRecord(state, agentSessionId);
+}
+
+function replaceRecord(
+  state: PromptQueueState,
+  agentSessionId: string,
+  record: PromptQueueRecord
+): PromptQueueState {
+  return {
+    ...state,
+    recordsBySessionId: {
+      ...state.recordsBySessionId,
+      [agentSessionId]: record
+    }
+  };
+}
+
+function deleteRecord(
+  state: PromptQueueState,
+  agentSessionId: string
+): PromptQueueState {
+  const records = { ...state.recordsBySessionId };
+  delete records[agentSessionId];
+  return { ...state, recordsBySessionId: records };
+}
+
+function result(
+  state: PromptQueueState
+): EngineReducerResult<PromptQueueState> {
+  return { commands: NO_COMMANDS, state };
+}
+
+function unchanged(
+  state: PromptQueueState
+): EngineReducerResult<PromptQueueState> {
+  return { commands: NO_COMMANDS, state };
+}

--- a/packages/agent/activity-core/src/engine/promptQueue.types.ts
+++ b/packages/agent/activity-core/src/engine/promptQueue.types.ts
@@ -33,12 +33,24 @@ export interface PromptQueueInFlightCommand {
   stage?: "preparingSettings" | "sending";
 }
 
+export interface PromptQueuePendingSendNow {
+  awaitingTurnExpiresAtUnixMs: number;
+  cancelCommandId: string;
+  promptId: string;
+  targetTurnId: string;
+  timeoutMs: number;
+}
+
 export interface PromptQueueRecord {
   agentSessionId: string;
   deliveryBarrierTurnId: string | null;
   failedPromptId: string | null;
   failureMessage: string | null;
   inFlight: PromptQueueInFlightCommand | null;
+  /** Omitted by snapshots produced before deferred send-now admission existed. */
+  pendingSendNowByPromptId?: Readonly<
+    Record<string, PromptQueuePendingSendNow>
+  >;
   prompts: readonly EngineQueuedPrompt[];
   sendNextPromptId: string | null;
   suspendReason: PromptQueueSuspendReason | null;
@@ -69,6 +81,8 @@ export interface PromptQueueSendNowRequestedIntent {
   agentSessionId: string;
   cancelCommandId: string;
   promptId: string;
+  /** Exact active Turn observed when this deferred intent was admitted. */
+  targetTurnId?: string;
   awaitingTurnExpiresAtUnixMs: number;
   timeoutMs: number;
 }

--- a/packages/agent/activity-core/src/engine/promptSendFailure.ts
+++ b/packages/agent/activity-core/src/engine/promptSendFailure.ts
@@ -1,0 +1,21 @@
+import type { EngineIntent } from "./types.ts";
+
+export function isPreTurnSendFailure(intent: EngineIntent): boolean {
+  if (
+    intent.type !== "engine/commandResult" ||
+    intent.commandType !== "queue/sendPrompt" ||
+    intent.outcome !== "failed"
+  ) {
+    return false;
+  }
+  const errorReason = intent.errorReason?.trim();
+  const errorCode = intent.errorCode?.trim();
+  return (
+    errorReason === "agent.no_active_turn" ||
+    errorCode === "agent.no_active_turn" ||
+    errorReason === "agent.session_no_active_turn" ||
+    errorCode === "agent.session_no_active_turn" ||
+    errorReason === "agent.process_cleanup_pending" ||
+    errorCode === "agent.process_cleanup_pending"
+  );
+}

--- a/packages/agent/activity-core/src/engine/rootReducer.ts
+++ b/packages/agent/activity-core/src/engine/rootReducer.ts
@@ -63,6 +63,7 @@ import {
 } from "./composerOptions.reducer.ts";
 import { canonicalTurnKey } from "./sessionEntityKeys.ts";
 import { deriveCanonicalSubmitAvailability } from "./sessionLifecycle.availability.ts";
+import { activeTurnIdForSession } from "./promptQueue.drainDecision.ts";
 import {
   createInitialSessionMutationsState,
   sessionMutationsReducer
@@ -300,21 +301,35 @@ export function rootEngineReducer(
     planTurnValid &&
     submitRequestAccepted
   );
+  const queuedSendNowTargetTurnId =
+    intent.type === "queue/sendNowRequested"
+      ? (intent.targetTurnId?.trim() ?? "")
+      : "";
+  const queuedSendNowCurrentTurnId =
+    intent.type === "queue/sendNowRequested"
+      ? (activeTurnIdForSession(
+          state.sessionLifecycle,
+          intent.agentSessionId
+        ) ?? "")
+      : "";
   const sendNowStrategy =
     intent.type === "submit/requested" && intent.routing === "send_now"
       ? submitSendNowStrategy
       : intent.type === "queue/sendNowRequested"
-        ? resolveQueuedPromptSendNowStrategy(
-            state.promptQueue,
-            intent.agentSessionId,
-            intent.promptId,
-            deriveCanonicalSubmitAvailability(
-              state.sessionLifecycle,
-              intent.agentSessionId
-            ),
-            state.sessionLifecycle.sessionsById[intent.agentSessionId.trim()]
-              ?.capabilities
-          )
+        ? queuedSendNowTargetTurnId &&
+          queuedSendNowTargetTurnId !== queuedSendNowCurrentTurnId
+          ? "send_available"
+          : resolveQueuedPromptSendNowStrategy(
+              state.promptQueue,
+              intent.agentSessionId,
+              intent.promptId,
+              deriveCanonicalSubmitAvailability(
+                state.sessionLifecycle,
+                intent.agentSessionId
+              ),
+              state.sessionLifecycle.sessionsById[intent.agentSessionId.trim()]
+                ?.capabilities
+            )
         : null;
   const expiringSubmitId =
     intent.type === "engine/intentExpired" &&

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.cancel.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.cancel.ts
@@ -10,7 +10,7 @@ import {
 } from "./sessionLifecycle.state.ts";
 
 const NO_COMMANDS: readonly EngineCommand[] = [];
-const TURN_CANCEL_TIMEOUT_MS = 30_000;
+export const TURN_CANCEL_TIMEOUT_MS = 30_000;
 
 export function reconcilePendingCancels(
   previous: SessionLifecycleState,

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.ts
@@ -45,10 +45,11 @@ import {
   reconcilePendingCancelForSubmit,
   reconcilePendingCancelFromMessages,
   reconcilePendingCancels,
-  sessionVersion
+  sessionVersion,
+  TURN_CANCEL_TIMEOUT_MS
 } from "./sessionLifecycle.cancel.ts";
+import { isPreTurnSendFailure } from "./promptSendFailure.ts";
 const NO_COMMANDS: readonly EngineCommand[] = [];
-const TURN_CANCEL_TIMEOUT_MS = 30_000;
 const STALE_INTERACTIVE_REQUEST_ERROR_REASON =
   "agent_interactive_request_stale";
 
@@ -275,26 +276,6 @@ export function sessionLifecycleReducer(
     default:
       return unchanged(state);
   }
-}
-
-function isPreTurnSendFailure(intent: EngineIntent): boolean {
-  if (
-    intent.type !== "engine/commandResult" ||
-    intent.commandType !== "queue/sendPrompt" ||
-    intent.outcome !== "failed"
-  ) {
-    return false;
-  }
-  const errorReason = intent.errorReason?.trim();
-  const errorCode = intent.errorCode?.trim();
-  return (
-    errorReason === "agent.no_active_turn" ||
-    errorCode === "agent.no_active_turn" ||
-    errorReason === "agent.session_no_active_turn" ||
-    errorCode === "agent.session_no_active_turn" ||
-    errorReason === "agent.process_cleanup_pending" ||
-    errorCode === "agent.process_cleanup_pending"
-  );
 }
 
 function abandonPendingSubmitCancel(

--- a/packages/agent/activity-core/src/engine/sessionPrompt.semantic.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionPrompt.semantic.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { normalizeAgentActivitySession } from "../sessionNormalization.ts";
-import type { AgentActivityTurn } from "../types.ts";
+import type {
+  AgentActivitySessionCapabilities,
+  AgentActivityTurn
+} from "../types.ts";
 import { createAgentSessionEngine } from "./createAgentSessionEngine.ts";
 import { createTestEngineCommandPort } from "./testEngineCommandPort.ts";
 import type {
@@ -126,6 +129,300 @@ test("semantic prompt submission reports visible queue admission for a busy Sess
   );
 });
 
+test("send-now retains the prompt until authoritative guidance capabilities arrive", () => {
+  const harness = createHarness(true);
+
+  const result = harness.engine.submitPrompt({
+    agentSessionId: "session-1",
+    clientSubmitId: "submit-guidance",
+    content: [{ text: "steer when ready", type: "text" }],
+    routing: "send_now"
+  });
+
+  assert.deepEqual(result, { accepted: true, queued: true });
+  assert.equal(harness.commands.length, 0);
+
+  const capabilitySnapshot = {
+    sessions: [
+      sessionWithCapabilities(
+        activeTurn(),
+        capabilities({ activeTurnGuidance: true })
+      )
+    ],
+    type: "session/snapshotReceived" as const
+  };
+  harness.engine.dispatch(capabilitySnapshot);
+  harness.engine.dispatch(capabilitySnapshot);
+
+  assert.deepEqual(harness.commands, [
+    {
+      agentSessionId: "session-1",
+      clientSubmitId: "submit-guidance",
+      commandId: "queue:send:session-1:1",
+      content: [{ text: "steer when ready", type: "text" }],
+      correlationId: "submit-guidance",
+      guidance: true,
+      promptId: "submit-guidance",
+      submitDiagnostics: {
+        blockCount: 1,
+        queued: true,
+        submittedAtUnixMs: 100
+      },
+      targetTurnId: "turn-1",
+      timeoutMs: 90_000,
+      type: "queue/sendPrompt",
+      workspaceId: "workspace-1"
+    }
+  ]);
+});
+
+test("send-now retains the prompt until authoritative interrupt capability arrives", () => {
+  const harness = createHarness(true);
+
+  const result = harness.engine.submitPrompt({
+    agentSessionId: "session-1",
+    clientSubmitId: "submit-interrupt",
+    content: [{ text: "interrupt when ready", type: "text" }],
+    routing: "send_now"
+  });
+
+  assert.deepEqual(result, { accepted: true, queued: true });
+  assert.equal(harness.commands.length, 0);
+
+  harness.engine.dispatch({
+    sessions: [
+      sessionWithCapabilities(activeTurn(), capabilities({ interrupt: true }))
+    ],
+    type: "session/snapshotReceived"
+  });
+
+  assert.deepEqual(harness.commands, [
+    {
+      agentSessionId: "session-1",
+      commandId: "submit:cancel:submit-interrupt",
+      timeoutMs: 30_000,
+      turnId: "turn-1",
+      type: "turn/cancel",
+      workspaceId: "workspace-1"
+    }
+  ]);
+  assert.equal(
+    harness.engine.getSnapshot().promptQueue.recordsBySessionId["session-1"]
+      ?.sendNextPromptId,
+    "submit-interrupt"
+  );
+});
+
+test("send-now stays queued when authoritative capabilities do not support active-turn delivery", () => {
+  const harness = createHarness(true);
+
+  const result = harness.engine.submitPrompt({
+    agentSessionId: "session-1",
+    clientSubmitId: "submit-queued",
+    content: [{ text: "send after the turn", type: "text" }],
+    routing: "send_now"
+  });
+
+  assert.deepEqual(result, { accepted: true, queued: true });
+  harness.engine.dispatch({
+    sessions: [sessionWithCapabilities(activeTurn(), capabilities({}))],
+    type: "session/snapshotReceived"
+  });
+  assert.equal(harness.commands.length, 0);
+  assert.equal(
+    harness.engine.getSnapshot().promptQueue.recordsBySessionId["session-1"]
+      ?.prompts[0]?.clientSubmitId,
+    "submit-queued"
+  );
+
+  harness.engine.dispatch({
+    sessions: [
+      sessionWithCapabilities(
+        {
+          ...activeTurn(),
+          outcome: "completed",
+          phase: "settled",
+          settledAtUnixMs: 3,
+          updatedAtUnixMs: 3
+        },
+        capabilities({})
+      )
+    ],
+    type: "session/snapshotReceived"
+  });
+
+  const send = harness.commands.at(-1);
+  assert.equal(send?.type, "queue/sendPrompt");
+  assert.equal(
+    send?.type === "queue/sendPrompt" ? send.clientSubmitId : null,
+    "submit-queued"
+  );
+  assert.equal(
+    send?.type === "queue/sendPrompt" ? send.guidance : undefined,
+    undefined
+  );
+});
+
+test("send-now drains as a plain prompt when the active turn settles before capabilities arrive", () => {
+  const harness = createHarness(true);
+
+  const result = harness.engine.submitPrompt({
+    agentSessionId: "session-1",
+    clientSubmitId: "submit-after-settle",
+    content: [{ text: "send after settlement", type: "text" }],
+    routing: "send_now"
+  });
+
+  assert.deepEqual(result, { accepted: true, queued: true });
+  assert.equal(harness.commands.length, 0);
+
+  const settledTurn: AgentActivityTurn = {
+    ...activeTurn(),
+    outcome: "completed",
+    phase: "settled",
+    settledAtUnixMs: 3,
+    updatedAtUnixMs: 3
+  };
+  harness.engine.dispatch({
+    sessions: [
+      {
+        ...session(null),
+        latestTurn: settledTurn,
+        updatedAtUnixMs: settledTurn.updatedAtUnixMs
+      }
+    ],
+    type: "session/snapshotReceived"
+  });
+
+  assert.equal(harness.commands.length, 1);
+  const send = harness.commands[0];
+  assert.equal(send?.type, "queue/sendPrompt");
+  assert.equal(
+    send?.type === "queue/sendPrompt" ? send.clientSubmitId : null,
+    "submit-after-settle"
+  );
+  assert.equal(
+    send?.type === "queue/sendPrompt" ? send.guidance : undefined,
+    undefined
+  );
+});
+
+test("deferred send-now never targets a successor active turn", () => {
+  const harness = createHarness(true);
+  harness.engine.submitPrompt({
+    agentSessionId: "session-1",
+    clientSubmitId: "submit-for-turn-a",
+    content: [{ text: "only steer turn A", type: "text" }],
+    routing: "send_now"
+  });
+
+  const turnB: AgentActivityTurn = {
+    ...activeTurn(),
+    startedAtUnixMs: 3,
+    turnId: "turn-2",
+    updatedAtUnixMs: 4
+  };
+  harness.engine.dispatch({
+    sessions: [
+      sessionWithCapabilities(
+        turnB,
+        capabilities({ activeTurnGuidance: true, interrupt: true })
+      )
+    ],
+    type: "session/snapshotReceived"
+  });
+
+  assert.equal(harness.commands.length, 0);
+  const waiting =
+    harness.engine.getSnapshot().promptQueue.recordsBySessionId["session-1"];
+  assert.deepEqual(waiting?.pendingSendNowByPromptId, undefined);
+  assert.equal(waiting?.prompts[0]?.guidance, undefined);
+
+  harness.engine.dispatch({
+    sessions: [
+      sessionWithCapabilities(
+        {
+          ...turnB,
+          outcome: "completed",
+          phase: "settled",
+          settledAtUnixMs: 5,
+          updatedAtUnixMs: 5
+        },
+        capabilities({ activeTurnGuidance: true, interrupt: true })
+      )
+    ],
+    type: "session/snapshotReceived"
+  });
+
+  assert.equal(harness.commands.length, 1);
+  const send = harness.commands[0];
+  assert.equal(send?.type, "queue/sendPrompt");
+  assert.equal(
+    send?.type === "queue/sendPrompt" ? send.clientSubmitId : null,
+    "submit-for-turn-a"
+  );
+  assert.equal(
+    send?.type === "queue/sendPrompt" ? send.guidance : undefined,
+    undefined
+  );
+});
+
+test("consecutive deferred send-now prompts retain independent decisions", () => {
+  const scenarios = [
+    {
+      capabilities: capabilities({ activeTurnGuidance: true }),
+      commandType: "queue/sendPrompt",
+      name: "guidance"
+    },
+    {
+      capabilities: capabilities({ interrupt: true }),
+      commandType: "turn/cancel",
+      name: "interrupt"
+    },
+    {
+      capabilities: capabilities({}),
+      commandType: null,
+      name: "unsupported"
+    }
+  ] as const;
+
+  for (const scenario of scenarios) {
+    const harness = createHarness(true);
+    for (const id of ["first", "second"] as const) {
+      const result = harness.engine.submitPrompt({
+        agentSessionId: "session-1",
+        clientSubmitId: `${scenario.name}-${id}`,
+        content: [{ text: `${scenario.name} ${id}`, type: "text" }],
+        routing: "send_now"
+      });
+      assert.deepEqual(result, { accepted: true, queued: true });
+    }
+
+    const before =
+      harness.engine.getSnapshot().promptQueue.recordsBySessionId["session-1"];
+    assert.deepEqual(
+      Object.keys(before?.pendingSendNowByPromptId ?? {}).sort(),
+      [`${scenario.name}-first`, `${scenario.name}-second`]
+    );
+    assert.deepEqual(
+      before?.prompts.map((prompt) => prompt.id),
+      [`${scenario.name}-second`, `${scenario.name}-first`]
+    );
+
+    harness.engine.dispatch({
+      sessions: [sessionWithCapabilities(activeTurn(), scenario.capabilities)],
+      type: "session/snapshotReceived"
+    });
+
+    assert.equal(harness.commands[0]?.type ?? null, scenario.commandType);
+    const after =
+      harness.engine.getSnapshot().promptQueue.recordsBySessionId["session-1"];
+    assert.deepEqual(Object.keys(after?.pendingSendNowByPromptId ?? {}), [
+      `${scenario.name}-first`
+    ]);
+  }
+});
+
 test("semantic prompt submission rejects an invalid identity without side effects", () => {
   const harness = createHarness(false);
 
@@ -164,4 +461,46 @@ function session(turn: AgentActivityTurn | null) {
     title: "Session",
     workspaceId: "workspace-1"
   });
+}
+
+function sessionWithCapabilities(
+  turn: AgentActivityTurn,
+  sessionCapabilities: AgentActivitySessionCapabilities
+) {
+  const activeTurn = turn.phase === "settled" ? null : turn;
+  return {
+    ...session(activeTurn),
+    activeTurn,
+    activeTurnId: activeTurn?.turnId ?? null,
+    capabilities: sessionCapabilities,
+    latestTurn: turn,
+    updatedAtUnixMs: turn.updatedAtUnixMs
+  };
+}
+
+function capabilities(
+  overrides: Partial<AgentActivitySessionCapabilities>
+): AgentActivitySessionCapabilities {
+  return {
+    activeTurnGuidance: false,
+    browserUse: false,
+    compact: false,
+    computerUse: false,
+    goalPause: false,
+    imageInput: false,
+    interrupt: false,
+    modelImageInputRequired: false,
+    modelPlanBinding: false,
+    modelSwitch: false,
+    permissionModeChangeDeferred: false,
+    permissionModeChangeDuringTurn: false,
+    planImplementation: false,
+    planMode: false,
+    rateLimits: false,
+    resumeRunningTurn: false,
+    review: false,
+    skills: false,
+    tokenUsage: false,
+    ...overrides
+  };
 }

--- a/packages/agent/activity-core/src/engine/sessionPrompt.semantic.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionPrompt.semantic.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { normalizeAgentActivitySession } from "../sessionNormalization.ts";
 import type {
+  AgentActivityInteraction,
   AgentActivitySessionCapabilities,
   AgentActivityTurn
 } from "../types.ts";
@@ -263,6 +264,92 @@ test("send-now stays queued when authoritative capabilities do not support activ
   );
 });
 
+test("deferred send-now survives a temporary interaction blocker for the same turn", () => {
+  const harness = createHarness(true);
+  harness.engine.submitPrompt({
+    agentSessionId: "session-1",
+    clientSubmitId: "submit-after-approval",
+    content: [{ text: "steer after approval", type: "text" }],
+    routing: "send_now"
+  });
+  const pendingInteraction: AgentActivityInteraction = {
+    agentSessionId: "session-1",
+    createdAtUnixMs: 3,
+    kind: "approval",
+    requestId: "approval-1",
+    status: "pending",
+    turnId: "turn-1",
+    updatedAtUnixMs: 3
+  };
+  const blockedSession = {
+    ...sessionWithCapabilities(
+      activeTurn(),
+      capabilities({ activeTurnGuidance: true })
+    ),
+    latestTurnInteractions: [pendingInteraction],
+    pendingInteractions: [pendingInteraction]
+  };
+
+  harness.engine.dispatch({
+    sessions: [blockedSession],
+    type: "session/snapshotReceived"
+  });
+
+  assert.equal(harness.commands.length, 0);
+  assert.ok(
+    harness.engine.getSnapshot().promptQueue.recordsBySessionId["session-1"]
+      ?.pendingSendNowByPromptId?.["submit-after-approval"]
+  );
+
+  harness.engine.dispatch({
+    interaction: {
+      ...pendingInteraction,
+      status: "answered",
+      updatedAtUnixMs: 4
+    },
+    type: "interaction/upserted"
+  });
+
+  const send = harness.commands.at(-1);
+  assert.equal(send?.type, "queue/sendPrompt");
+  assert.equal(
+    send?.type === "queue/sendPrompt" ? send.clientSubmitId : null,
+    "submit-after-approval"
+  );
+  assert.equal(
+    send?.type === "queue/sendPrompt" ? send.targetTurnId : null,
+    "turn-1"
+  );
+});
+
+test("unsupported deferred send-now restores ordinary FIFO order", () => {
+  const harness = createHarness(true);
+  harness.engine.submitPrompt({
+    agentSessionId: "session-1",
+    clientSubmitId: "ordinary-first",
+    content: [{ text: "first", type: "text" }]
+  });
+  harness.engine.submitPrompt({
+    agentSessionId: "session-1",
+    clientSubmitId: "send-now-second",
+    content: [{ text: "second", type: "text" }],
+    routing: "send_now"
+  });
+
+  harness.engine.dispatch({
+    sessions: [sessionWithCapabilities(activeTurn(), capabilities({}))],
+    type: "session/snapshotReceived"
+  });
+
+  const queued =
+    harness.engine.getSnapshot().promptQueue.recordsBySessionId["session-1"];
+  assert.deepEqual(
+    queued?.prompts.map((prompt) => prompt.id),
+    ["ordinary-first", "send-now-second"]
+  );
+  assert.deepEqual(queued?.pendingSendNowByPromptId, undefined);
+});
+
 test("send-now drains as a plain prompt when the active turn settles before capabilities arrive", () => {
   const harness = createHarness(true);
 
@@ -406,7 +493,7 @@ test("consecutive deferred send-now prompts retain independent decisions", () =>
     );
     assert.deepEqual(
       before?.prompts.map((prompt) => prompt.id),
-      [`${scenario.name}-second`, `${scenario.name}-first`]
+      [`${scenario.name}-first`, `${scenario.name}-second`]
     );
 
     harness.engine.dispatch({
@@ -418,8 +505,12 @@ test("consecutive deferred send-now prompts retain independent decisions", () =>
     const after =
       harness.engine.getSnapshot().promptQueue.recordsBySessionId["session-1"];
     assert.deepEqual(Object.keys(after?.pendingSendNowByPromptId ?? {}), [
-      `${scenario.name}-first`
+      `${scenario.name}-second`
     ]);
+    const command = harness.commands[0];
+    if (command?.type === "queue/sendPrompt") {
+      assert.equal(command.clientSubmitId, `${scenario.name}-first`);
+    }
   }
 });
 


### PR DESCRIPTION
## Summary

- retain active-turn send-now prompts while session capabilities are unresolved
- bind deferred decisions to the exact prompt and target turn
- preserve intent across temporary interaction/transport blockers
- route supported requests in original submission order and degrade unsupported requests to ordinary FIFO
- preserve compatibility with older prompt queue snapshots

## Tests

- pnpm --filter @tutti-os/agent-activity-core test (508 passed)
- pnpm --filter @tutti-os/agent-activity-core typecheck
- pnpm check:agent-provider-strategy-boundaries
- pnpm check:changed (58/59 lanes passed; the unrelated services/tuttid Go lane reproduces the existing TestOpenCodeSlashCommandPolicyComesFromProviderDescriptor failure on current main)