### PR TITLE
fix(agent-gui): align Windows tool sidebar header

### DIFF
--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -5362,15 +5362,18 @@ aside.workspace-agents-status-panel
 
 /*
  * The tool-sidebar actions are removed from the flex flow above. On Windows
- * the native caption buttons occupy the right edge of the same overlay, so a
- * bare `right: 0` puts those actions underneath minimize/restore/close. Move
- * the absolute action group to the same safe edge used by the header padding.
+ * the native caption buttons occupy the right edge of the same overlay. Keep
+ * the tool header anchored to the same edge as its body panel, then reserve
+ * the caption-button hit area inside that header so its controls stay clear
+ * without shifting the header border into the Agent surface.
  */
 .agent-gui-workbench-header[data-tutti-titlebar-overlay="true"]
-  .agent-gui-workbench-header__secondary-accessory:has(
-    [data-agent-tool-sidebar-header="true"]
-  ) {
-  right: var(--tutti-titlebar-controls-inset);
+  [data-agent-tool-sidebar-header="true"] {
+  box-sizing: border-box;
+  padding-right: calc(
+    var(--tutti-titlebar-controls-inset) +
+      var(--agent-gui-workbench-header-padding-x)
+  );
 }
 
 /*


### PR DESCRIPTION
## Summary

- keep the standalone Agent tool-sidebar header anchored to the same right edge as its body panel
- reserve the Windows native caption-button hit area as internal header padding
- prevent the tool header border from extending into the Agent surface while keeping tool actions clear of minimize, maximize, and close

## Root cause

The Windows title-bar overlay rule moved the entire absolutely positioned tool header left by `--tutti-titlebar-controls-inset`. The sidebar body remained anchored at `right: 0`, so the header and its bottom border protruded into the Agent surface.

## Impact

On Windows Agent-mode windows, the Files/Terminal/etc. header now aligns with the right sidebar body. Tool actions retain the native caption-button safety inset and do not overlap the system controls.

## Validation

This is a CSS-only presentation change. Per the repository UI-only validation exception, no automated checks were run. A Windows native-titlebar visual pass remains the manual gate: verify header/body left-edge alignment and separation between tool actions and native caption controls.

## AgentGUI review

| Lane | Trigger | Result | Evidence | Affected consumers |
| --- | --- | --- | --- | --- |
| Architecture | Workbench integration CSS | pass | Existing header/body ownership and DOM structure are unchanged; only the Windows inset projection moves from external positioning to internal padding | Desktop standalone Agent window |
| Performance | Layout CSS | pass | Static selector replacement; no observers, measurements, render subscriptions, or animation budgets changed | Desktop standalone Agent window |
| Consumers | No exported contract or runtime behavior changed | not applicable | No TypeScript exports, props, DTOs, or host capabilities changed | None outside CSS presentation |

## Documentation impact

No durable documentation update is needed because module ownership, data flow, public contracts, configuration, and troubleshooting procedures are unchanged.