### PR TITLE
feat(agent): inject connector routing updates into live session turns

### DIFF
--- a/packages/agent/daemon/hostadapter/runtime.go
+++ b/packages/agent/daemon/hostadapter/runtime.go
@@ -790,7 +790,16 @@ func runtimeExecInput(input host.RuntimeExecInput) agentruntime.ExecInput {
 		Metadata: cloneMap(input.Metadata), Guidance: input.Guidance,
 		HistoryReplacement:        input.HistoryReplacement,
 		RequireProviderAcceptance: input.RequireProviderAcceptance,
+		ConnectorRoutingUpdate:    cloneStringPointer(input.ConnectorRoutingUpdate),
 	}
+}
+
+func cloneStringPointer(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
 }
 
 func runtimeHistoryInput(input host.RuntimeHistoryInput) agentruntime.EffectiveHistoryInput {

--- a/packages/agent/daemon/runtime/controller_exec.go
+++ b/packages/agent/daemon/runtime/controller_exec.go
@@ -120,7 +120,10 @@ func (c *Controller) Exec(ctx context.Context, input ExecInput) (result ExecResu
 	if len(content) == 0 {
 		return ExecResult{}, fmt.Errorf("prompt is required")
 	}
-	providerContent := projectRuntimeConnectorPromptContent(content)
+	providerContent := prependConnectorRoutingUpdate(
+		projectRuntimeConnectorPromptContent(content),
+		input.ConnectorRoutingUpdate,
+	)
 	displayPrompt := strings.TrimSpace(input.DisplayPrompt)
 	if promptAdapter, ok := adapter.(PromptContentAdapter); ok {
 		if err := promptAdapter.ValidatePromptContent(session, providerContent); err != nil {

--- a/packages/agent/daemon/runtime/prompt_content.go
+++ b/packages/agent/daemon/runtime/prompt_content.go
@@ -235,6 +235,28 @@ func projectRuntimeConnectorPromptContent(content []PromptContentBlock) []Prompt
 	return append([]PromptContentBlock{{Type: "text", Text: instruction}}, providerContent...)
 }
 
+// prependConnectorRoutingUpdate renders a provider-only notice that the
+// connector alias index changed after this session's instructions were
+// materialized. Callers must keep the update out of canonical prompt content.
+func prependConnectorRoutingUpdate(content []PromptContentBlock, update *string) []PromptContentBlock {
+	if update == nil {
+		return content
+	}
+	var instruction string
+	if index := strings.TrimSpace(*update); index == "" {
+		instruction = fmt.Sprintf(
+			"Connector routing update: no Tutti connectors are currently available. This supersedes the connector alias index in earlier instructions. Confirm availability with `%s connector available --json` before invoking any connector.",
+			tuttiCLICommandName(),
+		)
+	} else {
+		instruction = fmt.Sprintf(
+			"Connector routing update: aliases `%s`. This supersedes the connector alias index in earlier instructions. On an alias or `连接器`/`connector`, run `%s connector available --json` to discover native interfaces; connectors absent from this index are no longer available.",
+			index, tuttiCLICommandName(),
+		)
+	}
+	return append([]PromptContentBlock{{Type: "text", Text: instruction}}, content...)
+}
+
 func validatePromptContentImagesForPreflight(content []PromptContentBlock) error {
 	return validatePromptContentImages(content, true)
 }

--- a/packages/agent/daemon/runtime/prompt_content_test.go
+++ b/packages/agent/daemon/runtime/prompt_content_test.go
@@ -104,6 +104,51 @@ func TestProjectRuntimeConnectorPromptContentUsesNativeInterfaces(t *testing.T) 
 	}
 }
 
+func TestPrependConnectorRoutingUpdateRendersProviderOnlyInstruction(t *testing.T) {
+	content := []PromptContentBlock{{Type: "text", Text: "check my calendar"}}
+	if got := prependConnectorRoutingUpdate(content, nil); len(got) != 1 || got[0].Text != "check my calendar" {
+		t.Fatalf("nil update projected content = %#v, want unchanged", got)
+	}
+
+	index := "calendar=Calendar|日历;github=GitHub"
+	updated := prependConnectorRoutingUpdate(content, &index)
+	if len(updated) != 2 || updated[0].Type != "text" {
+		t.Fatalf("updated content = %#v, want prepended instruction", updated)
+	}
+	if !strings.Contains(updated[0].Text, "Connector routing update") ||
+		!strings.Contains(updated[0].Text, index) ||
+		!strings.Contains(updated[0].Text, "supersedes the connector alias index") ||
+		!strings.Contains(updated[0].Text, "connector available --json") {
+		t.Fatalf("routing update instruction = %q", updated[0].Text)
+	}
+	if updated[1].Text != "check my calendar" {
+		t.Fatalf("user prompt = %#v, want preserved text", updated[1])
+	}
+
+	empty := "  "
+	drained := prependConnectorRoutingUpdate(content, &empty)
+	if len(drained) != 2 || !strings.Contains(drained[0].Text, "no Tutti connectors are currently available") {
+		t.Fatalf("empty index instruction = %#v", drained)
+	}
+}
+
+func TestConnectorRoutingUpdatePrecedesSelectedConnectorInstruction(t *testing.T) {
+	content := normalizeRuntimePromptContent([]PromptContentBlock{
+		{Type: "text", Text: "list my calendar events"},
+		{Type: "connector", ConnectorKey: "lark-cli"},
+	})
+	index := "lark-cli=Lark CLI|飞书"
+	projected := prependConnectorRoutingUpdate(projectRuntimeConnectorPromptContent(content), &index)
+	if len(projected) != 3 {
+		t.Fatalf("projected content = %#v, want update, selection, and user text", projected)
+	}
+	if !strings.Contains(projected[0].Text, "Connector routing update") ||
+		!strings.Contains(projected[1].Text, "Selected local connector(s): lark-cli") ||
+		projected[2].Text != "list my calendar events" {
+		t.Fatalf("projected order = %#v", projected)
+	}
+}
+
 func TestProviderPromptImageHTTPClientUsesSystemNetworkForReservedAddress(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/types.go
+++ b/packages/agent/daemon/runtime/types.go
@@ -219,6 +219,11 @@ type ExecInput struct {
 	InitialTitleBase                string
 	Metadata                        map[string]any
 	Guidance                        bool
+	// ConnectorRoutingUpdate carries the current connector alias index when it
+	// diverged from the index materialized into the session's instructions at
+	// preparation time. The controller renders it into provider-facing content
+	// only; canonical prompt content never includes it. Nil means no update.
+	ConnectorRoutingUpdate *string
 	// HistoryReplacement requires a fresh provider turn. It may not steer an
 	// active turn or reinterpret the edited text as a provider slash command.
 	// The provider's complete EffectiveHistoryAdapter seam always returns one

--- a/packages/agent/host/lifecycle.go
+++ b/packages/agent/host/lifecycle.go
@@ -637,6 +637,7 @@ func (h *Host) sendInputSerialized(
 			DisplayPrompt: displayPrompt, InitialTitle: initialTitle, InitialTitleBase: session.Title,
 			Guidance: input.Guidance, Metadata: cloneMap(metadata), TuttiModeSnapshot: input.TuttiModeSnapshot,
 			RequireProviderAcceptance: !input.Guidance,
+			ConnectorRoutingUpdate:    cloneStringPointer(input.ConnectorRoutingUpdate),
 		})
 	}()
 	recordProviderAcceptanceDiagnostics(ctx, execResult.ProviderDispatch)

--- a/packages/agent/host/lifecycle_values.go
+++ b/packages/agent/host/lifecycle_values.go
@@ -123,6 +123,14 @@ func valueBoolDefault(input *bool, fallback bool) bool {
 
 func boolPointer(value bool) *bool { return &value }
 
+func cloneStringPointer(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
 func firstMap(values ...map[string]any) map[string]any {
 	for _, value := range values {
 		if len(value) > 0 {

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -401,6 +401,11 @@ type RuntimeExecInput struct {
 	HistoryReplacement              bool
 	RequireProviderAcceptance       bool
 	TuttiModeSnapshot               *TuttiModeTurnSnapshot
+	// ConnectorRoutingUpdate carries the current connector alias index when it
+	// diverged from the index materialized into the session's instructions.
+	// The runtime renders it into provider-only content; canonical prompt
+	// content never includes it. Nil means the instructions are still current.
+	ConnectorRoutingUpdate *string
 }
 
 type CapabilityReference = storesqlite.CapabilityReference
@@ -694,6 +699,10 @@ type SendInput struct {
 	// overrides any legacy clientSubmitId value carried in Metadata.
 	ClientSubmitID string
 	Guidance       bool
+	// ConnectorRoutingUpdate is set by the service when the connector alias
+	// index changed after this session's instructions were prepared. See
+	// RuntimeExecInput.ConnectorRoutingUpdate.
+	ConnectorRoutingUpdate *string
 }
 
 type SubmitInteractiveInput struct {

--- a/packages/agent/runtimeprep/provider_skill.go
+++ b/packages/agent/runtimeprep/provider_skill.go
@@ -133,6 +133,13 @@ func renderRuntimeTemplate(name string, content string, input PrepareInput, repl
 	return rendered.String(), nil
 }
 
+// ConnectorRoutingIndex renders the bounded connector alias index. Session
+// preparation templates and turn-level routing updates share this projection
+// so both surfaces stay byte-identical for the same routing hints.
+func ConnectorRoutingIndex(hints []ConnectorRoutingHint) string {
+	return connectorRoutingIndex(hints)
+}
+
 func connectorRoutingIndex(hints []ConnectorRoutingHint) string {
 	if len(hints) == 0 {
 		return ""

--- a/packages/agent/runtimeprep/provider_skill_test.go
+++ b/packages/agent/runtimeprep/provider_skill_test.go
@@ -174,6 +174,9 @@ func TestConnectorRoutingIndexIsDeterministicDeduplicatedAndBounded(t *testing.T
 	if got != want {
 		t.Fatalf("connectorRoutingIndex() = %s, want %s", got, want)
 	}
+	if exported := ConnectorRoutingIndex(hints); exported != want {
+		t.Fatalf("ConnectorRoutingIndex() = %s, want internal rendering %s", exported, want)
+	}
 
 	large := make([]ConnectorRoutingHint, 0, 40)
 	for index := 0; index < 40; index++ {

--- a/services/tuttid/service/agent/connector_routing_baseline.go
+++ b/services/tuttid/service/agent/connector_routing_baseline.go
@@ -1,0 +1,68 @@
+package agent
+
+import (
+	"strings"
+	"sync"
+
+	runtimeprep "github.com/tutti-os/tutti/packages/agent/runtimeprep"
+)
+
+// connectorRoutingBaselines tracks, per prepared session, the connector alias
+// index that was materialized into the session's provider instructions. A
+// missing entry means the session was prepared without Connector enhancement,
+// so no turn-level routing update may be injected for it. Entries live in
+// memory only: after a daemon restart every session is re-prepared on resume,
+// which re-materializes a current index before the next turn is admitted.
+type connectorRoutingBaselines struct {
+	entries sync.Map // key -> rendered alias index (string)
+}
+
+func connectorRoutingBaselineKey(workspaceID, agentSessionID string) string {
+	return strings.TrimSpace(workspaceID) + "\x00" + strings.TrimSpace(agentSessionID)
+}
+
+func (b *connectorRoutingBaselines) record(workspaceID, agentSessionID, index string) {
+	b.entries.Store(connectorRoutingBaselineKey(workspaceID, agentSessionID), index)
+}
+
+func (b *connectorRoutingBaselines) clear(workspaceID, agentSessionID string) {
+	b.entries.Delete(connectorRoutingBaselineKey(workspaceID, agentSessionID))
+}
+
+func (b *connectorRoutingBaselines) load(workspaceID, agentSessionID string) (string, bool) {
+	value, ok := b.entries.Load(connectorRoutingBaselineKey(workspaceID, agentSessionID))
+	if !ok {
+		return "", false
+	}
+	index, ok := value.(string)
+	return index, ok
+}
+
+// commit advances the baseline only while the session is still tracked, so a
+// concurrent cleanup cannot be resurrected by a late turn admission.
+func (b *connectorRoutingBaselines) commit(workspaceID, agentSessionID, index string) {
+	key := connectorRoutingBaselineKey(workspaceID, agentSessionID)
+	if _, ok := b.entries.Load(key); ok {
+		b.entries.Store(key, index)
+	}
+}
+
+// pendingConnectorRoutingUpdate reports the current connector alias index when
+// it diverged from the index rendered into this session's instructions at
+// preparation time. The comparison uses the rendered index rather than a raw
+// registry revision so changes that cannot affect the prompt (for example
+// beyond the index rune budget) never trigger an update.
+func (s *Service) pendingConnectorRoutingUpdate(workspaceID, agentSessionID string) (string, bool) {
+	if s == nil || s.ConnectorRuntime == nil {
+		return "", false
+	}
+	baseline, tracked := s.connectorRoutingBaselines.load(workspaceID, agentSessionID)
+	if !tracked {
+		return "", false
+	}
+	current := runtimeprep.ConnectorRoutingIndex(s.ConnectorRuntime.RoutingHints())
+	if current == baseline {
+		return "", false
+	}
+	return current, true
+}

--- a/services/tuttid/service/agent/connector_routing_baseline_test.go
+++ b/services/tuttid/service/agent/connector_routing_baseline_test.go
@@ -1,0 +1,122 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	runtimeprep "github.com/tutti-os/tutti/packages/agent/runtimeprep"
+	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
+)
+
+func TestSendInputInjectsConnectorRoutingUpdateWhenIndexDiverges(t *testing.T) {
+	runtime := newFakeRuntime()
+	service := newTestService(runtime)
+	service.SubmitClaimStore = openAgentServiceSQLiteStore(t)
+	service.RuntimePreparer = fakeRuntimePreparer{result: runtimeprep.PreparedRuntime{Cwd: t.TempDir()}}
+	connector := &testConnectorRuntime{
+		hints: []runtimeprep.ConnectorRoutingHint{{ConnectorKey: "lark-cli", DisplayName: "Lark CLI", Aliases: []string{"飞书"}}},
+		context: runtimeprep.ConnectorAgentContext{MCPServers: []runtimeprep.MCPServerBinding{{
+			Name: "connector", Type: "http", URL: "http://127.0.0.1:1234/mcp/connector",
+		}}},
+	}
+	service.ConnectorRuntime = connector
+	service.ConnectorCapabilities = &testConnectorCapabilityResolver{supported: true}
+
+	if _, err := service.Create(context.Background(), "ws-1", CreateSessionInput{
+		AgentSessionID: "11111111-1111-4111-8111-111111111111",
+		AgentTargetID:  agenttargetbiz.IDLocalCodex,
+		Provider:       "codex",
+		InitialContent: TextPromptContent("hello"),
+	}); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if len(runtime.execCalls) != 1 || runtime.execCalls[0].ConnectorRoutingUpdate != nil {
+		t.Fatalf("create exec calls = %#v, want one call without routing update", runtime.execCalls)
+	}
+
+	if _, err := service.SendInput(context.Background(), "ws-1", "11111111-1111-4111-8111-111111111111", SendInput{
+		Content: TextPromptContent("first"),
+	}); err != nil {
+		t.Fatalf("SendInput() with unchanged index error = %v", err)
+	}
+	if len(runtime.execCalls) != 2 || runtime.execCalls[1].ConnectorRoutingUpdate != nil {
+		t.Fatalf("unchanged index exec = %#v, want no routing update", runtime.execCalls[1].ConnectorRoutingUpdate)
+	}
+
+	connector.hints = append(connector.hints, runtimeprep.ConnectorRoutingHint{ConnectorKey: "github", DisplayName: "GitHub"})
+	if _, err := service.SendInput(context.Background(), "ws-1", "11111111-1111-4111-8111-111111111111", SendInput{
+		Content: TextPromptContent("second"),
+	}); err != nil {
+		t.Fatalf("SendInput() with diverged index error = %v", err)
+	}
+	update := runtime.execCalls[2].ConnectorRoutingUpdate
+	if update == nil || *update != runtimeprep.ConnectorRoutingIndex(connector.hints) {
+		t.Fatalf("routing update = %#v, want current index", update)
+	}
+
+	if _, err := service.SendInput(context.Background(), "ws-1", "11111111-1111-4111-8111-111111111111", SendInput{
+		Content: TextPromptContent("third"),
+	}); err != nil {
+		t.Fatalf("SendInput() after committed baseline error = %v", err)
+	}
+	if runtime.execCalls[3].ConnectorRoutingUpdate != nil {
+		t.Fatalf("committed baseline exec routing update = %#v, want nil", runtime.execCalls[3].ConnectorRoutingUpdate)
+	}
+}
+
+func TestSendInputSkipsConnectorRoutingUpdateForGuidanceAndUntrackedSessions(t *testing.T) {
+	runtime := newFakeRuntime()
+	service := newIsolatedAgentService(runtime)
+	service.SubmitClaimStore = openAgentServiceSQLiteStore(t)
+	connector := &testConnectorRuntime{
+		hints: []runtimeprep.ConnectorRoutingHint{{ConnectorKey: "github", DisplayName: "GitHub"}},
+	}
+	service.ConnectorRuntime = connector
+	activeTurnID := "turn-1"
+	runtime.sessions["ws-1:session-guidance"] = ProviderRuntimeSession{
+		ID: "session-guidance", WorkspaceID: "ws-1", Provider: "codex", Status: "ready", Visible: true,
+		TurnLifecycle: &TurnLifecycle{ActiveTurnID: &activeTurnID, Phase: "running"},
+	}
+	runtime.sessions["ws-1:session-untracked"] = ProviderRuntimeSession{
+		ID: "session-untracked", WorkspaceID: "ws-1", Provider: "codex", Status: "ready", Visible: true,
+	}
+
+	// Guidance turns never carry a routing update even when the index diverged.
+	service.connectorRoutingBaselines.record("ws-1", "session-guidance", "stale-index")
+	if _, err := service.SendInput(context.Background(), "ws-1", "session-guidance", SendInput{
+		Content: TextPromptContent("steer"), Guidance: true, TurnID: activeTurnID, ClientSubmitID: "submit-guidance",
+	}); err != nil {
+		t.Fatalf("guidance SendInput() error = %v", err)
+	}
+	if len(runtime.execCalls) != 1 || runtime.execCalls[0].ConnectorRoutingUpdate != nil {
+		t.Fatalf("guidance exec = %#v, want no routing update", runtime.execCalls)
+	}
+
+	// Sessions prepared without Connector enhancement have no baseline and
+	// must not receive an update pointing at unavailable discovery commands.
+	if _, err := service.SendInput(context.Background(), "ws-1", "session-untracked", SendInput{
+		Content: TextPromptContent("hello"),
+	}); err != nil {
+		t.Fatalf("untracked SendInput() error = %v", err)
+	}
+	if len(runtime.execCalls) != 2 || runtime.execCalls[1].ConnectorRoutingUpdate != nil {
+		t.Fatalf("untracked exec = %#v, want no routing update", runtime.execCalls)
+	}
+}
+
+func TestCleanupSessionResourcesClearsConnectorRoutingBaseline(t *testing.T) {
+	service := newTestService(newFakeRuntime())
+	service.RuntimePreparer = nil
+	connector := &testConnectorRuntime{
+		hints: []runtimeprep.ConnectorRoutingHint{{ConnectorKey: "github", DisplayName: "GitHub"}},
+	}
+	service.ConnectorRuntime = connector
+	service.connectorRoutingBaselines.record("ws-1", "session-1", "stale-index")
+
+	if err := service.cleanupSessionResources(t.Context(), "ws-1", "session-1"); err != nil {
+		t.Fatalf("cleanupSessionResources() error = %v", err)
+	}
+	if update, changed := service.pendingConnectorRoutingUpdate("ws-1", "session-1"); changed {
+		t.Fatalf("pending routing update after cleanup = %q, want untracked", update)
+	}
+}

--- a/services/tuttid/service/agent/service_create.go
+++ b/services/tuttid/service/agent/service_create.go
@@ -706,6 +706,10 @@ func (s *Service) prepareRuntimeWithModelEndpoint(
 	if strings.TrimSpace(prepared.Cwd) == "" {
 		prepared.Cwd = cwd
 	}
+	// Every non-Connector preparation outcome below leaves the session without
+	// a materialized alias index, so drop any stale routing baseline first and
+	// re-record it only when Connector enhancement succeeds.
+	s.connectorRoutingBaselines.clear(workspaceID, strings.TrimSpace(input.AgentSessionID))
 	if s.ConnectorRuntime != nil && s.ConnectorCapabilities != nil {
 		httpMCP, capabilityErr := s.ConnectorCapabilities.ConnectorHTTPMCPSupported(ctx, ConnectorCapabilityInput{
 			WorkspaceID: workspaceID, AgentSessionID: strings.TrimSpace(input.AgentSessionID),
@@ -747,6 +751,10 @@ func (s *Service) prepareRuntimeWithModelEndpoint(
 					}
 				} else {
 					prepared = enhanced
+					s.connectorRoutingBaselines.record(
+						workspaceID, strings.TrimSpace(input.AgentSessionID),
+						runtimeprep.ConnectorRoutingIndex(contextBinding.RoutingHints),
+					)
 				}
 			}
 		}

--- a/services/tuttid/service/agent/service_send_input.go
+++ b/services/tuttid/service/agent/service_send_input.go
@@ -51,6 +51,13 @@ func (s *Service) SendInput(ctx context.Context, workspaceID string, agentSessio
 		Metadata: cloneMetadata(input.Metadata), ClientSubmitID: input.ClientSubmitID, Guidance: input.Guidance,
 		TurnID: input.TurnID,
 	}
+	connectorRoutingUpdate, connectorRoutingChanged := "", false
+	if !input.Guidance {
+		connectorRoutingUpdate, connectorRoutingChanged = s.pendingConnectorRoutingUpdate(workspaceID, agentSessionID)
+		if connectorRoutingChanged {
+			hostInput.ConnectorRoutingUpdate = &connectorRoutingUpdate
+		}
+	}
 	var preparedTurnID string
 	var preparedSnapshot tuttimodeactivationbiz.TurnSnapshot
 	if _, typedGoal := agenthost.ParseTypedGoalControl(normalizedContent, input.Guidance); !typedGoal {
@@ -102,6 +109,12 @@ func (s *Service) SendInput(ctx context.Context, workspaceID string, agentSessio
 	}
 	if preparedTurnID != "" && strings.TrimSpace(hostResult.TurnID) != preparedTurnID {
 		return SendInputResult{}, ErrSubmitDeliveryUnknown
+	}
+	if connectorRoutingChanged {
+		// The provider observed the routing update with this turn; later turns
+		// only need another update after the index diverges again. Ambiguous
+		// delivery outcomes above skip this commit and re-inject next turn.
+		s.connectorRoutingBaselines.commit(workspaceID, agentSessionID, connectorRoutingUpdate)
 	}
 	turnID := hostResult.TurnID
 	provider := strings.TrimSpace(hostResult.Session.Provider)

--- a/services/tuttid/service/agent/service_session_query.go
+++ b/services/tuttid/service/agent/service_session_query.go
@@ -179,6 +179,7 @@ func (s *Service) cleanupRuntimeWithOptions(
 	if s.ConnectorRuntime != nil {
 		s.ConnectorRuntime.RevokeSession(workspaceID, agentSessionID)
 	}
+	s.connectorRoutingBaselines.clear(workspaceID, agentSessionID)
 	return runtimeErr
 }
 

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -69,6 +69,7 @@ type Service struct {
 	RuntimePreparer                runtimeprep.Preparer
 	ConnectorRuntime               ConnectorRuntime
 	ConnectorCapabilities          ConnectorCapabilityResolver
+	connectorRoutingBaselines      connectorRoutingBaselines
 	ModelGateway                   ModelGatewayRegistry
 	BrowserUseAvailable            func() bool
 	ComputerUseAvailable           func() bool


### PR DESCRIPTION
## Summary

- The connector alias index only enters provider instructions (`AGENTS.md` / system prompt) at session prepare time, so connectors installed mid-session were invisible to live sessions unless the user used a generic trigger word (`连接器`/`connector`). This PR makes the next turn aware of routing changes.
- Service tracks the rendered alias index per prepared session (`connectorRoutingBaselines`, recorded on successful Connector enhancement, cleared on all fallback paths and session cleanup). On each non-guidance send, the current index is re-rendered via the newly exported `runtimeprep.ConnectorRoutingIndex`; if it diverged, the update travels through `SendInput` → `RuntimeExecInput` → hostadapter → `ExecInput` as a new `ConnectorRoutingUpdate *string` field.
- The daemon runtime renders the update as a provider-only instruction at the existing connector projection point (before the selected-connector instruction). Canonical prompt content never includes it, so chat history stays clean. The baseline is committed only after the turn is durably admitted; ambiguous outcomes re-inject next turn.

## Test plan

- [x] New: end-to-end service test (create → unchanged index no-op → new connector injects current index → committed baseline stops re-injection)
- [x] New: guidance turns and untracked (non-Connector) sessions never receive updates; cleanup clears the baseline
- [x] New: runtime projection rendering (index / empty-index variants, ordering before selected-connector instruction), exported index renderer parity
- [x] Full package tests green: `runtimeprep`, `host`, `host/conformance`, `hostadapter`
- [x] Pre-existing failures confirmed unrelated on clean base: `TestOpenCodeSlashCommandPolicyComesFromProviderDescriptor` (fails on main) and 3 `SidecarTestDriver` tests (require local Claude sidecar)

Made with [Cursor](https://cursor.com)