### PR TITLE
fix(agent): allow Side from historical Codex sessions

### DIFF
--- a/docs/architecture/agent-side-conversations.md
+++ b/docs/architecture/agent-side-conversations.md
@@ -1,22 +1,22 @@
 # Agent Side Conversations
 
-Side is a runtime-only branch of a live Agent session. It is deliberately not
+Side is a runtime-only branch of an Agent session. It is deliberately not
 Session Fork:
 
 | Property | Session Fork                                | Side                                             |
 | -------- | ------------------------------------------- | ------------------------------------------------ |
 | Identity | canonical child Session                     | runtime-scoped side id                           |
 | Storage  | durable history and lineage                 | no canonical writes                              |
-| Boundary | full session or settled Turn                | live provider snapshot, including an active Turn |
+| Boundary | full session or settled Turn                | provider snapshot, including an active live Turn |
 | Recovery | saga recovery and provider resume           | expires when its provider process is lost        |
 | Events   | optimistic stream plus committed projection | transient stream only                            |
 
 ## Standard provider contract
 
-A provider integrates Side by implementing `SideConversationAdapter` together
-with `LiveSessionProbeAdapter`:
+A provider integrates Side by implementing `SideConversationAdapter`:
 
-1. `SideCapabilities` attests support for the exact selected runtime.
+1. `SideCapabilities` attests support for the selected runtime and may use
+   persisted provider metadata when the source connection is idle.
 2. `OpenSide` creates the provider-native ephemeral branch and returns its
    provider session id.
 3. `OpenSide` quiesces callbacks and releases any child it created before
@@ -84,7 +84,15 @@ current connection state plus connection-state subscription. The canonical
 
 ## Codex reference adapter
 
-Codex uses the source-owned app-server connection and sends:
+Codex uses the source-owned app-server connection while it is live. For an
+idle or historical source, it starts a Side-owned app-server connection and
+loads the persisted source by `threadId`. The historical path restores the
+source's isolated `CODEX_HOME` from persisted runtime metadata so the new
+process can find the original rollout; capability discovery fails closed when
+that metadata is absent. The dedicated process is launched with the Side
+session identity while the source `threadId` is used only by `thread/fork`, so
+resource preparation, logs, and initialization-time events cannot attach to
+the canonical source. Both paths send:
 
 1. `thread/fork` with `ephemeral: true`, `excludeTurns: true`, no
    `lastTurnId`, and Side-specific developer instructions composed with the
@@ -97,13 +105,17 @@ does not remove them from the provider fork's model context. Subsequent Side
 Turns keep both the inherited Tutti host context and the Side-specific
 instructions in their collaboration settings.
 
-The connection has a thread-aware router and is referenced by both runtime
-sessions. Notifications for a new child that arrive before `thread/fork`
-responds are buffered in a provisional route and replayed only after lineage
-validation and Side registration. Closing Side unsubscribes the ephemeral
-child and drops only the Side reference; it does not issue `thread/delete` and
-cannot close the live parent connection. Losing the shared connection produces
-`ErrSideConversationExpired`; Side is never resumed as a canonical thread.
+The connection has a thread-aware router. A live-source connection is
+referenced by both runtime sessions; a historical-source connection is owned
+only by Side and closes with it. Notifications for a new child that arrive
+before `thread/fork` responds are buffered in a provisional route and replayed
+only after lineage validation and Side registration. Closing Side unsubscribes
+the ephemeral child and drops only the Side reference; it does not issue
+`thread/delete` and cannot close the live parent connection. Losing the Side
+connection produces `ErrSideConversationExpired`; Side is never resumed as a
+canonical thread.
+If a physical close fails, the adapter retains the dedicated connection as a
+cleanup owner and retries it through the bounded runtime resource sweeper.
 
 This change establishes the infrastructure, Codex reference vertical slice,
 typed daemon API, and AgentGUI Side pane.

--- a/docs/specs/2026-07-28-agent-side-conversation-technical-design.md
+++ b/docs/specs/2026-07-28-agent-side-conversation-technical-design.md
@@ -92,14 +92,14 @@ type SideConversationAdapter interface {
 }
 ```
 
-`SideCapabilities` is resolved from the exact selected live runtime, not
-inferred from the provider name or a historical binary probe. `OpenSide` is
-the provider-specific creation operation. The Adapter must also implement
-`LiveSessionProbeAdapter`; interactive Side flows require the existing
-`InteractiveAdapter`. Standard event, command, and config sinks remain part of
-the provider integration. After open, the Controller reuses ordinary Exec,
-Cancel, interactive response, state, and Close behavior against the
-side-scoped Session.
+`SideCapabilities` is resolved by the exact selected adapter, not inferred
+from the provider name. The adapter may use persisted runtime metadata when
+the provider supports loading a historical source identity. `OpenSide` is the
+provider-specific creation operation; interactive Side flows require the
+existing `InteractiveAdapter`. Standard event, command, and config sinks
+remain part of the provider integration. After open, the Controller reuses
+ordinary Exec, Cancel, interactive response, state, and Close behavior against
+the side-scoped Session.
 
 `OpenSide` owns failure cleanup: before returning an error it must quiesce its
 callbacks and release any provider child it created. A successful return
@@ -233,13 +233,21 @@ registrations are durable.
 
 ## 8. Codex Reference Implementation
 
-Codex forks on the source-owned app-server connection. This is required for a
-source Turn whose newest state exists only in that process's memory.
+Codex forks on the source-owned app-server connection while it is live. This is
+required for a source Turn whose newest state exists only in that process's
+memory. For an idle or historical source, Codex starts a Side-owned app-server
+connection and loads the persisted source by `threadId` without resuming the
+canonical source session. Host supplies the persisted runtime snapshot through
+the host-adapter boundary, including the isolated `CODEX_HOME` needed to locate
+the source rollout. The historical capability probe fails closed if this
+location metadata is absent. Process launch and provider preparation use the
+Side identity; only the `thread/fork` request carries the canonical source
+thread id.
 
 ```mermaid
 sequenceDiagram
   participant H as Host/Controller
-  participant C as Source-owned app-server client
+  participant C as Live-source or Side-owned app-server client
   participant P as Codex app-server
 
   C->>P: thread/fork(threadId=parent, ephemeral=true, excludeTurns=true)
@@ -254,18 +262,23 @@ sequenceDiagram
 Codex validation rules:
 
 - exact initialized runtime version must support the required protocol;
-- the source client must still be live and own the exact parent thread;
+- a live client must own the exact parent thread, or the historical snapshot
+  must carry the exact provider thread and isolated Codex home;
 - child id must be non-empty and different from the parent;
 - `forkedFromId` must equal the parent thread id;
 - boundary injection must succeed before open commits;
-- parent and child remain on one connection and are routed by `threadId`;
+- a live parent and child remain on one connection and are routed by
+  `threadId`; a historical child uses a dedicated connection;
 - child notifications that arrive before `thread/fork` responds are buffered
   by a provisional connection route and replayed only after child identity
   validation;
 - per-RPC handlers cannot override the connection-wide thread router;
-- the client is reference-counted across its parent and Side sessions;
-- closing Side unsubscribes and releases only the ephemeral child thread; the parent client and
-  active Turn are unchanged.
+- a shared client is reference-counted across its parent and Side sessions;
+- closing Side unsubscribes the ephemeral child and either drops only the
+  shared Side reference or closes its dedicated historical connection; the
+  parent identity and active Turn are unchanged.
+- a failed physical close retains a Side-owned cleanup handle for bounded
+  retry instead of orphaning the dedicated process.
 
 The injected developer instructions and user boundary tell the model that
 inherited turns are read-only context and subsequent messages belong only to
@@ -391,7 +404,6 @@ Minimum provider composition:
 | Capability                         | Required when                                    |
 | ---------------------------------- | ------------------------------------------------ |
 | `SideConversationAdapter`          | always                                           |
-| `LiveSessionProbeAdapter`          | always                                           |
 | ordinary `Exec`, `Cancel`, `Close` | always                                           |
 | `InteractiveAdapter`               | provider can emit approvals/questions            |
 | command/config/event sink adapters | provider advertises those live updates           |
@@ -417,28 +429,28 @@ prompt text, injected model context, credentials, or environment values.
 
 The implementation review produced the following corrections:
 
-| Review risk                                                       | Resolution                                                                                                     |
-| ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| cross-process fork could miss the active source suffix            | Codex now forks on the source-owned connection                                                                 |
-| one callback handler could mix parent and Side events             | connection-wide `threadId` router overrides per-RPC handlers                                                   |
-| fork could emit a child notification before child identity exists | provisional connection route buffers then replays against the committed Side                                   |
-| legacy approval requests use `conversationId`                     | one thread-id extractor handles modern and legacy request schemas                                              |
-| closing Side could terminate the parent process                   | shared-client reference counting plus child `thread/unsubscribe`                                               |
-| an unhealthy shared transport could leave sibling refs live       | transport invalidation expires every parent/Side ref and closes once                                           |
-| Host Open/Close could create a ghost ready entry                  | source/side session actors serialize the transition                                                            |
-| a stale Host registration could target a canonical runtime        | every Side operation revalidates scope, source, and request                                                    |
-| a canonical id could be reused as a Side id                       | Host checks the canonical store before reservation                                                             |
-| events or command/config snapshots could overtake open            | one provisional drain loop covers all three channels                                                           |
-| partial capability claims could commit                            | preflight and open results validate every mandatory fact                                                       |
-| an offline source could be treated as live                        | `LiveSessionProbeAdapter` is mandatory and historical fallback is forbidden                                    |
-| goal/provenance paths could write Side state durably              | goal APIs are disabled and every durable sink has a Side guard                                                 |
-| the canonical idle reaper could silently expire Side              | Side is excluded; explicit Side lifecycle owns expiration                                                      |
-| provider failure could leave delayed callbacks/resources          | `OpenSide` keeps resource-creating response identities until response/client shutdown and cleans late children |
-| malformed fork lineage could leak an ephemeral child              | cleanup is armed as soon as a distinct child id is returned                                                    |
-| invalid provider identity could close a canonical session         | unvalidated identities are never passed to ordinary `Close`                                                    |
-| two AgentGUI surfaces could share transient Side ownership        | Desktop injects a factory and each mounted surface owns one runtime                                            |
-| a stale connection sample could admit Side without events         | connection state methods are mandatory and sampled around subscription/open                                    |
-| a parent child index could steal the exact Side thread            | exact provider-session matches run before child-thread fallback                                                |
+| Review risk                                                       | Resolution                                                                                                      |
+| ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| cross-process fork could miss the active source suffix            | Codex now forks on the source-owned connection                                                                  |
+| one callback handler could mix parent and Side events             | connection-wide `threadId` router overrides per-RPC handlers                                                    |
+| fork could emit a child notification before child identity exists | provisional connection route buffers then replays against the committed Side                                    |
+| legacy approval requests use `conversationId`                     | one thread-id extractor handles modern and legacy request schemas                                               |
+| closing Side could terminate the parent process                   | shared-client reference counting plus child `thread/unsubscribe`                                                |
+| an unhealthy shared transport could leave sibling refs live       | transport invalidation expires every parent/Side ref and closes once                                            |
+| Host Open/Close could create a ghost ready entry                  | source/side session actors serialize the transition                                                             |
+| a stale Host registration could target a canonical runtime        | every Side operation revalidates scope, source, and request                                                     |
+| a canonical id could be reused as a Side id                       | Host checks the canonical store before reservation                                                              |
+| events or command/config snapshots could overtake open            | one provisional drain loop covers all three channels                                                            |
+| partial capability claims could commit                            | preflight and open results validate every mandatory fact                                                        |
+| historical Side open could mutate canonical source liveness       | the dedicated client loads by `threadId`, routes fallback events as Side, and is owned only by the Side session |
+| goal/provenance paths could write Side state durably              | goal APIs are disabled and every durable sink has a Side guard                                                  |
+| the canonical idle reaper could silently expire Side              | Side is excluded; explicit Side lifecycle owns expiration                                                       |
+| provider failure could leave delayed callbacks/resources          | `OpenSide` keeps resource-creating response identities until response/client shutdown and cleans late children  |
+| malformed fork lineage could leak an ephemeral child              | cleanup is armed as soon as a distinct child id is returned                                                     |
+| invalid provider identity could close a canonical session         | unvalidated identities are never passed to ordinary `Close`                                                     |
+| two AgentGUI surfaces could share transient Side ownership        | Desktop injects a factory and each mounted surface owns one runtime                                             |
+| a stale connection sample could admit Side without events         | connection state methods are mandatory and sampled around subscription/open                                     |
+| a parent child index could steal the exact Side thread            | exact provider-session matches run before child-thread fallback                                                 |
 
 This document covers the provider-neutral infrastructure, Codex adapter,
 public service command/event schema, and the user-visible AgentGUI `/side`

--- a/packages/agent/daemon/hostadapter/runtime_side_conversation.go
+++ b/packages/agent/daemon/hostadapter/runtime_side_conversation.go
@@ -8,7 +8,7 @@ import (
 )
 
 type sideConversationRuntimeBackend interface {
-	SideCapabilities(context.Context, string, string) (agentruntime.SideConversationCapabilities, error)
+	SideCapabilitiesForSource(context.Context, agentruntime.Session) (agentruntime.SideConversationCapabilities, error)
 	OpenSide(context.Context, agentruntime.SideConversationOpenInput) (agentruntime.SideConversationOpenResult, error)
 }
 
@@ -23,9 +23,7 @@ func (a *RuntimeController) ResolveSideConversation(
 	if !ok {
 		return host.SideConversationCapabilities{}, nil
 	}
-	capabilities, err := backend.SideCapabilities(
-		ctx, source.WorkspaceID, source.ID,
-	)
+	capabilities, err := backend.SideCapabilitiesForSource(ctx, runtimeSession(source))
 	return hostSideCapabilities(capabilities), mapRuntimeError(err)
 }
 
@@ -47,6 +45,7 @@ func (a *RuntimeController) OpenSideConversation(
 			SourceAgentSessionID: input.Source.ID,
 			SideAgentSessionID:   input.SideAgentSessionID,
 			RequestID:            input.RequestID,
+			Source:               runtimeSession(input.Source),
 		},
 	)
 	if err != nil {

--- a/packages/agent/daemon/runtime/adapter.go
+++ b/packages/agent/daemon/runtime/adapter.go
@@ -228,10 +228,11 @@ type ProviderTurnBindingRecoveryAdapter interface {
 	) (ProviderTurnBindingRecoveryResult, error)
 }
 
-// SideConversationAdapter is the provider-specific open surface for live,
-// runtime-only side conversations. A Side-capable Adapter must also implement
-// LiveSessionProbeAdapter; interactive Side flows additionally require the
-// ordinary InteractiveAdapter contract. Once OpenSide returns, the Controller
+// SideConversationAdapter is the provider-specific open surface for
+// runtime-only side conversations. The adapter decides whether a live source
+// connection or persisted provider identity can satisfy the request;
+// interactive Side flows additionally require the ordinary InteractiveAdapter
+// contract. Once OpenSide returns, the Controller
 // reuses Adapter Exec/Cancel/Close and the configured event/command/config
 // sinks against the returned side-scoped Session.
 //

--- a/packages/agent/daemon/runtime/codex_appserver_lifecycle_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_lifecycle_test.go
@@ -19,11 +19,12 @@ import (
 type multiProcAppServerTransport struct {
 	mu        sync.Mutex
 	conns     []*scriptedAppServerConnection
+	specs     []ProcessSpec
 	startErr  error
 	configure func(server *fakeCodexAppServer)
 }
 
-func (t *multiProcAppServerTransport) Start(_ context.Context, _ ProcessSpec) (ProcessConnection, error) {
+func (t *multiProcAppServerTransport) Start(_ context.Context, spec ProcessSpec) (ProcessConnection, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.startErr != nil {
@@ -34,6 +35,7 @@ func (t *multiProcAppServerTransport) Start(_ context.Context, _ ProcessSpec) (P
 		t.configure(server)
 	}
 	t.conns = append(t.conns, conn)
+	t.specs = append(t.specs, spec)
 	return conn, nil
 }
 
@@ -73,6 +75,15 @@ func (t *multiProcAppServerTransport) conn(index int) *scriptedAppServerConnecti
 		return nil
 	}
 	return t.conns[index]
+}
+
+func (t *multiProcAppServerTransport) spec(index int) ProcessSpec {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if index < 0 || index >= len(t.specs) {
+		return ProcessSpec{}
+	}
+	return t.specs[index]
 }
 
 func connClosed(conn *scriptedAppServerConnection) bool {

--- a/packages/agent/daemon/runtime/codex_appserver_side.go
+++ b/packages/agent/daemon/runtime/codex_appserver_side.go
@@ -48,6 +48,23 @@ func codexSideInstructions(
 	return base + "\n\n" + codexSideDeveloperInstructions
 }
 
+func usableCodexSideSourceSession(
+	appSession *codexAppServerSession,
+	sourceThreadID string,
+) bool {
+	if appSession == nil || appSession.client == nil || appSession.releasing ||
+		appSession.releaseFailed ||
+		strings.TrimSpace(appSession.threadID) != strings.TrimSpace(sourceThreadID) {
+		return false
+	}
+	select {
+	case <-appSession.client.Done():
+		return false
+	default:
+		return true
+	}
+}
+
 func (a *CodexAppServerAdapter) SideCapabilities(
 	_ context.Context,
 	source Session,
@@ -60,8 +77,7 @@ func (a *CodexAppServerAdapter) SideCapabilities(
 	sourceThreadID := strings.TrimSpace(source.ProviderSessionID)
 	a.mu.Lock()
 	appSession := a.sessions[strings.TrimSpace(source.AgentSessionID)]
-	if appSession != nil && appSession.client != nil &&
-		appSession.threadID == sourceThreadID {
+	if usableCodexSideSourceSession(appSession, sourceThreadID) {
 		serverInfo := clonePayload(appSession.serverInfo)
 		a.mu.Unlock()
 		if version, ok := appServerForkVersion(strategy, serverInfo); ok &&
@@ -71,10 +87,119 @@ func (a *CodexAppServerAdapter) SideCapabilities(
 		return SideConversationCapabilities{}, nil
 	}
 	a.mu.Unlock()
-	// Side snapshots provider memory, including an in-progress Turn. A
-	// historical probe can attest a binary version but cannot attest that
-	// exact live context, so offline sources fail closed.
+	persistedServerInfo, _ := source.RuntimeContext["agent"].(map[string]any)
+	if strings.TrimSpace(asString(persistedServerInfo["codexHome"])) != "" {
+		if version, ok := appServerForkVersion(strategy, persistedServerInfo); ok &&
+			versionAtLeast(version, strategy.throughTurnMinimumVersion) {
+			return codexSideCapabilities(), nil
+		}
+	}
 	return SideConversationCapabilities{}, nil
+}
+
+type codexSideClientState struct {
+	client               *codexAppServerClient
+	serverInfo           map[string]any
+	account              map[string]any
+	models               []map[string]any
+	planModeMask         map[string]any
+	defaultModeMask      map[string]any
+	defaultModel         string
+	tuttiModeHostContext string
+	routerFallback       Session
+	dedicated            bool
+}
+
+func (a *CodexAppServerAdapter) sideClient(
+	ctx context.Context,
+	source Session,
+	side Session,
+	trace *codexAppServerStartupTrace,
+) (codexSideClientState, error) {
+	sourceThreadID := strings.TrimSpace(source.ProviderSessionID)
+	a.mu.Lock()
+	sourceAppSession := a.sessions[strings.TrimSpace(source.AgentSessionID)]
+	if usableCodexSideSourceSession(sourceAppSession, sourceThreadID) {
+		state := codexSideClientState{
+			client:               sourceAppSession.client,
+			serverInfo:           clonePayload(sourceAppSession.serverInfo),
+			account:              clonePayload(sourceAppSession.account),
+			models:               cloneCodexAppServerModels(sourceAppSession.models),
+			planModeMask:         clonePayload(sourceAppSession.planModeMask),
+			defaultModeMask:      clonePayload(sourceAppSession.defaultModeMask),
+			defaultModel:         sourceAppSession.defaultModel,
+			tuttiModeHostContext: sourceAppSession.tuttiModeHostContext,
+			routerFallback:       source,
+		}
+		a.mu.Unlock()
+		return state, nil
+	}
+	a.mu.Unlock()
+
+	launchSource, err := codexHistoricalSideSourceForLaunch(source, side)
+	if err != nil {
+		return codexSideClientState{}, err
+	}
+	client, initializeResult, err := a.startInitializedClient(ctx, launchSource, trace)
+	if err != nil {
+		return codexSideClientState{}, err
+	}
+	cleanupOwner := &codexAppServerSession{
+		client: client, runtimeSession: side,
+	}
+	keepClient := false
+	defer func() {
+		if !keepClient {
+			a.closeOrRetainCodexSession(side.AgentSessionID, cleanupOwner)
+		}
+	}()
+	// Upgrade the initialization handler to the thread-aware router before any
+	// metadata RPC so every later notification remains Side-scoped.
+	a.installSharedAppServerRouter(client, side)
+
+	planModeMask, defaultModeMask, defaultModel, _ :=
+		codexAppServerProtocolCheckpointFromRuntimeContext(source.RuntimeContext)
+	defaultModel = firstNonEmpty(
+		strings.TrimSpace(source.SettingsValue().Model),
+		defaultModel,
+	)
+	account, _ := source.RuntimeContext["account"].(map[string]any)
+	keepClient = true
+	return codexSideClientState{
+		client:          client,
+		serverInfo:      a.appServerInfo(initializeResult),
+		account:         clonePayload(account),
+		planModeMask:    planModeMask,
+		defaultModeMask: defaultModeMask,
+		defaultModel:    defaultModel,
+		routerFallback:  side,
+		dedicated:       true,
+	}, nil
+}
+
+func codexHistoricalSideSourceForLaunch(source Session, side Session) (Session, error) {
+	launchSource := cloneProviderLaunchSession(source)
+	launchSource.RoomID = side.RoomID
+	launchSource.AgentSessionID = side.AgentSessionID
+	launchSource.RootAgentSessionID = side.RootAgentSessionID
+	launchSource.Scope = RuntimeSessionScopeSide
+	launchSource.SourceAgentSessionID = side.SourceAgentSessionID
+	launchSource.SideRequestID = side.SideRequestID
+	launchSource.ProviderSessionID = ""
+	launchSource.Resumable = false
+	launchSource.Visible = false
+	agent, _ := source.RuntimeContext["agent"].(map[string]any)
+	codexHome := strings.TrimSpace(asString(agent["codexHome"]))
+	if codexHome == "" {
+		return Session{}, errors.New(
+			"historical Codex Side requires persisted CODEX_HOME",
+		)
+	}
+	launchSource.Env = append(
+		withoutEnvironmentKey(launchSource.Env, "CODEX_HOME"),
+		"CODEX_HOME="+codexHome,
+	)
+	return launchSource, nil
 }
 
 func codexSideCapabilities() SideConversationCapabilities {
@@ -106,26 +231,25 @@ func (a *CodexAppServerAdapter) OpenSide(
 
 	unlockLifecycle := a.lockSessionLifecycle(side.AgentSessionID)
 	defer unlockLifecycle()
+	if err := a.admitCodexReplacementLocked(side.AgentSessionID); err != nil {
+		return SideConversationOpenResult{}, err
+	}
 	trace := newCodexAppServerStartupTrace(side)
 	defer func() { trace.Finish(err) }()
-	a.mu.Lock()
-	sourceAppSession := a.sessions[strings.TrimSpace(source.AgentSessionID)]
-	if sourceAppSession == nil ||
-		sourceAppSession.client == nil ||
-		strings.TrimSpace(sourceAppSession.threadID) != sourceThreadID {
-		a.mu.Unlock()
-		return SideConversationOpenResult{}, ErrSideConversationExpired
+	clientState, err := a.sideClient(ctx, source, side, trace)
+	if err != nil {
+		return SideConversationOpenResult{}, err
 	}
-	client := sourceAppSession.client
-	serverInfo := clonePayload(sourceAppSession.serverInfo)
-	account := clonePayload(sourceAppSession.account)
-	models := cloneCodexAppServerModels(sourceAppSession.models)
-	planModeMask := sourceAppSession.planModeMask
-	defaultModeMask := sourceAppSession.defaultModeMask
-	defaultModel := sourceAppSession.defaultModel
-	tuttiModeHostContext := sourceAppSession.tuttiModeHostContext
-	a.mu.Unlock()
-	version, ok := appServerForkVersion(strategy, serverInfo)
+	client := clientState.client
+	keepDedicatedClient := false
+	defer func() {
+		if clientState.dedicated && !keepDedicatedClient {
+			a.closeOrRetainCodexSession(side.AgentSessionID, &codexAppServerSession{
+				client: client, runtimeSession: side,
+			})
+		}
+	}()
+	version, ok := appServerForkVersion(strategy, clientState.serverInfo)
 	if !ok || !versionAtLeast(version, strategy.throughTurnMinimumVersion) {
 		return SideConversationOpenResult{}, ErrSideConversationUnsupported
 	}
@@ -138,10 +262,11 @@ func (a *CodexAppServerAdapter) OpenSide(
 			a.discardPendingSideRoute(client)
 		}
 	}()
-	// From this point all per-RPC and idle messages on the source-owned
-	// connection are dispatched by thread id. This matches Codex App's Side
-	// topology and preserves the source's in-memory active-Turn snapshot.
-	a.installSharedAppServerRouter(client, source)
+	// A live source shares its connection so an in-progress Turn remains in the
+	// provider snapshot. A historical source owns a dedicated Side connection;
+	// its fallback is Side-scoped so provider startup events cannot enter the
+	// canonical source stream.
+	a.installSharedAppServerRouter(client, clientState.routerFallback)
 
 	params := map[string]any{
 		"threadId":     sourceThreadID,
@@ -149,9 +274,9 @@ func (a *CodexAppServerAdapter) OpenSide(
 		"excludeTurns": true,
 		"developerInstructions": codexSideInstructions(
 			source,
-			planModeMask,
-			defaultModeMask,
-			tuttiModeHostContext,
+			clientState.planModeMask,
+			clientState.defaultModeMask,
+			clientState.tuttiModeHostContext,
 		),
 	}
 	raw, err := trace.TypedCall(
@@ -239,7 +364,7 @@ func (a *CodexAppServerAdapter) OpenSide(
 	liveState.commandsKnown = true
 	applyACPConfigOptionDescriptors(
 		&liveState,
-		codexAppServerConfigOptionDescriptors(models, side, raw),
+		codexAppServerConfigOptionDescriptors(clientState.models, side, raw),
 	)
 	// Register the child before boundary injection so connection-scoped
 	// notifications and server requests already have an exact Side owner.
@@ -247,15 +372,15 @@ func (a *CodexAppServerAdapter) OpenSide(
 		client:                 client,
 		threadID:               childThreadID,
 		runtimeSession:         side,
-		serverInfo:             serverInfo,
-		account:                account,
-		models:                 cloneCodexAppServerModels(models),
-		startupModelsReady:     len(models) > 0,
+		serverInfo:             clientState.serverInfo,
+		account:                clientState.account,
+		models:                 cloneCodexAppServerModels(clientState.models),
+		startupModelsReady:     len(clientState.models) > 0,
 		startupRateLimitsReady: false,
-		planModeMask:           planModeMask,
-		defaultModeMask:        defaultModeMask,
-		defaultModel:           defaultModel,
-		tuttiModeHostContext:   tuttiModeHostContext,
+		planModeMask:           clientState.planModeMask,
+		defaultModeMask:        clientState.defaultModeMask,
+		defaultModel:           clientState.defaultModel,
+		tuttiModeHostContext:   clientState.tuttiModeHostContext,
 		authState:              "authenticated",
 		acpLiveState:           liveState,
 		pendingRequests:        make(map[string]*pendingInteractiveRequest),
@@ -274,7 +399,7 @@ func (a *CodexAppServerAdapter) OpenSide(
 			if err := a.routeSharedAppServerMessageWithPending(
 				ctx,
 				client,
-				source,
+				clientState.routerFallback,
 				buffered.message,
 				false,
 			); err != nil {
@@ -323,6 +448,7 @@ func (a *CodexAppServerAdapter) OpenSide(
 		Commands:       codexAppServerCommands(),
 	})
 	committed = true
+	keepDedicatedClient = true
 	return SideConversationOpenResult{
 		Session: side, Capabilities: codexSideCapabilities(),
 	}, nil

--- a/packages/agent/daemon/runtime/codex_appserver_side_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_side_test.go
@@ -16,6 +16,51 @@ type sideRoutingObserver struct {
 	events map[string][]StreamEvent
 }
 
+func TestCodexSideSourceForLaunchRestoresPersistedCodexHome(t *testing.T) {
+	source, err := codexHistoricalSideSourceForLaunch(Session{
+		RoomID: "workspace", AgentSessionID: "canonical",
+		Env: []string{"CODEX_HOME=/stale", "EXISTING=value"},
+		RuntimeContext: map[string]any{"agent": map[string]any{
+			"codexHome": "/persisted/codex-home",
+		}},
+	}, Session{
+		RoomID: "workspace", AgentSessionID: "side-history",
+		RootAgentSessionID: "side-history", Scope: RuntimeSessionScopeSide,
+		SourceAgentSessionID: "canonical", SideRequestID: "request",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if source.AgentSessionID != "side-history" ||
+		source.RootAgentSessionID != "side-history" ||
+		source.SourceAgentSessionID != "canonical" ||
+		source.Scope != RuntimeSessionScopeSide || source.Resumable {
+		t.Fatalf("historical launch identity = %#v", source)
+	}
+	if got := envValueLast(source.Env, "CODEX_HOME"); got != "/persisted/codex-home" {
+		t.Fatalf("CODEX_HOME = %q, want persisted home", got)
+	}
+	if got := envValueLast(source.Env, "EXISTING"); got != "value" {
+		t.Fatalf("EXISTING = %q, want preserved", got)
+	}
+}
+
+func TestCodexHistoricalSideCapabilitiesRequirePersistedCodexHome(t *testing.T) {
+	adapter := NewCodexAppServerAdapter(nil)
+	capabilities, err := adapter.SideCapabilities(t.Context(), Session{
+		AgentSessionID: "historical", ProviderSessionID: "thread-1",
+		RuntimeContext: map[string]any{"agent": map[string]any{
+			"userAgent": "codex/0.144.1",
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if capabilities.Supported {
+		t.Fatalf("capabilities = %#v, want fail closed without codexHome", capabilities)
+	}
+}
+
 func (o *sideRoutingObserver) ObserveRuntimeStreamEvents(
 	_ context.Context,
 	_ string,
@@ -241,6 +286,230 @@ func TestCodexAppServerSideUsesEphemeralForkAndInjectedBoundary(t *testing.T) {
 		RoomID: "workspace-side-codex", AgentSessionID: "parent",
 	}); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestCodexAppServerSideOpensFromReleasedHistoricalSource(t *testing.T) {
+	transport := &multiProcAppServerTransport{}
+	transport.setConfigure(func(server *fakeCodexAppServer) {
+		server.userAgent = "codex/0.144.1"
+	})
+	adapter := NewCodexAppServerAdapter(transport)
+	var prepared Session
+	adapter.SetProviderLaunchPreparer(func(
+		_ context.Context,
+		input ProviderLaunchPrepareInput,
+	) (ProviderLaunchPrepareResult, error) {
+		prepared = input.Session
+		return ProviderLaunchPrepareResult{
+			Command: input.Command, Env: input.Env, CWD: input.CWD,
+		}, nil
+	})
+	controller := NewController([]Adapter{adapter}, nil)
+	started, err := controller.Start(t.Context(), StartInput{
+		RoomID: "workspace-side-history", AgentSessionID: "parent",
+		Provider: ProviderCodex, CWD: "/workspace",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := started.Session
+	source.RuntimeContext = adapter.SessionState(source).RuntimeContext
+	controller.store(source)
+	if _, ok := source.RuntimeContext["agent"].(map[string]any); !ok {
+		t.Fatalf("source runtime context omitted persisted agent metadata: %#v", source.RuntimeContext)
+	}
+	if err := adapter.ReleaseLiveSession(t.Context(), source); err != nil {
+		t.Fatal(err)
+	}
+	if adapter.HasLiveSession(source) {
+		t.Fatal("source remained live after release")
+	}
+	coldController := NewController([]Adapter{adapter}, nil)
+
+	capabilities, err := coldController.SideCapabilitiesForSource(
+		t.Context(), source,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !validRequiredSideCapabilities(capabilities) {
+		t.Fatalf("historical Side capabilities = %#v, want supported", capabilities)
+	}
+	if count, live := transport.snapshot(); count != 1 || len(live) != 0 {
+		t.Fatalf("capability probe spawned a process: spawned %d/live %d", count, len(live))
+	}
+
+	opened, err := coldController.OpenSide(t.Context(), SideConversationOpenInput{
+		RoomID: source.RoomID, SourceAgentSessionID: source.AgentSessionID,
+		SideAgentSessionID: "side-history", RequestID: "open-side-history",
+		Source: source,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opened.Session.ProviderSessionID != "codex-thread-fork" {
+		t.Fatalf("opened historical Side = %#v", opened.Session)
+	}
+	if adapter.HasLiveSession(source) {
+		t.Fatal("opening Side unexpectedly resumed the canonical source")
+	}
+	if count, live := transport.snapshot(); count != 2 || len(live) != 1 {
+		t.Fatalf("historical Side processes = spawned %d/live %d, want 2/1", count, len(live))
+	}
+	dedicatedConn := transport.conn(1)
+	dedicatedSpec := transport.spec(1)
+	if dedicatedSpec.AgentSessionID != "side-history" ||
+		dedicatedSpec.RootAgentSessionID != "side-history" {
+		t.Fatalf("historical Side process spec = %#v", dedicatedSpec)
+	}
+	if prepared.AgentSessionID != "side-history" ||
+		prepared.RootAgentSessionID != "side-history" ||
+		prepared.SourceAgentSessionID != source.AgentSessionID ||
+		prepared.Scope != RuntimeSessionScopeSide {
+		t.Fatalf("historical Side prepared identity = %#v", prepared)
+	}
+	fork := appServerRequestParams(t, dedicatedConn, appServerMethodThreadFork)
+	if asString(fork["threadId"]) != source.ProviderSessionID ||
+		fork["ephemeral"] != true || fork["excludeTurns"] != true {
+		t.Fatalf("historical Side thread/fork params = %#v", fork)
+	}
+	if requests := appServerRequestParamsList(
+		t,
+		dedicatedConn,
+		appServerMethodCollaborationModeList,
+	); len(requests) != 0 {
+		t.Fatalf("historical Side refreshed persisted collaboration modes: %#v", requests)
+	}
+
+	if _, err := coldController.Exec(t.Context(), ExecInput{
+		RoomID: source.RoomID, AgentSessionID: "side-history",
+		TurnID:  "side-history-turn",
+		Content: []PromptContentBlock{{Type: "text", Text: "question from history"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := coldController.Close(t.Context(), CloseInput{
+		RoomID: source.RoomID, AgentSessionID: "side-history",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if count, live := transport.snapshot(); count != 2 || len(live) != 0 {
+		t.Fatalf("after historical Side close = spawned %d/live %d, want 2/0", count, len(live))
+	}
+}
+
+func TestCodexHistoricalSideFallsBackWhenRegisteredSourceClientIsDead(t *testing.T) {
+	transport := &multiProcAppServerTransport{}
+	transport.setConfigure(func(server *fakeCodexAppServer) {
+		server.userAgent = "codex/0.144.1"
+	})
+	adapter := NewCodexAppServerAdapter(transport)
+	controller := NewController([]Adapter{adapter}, nil)
+	started, err := controller.Start(t.Context(), StartInput{
+		RoomID: "workspace-side-dead-source", AgentSessionID: "parent",
+		Provider: ProviderCodex, CWD: "/workspace",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := started.Session
+	source.RuntimeContext = adapter.SessionState(source).RuntimeContext
+	deadConn := transport.conn(0)
+	if err := deadConn.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	capabilities, err := adapter.SideCapabilities(t.Context(), source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !validRequiredSideCapabilities(capabilities) {
+		t.Fatalf("dead-source fallback capabilities = %#v", capabilities)
+	}
+	side := source
+	side.AgentSessionID = "side-dead-source"
+	side.RootAgentSessionID = side.AgentSessionID
+	side.ProviderSessionID = ""
+	side.Scope = RuntimeSessionScopeSide
+	side.SourceAgentSessionID = source.AgentSessionID
+	side.SideRequestID = "request-dead-source"
+	side.Resumable = false
+	opened, err := adapter.OpenSide(t.Context(), SideConversationAdapterOpenInput{
+		Source: source, Side: side, RequestID: side.SideRequestID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count, live := transport.snapshot(); count != 2 || len(live) != 1 {
+		t.Fatalf("fallback processes = spawned %d/live %d, want 2/1", count, len(live))
+	}
+	if forks := appServerRequestParamsList(
+		t, deadConn, appServerMethodThreadFork,
+	); len(forks) != 0 {
+		t.Fatalf("dead source client received fork = %#v", forks)
+	}
+	if err := adapter.Close(t.Context(), opened.Session); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type historicalSideCloseFailureTransport struct {
+	conn *scriptedAppServerConnection
+}
+
+func (t *historicalSideCloseFailureTransport) Start(
+	_ context.Context,
+	_ ProcessSpec,
+) (ProcessConnection, error) {
+	conn, server := newScriptedAppServerHarness()
+	server.userAgent = "codex/0.144.1"
+	server.forkRPCError = true
+	conn.closeFailures = 1
+	t.conn = conn
+	return conn, nil
+}
+
+func TestCodexHistoricalSideRetainsDedicatedClientAfterCloseFailure(t *testing.T) {
+	transport := &historicalSideCloseFailureTransport{}
+	adapter := NewCodexAppServerAdapter(transport)
+	source := Session{
+		RoomID: "workspace-side-history", AgentSessionID: "parent",
+		RootAgentSessionID: "parent", Provider: ProviderCodex,
+		ProviderSessionID: "codex-thread-1", CWD: "/workspace",
+		RuntimeContext: map[string]any{"agent": map[string]any{
+			"userAgent": "codex/0.144.1", "codexHome": "/persisted/codex-home",
+		}},
+	}
+	side := source
+	side.AgentSessionID = "side-history-failed"
+	side.RootAgentSessionID = side.AgentSessionID
+	side.ProviderSessionID = ""
+	side.Scope = RuntimeSessionScopeSide
+	side.SourceAgentSessionID = source.AgentSessionID
+	side.SideRequestID = "request-failed"
+	side.Resumable = false
+
+	if _, err := adapter.OpenSide(t.Context(), SideConversationAdapterOpenInput{
+		Source: source, Side: side, RequestID: side.SideRequestID,
+	}); err == nil {
+		t.Fatal("OpenSide unexpectedly succeeded")
+	}
+	if !adapter.hasRetiredCodexSessions(side.AgentSessionID) {
+		t.Fatal("close-failed dedicated process lost its retained owner")
+	}
+	cleanup := adapter.CleanupLiveSessionResources(t.Context(), 1)
+	if cleanup.Attempted != 1 || cleanup.Cleaned != 1 || cleanup.Failed != 0 {
+		t.Fatalf("cleanup = %#v, want one successful retry", cleanup)
+	}
+	if adapter.hasRetiredCodexSessions(side.AgentSessionID) {
+		t.Fatal("dedicated process remained retained after successful retry")
+	}
+	transport.conn.mu.Lock()
+	closeCount := transport.conn.closeCount
+	transport.conn.mu.Unlock()
+	if closeCount != 2 {
+		t.Fatalf("physical close attempts = %d, want 2", closeCount)
 	}
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_side_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_side_test.go
@@ -415,9 +415,15 @@ func TestCodexHistoricalSideFallsBackWhenRegisteredSourceClientIsDead(t *testing
 	}
 	source := started.Session
 	source.RuntimeContext = adapter.SessionState(source).RuntimeContext
+	sourceClient := adapter.getSession(source.AgentSessionID).client
 	deadConn := transport.conn(0)
 	if err := deadConn.Close(); err != nil {
 		t.Fatal(err)
+	}
+	select {
+	case <-sourceClient.Done():
+	case <-time.After(time.Second):
+		t.Fatal("source client did not observe the closed connection")
 	}
 
 	capabilities, err := adapter.SideCapabilities(t.Context(), source)

--- a/packages/agent/daemon/runtime/controller_side_conversation.go
+++ b/packages/agent/daemon/runtime/controller_side_conversation.go
@@ -24,7 +24,31 @@ func (c *Controller) SideCapabilities(
 	}
 	defer release()
 	_, _, capabilities, err := c.sideSourceCapabilitiesLocked(
-		ctx, roomID, sourceAgentSessionID,
+		ctx, roomID, sourceAgentSessionID, nil,
+	)
+	return capabilities, err
+}
+
+// SideCapabilitiesForSource resolves Side support from a Host-prepared source
+// snapshot when the canonical provider connection is no longer retained.
+func (c *Controller) SideCapabilitiesForSource(
+	ctx context.Context,
+	source Session,
+) (SideConversationCapabilities, error) {
+	roomID := strings.TrimSpace(source.RoomID)
+	sourceID := strings.TrimSpace(source.AgentSessionID)
+	if roomID == "" || sourceID == "" {
+		return SideConversationCapabilities{}, fmt.Errorf(
+			"room and source session ids are required",
+		)
+	}
+	release, err := c.acquireLifecycleLockContext(ctx, roomID, sourceID)
+	if err != nil {
+		return SideConversationCapabilities{}, err
+	}
+	defer release()
+	_, _, capabilities, err := c.sideSourceCapabilitiesLocked(
+		ctx, roomID, sourceID, &source,
 	)
 	return capabilities, err
 }
@@ -33,20 +57,24 @@ func (c *Controller) sideSourceCapabilitiesLocked(
 	ctx context.Context,
 	roomID string,
 	sourceAgentSessionID string,
+	requested *Session,
 ) (Session, Adapter, SideConversationCapabilities, error) {
-	source, adapter, err := c.sessionAndAdapter(
-		strings.TrimSpace(roomID),
-		strings.TrimSpace(sourceAgentSessionID),
-	)
+	var source Session
+	var adapter Adapter
+	var err error
+	if requested == nil {
+		source, adapter, err = c.sessionAndAdapter(
+			strings.TrimSpace(roomID),
+			strings.TrimSpace(sourceAgentSessionID),
+		)
+	} else {
+		source, adapter, err = c.sessionForkSource(ctx, *requested)
+	}
 	if err != nil {
 		return Session{}, nil, SideConversationCapabilities{}, err
 	}
 	if source.IsSideConversation() {
 		return Session{}, nil, SideConversationCapabilities{}, ErrSideConversationUnsupported
-	}
-	probe, ok := adapter.(LiveSessionProbeAdapter)
-	if !ok || !probe.HasLiveSession(source) {
-		return Session{}, nil, SideConversationCapabilities{}, ErrSessionDisconnected
 	}
 	sideAdapter, ok := adapter.(SideConversationAdapter)
 	if !ok {
@@ -76,6 +104,13 @@ func (c *Controller) OpenSide(
 	if sourceID == sideID {
 		return SideConversationOpenResult{}, ErrSideConversationConflict
 	}
+	if requested := sideRequestedSource(input); requested != nil &&
+		(strings.TrimSpace(requested.RoomID) != roomID ||
+			strings.TrimSpace(requested.AgentSessionID) != sourceID) {
+		return SideConversationOpenResult{}, fmt.Errorf(
+			"prepared source identity does not match side open input",
+		)
+	}
 
 	release, err := c.acquireSideConversationLifecycleLocks(
 		ctx,
@@ -94,7 +129,7 @@ func (c *Controller) OpenSide(
 			existing.SourceAgentSessionID == sourceID &&
 			existing.SideRequestID == requestID {
 			_, _, capabilities, err := c.sideSourceCapabilitiesLocked(
-				ctx, roomID, sourceID,
+				ctx, roomID, sourceID, sideRequestedSource(input),
 			)
 			return SideConversationOpenResult{
 				Session: existing, Capabilities: capabilities,
@@ -104,7 +139,7 @@ func (c *Controller) OpenSide(
 	}
 
 	source, adapter, capabilities, err := c.sideSourceCapabilitiesLocked(
-		ctx, roomID, sourceID,
+		ctx, roomID, sourceID, sideRequestedSource(input),
 	)
 	if err != nil {
 		return SideConversationOpenResult{}, err
@@ -222,6 +257,14 @@ func (c *Controller) OpenSide(
 		c.publishAdapterCommandSnapshot(opened, adapter)
 	}
 	return result, nil
+}
+
+func sideRequestedSource(input SideConversationOpenInput) *Session {
+	if strings.TrimSpace(input.Source.AgentSessionID) == "" {
+		return nil
+	}
+	source := input.Source
+	return &source
 }
 
 func (c *Controller) acquireSideConversationLifecycleLocks(

--- a/packages/agent/daemon/runtime/controller_side_conversation_test.go
+++ b/packages/agent/daemon/runtime/controller_side_conversation_test.go
@@ -417,7 +417,7 @@ func TestExpiredSideConversationNeverResumes(t *testing.T) {
 	}
 }
 
-func TestSideCapabilitiesFailsClosedAfterCanonicalSourceIdleRelease(t *testing.T) {
+func TestSideCapabilitiesDelegatesAfterCanonicalSourceIdleRelease(t *testing.T) {
 	adapter := newSideConformanceAdapter()
 	controller := NewController([]Adapter{adapter}, nil)
 	if _, err := controller.Resume(t.Context(), ResumeInput{
@@ -433,11 +433,14 @@ func TestSideCapabilitiesFailsClosedAfterCanonicalSourceIdleRelease(t *testing.T
 	adapter.live["parent"] = false
 	adapter.mu.Unlock()
 
-	_, err := controller.SideCapabilities(
+	capabilities, err := controller.SideCapabilities(
 		t.Context(), "workspace-side", "parent",
 	)
-	if !errors.Is(err, ErrSessionDisconnected) {
-		t.Fatalf("SideCapabilities error = %v, want ErrSessionDisconnected", err)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !validRequiredSideCapabilities(capabilities) {
+		t.Fatalf("SideCapabilities = %#v, want supported", capabilities)
 	}
 	adapter.mu.Lock()
 	defer adapter.mu.Unlock()
@@ -446,7 +449,7 @@ func TestSideCapabilitiesFailsClosedAfterCanonicalSourceIdleRelease(t *testing.T
 	}
 }
 
-func TestOpenSideFailsClosedAfterCanonicalSourceIdleRelease(t *testing.T) {
+func TestOpenSideDelegatesAfterCanonicalSourceIdleRelease(t *testing.T) {
 	adapter := newSideConformanceAdapter()
 	controller := NewController([]Adapter{adapter}, nil)
 	if _, err := controller.Resume(t.Context(), ResumeInput{
@@ -462,14 +465,17 @@ func TestOpenSideFailsClosedAfterCanonicalSourceIdleRelease(t *testing.T) {
 	adapter.live["parent"] = false
 	adapter.mu.Unlock()
 
-	_, err := controller.OpenSide(t.Context(), SideConversationOpenInput{
+	opened, err := controller.OpenSide(t.Context(), SideConversationOpenInput{
 		RoomID:               "workspace-side",
 		SourceAgentSessionID: "parent",
 		SideAgentSessionID:   "side-after-release",
 		RequestID:            "open-after-release",
 	})
-	if !errors.Is(err, ErrSessionDisconnected) {
-		t.Fatalf("OpenSide error = %v, want ErrSessionDisconnected", err)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opened.Session.ProviderSessionID != "provider-side" {
+		t.Fatalf("opened Side = %#v", opened.Session)
 	}
 	adapter.mu.Lock()
 	defer adapter.mu.Unlock()

--- a/packages/agent/daemon/runtime/types.go
+++ b/packages/agent/daemon/runtime/types.go
@@ -473,10 +473,11 @@ type SideConversationCapabilities struct {
 }
 
 type SideConversationOpenInput struct {
-	RoomID               string `json:"roomId"`
-	SourceAgentSessionID string `json:"sourceAgentSessionId"`
-	SideAgentSessionID   string `json:"sideAgentSessionId"`
-	RequestID            string `json:"requestId"`
+	RoomID               string  `json:"roomId"`
+	SourceAgentSessionID string  `json:"sourceAgentSessionId"`
+	SideAgentSessionID   string  `json:"sideAgentSessionId"`
+	RequestID            string  `json:"requestId"`
+	Source               Session `json:"-"`
 }
 
 type SideConversationAdapterOpenInput struct {

--- a/packages/agent/host/goal_reconcile_types.go
+++ b/packages/agent/host/goal_reconcile_types.go
@@ -1,0 +1,15 @@
+package agenthost
+
+type GoalReconcileRequiredInput struct {
+	WorkspaceID         string
+	AgentSessionID      string
+	RequestID           string
+	ProviderTurnID      string
+	Reason              string
+	FenceMode           string
+	ExpectedOperationID string
+	ExpectedRevision    int64
+	ExpectedRepairEpoch int64
+	QuiesceSucceeded    bool
+	QuiesceError        string
+}

--- a/packages/agent/host/side_conversation.go
+++ b/packages/agent/host/side_conversation.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 )
 
 type sideConversationRegistration struct {
@@ -31,7 +33,7 @@ func (h *Host) ResolveSideConversation(
 	}
 	workspaceID = strings.TrimSpace(workspaceID)
 	sourceAgentSessionID = strings.TrimSpace(sourceAgentSessionID)
-	source, err := h.sideSourceRuntime(workspaceID, sourceAgentSessionID)
+	source, err := h.sideSourceRuntime(ctx, workspaceID, sourceAgentSessionID)
 	if err != nil {
 		return SideConversationCapabilities{}, err
 	}
@@ -42,14 +44,52 @@ func (h *Host) ResolveSideConversation(
 }
 
 func (h *Host) sideSourceRuntime(
+	ctx context.Context,
 	workspaceID string,
 	sourceAgentSessionID string,
 ) (ProviderRuntimeSession, error) {
 	source, found := h.runtime.Session(workspaceID, sourceAgentSessionID)
+	if found {
+		return source, nil
+	}
+	if h.store == nil {
+		return ProviderRuntimeSession{}, ErrRuntimeSessionDisconnected
+	}
+	canonical, found, err := h.store.GetSession(ctx, workspaceID, sourceAgentSessionID)
+	if err != nil {
+		return ProviderRuntimeSession{}, err
+	}
 	if !found {
 		return ProviderRuntimeSession{}, ErrRuntimeSessionDisconnected
 	}
-	return source, nil
+	return historicalSideRuntimeSource(canonical)
+}
+
+func historicalSideRuntimeSource(
+	canonical storesqlite.Session,
+) (ProviderRuntimeSession, error) {
+	settings := composerSettingsFromMap(canonical.Settings)
+	env, err := runtimeEnvironmentForCanonicalSession(
+		nil,
+		canonical.Cwd,
+		canonical,
+	)
+	if err != nil {
+		return ProviderRuntimeSession{}, err
+	}
+	return ProviderRuntimeSession{
+		ID: canonical.ID, WorkspaceID: canonical.WorkspaceID,
+		UserID: canonical.UserID, AgentTargetID: canonical.AgentTargetID,
+		Provider: canonical.Provider, ProviderSessionID: canonical.ProviderSessionID,
+		Resumable: true, Cwd: canonical.Cwd, Env: env, Settings: &settings,
+		Capabilities:   canonical.Capabilities,
+		RuntimeContext: cloneMap(canonical.InternalRuntimeContext),
+		Status:         persistedRuntimeStatus(canonical.ActiveTurnID),
+		Visible:        canonical.Metadata.Visible, Title: canonical.Title,
+		PinnedAtUnixMS:  canonical.PinnedAtUnixMS,
+		CreatedAtUnixMS: canonical.CreatedAtUnixMS,
+		UpdatedAtUnixMS: canonical.UpdatedAtUnixMS,
+	}, nil
 }
 
 func (h *Host) OpenSideConversation(
@@ -193,8 +233,7 @@ func (h *Host) ensureSideSourceRuntimeLocked(
 	workspaceID string,
 	sourceAgentSessionID string,
 ) (ProviderRuntimeSession, error) {
-	_ = ctx
-	return h.sideSourceRuntime(workspaceID, sourceAgentSessionID)
+	return h.sideSourceRuntime(ctx, workspaceID, sourceAgentSessionID)
 }
 
 func (h *Host) SendSideConversation(

--- a/packages/agent/host/side_conversation_conformance_test.go
+++ b/packages/agent/host/side_conversation_conformance_test.go
@@ -8,6 +8,7 @@ import (
 
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	"github.com/tutti-os/tutti/packages/agent/host/conformance"
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 )
 
 type sideHostConformanceDriver struct {
@@ -21,6 +22,7 @@ type sideHostRuntime struct {
 	sideLive        bool
 	transientEvents int
 	canonicalWrites int
+	resumeCalls     int
 }
 
 func (d *sideHostConformanceDriver) ResetSideConversation(context.Context) error {
@@ -92,10 +94,11 @@ func (*sideHostRuntime) Start(
 	return agenthost.RuntimeStartResult{}, nil
 }
 
-func (*sideHostRuntime) Resume(
+func (r *sideHostRuntime) Resume(
 	context.Context,
 	agenthost.RuntimeResumeInput,
 ) (agenthost.ProviderRuntimeSession, error) {
+	r.resumeCalls++
 	return agenthost.ProviderRuntimeSession{}, nil
 }
 
@@ -219,6 +222,57 @@ func TestHostSideConversationConformance(t *testing.T) {
 				t.Fatal(err)
 			}
 		})
+	}
+}
+
+type historicalSideCanonicalStore struct {
+	agenthost.CanonicalStore
+	session storesqlite.Session
+}
+
+func (s historicalSideCanonicalStore) GetSession(
+	_ context.Context,
+	workspaceID string,
+	agentSessionID string,
+) (storesqlite.Session, bool, error) {
+	if workspaceID != s.session.WorkspaceID || agentSessionID != s.session.ID {
+		return storesqlite.Session{}, false, nil
+	}
+	return s.session, true, nil
+}
+
+func TestHostSideConversationUsesPersistedSourceWithoutResumingCanonical(t *testing.T) {
+	runtime := &sideHostRuntime{sessions: map[string]agenthost.ProviderRuntimeSession{}}
+	store := historicalSideCanonicalStore{session: storesqlite.Session{
+		ID: "historical-parent", WorkspaceID: "workspace-side",
+		Provider: "codex", ProviderSessionID: "provider-parent",
+		Cwd: "/workspace", InternalRuntimeContext: map[string]any{
+			"agent": map[string]any{"userAgent": "codex_cli_rs/1.0.0"},
+		},
+	}}
+	host := agenthost.New(agenthost.Config{
+		CanonicalStore: store, Runtime: runtime, SideConversationRuntime: runtime,
+	})
+
+	capabilities, err := host.ResolveSideConversation(
+		t.Context(), "workspace-side", "historical-parent",
+	)
+	if err != nil || !capabilities.Supported {
+		t.Fatalf("ResolveSideConversation() = (%#v, %v), want supported", capabilities, err)
+	}
+	result, err := host.OpenSideConversation(t.Context(), agenthost.OpenSideConversationInput{
+		WorkspaceID: "workspace-side", SourceAgentSessionID: "historical-parent",
+		SideAgentSessionID: "historical-side", RequestID: "historical-open",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Session.SourceAgentSessionID != "historical-parent" ||
+		result.Session.Scope != agenthost.RuntimeSessionScopeSide {
+		t.Fatalf("OpenSideConversation() session = %#v", result.Session)
+	}
+	if runtime.resumeCalls != 0 {
+		t.Fatalf("Resume() calls = %d, want 0", runtime.resumeCalls)
 	}
 }
 

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -1070,17 +1070,3 @@ type FenceGoalGenerationResult struct {
 	IntentAccepted bool
 	Settled        bool
 }
-
-type GoalReconcileRequiredInput struct {
-	WorkspaceID         string
-	AgentSessionID      string
-	RequestID           string
-	ProviderTurnID      string
-	Reason              string
-	FenceMode           string
-	ExpectedOperationID string
-	ExpectedRevision    int64
-	ExpectedRepairEpoch int64
-	QuiesceSucceeded    bool
-	QuiesceError        string
-}


### PR DESCRIPTION
## Summary

- resolve Side capability/open from the persisted canonical session when the source runtime is no longer live, without resuming the parent
- launch historical Codex Side on a Side-owned app-server identity, restore its persisted isolated CODEX_HOME, and fork the original thread ephemerally
- retain failed dedicated-process closes for bounded cleanup, and fall back from dead/releasing live clients to the historical path
- document the live and historical ownership/lifecycle contract

## Verification

- `go test ./packages/agent/host ./packages/agent/daemon/hostadapter ./packages/agent/daemon/runtime`
- push hook: `pnpm check:changed -- --push-ready` (10/10 lanes passed)
- historical settled-session API: capabilities 200, open 200, close 204; canonical source was not resumed
- AgentGUI E2E: Slash Side entry visible, opening shell rendered, Side reached ready state
- independent subagent review completed; identity isolation, cleanup ownership, and dead-client fallback findings fixed and re-reviewed with no blockers

## Platform assessment

No OS-specific process or path behavior was introduced. Environment restoration uses the existing ProcessSpec/provider-launch abstractions; Windows remains covered by the existing adapter contracts and CI.

## Risk

Historical Side intentionally fails closed when the persisted Codex runtime metadata lacks the isolated CODEX_HOME required to locate the original rollout. Side remains runtime-only and ephemeral.