### PR TITLE
Fix standalone Agent app webview sizing

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentAppViewerToolPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentAppViewerToolPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ReactNode } from "react";
+import { useLayoutEffect, useMemo, useRef, type ReactNode } from "react";
 import {
   createWorkbenchHostLaunchedNodeId,
   type WorkbenchContribution,
@@ -16,6 +16,7 @@ import {
   workspaceAppWebviewTypeID
 } from "@renderer/features/workspace-app-center";
 import { createStandaloneAgentDirectToolHost } from "./standaloneAgentToolWorkbench.ts";
+import { syncStandaloneAgentAppViewerWebviewBounds } from "./standaloneAgentAppViewerLayout.ts";
 
 export function StandaloneAgentAppViewerToolPanel({
   active,
@@ -32,8 +33,43 @@ export function StandaloneAgentAppViewerToolPanel({
 }): ReactNode {
   const { service } = useWorkspaceAppCenterService();
   const resolved = resolveStandaloneAgentAppWebviewContribution(contributions);
+  const viewerAvailable = resolved !== null;
   const directHost = useMemo(createStandaloneAgentDirectToolHost, []);
   const app = findWorkspaceApp(service, appId);
+  const surfaceRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const surface = surfaceRef.current;
+    if (!active || !surface) return;
+
+    let animationFrameId: number | null = null;
+    const syncBounds = (): void => {
+      animationFrameId = null;
+      syncStandaloneAgentAppViewerWebviewBounds(surface);
+    };
+    const scheduleBoundsSync = (): void => {
+      if (animationFrameId !== null) return;
+      animationFrameId = window.requestAnimationFrame(syncBounds);
+    };
+    const mutationObserver = new MutationObserver(scheduleBoundsSync);
+    mutationObserver.observe(surface, { childList: true, subtree: true });
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(scheduleBoundsSync);
+    resizeObserver?.observe(surface);
+    window.addEventListener("resize", scheduleBoundsSync);
+    scheduleBoundsSync();
+
+    return () => {
+      if (animationFrameId !== null) {
+        window.cancelAnimationFrame(animationFrameId);
+      }
+      mutationObserver.disconnect();
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", scheduleBoundsSync);
+    };
+  }, [active, viewerAvailable]);
 
   if (!resolved) {
     return (
@@ -92,7 +128,7 @@ export function StandaloneAgentAppViewerToolPanel({
     isDragging: false,
     isFocused: active,
     isResizing: false,
-    isVisible: true,
+    isVisible: active,
     node,
     setNodeRuntimeState: () => undefined,
     setSnapshotNodeState: () => undefined
@@ -100,10 +136,14 @@ export function StandaloneAgentAppViewerToolPanel({
 
   return (
     <div
-      className="h-full min-h-0 w-full overflow-hidden"
+      className="relative h-full min-h-0 w-full overflow-hidden"
+      data-active={active ? "true" : "false"}
       data-standalone-agent-app-viewer-surface="true"
+      ref={surfaceRef}
     >
-      {resolved.definition.renderBody(context)}
+      <div className="absolute inset-0 min-h-0 overflow-hidden">
+        {resolved.definition.renderBody(context)}
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
@@ -581,7 +581,7 @@ export function StandaloneAgentWindow({
   const isConversationRailCollapsed = conversationRailPresentation.isCollapsed;
   const minimumAgentGuiViewportWidthPx =
     resolveStandaloneAgentGUIViewportMinimumWidthPx({
-      conversationRailCollapsed: nodeState.conversationRailCollapsed === true,
+      conversationRailCollapsed: isConversationRailCollapsed,
       conversationRailWidthPx: nodeState.conversationRailWidthPx
     });
   const host = useMemo(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentAppViewerLayout.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentAppViewerLayout.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { syncStandaloneAgentAppViewerWebviewBounds } from "./standaloneAgentAppViewerLayout.ts";
+
+test("standalone Agent app viewer gives the Electron webview explicit host bounds", () => {
+  const webview = { style: { height: "150px", width: "300px" } };
+  const surface = {
+    clientHeight: 468,
+    clientWidth: 796,
+    querySelector: () => webview
+  };
+
+  assert.equal(syncStandaloneAgentAppViewerWebviewBounds(surface), true);
+  assert.deepEqual(webview.style, { height: "468px", width: "796px" });
+});
+
+test("standalone Agent app viewer waits until its hidden surface has layout bounds", () => {
+  const webview = { style: { height: "150px", width: "300px" } };
+  const surface = {
+    clientHeight: 0,
+    clientWidth: 796,
+    querySelector: () => webview
+  };
+
+  assert.equal(syncStandaloneAgentAppViewerWebviewBounds(surface), false);
+  assert.deepEqual(webview.style, { height: "150px", width: "300px" });
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentAppViewerLayout.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentAppViewerLayout.ts
@@ -1,0 +1,24 @@
+const workspaceAppWebviewSelector = 'webview[data-browser-node-webview="true"]';
+
+export interface StandaloneAgentAppViewerSurface {
+  clientHeight: number;
+  clientWidth: number;
+  querySelector(selectors: string): {
+    style: { height: string; width: string };
+  } | null;
+}
+
+export function syncStandaloneAgentAppViewerWebviewBounds(
+  surface: StandaloneAgentAppViewerSurface
+): boolean {
+  const width = Math.round(surface.clientWidth);
+  const height = Math.round(surface.clientHeight);
+  const webview = surface.querySelector(workspaceAppWebviewSelector);
+  if (!webview || width <= 0 || height <= 0) return false;
+
+  const nextWidth = `${width}px`;
+  const nextHeight = `${height}px`;
+  if (webview.style.width !== nextWidth) webview.style.width = nextWidth;
+  if (webview.style.height !== nextHeight) webview.style.height = nextHeight;
+  return true;
+}


### PR DESCRIPTION
## 改动说明

- 为 Agent 模式独立应用 viewer 补全绝对定位的高度链，避免 Electron `<webview>` 回落到默认 `300×150`。
- 在应用激活、宿主尺寸变化和 webview 延迟挂载时，将 webview 的像素宽高同步到实际容器。
- 非激活标签向 BrowserNode 传递不可见状态，重新激活时重新同步尺寸。
- Agent 会话栏因空间约束自动折叠后，应用侧栏按实际折叠态重新计算主区最小宽度，不再为已经隐藏的会话栏继续预留约 290px。
- 增加尺寸同步的聚焦回归测试，覆盖默认尺寸恢复和隐藏容器保护。

## 根因

独立 Agent 应用面板只依赖百分比高度；应用与浏览器标签切换后，Electron webview 可能在隐藏/重新挂载阶段保留默认 `300×150`，且原实现没有在重新激活或延迟 contribution 就绪时重新写入宿主像素边界。

同时，右侧工具栏打开后 AgentGUI 会自动折叠会话栏，但工具栏宽度上限仍按显式持久化的展开状态计算，导致已折叠的会话栏继续占用宽度预算。

## 验证

- 聚焦 Node 测试：2/2 通过。
- `@tutti-os/desktop` typecheck：通过（新增宽度预算提交后已重跑）。
- `@tutti-os/desktop` production build：通过，renderer CSS contracts 通过。
- 隔离 Electron E2E：安装并打开 AI 幻灯片，切到浏览器；在 inactive 状态注入 `300×150`，切回应用后恢复为容器 `530×635`。
- 独立 subagent review：发现并修复 contribution `unresolved → resolved` 时 effect 不重跑的问题；复查后无代码阻塞项。

## Windows 影响

改动仅影响 Desktop renderer 的布局计算和 Electron webview 展示边界，不涉及路径、进程、shell 或平台 API。Windows 报告场景由上述 Electron E2E 覆盖。

## 已知基线问题

- 仓库 `check:ui-boundaries` 在未修改 token 文件的情况下报告 `origin/main` 的 renderer token 生成物已陈旧。
- `check:changed` 对 desktop 聚焦测试的参数会被 package script 追加到 `./src/**/*.test.ts` 之后，从而运行全量测试；本地 10 分钟未结束，聚焦测试已用底层 Node 命令独立通过。
