### PR TITLE
fix(connector): support cache durability on Windows

### DIFF
--- a/packages/connector/runtime/artifact/preparer.go
+++ b/packages/connector/runtime/artifact/preparer.go
@@ -759,18 +759,6 @@ func inventoryDigest(root string) (string, error) {
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
-func syncDirectory(path string) error {
-	directory, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer directory.Close()
-	if err := directory.Sync(); err != nil {
-		return fmt.Errorf("sync connector artifact directory: %w", err)
-	}
-	return nil
-}
-
 func sameMediaType(actual, expected string) bool {
 	actualType, _, actualErr := mime.ParseMediaType(actual)
 	expectedType, _, expectedErr := mime.ParseMediaType(expected)

--- a/packages/connector/runtime/artifact/sync_directory_test.go
+++ b/packages/connector/runtime/artifact/sync_directory_test.go
@@ -1,0 +1,23 @@
+package artifact
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSyncDirectoryAcceptsExistingDirectory(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "artifact"), []byte("verified"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := syncDirectory(root); err != nil {
+		t.Fatalf("syncDirectory() error = %v, want nil", err)
+	}
+}
+
+func TestSyncDirectoryRejectsMissingDirectory(t *testing.T) {
+	if err := syncDirectory(filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatal("syncDirectory() error = nil, want missing directory rejected")
+	}
+}

--- a/packages/connector/runtime/artifact/sync_directory_unix.go
+++ b/packages/connector/runtime/artifact/sync_directory_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package artifact
+
+import (
+	"fmt"
+	"os"
+)
+
+func syncDirectory(path string) error {
+	directory, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer directory.Close()
+	if err := directory.Sync(); err != nil {
+		return fmt.Errorf("sync connector artifact directory: %w", err)
+	}
+	return nil
+}

--- a/packages/connector/runtime/artifact/sync_directory_windows.go
+++ b/packages/connector/runtime/artifact/sync_directory_windows.go
@@ -1,0 +1,25 @@
+package artifact
+
+import (
+	"fmt"
+	"os"
+)
+
+// Windows does not expose a portable directory fsync operation. Opening and
+// validating the directory preserves error reporting without calling
+// os.File.Sync, which returns ERROR_ACCESS_DENIED for directory handles.
+func syncDirectory(path string) error {
+	directory, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	info, statErr := directory.Stat()
+	closeErr := directory.Close()
+	if statErr != nil {
+		return statErr
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("sync connector artifact directory: %s is not a directory", path)
+	}
+	return closeErr
+}


### PR DESCRIPTION
## What changed

- split connector artifact directory sync into platform-owned implementations
- keep directory fsync on POSIX
- validate and close directory handles on Windows without calling unsupported directory Sync
- add native filesystem regression coverage

## Why

Windows returns ERROR_ACCESS_DENIED when os.File.Sync is called on a directory handle. That made Connector artifact candidate publication fail during PrepareCandidate and blocked TSH Windows validation.

## Risk

The change is limited to the Connector runtime artifact cache durability boundary. POSIX behavior is unchanged. Windows retains file fsync and atomic rename behavior; only unsupported directory fsync is omitted after validating the target directory.

## Verification

- GOWORK=off go test ./artifact with TestSyncDirectoryAcceptsExistingDirectory, TestSyncDirectoryRejectsMissingDirectory, and TestDownloadCacheKeepsCurrentUntilCandidateIsPromoted on Windows

## Documentation impact

No public API, configuration, ownership, or user-visible workflow changed; no durable documentation update is required.