### PR TITLE
fix(agent-gui): align Windows tool sidebar header

### DIFF
--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -5364,15 +5364,18 @@ aside.workspace-agents-status-panel
 
 /*
  * The tool-sidebar actions are removed from the flex flow above. On Windows
- * the native caption buttons occupy the right edge of the same overlay, so a
- * bare `right: 0` puts those actions underneath minimize/restore/close. Move
- * the absolute action group to the same safe edge used by the header padding.
+ * the native caption buttons occupy the right edge of the same overlay. Keep
+ * the tool header anchored to the same edge as its body panel, then reserve
+ * the caption-button hit area inside that header so its controls stay clear
+ * without shifting the header border into the Agent surface.
  */
 .agent-gui-workbench-header[data-tutti-titlebar-overlay="true"]
-  .agent-gui-workbench-header__secondary-accessory:has(
-    [data-agent-tool-sidebar-header="true"]
-  ) {
-  right: var(--tutti-titlebar-controls-inset);
+  [data-agent-tool-sidebar-header="true"] {
+  box-sizing: border-box;
+  padding-right: calc(
+    var(--tutti-titlebar-controls-inset) +
+      var(--agent-gui-workbench-header-padding-x)
+  );
 }
 
 /*


### PR DESCRIPTION
## Summary

Cherry-pick the Windows Agent tool-sidebar header alignment fix from #2499 onto `release/0818`.

- keep the tool header aligned with the sidebar body
- reserve native Windows caption controls as internal padding
- remove the bottom-border overflow into the Agent surface

Source commit on `main`: `6f04c1782f2fa24927b4d2770f53b11fdee13db0`
Release cherry-pick: `7a09698b1`

## Validation

The source PR's selected CI checks passed before merge. This release PR contains the same one-file CSS change, cherry-picked without conflict.