### PR TITLE
fix(connector): discard pre-HTTPS local catalog on store migrate

### DIFF
--- a/docs/architecture/connector.md
+++ b/docs/architecture/connector.md
@@ -226,6 +226,13 @@ its CDN URL in the Market manifest. The daemon rejects missing URLs, inline
 `data:` images, non-HTTPS schemes, credentials, surrounding whitespace, and
 URLs longer than 2048 bytes before the release reaches a renderer or runtime.
 
+The sqlite store records that presentation contract as `store_contract`.
+Opening a database below the current epoch discards catalog, install,
+operation, and outbox rows in one transaction, marks the catalog stale, and
+keeps authorization projections plus snapshot revisions. Catalog refresh reads
+the store revision without presentation validation so an obsolete local
+release cannot block recovery.
+
 Manifest permissions use a lowercase stable permission name with an optional
 scope (`permission`, `permission:scope`, or `permission:*`). The daemon keeps
 fail-closed validation for the permission name, scope grammar, duplicates, and

--- a/packages/connector/daemon/adapters/sqlite/store.go
+++ b/packages/connector/daemon/adapters/sqlite/store.go
@@ -19,6 +19,11 @@ import (
 
 const metadataID = 1
 
+// currentStoreContract is the durable release contract this binary can read.
+// Contract 1 is published HTTPS icons (#2481). Older local catalog/install
+// rows used data-URL icons and must not be loaded.
+const currentStoreContract = 1
+
 type Store struct {
 	db *sql.DB
 }
@@ -87,10 +92,11 @@ func (store *Store) migrate(ctx context.Context) error {
   id INTEGER PRIMARY KEY CHECK (id = 1),
   revision INTEGER NOT NULL,
   catalog_state TEXT NOT NULL,
-  source_revision TEXT NOT NULL
+  source_revision TEXT NOT NULL,
+  store_contract INTEGER NOT NULL DEFAULT 1
 )`,
-		`INSERT INTO connector_market_metadata (id, revision, catalog_state, source_revision)
-VALUES (1, 0, 'stale', '') ON CONFLICT(id) DO NOTHING`,
+		`INSERT INTO connector_market_metadata (id, revision, catalog_state, source_revision, store_contract)
+VALUES (1, 0, 'stale', '', 1) ON CONFLICT(id) DO NOTHING`,
 		`CREATE TABLE IF NOT EXISTS connector_market_connectors (
   connector_key TEXT PRIMARY KEY,
   connector_json TEXT NOT NULL
@@ -142,8 +148,11 @@ ON connector_market_outbox(published_at_unix_ms, sequence)`,
 		}
 	}
 	if _, err := store.db.ExecContext(ctx, `ALTER TABLE connector_market_operations ADD COLUMN lease_token INTEGER NOT NULL DEFAULT 0`); err != nil &&
-		!strings.Contains(strings.ToLower(err.Error()), "duplicate column") {
+		!isDuplicateColumnError(err) {
 		return fmt.Errorf("migrate connector market operation lease token: %w", err)
+	}
+	if err := store.migrateStoreContract(ctx); err != nil {
+		return err
 	}
 	if err := store.migrateLifecycle(ctx); err != nil {
 		return err

--- a/packages/connector/daemon/adapters/sqlite/store_contract.go
+++ b/packages/connector/daemon/adapters/sqlite/store_contract.go
@@ -33,10 +33,7 @@ SELECT store_contract FROM connector_market_metadata WHERE id = ?`, metadataID).
 	if err := discardIncompatibleStoreContractOn(ctx, tx); err != nil {
 		return err
 	}
-	if err := tx.Commit(); err != nil {
-		return err
-	}
-	return nil
+	return tx.Commit()
 }
 
 func (store *Store) ensureStoreContractTables(ctx context.Context) error {

--- a/packages/connector/daemon/adapters/sqlite/store_contract.go
+++ b/packages/connector/daemon/adapters/sqlite/store_contract.go
@@ -1,0 +1,94 @@
+package storesqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	market "github.com/tutti-os/tutti/packages/connector/daemon/core"
+)
+
+func (store *Store) migrateStoreContract(ctx context.Context) error {
+	if _, err := store.db.ExecContext(ctx, `
+ALTER TABLE connector_market_metadata ADD COLUMN store_contract INTEGER NOT NULL DEFAULT 0`); err != nil &&
+		!isDuplicateColumnError(err) {
+		return fmt.Errorf("migrate connector market store contract: %w", err)
+	}
+	if err := store.ensureStoreContractTables(ctx); err != nil {
+		return err
+	}
+	var contract int
+	if err := store.db.QueryRowContext(ctx, `
+SELECT store_contract FROM connector_market_metadata WHERE id = ?`, metadataID).Scan(&contract); err != nil {
+		return fmt.Errorf("read connector market store contract: %w", err)
+	}
+	if contract >= currentStoreContract {
+		return nil
+	}
+	tx, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := discardIncompatibleStoreContractOn(ctx, tx); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (store *Store) ensureStoreContractTables(ctx context.Context) error {
+	statements := []string{
+		`CREATE TABLE IF NOT EXISTS connector_market_release_installations (
+  connector_key TEXT NOT NULL,
+  release_digest TEXT NOT NULL,
+  release_json TEXT NOT NULL,
+  PRIMARY KEY (connector_key, release_digest)
+)`,
+		`CREATE TABLE IF NOT EXISTS connector_market_runtime_convergence (
+  account_id TEXT NOT NULL,
+  connector_key TEXT NOT NULL,
+  desired_generation INTEGER NOT NULL CHECK (desired_generation > 0),
+  observed_generation INTEGER NOT NULL CHECK (observed_generation >= 0),
+  observed_boot_epoch TEXT NOT NULL,
+  next_attempt_at_unix_ms INTEGER NOT NULL,
+  lease_owner TEXT NOT NULL,
+  lease_token INTEGER NOT NULL DEFAULT 0,
+  lease_expires_at_unix_ms INTEGER,
+  updated_at_unix_ms INTEGER NOT NULL,
+  convergence_json TEXT NOT NULL,
+  PRIMARY KEY (account_id, connector_key)
+)`,
+	}
+	for _, statement := range statements {
+		if _, err := store.db.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf("ensure connector market store contract tables: %w", err)
+		}
+	}
+	return nil
+}
+
+func discardIncompatibleStoreContractOn(ctx context.Context, tx *sql.Tx) error {
+	statements := []string{
+		`DELETE FROM connector_market_connectors`,
+		`DELETE FROM connector_market_installed_releases`,
+		`DELETE FROM connector_market_release_installations`,
+		`DELETE FROM connector_market_runtime_convergence`,
+		`DELETE FROM connector_market_operations`,
+		`DELETE FROM connector_market_outbox`,
+	}
+	for _, statement := range statements {
+		if _, err := tx.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf("discard incompatible connector market rows: %w", err)
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `
+UPDATE connector_market_metadata
+SET catalog_state = ?, source_revision = '', store_contract = ?
+WHERE id = ?`, market.CatalogStateStale, currentStoreContract, metadataID); err != nil {
+		return fmt.Errorf("record connector market store contract: %w", err)
+	}
+	return nil
+}

--- a/packages/connector/daemon/adapters/sqlite/store_contract_test.go
+++ b/packages/connector/daemon/adapters/sqlite/store_contract_test.go
@@ -1,0 +1,184 @@
+package storesqlite
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	market "github.com/tutti-os/tutti/packages/connector/daemon/core"
+)
+
+func TestStoreContractDiscardLeavesAuthorizationAndRevision(t *testing.T) {
+	ctx := context.Background()
+	databasePath := filepath.Join(t.TempDir(), "tuttid.db")
+	store, err := Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	connector := testConnector()
+	connector.Release.Manifest.IconURL = "data:image/png;base64,iVBORw0KGgo="
+	connector.Installation = market.Installation{
+		State: market.InstallationStateInstalled, InstalledVersion: connector.Release.Version,
+		InstalledReleaseID: connector.Release.ReleaseID, InstalledReleaseDigest: connector.Release.ReleaseDigest,
+	}
+	now := time.Unix(1, 0).UTC()
+	if err := store.Transaction(ctx, func(tx market.Transaction) error {
+		connector.Revision = tx.AdvanceRevision()
+		if err := tx.SaveConnector(connector); err != nil {
+			return err
+		}
+		if err := tx.EnqueueConnectorMarketChanged(market.ChangedEvent{ConnectorKey: connector.Key, Revision: connector.Revision}); err != nil {
+			return err
+		}
+		return tx.SaveOperation(market.Operation{
+			OperationID: "refresh-stale", ClientRequestID: "refresh-stale", ConnectorKey: "",
+			Kind: market.OperationKindRefreshCatalog, State: market.OperationStateAccepted,
+			CreatedAt: now, UpdatedAt: now,
+		})
+	}); err != nil {
+		t.Fatal(err)
+	}
+	releasePayload, err := json.Marshal(connector.Release)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+INSERT INTO connector_market_installed_releases (connector_key, release_digest, release_json)
+VALUES (?, ?, ?)`, connector.Key, connector.Release.ReleaseDigest, string(releasePayload)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+INSERT INTO connector_market_release_installations (connector_key, release_digest, release_json)
+VALUES (?, ?, ?)`, connector.Key, connector.Release.ReleaseDigest, string(releasePayload)); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveAuthorizationProjection(ctx, market.AuthorizationProjection{
+		AccountID: "account-1", ConnectorKey: connector.Key, State: market.AuthorizationStateConnected,
+		ServerSynchronized: true, ServerRevision: 7, UpdatedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+INSERT INTO connector_market_authorization_snapshot_revisions (account_id, revision) VALUES (?, ?)
+ON CONFLICT(account_id) DO UPDATE SET revision = excluded.revision`, "account-1", 7); err != nil {
+		t.Fatal(err)
+	}
+	before, err := store.Snapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.Revision == 0 {
+		t.Fatal("expected a preserved metadata revision")
+	}
+	if _, err := store.db.ExecContext(ctx, `
+UPDATE connector_market_metadata
+SET store_contract = 0, catalog_state = ?, source_revision = 'old-source'
+WHERE id = ?`, market.CatalogStateReady, metadataID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	assertDiscardedStoreContract(t, reopened, before.Revision)
+
+	again, err := Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer again.Close()
+	assertDiscardedStoreContract(t, again, before.Revision)
+	if err := again.Transaction(ctx, func(tx market.Transaction) error {
+		return tx.SaveOperation(market.Operation{
+			OperationID: "refresh-new", ClientRequestID: "refresh-new", ConnectorKey: "",
+			Kind: market.OperationKindRefreshCatalog, State: market.OperationStateAccepted,
+			CreatedAt: now, UpdatedAt: now,
+		})
+	}); err != nil {
+		t.Fatalf("new catalog refresh blocked after contract discard: %v", err)
+	}
+}
+
+func TestStoreContractIdempotentWhenCurrent(t *testing.T) {
+	ctx := context.Background()
+	databasePath := filepath.Join(t.TempDir(), "tuttid.db")
+	store, err := Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	connector := testConnector()
+	if err := store.Transaction(ctx, func(tx market.Transaction) error {
+		connector.Revision = tx.AdvanceRevision()
+		return tx.SaveConnector(connector)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	snapshot, err := reopened.Snapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.Connectors) != 1 || snapshot.Connectors[0].Key != connector.Key {
+		t.Fatalf("current-contract connectors = %#v", snapshot.Connectors)
+	}
+	if snapshot.CatalogState != market.CatalogStateStale {
+		t.Fatalf("catalog state = %q", snapshot.CatalogState)
+	}
+}
+
+func assertDiscardedStoreContract(t *testing.T, store *Store, wantRevision uint64) {
+	t.Helper()
+	ctx := context.Background()
+	snapshot, err := store.Snapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.Revision != wantRevision {
+		t.Fatalf("revision = %d, want %d", snapshot.Revision, wantRevision)
+	}
+	if snapshot.CatalogState != market.CatalogStateStale || snapshot.SourceRevision != "" {
+		t.Fatalf("catalog = %#v", snapshot)
+	}
+	if len(snapshot.Connectors) != 0 || len(snapshot.Operations) != 0 {
+		t.Fatalf("discarded snapshot = %#v", snapshot)
+	}
+	if _, err := store.InstalledRelease(ctx, "github", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"); !errors.Is(err, market.ErrNotFound) {
+		t.Fatalf("installed release after discard = %v", err)
+	}
+	var contract int
+	if err := store.db.QueryRowContext(ctx, `SELECT store_contract FROM connector_market_metadata WHERE id = 1`).Scan(&contract); err != nil {
+		t.Fatal(err)
+	}
+	if contract != currentStoreContract {
+		t.Fatalf("store_contract = %d, want %d", contract, currentStoreContract)
+	}
+	projection, err := store.AuthorizationProjection(ctx, "account-1", "github")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if projection.State != market.AuthorizationStateConnected || projection.ServerRevision != 7 {
+		t.Fatalf("authorization projection = %#v", projection)
+	}
+	var snapshotRevision uint64
+	if err := store.db.QueryRowContext(ctx, `SELECT revision FROM connector_market_authorization_snapshot_revisions WHERE account_id = ?`, "account-1").Scan(&snapshotRevision); err != nil {
+		t.Fatal(err)
+	}
+	if snapshotRevision != 7 {
+		t.Fatalf("authorization snapshot revision = %d, want 7", snapshotRevision)
+	}
+}

--- a/packages/connector/daemon/application/host.go
+++ b/packages/connector/daemon/application/host.go
@@ -664,7 +664,12 @@ func (host *Host) recoverAndWait(ctx context.Context) error {
 }
 
 func (host *Host) refreshAndWait(ctx context.Context) error {
-	snapshot, err := host.Application.Snapshot(ctx)
+	if host.repository == nil {
+		return errors.New("connector market repository is unavailable")
+	}
+	// Read revision from the durable store without presentation validation so a
+	// leftover incompatible local release cannot block catalog refresh.
+	snapshot, err := host.repository.Snapshot(ctx)
 	if err != nil {
 		return err
 	}

--- a/packages/connector/daemon/application/host_test.go
+++ b/packages/connector/daemon/application/host_test.go
@@ -683,3 +683,63 @@ func hostTestRelease() market.Release {
 		Status:      market.ReleaseStatusAvailable,
 	}
 }
+
+func TestRefreshAndWaitIgnoresObsoleteLocalReleasePresentation(t *testing.T) {
+	ctx := context.Background()
+	store, err := marketdata.Open(ctx, filepath.Join(t.TempDir(), "tuttid.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	release := hostTestRelease()
+	obsolete := release
+	obsolete.Manifest.IconURL = "data:image/png;base64,iVBORw0KGgo="
+	if err := store.Transaction(ctx, func(tx market.Transaction) error {
+		connector := market.Connector{
+			Key: obsolete.ConnectorKey, Release: obsolete,
+			Installation:  market.Installation{State: market.InstallationStateNotInstalled},
+			Authorization: market.Authorization{State: market.AuthorizationStateNotRequired},
+			Compatibility: market.Compatibility{State: market.CompatibilityStateSupported},
+		}
+		connector.Revision = tx.AdvanceRevision()
+		return tx.SaveConnector(connector)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	source := &countingCatalogSource{release: release}
+	runtime := &activationGateDelegate{}
+	host, err := NewHost(ctx, HostConfig{
+		Repository:             store,
+		CatalogSource:          source,
+		ReleaseInstallations:   runtime,
+		ImplementationHost:     runtime,
+		Authorization:          unavailableAuthorization{},
+		Compatibility:          rejectingCompatibility{},
+		ImplementationRegistry: market.NewImplementationRegistry(nil),
+		Outbox:                 store,
+		Lifecycle:              store,
+		Publisher:              discardChangedEventPublisher{},
+		Publication:            &recordingPublicationController{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	host.refreshWorkerStarted = true
+	t.Cleanup(host.Close)
+	if _, err := host.Application.Snapshot(ctx); err == nil || !strings.Contains(err.Error(), "iconUrl") {
+		t.Fatalf("validated snapshot error = %v, want iconUrl rejection", err)
+	}
+	if err := host.refreshAndWait(ctx); err != nil {
+		t.Fatalf("refreshAndWait = %v", err)
+	}
+	if source.refreshes != 1 {
+		t.Fatalf("catalog refreshes = %d, want 1", source.refreshes)
+	}
+	snapshot, err := host.Application.Snapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.Connectors) != 1 || snapshot.Connectors[0].Release.Manifest.IconURL != release.Manifest.IconURL {
+		t.Fatalf("refreshed snapshot = %#v", snapshot.Connectors)
+	}
+}


### PR DESCRIPTION
## Summary
- Old local connector catalog/install rows still store data-URL icons. After #2481, `Snapshot()` fail-closes the whole market and catalog refresh never runs.
- SQLite now records `store_contract`. Opening a database below epoch 1 discards catalog, install, operation, and outbox rows, marks the catalog stale, and keeps authorization projections plus snapshot revisions.
- Catalog refresh reads the store revision without presentation validation so one obsolete local release cannot block recovery.

## Verification
- `go test ./adapters/sqlite ./application ./core` in `packages/connector/daemon`

## Fallback Three Questions
- Source: leftover catalog/install rows written before the HTTPS-icon contract, which fail `Snapshot()` validation after #2481.
- Why can it not be fixed at that source: older binaries already persisted those rows; a new binary cannot rewrite every existing profile before it opens the store, and validating `Snapshot()` currently blocks `RefreshCatalog`.
- Removal condition: keep the epoch ladder. This discard is the contract-1 step; delete it only if a later epoch supersedes it and no shipped reader still opens pre-1 databases.

## Checklist
- [ ] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.


Made with [Cursor](https://cursor.com)