### PR TITLE
fix(device-link): detect stalled relay callers

### DIFF
--- a/packages/device-link/README.md
+++ b/packages/device-link/README.md
@@ -80,10 +80,12 @@ shared manager owns the authenticated link and incoming stream lifecycle.
 
 The `relaytransport` package owns the reusable mechanics for Relay-backed byte
 streams. `Dial` turns binary WebSocket messages into a `net.Conn` for one
-caller stream. `OwnerHost` maintains one WebSocket/yamux owner tunnel while at
-least one product driver holds a reference, accepts remote streams only after
-the product readiness barrier succeeds, and reconnects with bounded full-jitter
-backoff plus `Retry-After`.
+caller stream and uses Ping/Pong liveness so an unresponsive peer closes the
+stream for the product's existing reconnect policy. `DialLivenessConfig` has
+20-second ping and 60-second pong defaults. `OwnerHost` maintains one
+WebSocket/yamux owner tunnel while at least one product driver holds a
+reference, accepts remote streams only after the product readiness barrier
+succeeds, and reconnects with bounded full-jitter backoff plus `Retry-After`.
 
 `OwnerLifecycle.Activate` returns an `OwnerActivation`: its `Readiness`
 context is a continuous product health condition for the complete connection

--- a/packages/device-link/relaytransport/dial.go
+++ b/packages/device-link/relaytransport/dial.go
@@ -21,7 +21,7 @@ func Dial(ctx context.Context, request DialRequest) (net.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newWebSocketByteConn(ws), nil
+	return newDialWebSocketByteConn(ws, request.Liveness), nil
 }
 
 func dialWebSocket(ctx context.Context, request DialRequest) (*websocket.Conn, error) {

--- a/packages/device-link/relaytransport/dial_liveness.go
+++ b/packages/device-link/relaytransport/dial_liveness.go
@@ -1,0 +1,113 @@
+package relaytransport
+
+import (
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	defaultDialPingInterval = 20 * time.Second
+	defaultDialPongTimeout  = 60 * time.Second
+)
+
+type dialWebSocketByteConn struct {
+	*websocketByteConn
+
+	stopLiveness func()
+	closeOnce    sync.Once
+	closeErr     error
+}
+
+func newDialWebSocketByteConn(ws *websocket.Conn, config DialLivenessConfig) net.Conn {
+	return &dialWebSocketByteConn{
+		websocketByteConn: newWebSocketByteConn(ws),
+		stopLiveness:      startDialLiveness(ws, normalizeDialLiveness(config)),
+	}
+}
+
+func (c *dialWebSocketByteConn) Close() error {
+	c.closeOnce.Do(func() {
+		c.closeErr = c.websocketByteConn.Close()
+		c.stopLiveness()
+	})
+	return c.closeErr
+}
+
+func normalizeDialLiveness(config DialLivenessConfig) DialLivenessConfig {
+	if config.PingInterval <= 0 {
+		config.PingInterval = defaultDialPingInterval
+	}
+	if config.PongTimeout <= config.PingInterval {
+		config.PongTimeout = config.PingInterval * 3
+	}
+	return config
+}
+
+func startDialLiveness(ws *websocket.Conn, config DialLivenessConfig) func() {
+	var lastPongUnixNano atomic.Int64
+	lastPongUnixNano.Store(time.Now().UnixNano())
+	pongs := make(chan struct{}, 1)
+	ws.SetPongHandler(func(string) error {
+		lastPongUnixNano.Store(time.Now().UnixNano())
+		select {
+		case pongs <- struct{}{}:
+		default:
+		}
+		return nil
+	})
+
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		ticker := time.NewTicker(config.PingInterval)
+		defer ticker.Stop()
+		timeout := time.NewTimer(config.PongTimeout)
+		defer timeout.Stop()
+
+		for {
+			select {
+			case <-done:
+				return
+			case <-pongs:
+				resetTimer(timeout, config.PongTimeout)
+			case <-ticker.C:
+				if err := ws.WriteControl(websocket.PingMessage, []byte("caller"), time.Now().Add(time.Second)); err != nil {
+					_ = ws.Close()
+					return
+				}
+			case <-timeout.C:
+				lastPongAt := time.Unix(0, lastPongUnixNano.Load())
+				remaining := config.PongTimeout - time.Since(lastPongAt)
+				if remaining > 0 {
+					timeout.Reset(remaining)
+					continue
+				}
+				_ = ws.Close()
+				return
+			}
+		}
+	}()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			close(done)
+			<-stopped
+		})
+	}
+}
+
+func resetTimer(timer *time.Timer, duration time.Duration) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	timer.Reset(duration)
+}

--- a/packages/device-link/relaytransport/dial_test.go
+++ b/packages/device-link/relaytransport/dial_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -109,6 +110,203 @@ func TestDialCreatesAuthenticatedBinaryByteStream(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("server did not finish the binary stream exchange")
+	}
+}
+
+func TestDialClosesStreamWhenPeerDoesNotPong(t *testing.T) {
+	pings := make(chan struct{}, 1)
+	upgrader := websocket.Upgrader{
+		CheckOrigin:  func(*http.Request) bool { return true },
+		Subprotocols: []string{testSubprotocol},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.Close()
+		ws.SetPingHandler(func(string) error {
+			select {
+			case pings <- struct{}{}:
+			default:
+			}
+			return nil
+		})
+		for {
+			if _, _, err := ws.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	endpoint := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, err := Dial(context.Background(), DialRequest{
+		Endpoint: endpoint, Subprotocol: testSubprotocol,
+		Liveness: DialLivenessConfig{
+			PingInterval: 50 * time.Millisecond,
+			PongTimeout:  500 * time.Millisecond,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Dial() error = %v", err)
+	}
+	defer conn.Close()
+
+	readResult := make(chan error, 1)
+	go func() {
+		_, err := conn.Read(make([]byte, 1))
+		readResult <- err
+	}()
+
+	select {
+	case <-pings:
+	case <-time.After(2 * time.Second):
+		t.Fatal("caller did not send a liveness ping")
+	}
+	select {
+	case err := <-readResult:
+		if err == nil {
+			t.Fatal("stream read succeeded after peer ignored liveness ping")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream read remained blocked after peer ignored liveness ping")
+	}
+}
+
+func TestDialKeepsStreamOpenWhenPeerPongs(t *testing.T) {
+	upgrader := websocket.Upgrader{
+		CheckOrigin:  func(*http.Request) bool { return true },
+		Subprotocols: []string{testSubprotocol},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.Close()
+		pings := 0
+		ws.SetPingHandler(func(payload string) error {
+			pings++
+			if err := ws.WriteControl(websocket.PongMessage, []byte(payload), time.Now().Add(time.Second)); err != nil {
+				return err
+			}
+			if pings == 6 {
+				return ws.WriteMessage(websocket.BinaryMessage, []byte("ok"))
+			}
+			return nil
+		})
+		for {
+			if _, _, err := ws.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	endpoint := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, err := Dial(context.Background(), DialRequest{
+		Endpoint: endpoint, Subprotocol: testSubprotocol,
+		Liveness: DialLivenessConfig{
+			PingInterval: 100 * time.Millisecond,
+			PongTimeout:  500 * time.Millisecond,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Dial() error = %v", err)
+	}
+	defer conn.Close()
+
+	readResult := make(chan struct {
+		payload []byte
+		err     error
+	}, 1)
+	go func() {
+		payload := make([]byte, 2)
+		_, err := io.ReadFull(conn, payload)
+		readResult <- struct {
+			payload []byte
+			err     error
+		}{payload: payload, err: err}
+	}()
+
+	select {
+	case result := <-readResult:
+		if result.err != nil {
+			t.Fatalf("stream read after pongs: %v", result.err)
+		}
+		if got := string(result.payload); got != "ok" {
+			t.Fatalf("stream payload = %q, want ok", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream did not remain open while peer replied to liveness pings")
+	}
+}
+
+func TestDialLivenessDoesNotOverrideCallerReadDeadline(t *testing.T) {
+	pings := make(chan struct{}, 1)
+	upgrader := websocket.Upgrader{
+		CheckOrigin:  func(*http.Request) bool { return true },
+		Subprotocols: []string{testSubprotocol},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.Close()
+		ws.SetPingHandler(func(payload string) error {
+			if err := ws.WriteControl(websocket.PongMessage, []byte(payload), time.Now().Add(time.Second)); err != nil {
+				return err
+			}
+			select {
+			case pings <- struct{}{}:
+			default:
+			}
+			return nil
+		})
+		for {
+			if _, _, err := ws.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	endpoint := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, err := Dial(context.Background(), DialRequest{
+		Endpoint: endpoint, Subprotocol: testSubprotocol,
+		Liveness: DialLivenessConfig{
+			PingInterval: 50 * time.Millisecond,
+			PongTimeout:  500 * time.Millisecond,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Dial() error = %v", err)
+	}
+	defer conn.Close()
+
+	readResult := make(chan error, 1)
+	go func() {
+		_, err := conn.Read(make([]byte, 1))
+		readResult <- err
+	}()
+	select {
+	case <-pings:
+	case <-time.After(2 * time.Second):
+		t.Fatal("caller did not send a liveness ping")
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(120 * time.Millisecond)); err != nil {
+		t.Fatalf("SetReadDeadline() error = %v", err)
+	}
+	select {
+	case err := <-readResult:
+		var netErr net.Error
+		if !errors.As(err, &netErr) || !netErr.Timeout() {
+			t.Fatalf("stream read error = %v, want caller read deadline timeout", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("liveness pong extended the caller read deadline")
 	}
 }
 

--- a/packages/device-link/relaytransport/types.go
+++ b/packages/device-link/relaytransport/types.go
@@ -18,6 +18,18 @@ type DialRequest struct {
 	Query       url.Values
 	Header      http.Header
 	Subprotocol string
+	Liveness    DialLivenessConfig
+}
+
+// DialLivenessConfig controls WebSocket keepalive for one Relay caller stream.
+// A non-positive PingInterval uses the transport default. A PongTimeout not
+// greater than the effective ping interval uses three ping intervals.
+//
+// The returned net.Conn fails when its peer does not answer WebSocket pings
+// before PongTimeout. Callers can then apply their existing reconnect policy.
+type DialLivenessConfig struct {
+	PingInterval time.Duration
+	PongTimeout  time.Duration
 }
 
 // StreamHandler consumes one stream opened over an owner tunnel.


### PR DESCRIPTION
## Summary
- Add Ping/Pong liveness to Relay caller streams so a half-open WebSocket closes and the existing caller reconnect policy can run
- Preserve caller-controlled read deadlines while a healthy peer responds to Pings
- Add real-WebSocket coverage for missed Pongs, healthy Pongs, and caller read deadlines

## Verification
- `pnpm check:changed -- --push-ready`
- `go test -race ./relaytransport -count=1`

## Fallback Three Questions
- Source: a one-way network failure can let the Relay close a caller stream while the local WebSocket receives neither EOF nor an I/O error
- Why can it not be fixed only at that source: the remote close cannot be delivered across the half-open path, so the caller must independently detect the missing Pong
- Removal condition: the underlying transport guarantees a locally observable close within the reconnect SLO for every remote Relay termination

## Checklist
- [x] This does not change agent lifecycle semantics
- [x] The change is focused on product-neutral Relay transport mechanics
- [x] Updated the package README for the public `Dial` behavior
- [x] Ran the lowest meaningful local checks for the changed surface
- [x] Commit is DCO signed off