### PR TITLE
feat(connector): improve composer connector controls

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts
@@ -97,7 +97,7 @@ export type WorkspaceWorkbenchCapabilitySettingsTarget =
   | {
       kind: "connector";
       connectorKey: string;
-      action?: "open";
+      action?: "install" | "open";
     }
   | {
       kind: "connector";

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
@@ -46,6 +46,7 @@ import {
 import { useService } from "@tutti-os/infra/di";
 import {
   IConnectorMarketModule,
+  installAndOpenConnectorMarketDialog,
   openConnectorMarketDialog
 } from "@tutti-os/connector-renderer/application";
 import { IWorkspaceFileManagerService } from "@renderer/features/workspace-file-manager";
@@ -725,6 +726,12 @@ export function StandaloneAgentWindow({
             target.connectorKey,
             target.enabled
           );
+        }
+        if (target.action === "install") {
+          return installAndOpenConnectorMarketDialog(
+            connectorMarketModule.root,
+            target.connectorKey
+          ).then(() => undefined);
         }
         if (target.action === "open") {
           void openConnectorMarketDialog(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceWorkbenchShellRuntime.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceWorkbenchShellRuntime.tsx
@@ -9,6 +9,7 @@ import {
 import { useService } from "@tutti-os/infra/di";
 import {
   IConnectorMarketModule,
+  installAndOpenConnectorMarketDialog,
   openConnectorMarketDialog
 } from "@tutti-os/connector-renderer/application";
 import type {
@@ -197,6 +198,12 @@ export function useWorkspaceWorkbenchShellRuntime({
             target.connectorKey,
             target.enabled
           );
+        }
+        if (target.action === "install") {
+          return installAndOpenConnectorMarketDialog(
+            connectorMarketModule.root,
+            target.connectorKey
+          ).then(() => undefined);
         }
         if (target.action === "open") {
           void openConnectorMarketDialog(

--- a/packages/agent/activity-core/src/composerOptions.types.ts
+++ b/packages/agent/activity-core/src/composerOptions.types.ts
@@ -48,6 +48,7 @@ export interface AgentActivityComposerCapabilityOption {
   invocation: "promptItem" | "textTrigger" | "none";
   description?: string;
   iconUrl?: string;
+  installedAtUnixMs?: number;
   source?: string;
   pluginName?: string;
   serverName?: string;

--- a/packages/agent/activity-tuttid-adapter/src/composerOptions.test.ts
+++ b/packages/agent/activity-tuttid-adapter/src/composerOptions.test.ts
@@ -84,6 +84,7 @@ test("projects connector presentation icons from the daemon catalog", () => {
         status: "available",
         invocation: "textTrigger",
         iconUrl: "data:image/png;base64,Z2l0aHVi",
+        installedAtUnixMs: 1_786_089_600_000,
         trigger: "/github"
       }
     ],
@@ -106,5 +107,9 @@ test("projects connector presentation icons from the daemon catalog", () => {
   assert.equal(
     options.capabilityCatalog?.[0]?.iconUrl,
     "data:image/png;base64,Z2l0aHVi"
+  );
+  assert.equal(
+    options.capabilityCatalog?.[0]?.installedAtUnixMs,
+    1_786_089_600_000
   );
 });

--- a/packages/agent/activity-tuttid-adapter/src/composerOptions.ts
+++ b/packages/agent/activity-tuttid-adapter/src/composerOptions.ts
@@ -458,6 +458,9 @@ function capabilityOptionsFromValue(
     seen.add(id);
     const description = normalizeText(record.description);
     const iconUrl = normalizeText(record.iconUrl);
+    const installedAtUnixMs = normalizePositiveInteger(
+      record.installedAtUnixMs
+    );
     const source = normalizeText(record.source);
     const pluginName = normalizeText(record.pluginName);
     const serverName = normalizeText(record.serverName);
@@ -473,6 +476,7 @@ function capabilityOptionsFromValue(
       invocation,
       ...(description ? { description } : {}),
       ...(iconUrl ? { iconUrl } : {}),
+      ...(installedAtUnixMs ? { installedAtUnixMs } : {}),
       ...(source ? { source } : {}),
       ...(pluginName ? { pluginName } : {}),
       ...(serverName ? { serverName } : {}),
@@ -553,4 +557,10 @@ function recordValue(value: unknown): Record<string, unknown> {
 
 function normalizeText(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function normalizePositiveInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0
+    ? value
+    : null;
 }

--- a/packages/agent/daemon/composercatalog/connectors.go
+++ b/packages/agent/daemon/composercatalog/connectors.go
@@ -25,20 +25,21 @@ const (
 // projections. Provider-specific discovery may populate the optional identity
 // fields while connector projection uses ConnectorKey-compatible Name values.
 type Option struct {
-	ID          string
-	Kind        string
-	Name        string
-	Label       string
-	IconURL     string
-	Description string
-	Status      string
-	Source      string
-	PluginName  string
-	ServerName  string
-	ToolName    string
-	Trigger     string
-	Path        string
-	Invocation  string
+	ID                string
+	Kind              string
+	Name              string
+	Label             string
+	IconURL           string
+	Description       string
+	Status            string
+	Source            string
+	PluginName        string
+	ServerName        string
+	ToolName          string
+	Trigger           string
+	Path              string
+	Invocation        string
+	InstalledAtUnixMS int64
 }
 
 // ConnectorOptions reads one authoritative Connector Market snapshot and
@@ -68,16 +69,17 @@ func ProjectConnectorOptions(snapshot connectorhost.Snapshot) []Option {
 			label = key
 		}
 		options = append(options, Option{
-			ID:          "connector:" + key,
-			Kind:        CapabilityKindConnector,
-			Name:        key,
-			Label:       label,
-			IconURL:     strings.TrimSpace(connector.Release.Manifest.IconURL),
-			Description: strings.TrimSpace(connector.Release.Manifest.Description),
-			Status:      ConnectorStatus(connector),
-			Source:      CapabilitySourceLocalDB,
-			Trigger:     "/" + key,
-			Invocation:  CapabilityInvocationTextTrigger,
+			ID:                "connector:" + key,
+			Kind:              CapabilityKindConnector,
+			Name:              key,
+			Label:             label,
+			IconURL:           strings.TrimSpace(connector.Release.Manifest.IconURL),
+			Description:       strings.TrimSpace(connector.Release.Manifest.Description),
+			Status:            ConnectorStatus(connector),
+			Source:            CapabilitySourceLocalDB,
+			Trigger:           "/" + key,
+			Invocation:        CapabilityInvocationTextTrigger,
+			InstalledAtUnixMS: connector.Installation.InstalledAtUnixMS,
 		})
 	}
 	return options

--- a/packages/agent/daemon/composercatalog/connectors_test.go
+++ b/packages/agent/daemon/composercatalog/connectors_test.go
@@ -15,6 +15,7 @@ func TestConnectorOptionsProjectsEveryCatalogState(t *testing.T) {
 		connectorFixture("legacy", "Legacy", connectorhost.InstallationStateInstalled, connectorhost.AuthorizationStateConnected, connectorhost.CompatibilityStateUnsupportedVersion),
 		connectorFixture("slack", "Slack", connectorhost.InstallationStateNotInstalled, connectorhost.AuthorizationStateConnected, connectorhost.CompatibilityStateSupported),
 	}}}
+	source.snapshot.Connectors[0].Installation.InstalledAtUnixMS = 1786089600000
 
 	options, err := ConnectorOptions(context.Background(), source)
 	if err != nil {
@@ -23,7 +24,7 @@ func TestConnectorOptionsProjectsEveryCatalogState(t *testing.T) {
 	if len(options) != 4 {
 		t.Fatalf("options = %#v, want every catalog connector", options)
 	}
-	if got := options[0]; got.ID != "connector:github" || got.Label != "GitHub" || got.IconURL != "data:image/png;base64,aWNvbg==" || got.Status != CapabilityStatusAvailable || got.Trigger != "/github" || got.Invocation != CapabilityInvocationTextTrigger || got.Source != CapabilitySourceLocalDB {
+	if got := options[0]; got.ID != "connector:github" || got.Label != "GitHub" || got.IconURL != "data:image/png;base64,aWNvbg==" || got.InstalledAtUnixMS != 1786089600000 || got.Status != CapabilityStatusAvailable || got.Trigger != "/github" || got.Invocation != CapabilityInvocationTextTrigger || got.Source != CapabilitySourceLocalDB {
 		t.Fatalf("github option = %#v", got)
 	}
 	if got := options[1]; got.Label != "notion" || got.Status != CapabilityStatusAuthRequired {

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
@@ -490,7 +490,7 @@ export type AgentComposerCapabilitySettingsTarget =
   | {
       kind: "connector";
       connectorKey: string;
-      action?: "open";
+      action?: "install" | "open";
     }
   | {
       kind: "connector";

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerPrimaryCapabilityControl.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerPrimaryCapabilityControl.spec.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentComposerProps } from "./AgentComposer.types";
 import { ComposerPrimaryCapabilityControl } from "./ComposerPrimaryCapabilityControl";
@@ -115,8 +115,9 @@ describe("ComposerPrimaryCapabilityControl", () => {
       screen.getByTestId("connector-market-composer-trigger"),
       { button: 0, ctrlKey: false, pointerType: "mouse" }
     );
-    fireEvent.click(
-      screen.getByTestId("connector-market-composer-status-github")
+    fireEvent.pointerDown(
+      screen.getByTestId("connector-market-composer-status-github"),
+      { button: 0, ctrlKey: false, pointerType: "mouse" }
     );
 
     expect(onCapabilitySettingsRequest).toHaveBeenCalledWith({
@@ -126,6 +127,65 @@ describe("ComposerPrimaryCapabilityControl", () => {
       enabled: false
     });
     expect(onConnectorSelected).not.toHaveBeenCalled();
+  });
+
+  it("routes setup-required connectors directly to installation", async () => {
+    let completeInstall!: () => void;
+    const onCapabilitySettingsRequest = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          completeInstall = resolve;
+        })
+    );
+    const onRetryComposerOptions = vi.fn();
+    render(
+      <ComposerPrimaryCapabilityControl
+        availableSkills={[
+          {
+            connectorKey: "canva",
+            kind: "connector",
+            name: "Canva",
+            sourceKind: "connector",
+            status: "setupRequired",
+            trigger: "/canva"
+          }
+        ]}
+        connectorsVisible
+        disabled={false}
+        isTuttiModeActive={false}
+        isTuttiModeUpdating={false}
+        labels={labels}
+        loading={false}
+        onCapabilitySettingsRequest={onCapabilitySettingsRequest}
+        onConnectorSelected={vi.fn()}
+        onRetryComposerOptions={onRetryComposerOptions}
+        selectedConnectorKeys={[]}
+        tuttiModeSupported={false}
+      />
+    );
+
+    fireEvent.pointerDown(
+      screen.getByTestId("connector-market-composer-trigger"),
+      { button: 0, ctrlKey: false, pointerType: "mouse" }
+    );
+    const item = screen.getByTestId("connector-market-composer-item-canva");
+    fireEvent.pointerDown(item, {
+      button: 0,
+      ctrlKey: false,
+      pointerType: "mouse"
+    });
+
+    expect(onCapabilitySettingsRequest).toHaveBeenCalledWith({
+      kind: "connector",
+      connectorKey: "canva",
+      action: "install"
+    });
+    expect(item).toHaveAttribute("aria-busy", "true");
+
+    await act(async () => completeInstall());
+    expect(onRetryComposerOptions).toHaveBeenCalledWith({
+      section: "connectors"
+    });
   });
 
   it("keeps a shared connector catalog inspectable without mutation or management actions", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerPrimaryCapabilityControl.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerPrimaryCapabilityControl.tsx
@@ -84,6 +84,18 @@ export function ComposerPrimaryCapabilityControl({
           selected: labels.addContentConnectorSelected
         }}
         loading={loading}
+        onInstallConnector={
+          connectorsReadOnly || !onCapabilitySettingsRequest
+            ? undefined
+            : async (connectorKey) => {
+                await onCapabilitySettingsRequest({
+                  kind: "connector",
+                  connectorKey,
+                  action: "install"
+                });
+                onRetryComposerOptions?.({ section: "connectors" });
+              }
+        }
         onOpenChange={(open) => {
           if (open) {
             onRetryComposerOptions?.({ section: "connectors" });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerHelpers.ts
@@ -256,6 +256,9 @@ export function providerSkillsFromComposerOptions(
           ...(isConnector && capability.iconUrl
             ? { iconUrl: capability.iconUrl }
             : {}),
+          ...(isConnector && capability.installedAtUnixMs
+            ? { installedAtUnixMs: capability.installedAtUnixMs }
+            : {}),
           ...(capability.description
             ? { description: capability.description }
             : {}),
@@ -276,6 +279,7 @@ export function areProviderSkillOptionsEqual(
     left.name === right.name &&
     left.connectorKey === right.connectorKey &&
     left.iconUrl === right.iconUrl &&
+    left.installedAtUnixMs === right.installedAtUnixMs &&
     left.trigger === right.trigger &&
     left.invocation === right.invocation &&
     left.sourceKind === right.sourceKind &&

--- a/packages/agent/gui/agent-gui/agentGuiNode/integrations/connector/model/connectorPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/integrations/connector/model/connectorPresentation.ts
@@ -36,6 +36,7 @@ export function projectConnectorComposerItems(
       connectorKey,
       description: option.description,
       iconUrl: option.iconUrl,
+      installedAtUnixMs: option.installedAtUnixMs,
       name: option.name,
       selected: selectedKeys.has(connectorKey),
       status:

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
@@ -136,6 +136,8 @@ export interface AgentGUIProviderSkillOption {
   connectorKey?: string;
   /** Presentation icon projected by the connector catalog. */
   iconUrl?: string;
+  /** Successful installation time used only for stable composer ordering. */
+  installedAtUnixMs?: number;
   /** Daemon-issued invocation contract; never infer this from provider id. */
   invocation?: "promptItem" | "textTrigger";
   sourceKind:

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -2125,6 +2125,7 @@ export type AgentProviderCapabilityOption = {
   label: string;
   description?: string;
   iconUrl?: string;
+  installedAtUnixMs?: number;
   status:
     | "available"
     | "disabled"
@@ -5067,6 +5068,7 @@ export type ConnectorMarketImplementation = {
 export type ConnectorMarketInstallation = {
   state: ConnectorMarketInstallationState;
   installedVersion?: string;
+  installedAtUnixMs?: number;
   installedReleaseId?: string;
   installedReleaseDigest?: string;
   failureCode?: string;

--- a/packages/connector/contracts/openapi/connector-market.v1.yaml
+++ b/packages/connector/contracts/openapi/connector-market.v1.yaml
@@ -664,6 +664,10 @@ components:
           $ref: "#/components/schemas/ConnectorMarketInstallationState"
         installedVersion:
           type: string
+        installedAtUnixMs:
+          type: integer
+          format: int64
+          minimum: 1
         installedReleaseId:
           type: string
         installedReleaseDigest:

--- a/packages/connector/daemon/adapters/sqlite/lifecycle.go
+++ b/packages/connector/daemon/adapters/sqlite/lifecycle.go
@@ -91,10 +91,77 @@ WHERE updated_at_unix_ms = 0`)
 			return err
 		}
 	}
+	if err := backfillConnectorInstallationTimes(ctx, tx); err != nil {
+		return err
+	}
 	if err := backfillInstalledReleaseEvidence(ctx, tx); err != nil {
 		return err
 	}
 	return tx.Commit()
+}
+
+func backfillConnectorInstallationTimes(ctx context.Context, tx *sql.Tx) error {
+	rows, err := tx.QueryContext(ctx, `SELECT connector_key, connector_json FROM connector_market_connectors`)
+	if err != nil {
+		return err
+	}
+	type connectorBackfill struct {
+		connectorKey string
+		connector    market.Connector
+	}
+	var connectors []connectorBackfill
+	for rows.Next() {
+		var connectorKey, payload string
+		if err := rows.Scan(&connectorKey, &payload); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		connector, err := decodeConnector(payload)
+		if err != nil {
+			_ = rows.Close()
+			return err
+		}
+		connectors = append(connectors, connectorBackfill{connectorKey: connectorKey, connector: connector})
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, entry := range connectors {
+		if entry.connector.Installation.State != market.InstallationStateInstalled ||
+			entry.connector.Installation.InstalledAtUnixMS > 0 {
+			continue
+		}
+		var operationPayload string
+		err := tx.QueryRowContext(ctx, `SELECT operation_json FROM connector_market_operations
+WHERE connector_key = ? AND kind = ? AND state = ?
+ORDER BY updated_at_unix_ms DESC LIMIT 1`, entry.connectorKey, market.OperationKindInstall, market.OperationStateCompleted).Scan(&operationPayload)
+		if errors.Is(err, sql.ErrNoRows) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		operation, err := decodeOperation(operationPayload)
+		if err != nil {
+			return err
+		}
+		installedAtUnixMS := operation.UpdatedAt.UTC().UnixMilli()
+		if installedAtUnixMS <= 0 {
+			continue
+		}
+		entry.connector.Installation.InstalledAtUnixMS = installedAtUnixMS
+		payload, err := json.Marshal(entry.connector)
+		if err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE connector_market_connectors SET connector_json = ? WHERE connector_key = ?`, string(payload), entry.connectorKey); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func backfillInstalledReleaseEvidence(ctx context.Context, tx *sql.Tx) error {

--- a/packages/connector/daemon/adapters/sqlite/lifecycle_test.go
+++ b/packages/connector/daemon/adapters/sqlite/lifecycle_test.go
@@ -548,6 +548,13 @@ operation_id, client_request_id, connector_key, kind, state, lease_owner, lease_
 	if updatedAtMS != operation.UpdatedAt.UnixMilli() {
 		t.Fatalf("migrated updated timestamp = %d, want %d", updatedAtMS, operation.UpdatedAt.UnixMilli())
 	}
+	migratedConnector, err := store.Connector(ctx, connector.Key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if migratedConnector.Installation.InstalledAtUnixMS != operation.UpdatedAt.UnixMilli() {
+		t.Fatalf("migrated install timestamp = %d, want %d", migratedConnector.Installation.InstalledAtUnixMS, operation.UpdatedAt.UnixMilli())
+	}
 	release, err := store.InstalledRelease(ctx, connector.Key, installedRelease.ReleaseDigest)
 	if err != nil || release.ReleaseDigest != installedRelease.ReleaseDigest {
 		t.Fatalf("migrated installed release = %#v, error = %v", release, err)

--- a/packages/connector/daemon/core/application_runtime_convergence.go
+++ b/packages/connector/daemon/core/application_runtime_convergence.go
@@ -90,7 +90,9 @@ func (application *Application) finalizeInstallAfterRuntime(
 			return NewDomainError(ErrorCodeUnavailable, "connector runtime candidate is not observed", true, nil)
 		}
 		revision := tx.AdvanceRevision()
+		installedAt := application.config.Now().UTC()
 		connector.Installation.State = InstallationStateInstalled
+		connector.Installation.InstalledAtUnixMS = installedAt.UnixMilli()
 		connector.Installation.InstalledVersion = connector.Installation.CandidateVersion
 		connector.Installation.InstalledReleaseID = connector.Installation.CandidateReleaseID
 		connector.Installation.InstalledReleaseDigest = connector.Installation.CandidateReleaseDigest
@@ -102,7 +104,7 @@ func (application *Application) finalizeInstallAfterRuntime(
 		operation.State = OperationStateCompleted
 		operation.Stage = OperationStageCompleted
 		operation.FailureCode = ""
-		operation.UpdatedAt = application.config.Now().UTC()
+		operation.UpdatedAt = installedAt
 		if err := tx.SaveConnector(connector); err != nil {
 			return err
 		}

--- a/packages/connector/daemon/core/application_test.go
+++ b/packages/connector/daemon/core/application_test.go
@@ -355,6 +355,9 @@ func TestApplicationExecutesAcceptedInstall(t *testing.T) {
 	if installed.Installation.State != InstallationStateInstalled || installed.Installation.InstalledVersion != "1.0.0" {
 		t.Fatalf("installation = %#v", installed.Installation)
 	}
+	if installed.Installation.InstalledAtUnixMS != application.config.Now().UnixMilli() {
+		t.Fatalf("installed timestamp = %d, want %d", installed.Installation.InstalledAtUnixMS, application.config.Now().UnixMilli())
+	}
 	if operation.State != OperationStateCompleted || installationHost.prepares != 1 || installationHost.reconciles != 1 {
 		t.Fatalf("operation = %#v, prepares = %d, reconciles = %d", operation, installationHost.prepares, installationHost.reconciles)
 	}

--- a/packages/connector/daemon/core/types.go
+++ b/packages/connector/daemon/core/types.go
@@ -259,6 +259,7 @@ type RemoteStreamableHTTPImplementation struct {
 
 type Installation struct {
 	State                  InstallationState `json:"state"`
+	InstalledAtUnixMS      int64             `json:"installedAtUnixMs,omitempty"`
 	InstalledVersion       string            `json:"installedVersion,omitempty"`
 	InstalledReleaseID     string            `json:"installedReleaseId,omitempty"`
 	InstalledReleaseDigest string            `json:"installedReleaseDigest,omitempty"`

--- a/packages/connector/renderer/src/application/contracts/domain.ts
+++ b/packages/connector/renderer/src/application/contracts/domain.ts
@@ -156,6 +156,7 @@ export interface ConnectorRelease {
 
 export interface ConnectorInstallation {
   state: ConnectorInstallationState;
+  installedAtUnixMs?: number;
   installedVersion?: string;
   installedReleaseId?: string;
   installedReleaseDigest?: string;

--- a/packages/connector/renderer/src/application/services/index.ts
+++ b/packages/connector/renderer/src/application/services/index.ts
@@ -3,7 +3,9 @@ export {
   ConnectorMarketService
 } from "./connectorMarketService.ts";
 export {
+  installAndOpenConnectorMarketDialog,
   openConnectorMarketDialog,
+  type InstallAndOpenConnectorMarketDialogResult,
   type OpenConnectorMarketDialogResult
 } from "./openConnectorMarketDialog.ts";
 export {

--- a/packages/connector/renderer/src/application/services/openConnectorMarketDialog.test.ts
+++ b/packages/connector/renderer/src/application/services/openConnectorMarketDialog.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import type { IConnectorMarketRoot } from "./core/connectorMarketRoot.interface.ts";
-import { openConnectorMarketDialog } from "./openConnectorMarketDialog.ts";
+import {
+  installAndOpenConnectorMarketDialog,
+  openConnectorMarketDialog
+} from "./openConnectorMarketDialog.ts";
 
 test("opens the canonical dialog only after the connector exists in the loaded view", async () => {
   const calls: string[] = [];
@@ -42,12 +45,54 @@ test("does not open a dialog for invalid or unknown connector keys", async () =>
   assert.deepEqual(opened, []);
 });
 
+test("opens the canonical post-install dialog after installation completes", async () => {
+  const calls: string[] = [];
+  const root = createRoot({
+    ensureLoaded: async () => {
+      calls.push("load");
+      root.view.dataStore.cardsByKey.canva = {} as never;
+    },
+    install: async (connectorKey) => {
+      calls.push(`install:${connectorKey}`);
+      return "installed";
+    },
+    openConnector: (connectorKey) => calls.push(`open:${connectorKey}`)
+  });
+
+  const result = await installAndOpenConnectorMarketDialog(root, " canva ");
+
+  assert.equal(result, "opened");
+  assert.deepEqual(calls, ["install:canva", "load", "open:canva"]);
+});
+
+test("does not open a post-install dialog when installation is not admitted", async () => {
+  let loadCount = 0;
+  const opened: string[] = [];
+  const root = createRoot({
+    ensureLoaded: async () => {
+      loadCount += 1;
+    },
+    install: async () => "not_admitted",
+    openConnector: (connectorKey) => opened.push(connectorKey)
+  });
+
+  const result = await installAndOpenConnectorMarketDialog(root, "canva");
+
+  assert.equal(result, "not_admitted");
+  assert.equal(loadCount, 0);
+  assert.deepEqual(opened, []);
+});
+
 function createRoot(input: {
   ensureLoaded: () => Promise<void>;
+  install?: (connectorKey: string) => Promise<"installed" | "not_admitted">;
   openConnector: (connectorKey: string) => void;
 }): IConnectorMarketRoot {
   return {
-    market: { ensureLoaded: input.ensureLoaded },
+    market: {
+      ensureLoaded: input.ensureLoaded,
+      install: input.install ?? (async () => "installed")
+    },
     uiState: { openConnector: input.openConnector },
     view: { dataStore: { cardsByKey: {} } }
   } as IConnectorMarketRoot;

--- a/packages/connector/renderer/src/application/services/openConnectorMarketDialog.ts
+++ b/packages/connector/renderer/src/application/services/openConnectorMarketDialog.ts
@@ -5,6 +5,10 @@ export type OpenConnectorMarketDialogResult =
   | "invalid-connector-key"
   | "opened";
 
+export type InstallAndOpenConnectorMarketDialogResult =
+  | OpenConnectorMarketDialogResult
+  | "not_admitted";
+
 /**
  * Resolves a composer/catalog entry against the authoritative market snapshot
  * before opening the package-owned connector dialog state machine.
@@ -25,4 +29,25 @@ export async function openConnectorMarketDialog(
 
   root.uiState.openConnector(normalizedConnectorKey);
   return "opened";
+}
+
+/**
+ * Installs a composer connector and opens its canonical post-install dialog.
+ * The reconciled connector state determines whether that dialog presents
+ * authorization or management; failed admission never opens a dialog.
+ */
+export async function installAndOpenConnectorMarketDialog(
+  root: IConnectorMarketRoot,
+  connectorKey: string
+): Promise<InstallAndOpenConnectorMarketDialogResult> {
+  const normalizedConnectorKey = connectorKey.trim();
+  if (!normalizedConnectorKey) {
+    return "invalid-connector-key";
+  }
+
+  const outcome = await root.market.install(normalizedConnectorKey);
+  if (outcome !== "installed") {
+    return outcome;
+  }
+  return openConnectorMarketDialog(root, normalizedConnectorKey);
 }

--- a/packages/connector/renderer/src/ui/composer/ConnectorComposerMenu.spec.tsx
+++ b/packages/connector/renderer/src/ui/composer/ConnectorComposerMenu.spec.tsx
@@ -1,5 +1,11 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ConnectorComposerMenu,
@@ -22,10 +28,12 @@ const labels = {
 function connector(
   key: string,
   status: ConnectorComposerItem["status"],
-  selected = false
+  selected = false,
+  installedAtUnixMs?: number
 ): ConnectorComposerItem {
   return {
     connectorKey: key,
+    installedAtUnixMs,
     name: `Connector ${key}`,
     status,
     selected
@@ -306,6 +314,10 @@ describe("ConnectorComposerMenu", () => {
       "connector-market-composer-item-github"
     );
     expect(menuItem).not.toContainElement(toggle);
+    expect(toggle).toHaveAttribute("role", "switch");
+    expect(toggle).toHaveClass("absolute", "right-2.5", "-translate-y-1/2");
+    expect(toggle).toHaveAttribute("data-size", "default");
+    expect(toggle).toHaveAttribute("data-state", "checked");
     fireEvent.pointerDown(toggle, {
       button: 0,
       ctrlKey: false,
@@ -319,10 +331,82 @@ describe("ConnectorComposerMenu", () => {
     fireEvent.click(toggle);
 
     expect(onRuntimeEnabledChange).toHaveBeenCalledWith("github", false);
+    expect(onRuntimeEnabledChange).toHaveBeenCalledOnce();
     expect(onSelectConnector).not.toHaveBeenCalled();
     expect(toggle).not.toBeChecked();
+    expect(toggle).toHaveAttribute("data-state", "unchecked");
     expect(menuItem).toBeInTheDocument();
     expect(screen.getByRole("menu")).toHaveClass("w-[240px]");
+  });
+
+  it("toggles installed runtime from the keyboard without closing the menu", async () => {
+    const onRuntimeEnabledChange = vi.fn();
+    render(
+      <ConnectorComposerMenu
+        items={[connector("github", "connected")]}
+        disabled={false}
+        labels={labels}
+        onOpenMarket={vi.fn()}
+        onRuntimeEnabledChange={onRuntimeEnabledChange}
+      />
+    );
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Connectors" }), {
+      button: 0,
+      ctrlKey: false
+    });
+    const toggle = await screen.findByTestId(
+      "connector-market-composer-status-github"
+    );
+    fireEvent.keyDown(toggle, { key: "Enter" });
+
+    expect(onRuntimeEnabledChange).toHaveBeenCalledWith("github", false);
+    expect(toggle).not.toBeChecked();
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+  });
+
+  it("installs a setup-required connector in place without opening a dialog", async () => {
+    let completeInstall!: () => void;
+    const onInstallConnector = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          completeInstall = resolve;
+        })
+    );
+    const onOpenConnector = vi.fn();
+    render(
+      <ConnectorComposerMenu
+        items={[connector("canva", "setup_required")]}
+        disabled={false}
+        labels={labels}
+        onInstallConnector={onInstallConnector}
+        onOpenConnector={onOpenConnector}
+        onOpenMarket={vi.fn()}
+      />
+    );
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Connectors" }), {
+      button: 0,
+      ctrlKey: false
+    });
+    const item = await screen.findByTestId(
+      "connector-market-composer-item-canva"
+    );
+    fireEvent.pointerDown(item, {
+      button: 0,
+      ctrlKey: false,
+      pointerType: "mouse"
+    });
+
+    expect(onInstallConnector).toHaveBeenCalledOnce();
+    expect(onInstallConnector).toHaveBeenCalledWith("canva");
+    expect(onOpenConnector).not.toHaveBeenCalled();
+    expect(item).toHaveAttribute("aria-busy", "true");
+    expect(item.querySelector('[data-slot="spinner"]')).toBeInTheDocument();
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    await act(async () => completeInstall());
+    expect(item).not.toHaveAttribute("aria-busy");
   });
 
   it("limits the quick connector projection to ten catalog entries", async () => {
@@ -385,5 +469,100 @@ describe("ConnectorComposerMenu", () => {
     expect(
       screen.queryByTestId("connector-market-composer-item-setup-9")
     ).not.toBeInTheDocument();
+  });
+
+  it("shows four recently installed connectors and fills the remaining quick slots from discovery", async () => {
+    const connectedConnectors = Array.from({ length: 10 }, (_, index) =>
+      connector(`connected-${index}`, "connected", false, index + 1)
+    );
+    const discoveryConnectors = Array.from({ length: 6 }, (_, index) =>
+      connector(`setup-${index}`, "setup_required")
+    );
+    render(
+      <ConnectorComposerMenu
+        items={[
+          ...connectedConnectors,
+          ...discoveryConnectors,
+          connector("stopped", "disabled", false, 100)
+        ]}
+        disabled={false}
+        labels={labels}
+        onOpenConnector={vi.fn()}
+        onOpenMarket={vi.fn()}
+        onRuntimeEnabledChange={vi.fn()}
+      />
+    );
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Connectors" }), {
+      button: 0,
+      ctrlKey: false
+    });
+
+    expect(
+      await screen.findByTestId("connector-market-composer-item-setup-0")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("connector-market-composer-status-stopped")
+    ).not.toBeChecked();
+    expect(
+      screen.getAllByTestId(/^connector-market-composer-item-/)
+    ).toHaveLength(10);
+  });
+
+  it("keeps an installed connector in place when its runtime is stopped", async () => {
+    const props = {
+      disabled: false,
+      labels,
+      onOpenMarket: vi.fn(),
+      onRuntimeEnabledChange: vi.fn()
+    };
+    const rendered = render(
+      <ConnectorComposerMenu
+        {...props}
+        items={[
+          connector("github", "connected"),
+          connector("google-calendar", "connected", true),
+          connector("google-drive", "connected")
+        ]}
+      />
+    );
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Connectors" }), {
+      button: 0,
+      ctrlKey: false
+    });
+    expect(
+      screen
+        .getAllByTestId(/^connector-market-composer-item-/)
+        .map((item) => item.dataset.testid)
+    ).toEqual([
+      "connector-market-composer-item-github",
+      "connector-market-composer-item-google-calendar",
+      "connector-market-composer-item-google-drive"
+    ]);
+
+    rendered.rerender(
+      <ConnectorComposerMenu
+        {...props}
+        items={[
+          connector("github", "connected"),
+          connector("google-calendar", "disabled", true),
+          connector("google-drive", "connected")
+        ]}
+      />
+    );
+
+    expect(
+      screen
+        .getAllByTestId(/^connector-market-composer-item-/)
+        .map((item) => item.dataset.testid)
+    ).toEqual([
+      "connector-market-composer-item-github",
+      "connector-market-composer-item-google-calendar",
+      "connector-market-composer-item-google-drive"
+    ]);
+    expect(
+      screen.getByTestId("connector-market-composer-status-google-calendar")
+    ).not.toBeChecked();
   });
 });

--- a/packages/connector/renderer/src/ui/composer/ConnectorComposerMenu.tsx
+++ b/packages/connector/renderer/src/ui/composer/ConnectorComposerMenu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Badge,
   Button,
@@ -10,11 +10,13 @@ import {
   DropdownMenuTrigger,
   LinkIcon,
   OpenLinkLinedIcon,
+  Spinner,
   Switch
 } from "@tutti-os/ui-system";
 import { cn } from "@tutti-os/ui-system/utils";
 
 const QUICK_CONNECTOR_LIMIT = 10;
+const INSTALLED_CONNECTOR_PREVIEW_LIMIT = 4;
 const CONNECTOR_PREVIEW_LIMIT = 3;
 
 export type ConnectorComposerItemStatus =
@@ -27,6 +29,7 @@ export type ConnectorComposerItemStatus =
 export interface ConnectorComposerItem {
   connectorKey: string;
   iconUrl?: string;
+  installedAtUnixMs?: number;
   name: string;
   /** Caller-localized, credential-free presentation detail or disabled reason. */
   description?: string;
@@ -54,6 +57,7 @@ export interface ConnectorComposerMenuProps {
   onOpenChange?: (open: boolean) => void;
   onOpenConnector?: (connectorKey: string) => void;
   onOpenMarket?: () => void;
+  onInstallConnector?: (connectorKey: string) => void | Promise<void>;
   onRuntimeEnabledChange?: (
     connectorKey: string,
     enabled: boolean
@@ -75,6 +79,7 @@ export function ConnectorComposerMenu({
   onOpenChange,
   onOpenConnector,
   onOpenMarket,
+  onInstallConnector,
   onRuntimeEnabledChange,
   onSelectConnector,
   readOnly = false
@@ -83,8 +88,23 @@ export function ConnectorComposerMenu({
   const [runtimeIntents, setRuntimeIntents] = useState<
     Record<string, { desired: boolean; pending: boolean }>
   >({});
+  const installingConnectorKeysRef = useRef(new Set<string>());
+  const [installingConnectorKeys, setInstallingConnectorKeys] = useState<
+    ReadonlySet<string>
+  >(new Set());
   const normalizedItems = normalizeConnectorItems(items);
-  const quickItems = normalizedItems.slice(0, QUICK_CONNECTOR_LIMIT);
+  const installedItems = normalizedItems.filter(isInstalledConnectorItem);
+  const discoveryItems = normalizedItems.filter(
+    (item) => !isInstalledConnectorItem(item)
+  );
+  const quickItems = [
+    ...installedItems.slice(0, INSTALLED_CONNECTOR_PREVIEW_LIMIT),
+    ...discoveryItems.slice(
+      0,
+      QUICK_CONNECTOR_LIMIT -
+        Math.min(installedItems.length, INSTALLED_CONNECTOR_PREVIEW_LIMIT)
+    )
+  ];
   const connectedItems = normalizedItems.filter(
     (item) => item.status === "connected"
   );
@@ -94,6 +114,22 @@ export function ConnectorComposerMenu({
     setOpen(false);
     onOpenChange?.(false);
     action();
+  };
+  const installInPlace = (connectorKey: string): void => {
+    if (
+      !onInstallConnector ||
+      installingConnectorKeysRef.current.has(connectorKey)
+    ) {
+      return;
+    }
+    installingConnectorKeysRef.current.add(connectorKey);
+    setInstallingConnectorKeys(new Set(installingConnectorKeysRef.current));
+    void Promise.resolve(onInstallConnector(connectorKey))
+      .catch(() => undefined)
+      .finally(() => {
+        installingConnectorKeysRef.current.delete(connectorKey);
+        setInstallingConnectorKeys(new Set(installingConnectorKeysRef.current));
+      });
   };
   useEffect(() => {
     setRuntimeIntents((current) => {
@@ -178,53 +214,90 @@ export function ConnectorComposerMenu({
               item.status === "authorization_required"
                 ? labels.authorize
                 : labels.connect;
-            return (
-              <div key={item.connectorKey} className="relative" role="none">
-                <DropdownMenuItem
-                  className={cn("min-h-9 gap-2.5 px-2.5", installed && "pr-14")}
-                  data-testid={`connector-market-composer-item-${item.connectorKey}`}
-                  data-selected={selected ? "true" : undefined}
-                  disabled={
-                    readOnly ||
-                    (connected ? !onSelectConnector : !onOpenConnector)
-                  }
-                  onPointerDown={(event) => {
-                    if (event.button !== 0 || event.ctrlKey) {
-                      return;
+            const installingInPlace = installingConnectorKeys.has(
+              item.connectorKey
+            );
+            const setRuntimeEnabled = (nextEnabled: boolean): void => {
+              if (!onRuntimeEnabledChange) {
+                return;
+              }
+              setRuntimeIntents((current) => ({
+                ...current,
+                [item.connectorKey]: {
+                  desired: nextEnabled,
+                  pending: true
+                }
+              }));
+              void Promise.resolve(
+                onRuntimeEnabledChange(item.connectorKey, nextEnabled)
+              ).then(
+                () =>
+                  setRuntimeIntents((current) => {
+                    const intent = current[item.connectorKey];
+                    if (!intent || intent.desired !== nextEnabled) {
+                      return current;
                     }
-                    event.preventDefault();
-                    closeAndRun(() => {
-                      if (connected) {
-                        onSelectConnector?.(item.connectorKey, !selected);
+                    return {
+                      ...current,
+                      [item.connectorKey]: {
+                        desired: nextEnabled,
+                        pending: false
+                      }
+                    };
+                  }),
+                () =>
+                  setRuntimeIntents((current) => {
+                    const intent = current[item.connectorKey];
+                    if (!intent || intent.desired !== nextEnabled) {
+                      return current;
+                    }
+                    const next = { ...current };
+                    delete next[item.connectorKey];
+                    return next;
+                  })
+              );
+            };
+            if (installed) {
+              return (
+                <div key={item.connectorKey} className="relative" role="none">
+                  <DropdownMenuItem
+                    className="min-h-9 gap-2.5 px-2.5 pr-14"
+                    data-testid={`connector-market-composer-item-${item.connectorKey}`}
+                    data-selected={selected ? "true" : undefined}
+                    disabled={
+                      readOnly ||
+                      (connected ? !onSelectConnector : !onOpenConnector)
+                    }
+                    onPointerDown={(event) => {
+                      if (event.button !== 0 || event.ctrlKey) {
                         return;
                       }
-                      onOpenConnector?.(item.connectorKey);
-                    });
-                  }}
-                  onSelect={(event) => {
-                    event.preventDefault();
-                    closeAndRun(() => {
-                      if (connected) {
-                        onSelectConnector?.(item.connectorKey, !selected);
-                        return;
-                      }
-                      onOpenConnector?.(item.connectorKey);
-                    });
-                  }}
-                >
-                  <ConnectorComposerIcon
-                    iconUrl={item.iconUrl}
-                    label={item.name}
-                  />
-                  <span className="min-w-0 flex-1 truncate">{item.name}</span>
-                  {!installed && !readOnly ? (
-                    <div className="ml-auto inline-flex shrink-0 items-center gap-1 pl-3 text-xs text-[var(--text-primary)]">
-                      <LinkIcon aria-hidden className="size-4" />
-                      {actionLabel}
-                    </div>
-                  ) : null}
-                </DropdownMenuItem>
-                {installed ? (
+                      event.preventDefault();
+                      closeAndRun(() => {
+                        if (connected) {
+                          onSelectConnector?.(item.connectorKey, !selected);
+                          return;
+                        }
+                        onOpenConnector?.(item.connectorKey);
+                      });
+                    }}
+                    onSelect={(event) => {
+                      event.preventDefault();
+                      closeAndRun(() => {
+                        if (connected) {
+                          onSelectConnector?.(item.connectorKey, !selected);
+                          return;
+                        }
+                        onOpenConnector?.(item.connectorKey);
+                      });
+                    }}
+                  >
+                    <ConnectorComposerIcon
+                      iconUrl={item.iconUrl}
+                      label={item.name}
+                    />
+                    <span className="min-w-0 flex-1 truncate">{item.name}</span>
+                  </DropdownMenuItem>
                   <Switch
                     aria-label={item.name}
                     checked={runtimeEnabled}
@@ -235,51 +308,79 @@ export function ConnectorComposerMenu({
                       !onRuntimeEnabledChange ||
                       runtimeIntent?.pending === true
                     }
-                    onClick={(event) => event.stopPropagation()}
-                    onPointerDown={(event) => event.stopPropagation()}
-                    onCheckedChange={(nextEnabled) => {
-                      if (!onRuntimeEnabledChange) {
+                    onKeyDown={(event) => {
+                      if (event.key !== "Enter" && event.key !== " ") {
                         return;
                       }
-                      setRuntimeIntents((current) => ({
-                        ...current,
-                        [item.connectorKey]: {
-                          desired: nextEnabled,
-                          pending: true
-                        }
-                      }));
-                      void Promise.resolve(
-                        onRuntimeEnabledChange(item.connectorKey, nextEnabled)
-                      ).then(
-                        () =>
-                          setRuntimeIntents((current) => {
-                            const intent = current[item.connectorKey];
-                            if (!intent || intent.desired !== nextEnabled) {
-                              return current;
-                            }
-                            return {
-                              ...current,
-                              [item.connectorKey]: {
-                                desired: nextEnabled,
-                                pending: false
-                              }
-                            };
-                          }),
-                        () =>
-                          setRuntimeIntents((current) => {
-                            const intent = current[item.connectorKey];
-                            if (!intent || intent.desired !== nextEnabled) {
-                              return current;
-                            }
-                            const next = { ...current };
-                            delete next[item.connectorKey];
-                            return next;
-                          })
-                      );
+                      event.preventDefault();
+                      event.stopPropagation();
+                      setRuntimeEnabled(!runtimeEnabled);
+                    }}
+                    onPointerDown={(event) => {
+                      if (event.button !== 0 || event.ctrlKey) {
+                        return;
+                      }
+                      event.preventDefault();
+                      event.stopPropagation();
+                      setRuntimeEnabled(!runtimeEnabled);
+                    }}
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
                     }}
                   />
+                </div>
+              );
+            }
+            return (
+              <DropdownMenuItem
+                key={item.connectorKey}
+                className="min-h-9 gap-2.5 px-2.5"
+                data-testid={`connector-market-composer-item-${item.connectorKey}`}
+                aria-busy={installingInPlace || undefined}
+                disabled={
+                  readOnly ||
+                  installingInPlace ||
+                  (item.status === "setup_required"
+                    ? !onInstallConnector && !onOpenConnector
+                    : !onOpenConnector)
+                }
+                onPointerDown={(event) => {
+                  if (event.button !== 0 || event.ctrlKey) {
+                    return;
+                  }
+                  event.preventDefault();
+                  if (item.status === "setup_required" && onInstallConnector) {
+                    installInPlace(item.connectorKey);
+                    return;
+                  }
+                  closeAndRun(() => onOpenConnector?.(item.connectorKey));
+                }}
+                onSelect={(event) => {
+                  event.preventDefault();
+                  if (item.status === "setup_required" && onInstallConnector) {
+                    installInPlace(item.connectorKey);
+                    return;
+                  }
+                  closeAndRun(() => onOpenConnector?.(item.connectorKey));
+                }}
+              >
+                <ConnectorComposerIcon
+                  iconUrl={item.iconUrl}
+                  label={item.name}
+                />
+                <span className="min-w-0 flex-1 truncate">{item.name}</span>
+                {!readOnly ? (
+                  <div className="ml-auto inline-flex shrink-0 items-center gap-1 pl-3 text-xs text-[var(--text-primary)]">
+                    {installingInPlace ? (
+                      <Spinner aria-hidden size={14} />
+                    ) : (
+                      <LinkIcon aria-hidden className="size-4" />
+                    )}
+                    {actionLabel}
+                  </div>
                 ) : null}
-              </div>
+              </DropdownMenuItem>
             );
           })
         ) : loading ? (
@@ -323,8 +424,7 @@ export function ConnectorComposerMenu({
 export function normalizeConnectorItems(
   items: readonly ConnectorComposerItem[]
 ): ConnectorComposerItem[] {
-  const selectedItems: ConnectorComposerItem[] = [];
-  const connectedItems: ConnectorComposerItem[] = [];
+  const installedItems: ConnectorComposerItem[] = [];
   const remainingItems: ConnectorComposerItem[] = [];
   const seenConnectorKeys = new Set<string>();
   for (const item of items) {
@@ -334,15 +434,36 @@ export function normalizeConnectorItems(
     }
     seenConnectorKeys.add(connectorKey);
     const normalizedItem = { ...item, connectorKey };
-    if (normalizedItem.status === "connected" && normalizedItem.selected) {
-      selectedItems.push(normalizedItem);
-    } else if (normalizedItem.status === "connected") {
-      connectedItems.push(normalizedItem);
+    if (isInstalledConnectorItem(normalizedItem)) {
+      installedItems.push(normalizedItem);
     } else {
       remainingItems.push(normalizedItem);
     }
   }
-  return [...selectedItems, ...connectedItems, ...remainingItems];
+  installedItems.sort(compareInstalledConnectorItems);
+  return [...installedItems, ...remainingItems];
+}
+
+function compareInstalledConnectorItems(
+  left: ConnectorComposerItem,
+  right: ConnectorComposerItem
+): number {
+  const leftInstalledAt = left.installedAtUnixMs ?? 0;
+  const rightInstalledAt = right.installedAtUnixMs ?? 0;
+  if (leftInstalledAt === rightInstalledAt) {
+    return 0;
+  }
+  if (leftInstalledAt === 0) {
+    return 1;
+  }
+  if (rightInstalledAt === 0) {
+    return -1;
+  }
+  return rightInstalledAt - leftInstalledAt;
+}
+
+function isInstalledConnectorItem(item: ConnectorComposerItem): boolean {
+  return item.status === "connected" || item.status === "disabled";
 }
 
 function ConnectorComposerIcon({

--- a/packages/connector/renderer/src/ui/composer/connectorComposerMenuModel.test.ts
+++ b/packages/connector/renderer/src/ui/composer/connectorComposerMenuModel.test.ts
@@ -6,11 +6,12 @@ import {
   type ConnectorComposerItem
 } from "./ConnectorComposerMenu.tsx";
 
-test("prioritizes selected then authorized connectors while preserving first identity", () => {
+test("orders installed connectors by installation time and preserves catalog order for legacy entries", () => {
   const items: ConnectorComposerItem[] = [
     item(" github "),
-    item("figma", "connected"),
-    item("notion", "connected", true),
+    item("figma", "connected", false, 200),
+    item("notion", "connected", true, 300),
+    item("legacy", "disabled"),
     item("github"),
     item("lark"),
     item("   ")
@@ -18,19 +19,21 @@ test("prioritizes selected then authorized connectors while preserving first ide
 
   assert.deepEqual(
     normalizeConnectorItems(items).map((entry) => entry.connectorKey),
-    ["notion", "figma", "github", "lark"]
+    ["notion", "figma", "legacy", "github", "lark"]
   );
 });
 
 function item(
   connectorKey: string,
   status: ConnectorComposerItem["status"] = "setup_required",
-  selected = false
+  selected = false,
+  installedAtUnixMs?: number
 ): ConnectorComposerItem {
   return {
     connectorKey,
     name: connectorKey,
     selected,
+    installedAtUnixMs,
     status
   };
 }

--- a/services/tuttid/api/daemon_agent_composer_options.go
+++ b/services/tuttid/api/daemon_agent_composer_options.go
@@ -67,6 +67,9 @@ func generatedAgentProviderCapabilityOptions(options []agentservice.ComposerCapa
 		if iconURL := strings.TrimSpace(option.IconURL); iconURL != "" {
 			generated.IconUrl = optionalStringPointer(iconURL)
 		}
+		if option.InstalledAtUnixMS > 0 {
+			generated.InstalledAtUnixMs = &option.InstalledAtUnixMS
+		}
 		if source := strings.TrimSpace(option.Source); source != "" {
 			generated.Source = optionalStringPointer(source)
 		}

--- a/services/tuttid/api/daemon_agent_composer_options_test.go
+++ b/services/tuttid/api/daemon_agent_composer_options_test.go
@@ -314,15 +314,19 @@ func TestDaemonAPIGeneratedRoutesGetAgentProviderComposerOptionsLeavesTargetDefa
 
 func TestGeneratedAgentProviderCapabilityOptionsProjectsIconURL(t *testing.T) {
 	options := generatedAgentProviderCapabilityOptions([]agentservice.ComposerCapabilityOption{{
-		ID:         "connector:github",
-		Kind:       "connector",
-		Name:       "github",
-		Label:      "GitHub",
-		IconURL:    "https://cdn.example.test/tutti/connector-market/github/1.0.0/github-1.0.0-icon.svg",
-		Status:     "available",
-		Invocation: "textTrigger",
+		ID:                "connector:github",
+		Kind:              "connector",
+		Name:              "github",
+		Label:             "GitHub",
+		IconURL:           "https://cdn.example.test/tutti/connector-market/github/1.0.0/github-1.0.0-icon.svg",
+		InstalledAtUnixMS: 1786089600000,
+		Status:            "available",
+		Invocation:        "textTrigger",
 	}})
 	if len(options) != 1 || options[0].IconUrl == nil || *options[0].IconUrl != "https://cdn.example.test/tutti/connector-market/github/1.0.0/github-1.0.0-icon.svg" {
 		t.Fatalf("options = %#v, want connector icon URL", options)
+	}
+	if options[0].InstalledAtUnixMs == nil || *options[0].InstalledAtUnixMs != 1786089600000 {
+		t.Fatalf("options = %#v, want connector installation time", options)
 	}
 }

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -5440,20 +5440,21 @@ type AgentProviderAvailabilityStatus string
 
 // AgentProviderCapabilityOption defines model for AgentProviderCapabilityOption.
 type AgentProviderCapabilityOption struct {
-	Description *string                                 `json:"description,omitempty"`
-	IconUrl     *string                                 `json:"iconUrl,omitempty"`
-	Id          string                                  `json:"id"`
-	Invocation  AgentProviderCapabilityOptionInvocation `json:"invocation"`
-	Kind        AgentProviderCapabilityOptionKind       `json:"kind"`
-	Label       string                                  `json:"label"`
-	Name        string                                  `json:"name"`
-	Path        *string                                 `json:"path,omitempty"`
-	PluginName  *string                                 `json:"pluginName,omitempty"`
-	ServerName  *string                                 `json:"serverName,omitempty"`
-	Source      *string                                 `json:"source,omitempty"`
-	Status      AgentProviderCapabilityOptionStatus     `json:"status"`
-	ToolName    *string                                 `json:"toolName,omitempty"`
-	Trigger     *string                                 `json:"trigger,omitempty"`
+	Description       *string                                 `json:"description,omitempty"`
+	IconUrl           *string                                 `json:"iconUrl,omitempty"`
+	Id                string                                  `json:"id"`
+	InstalledAtUnixMs *int64                                  `json:"installedAtUnixMs,omitempty"`
+	Invocation        AgentProviderCapabilityOptionInvocation `json:"invocation"`
+	Kind              AgentProviderCapabilityOptionKind       `json:"kind"`
+	Label             string                                  `json:"label"`
+	Name              string                                  `json:"name"`
+	Path              *string                                 `json:"path,omitempty"`
+	PluginName        *string                                 `json:"pluginName,omitempty"`
+	ServerName        *string                                 `json:"serverName,omitempty"`
+	Source            *string                                 `json:"source,omitempty"`
+	Status            AgentProviderCapabilityOptionStatus     `json:"status"`
+	ToolName          *string                                 `json:"toolName,omitempty"`
+	Trigger           *string                                 `json:"trigger,omitempty"`
 }
 
 // AgentProviderCapabilityOptionInvocation defines model for AgentProviderCapabilityOption.Invocation.
@@ -6735,6 +6736,7 @@ type ConnectorMarketImplementationKind string
 // ConnectorMarketInstallation defines model for ConnectorMarketInstallation.
 type ConnectorMarketInstallation struct {
 	FailureCode            *string                          `json:"failureCode,omitempty"`
+	InstalledAtUnixMs      *int64                           `json:"installedAtUnixMs,omitempty"`
 	InstalledReleaseDigest *string                          `json:"installedReleaseDigest,omitempty"`
 	InstalledReleaseId     *string                          `json:"installedReleaseId,omitempty"`
 	InstalledVersion       *string                          `json:"installedVersion,omitempty"`

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -12244,6 +12244,10 @@ components:
           type: string
         iconUrl:
           type: string
+        installedAtUnixMs:
+          type: integer
+          format: int64
+          minimum: 1
         status:
           type: string
           enum:


### PR DESCRIPTION
## Summary

Connector availability in the composer menu was slow and ambiguous, and installed connectors could not be reliably enabled or disabled in place. Installing from Agent GUI also required an unnecessary confirmation step before authorization.

This change:

- presents installed connectors first in installation-time order while keeping disabled entries in place
- adds UI System runtime switches with optimistic feedback and authoritative daemon persistence
- keeps connector icons and menu density aligned with the composer UI
- installs discovery connectors inline with a loading state, then opens the canonical authorization or management dialog automatically
- carries `installedAtUnixMs` through storage, daemon composer options, OpenAPI, and renderer projections

## Verification

- `pnpm typecheck` — 37 packages passed
- `pnpm --filter @tutti-os/connector-renderer test` — 83 Node tests and 23 Vitest tests passed
- `pnpm --filter @tutti-os/agent-gui test` — 331 files and 2988 tests passed
- `go test ./services/tuttid/api` — passed
- `pnpm check:api-generated` — generated API and protocol checks passed
- pre-commit and push-ready hooks passed, including formatting, lint, UI boundaries, renderer boundaries, and changed-surface checks

## Checklist

- [x] This PR does not change agent session/turn/goal lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] Documentation changes are not required; the UI and runtime behavior are covered by targeted tests.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commit is signed off with DCO.
