### PR TITLE
fix(desktop): keep installed apps out of dock

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.tsx
@@ -158,7 +158,8 @@ export function createWorkspaceAppCenterDockEntries(input: {
           clickBehavior: projection.clickBehavior,
           index,
           launchEnabled: projection.launchEnabled,
-          state: projection.state
+          state: projection.state,
+          visibility: projection.visibility
         })
       )
   ];
@@ -200,6 +201,7 @@ function createWorkspaceAppDockEntry(input: {
   index: number;
   launchEnabled: boolean;
   state?: WorkbenchHostDockEntry["state"];
+  visibility: WorkbenchHostDockEntry["visibility"];
 }): WorkbenchHostDockEntry {
   const dockEntryId = workspaceAppDockEntryId(input.app.appId);
   const appTitle = resolveWorkspaceAppDisplayName(input.app);
@@ -236,7 +238,7 @@ function createWorkspaceAppDockEntry(input: {
     sectionId: "apps",
     state: input.state,
     typeId: workspaceAppWebviewTypeID,
-    visibility: "always"
+    visibility: input.visibility
   };
 }
 

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterDockProjection.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterDockProjection.test.ts
@@ -12,6 +12,10 @@ test("workspace app center dock order stays before task and app entries", () => 
 });
 
 test("projectWorkspaceAppCenterDockApps maps runtime status to dock state", () => {
+  assert.equal(
+    projectWorkspaceAppCenterDockApps([createApp()])[0]?.visibility,
+    "when-open"
+  );
   assert.deepEqual(
     projectSingleWorkspaceAppCenterDockApp({
       launchUrl: "https://app.local",
@@ -231,7 +235,12 @@ test("projectWorkspaceAppCenterDockApps includes only enabled apps", () => {
 function projectSingleWorkspaceAppCenterDockApp(
   input: Partial<ReturnType<typeof createApp>>
 ) {
-  return projectWorkspaceAppCenterDockApps([createApp(input)])[0] ?? null;
+  const projection = projectWorkspaceAppCenterDockApps([createApp(input)])[0];
+  if (!projection) {
+    return null;
+  }
+  const { visibility: _visibility, ...runtimeProjection } = projection;
+  return runtimeProjection;
 }
 
 function createApp(

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterDockProjection.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterDockProjection.ts
@@ -9,6 +9,7 @@ export interface WorkspaceAppCenterDockProjection {
   clickBehavior?: WorkbenchHostDockEntry["clickBehavior"];
   launchEnabled: boolean;
   state?: WorkbenchHostDockEntryState;
+  visibility: WorkbenchHostDockEntry["visibility"];
 }
 
 export function projectWorkspaceAppCenterDockApps(
@@ -82,7 +83,8 @@ export function projectWorkspaceAppCenterDockApps(
 
       return {
         app,
-        ...projection
+        ...projection,
+        visibility: "when-open"
       };
     });
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceDockRetention.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceDockRetention.test.ts
@@ -4,8 +4,39 @@ import { workbenchSnapshotSchemaVersion } from "@tutti-os/workbench-snapshot";
 import {
   readWorkspaceDockRetentionByEntryId,
   replaceWorkspaceDockSnapshotMetadata,
+  resolveWorkspaceDockRetentionDefault,
+  resolveWorkspaceDockRetentionState,
   writeWorkspaceDockRetentionToSnapshot
 } from "./workspaceDockRetention.ts";
+
+test("workspace dock retention follows the entry visibility default", () => {
+  const entry = {
+    icon: null,
+    id: "workspace-app:calendar",
+    label: "Calendar",
+    typeId: "workspace-app-center",
+    visibility: "when-open"
+  } as const;
+
+  assert.equal(resolveWorkspaceDockRetentionDefault(entry), false);
+  assert.equal(
+    resolveWorkspaceDockRetentionDefault({ ...entry, visibility: "always" }),
+    true
+  );
+  assert.deepEqual(resolveWorkspaceDockRetentionState(entry, {}), {
+    retained: false,
+    visibility: "when-open"
+  });
+  assert.deepEqual(
+    resolveWorkspaceDockRetentionState(entry, {
+      "workspace-app:calendar": true
+    }),
+    {
+      retained: true,
+      visibility: "always"
+    }
+  );
+});
 
 test("workspace dock retention round-trips explicit removed entries", () => {
   const snapshot = writeWorkspaceDockRetentionToSnapshot(createSnapshot(), {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceDockRetention.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceDockRetention.ts
@@ -1,4 +1,5 @@
 import type { WorkbenchSnapshot } from "@tutti-os/workbench-snapshot";
+import type { WorkbenchHostDockEntry } from "@tutti-os/workbench-surface";
 
 const workspaceDockMetadataKey = "workspaceDock";
 const workspaceDockMetadataSchemaVersion = 1;
@@ -6,6 +7,27 @@ const workspaceDockMetadataSchemaVersion = 1;
 interface WorkspaceDockSnapshotMetadata {
   retainedByEntryId: Record<string, boolean>;
   schemaVersion: typeof workspaceDockMetadataSchemaVersion;
+}
+
+export function resolveWorkspaceDockRetentionDefault(
+  entry: WorkbenchHostDockEntry
+): boolean {
+  return (entry.visibility ?? "always") === "always";
+}
+
+export function resolveWorkspaceDockRetentionState(
+  entry: WorkbenchHostDockEntry,
+  retainedByEntryId: Readonly<Record<string, boolean>>
+): {
+  retained: boolean;
+  visibility: NonNullable<WorkbenchHostDockEntry["visibility"]>;
+} {
+  const retained =
+    retainedByEntryId[entry.id] ?? resolveWorkspaceDockRetentionDefault(entry);
+  return {
+    retained,
+    visibility: retained ? "always" : "when-open"
+  };
 }
 
 export function readWorkspaceDockRetentionByEntryId(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
@@ -121,6 +121,10 @@ import {
 } from "../../../../../shared/featureFlags/catalog.ts";
 import { resolveWorkbenchShortcutAction } from "../services/workspaceWorkbenchShortcutService.ts";
 import {
+  resolveWorkspaceDockRetentionDefault,
+  resolveWorkspaceDockRetentionState
+} from "../services/workspaceDockRetention.ts";
+import {
   openWorkspaceWorkbenchAgentConversationShortcut,
   openWorkspaceWorkbenchSameTypeWindowShortcut
 } from "../services/workspaceWorkbenchShortcutActions.ts";
@@ -427,18 +431,12 @@ function ReadyWorkspaceWorkbenchWithSession({
         });
         const retained =
           runtime.dockRetentionByEntryId[request.entryId] ??
-          (entry
-            ? resolveWorkspaceDockRetentionDefault({
-                appCenterService,
-                entry
-              })
-            : false);
+          (entry ? resolveWorkspaceDockRetentionDefault(entry) : false);
         return runtime.setDockEntryRetained(request.entryId, !retained);
       }
       return hostInput.onDockEntryAction?.(request);
     },
     [
-      appCenterService,
       hostInput.contributions,
       hostInput.dockEntries,
       hostInput.onDockEntryAction,
@@ -449,13 +447,11 @@ function ReadyWorkspaceWorkbenchWithSession({
   const dockEntryPresentationOverrides = useMemo(
     () =>
       resolveWorkspaceDockEntryPresentationOverrides({
-        appCenterService,
         contributions: hostInput.contributions,
         dockEntries: hostInput.dockEntries,
         retainedByEntryId: runtime.dockRetentionByEntryId
       }),
     [
-      appCenterService,
       hostInput.contributions,
       hostInput.dockEntries,
       runtime.dockRetentionByEntryId
@@ -1021,12 +1017,10 @@ function ReadyWorkspaceWorkbenchWithSession({
 }
 
 function resolveWorkspaceDockEntryPresentationOverrides({
-  appCenterService,
   contributions,
   dockEntries,
   retainedByEntryId
 }: {
-  appCenterService: IWorkspaceAppCenterService;
   contributions: readonly WorkbenchContribution[] | undefined;
   dockEntries: readonly WorkbenchHostDockEntry[] | undefined;
   retainedByEntryId: Readonly<Record<string, boolean>>;
@@ -1043,7 +1037,6 @@ function resolveWorkspaceDockEntryPresentationOverrides({
   ];
   for (const entry of entries) {
     const presentationOverride = resolveWorkspaceDockRetentionPresentation({
-      appCenterService,
       entry,
       retainedByEntryId
     });
@@ -1055,11 +1048,9 @@ function resolveWorkspaceDockEntryPresentationOverrides({
 }
 
 function resolveWorkspaceDockRetentionPresentation({
-  appCenterService,
   entry,
   retainedByEntryId
 }: {
-  appCenterService: IWorkspaceAppCenterService;
   entry: WorkbenchHostDockEntry;
   retainedByEntryId: Readonly<Record<string, boolean>>;
 }): WorkbenchHostDockEntryPresentationOverride | null {
@@ -1069,28 +1060,14 @@ function resolveWorkspaceDockRetentionPresentation({
   ) {
     return null;
   }
-  const retained =
-    retainedByEntryId[entry.id] ??
-    resolveWorkspaceDockRetentionDefault({ appCenterService, entry });
+  const state = resolveWorkspaceDockRetentionState(entry, retainedByEntryId);
   return {
     dockRetention: {
       actionId: `${workspaceDockRetentionActionPrefix}${encodeURIComponent(entry.id)}`,
-      retained
+      retained: state.retained
     },
-    visibility: retained ? "always" : "when-open"
+    visibility: state.visibility
   };
-}
-
-function resolveWorkspaceDockRetentionDefault({
-  appCenterService,
-  entry
-}: {
-  appCenterService: IWorkspaceAppCenterService;
-  entry: WorkbenchHostDockEntry;
-}): boolean {
-  const appId = readWorkspaceAppIdFromDockEntryId(entry.id);
-  const app = appId ? findWorkspaceApp(appCenterService, appId) : null;
-  return app?.installed ?? (entry.visibility ?? "always") === "always";
 }
 
 function findWorkspaceDockRetentionEntry({
@@ -1109,15 +1086,6 @@ function findWorkspaceDockRetentionEntry({
       .find((entry) => entry.id === entryId) ??
     null
   );
-}
-
-function readWorkspaceAppIdFromDockEntryId(
-  value: string | null | undefined
-): string | null {
-  const prefix = "workspace-app:";
-  return value?.startsWith(prefix)
-    ? decodeURIComponent(value.slice(prefix.length))
-    : null;
 }
 
 function publishWorkspaceAppLaunchIntent(input: {

--- a/docs/architecture/workbench-dock-model.md
+++ b/docs/architecture/workbench-dock-model.md
@@ -220,6 +220,11 @@ Dock visibility and launchability should be modeled separately.
 default navigation set but should appear when a matching node is already open
 or restored from snapshot.
 
+Installed workspace applications default to `when-open`: installation makes an
+application launchable from App Center but does not pin it to the Dock. A host
+may persist an explicit Keep in Dock choice and override visibility to `always`;
+closing the last matching node hides an application without that retained choice.
+
 ### Open-State Indicator
 
 An entry with a matching open or minimized node renders the shared Dock state


### PR DESCRIPTION
## Summary

- make installed workspace apps use the shared when-open Dock policy
- derive default retention from Dock entry visibility while preserving explicit snapshot metadata
- keep explicitly retained apps visible after their last window closes
- document the workspace app Dock lifecycle

## Validation

- pnpm check:changed (11 lanes)
- pre-push pnpm check:changed -- --push-ready (12 lanes)
- focused Dock projection and retention tests: 7 passed
- pnpm perf:agent-gui -- --scenario workbench-window-lifecycle

## Risk

Low. Existing explicit retained true/false metadata remains authoritative; the behavior change only affects installed apps without an explicit Dock choice.