### PR TITLE
fix(desktop): backport standalone app sizing to release/0818

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentAppViewerToolPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentAppViewerToolPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ReactNode } from "react";
+import { useLayoutEffect, useMemo, useRef, type ReactNode } from "react";
 import {
   createWorkbenchHostLaunchedNodeId,
   type WorkbenchContribution,
@@ -16,6 +16,7 @@ import {
   workspaceAppWebviewTypeID
 } from "@renderer/features/workspace-app-center";
 import { createStandaloneAgentDirectToolHost } from "./standaloneAgentToolWorkbench.ts";
+import { syncStandaloneAgentAppViewerWebviewBounds } from "./standaloneAgentAppViewerLayout.ts";
 
 export function StandaloneAgentAppViewerToolPanel({
   active,
@@ -32,8 +33,43 @@ export function StandaloneAgentAppViewerToolPanel({
 }): ReactNode {
   const { service } = useWorkspaceAppCenterService();
   const resolved = resolveStandaloneAgentAppWebviewContribution(contributions);
+  const viewerAvailable = resolved !== null;
   const directHost = useMemo(createStandaloneAgentDirectToolHost, []);
   const app = findWorkspaceApp(service, appId);
+  const surfaceRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const surface = surfaceRef.current;
+    if (!active || !surface) return;
+
+    let animationFrameId: number | null = null;
+    const syncBounds = (): void => {
+      animationFrameId = null;
+      syncStandaloneAgentAppViewerWebviewBounds(surface);
+    };
+    const scheduleBoundsSync = (): void => {
+      if (animationFrameId !== null) return;
+      animationFrameId = window.requestAnimationFrame(syncBounds);
+    };
+    const mutationObserver = new MutationObserver(scheduleBoundsSync);
+    mutationObserver.observe(surface, { childList: true, subtree: true });
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(scheduleBoundsSync);
+    resizeObserver?.observe(surface);
+    window.addEventListener("resize", scheduleBoundsSync);
+    scheduleBoundsSync();
+
+    return () => {
+      if (animationFrameId !== null) {
+        window.cancelAnimationFrame(animationFrameId);
+      }
+      mutationObserver.disconnect();
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", scheduleBoundsSync);
+    };
+  }, [active, viewerAvailable]);
 
   if (!resolved) {
     return (
@@ -92,7 +128,7 @@ export function StandaloneAgentAppViewerToolPanel({
     isDragging: false,
     isFocused: active,
     isResizing: false,
-    isVisible: true,
+    isVisible: active,
     node,
     setNodeRuntimeState: () => undefined,
     setSnapshotNodeState: () => undefined
@@ -100,10 +136,14 @@ export function StandaloneAgentAppViewerToolPanel({
 
   return (
     <div
-      className="h-full min-h-0 w-full overflow-hidden"
+      className="relative h-full min-h-0 w-full overflow-hidden"
+      data-active={active ? "true" : "false"}
       data-standalone-agent-app-viewer-surface="true"
+      ref={surfaceRef}
     >
-      {resolved.definition.renderBody(context)}
+      <div className="absolute inset-0 min-h-0 overflow-hidden">
+        {resolved.definition.renderBody(context)}
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
@@ -572,7 +572,7 @@ export function StandaloneAgentWindow({
   const isConversationRailCollapsed = conversationRailPresentation.isCollapsed;
   const minimumAgentGuiViewportWidthPx =
     resolveStandaloneAgentGUIViewportMinimumWidthPx({
-      conversationRailCollapsed: nodeState.conversationRailCollapsed === true,
+      conversationRailCollapsed: isConversationRailCollapsed,
       conversationRailWidthPx: nodeState.conversationRailWidthPx
     });
   const host = useMemo(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentAppViewerLayout.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentAppViewerLayout.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { syncStandaloneAgentAppViewerWebviewBounds } from "./standaloneAgentAppViewerLayout.ts";
+
+test("standalone Agent app viewer gives the Electron webview explicit host bounds", () => {
+  const webview = { style: { height: "150px", width: "300px" } };
+  const surface = {
+    clientHeight: 468,
+    clientWidth: 796,
+    querySelector: () => webview
+  };
+
+  assert.equal(syncStandaloneAgentAppViewerWebviewBounds(surface), true);
+  assert.deepEqual(webview.style, { height: "468px", width: "796px" });
+});
+
+test("standalone Agent app viewer waits until its hidden surface has layout bounds", () => {
+  const webview = { style: { height: "150px", width: "300px" } };
+  const surface = {
+    clientHeight: 0,
+    clientWidth: 796,
+    querySelector: () => webview
+  };
+
+  assert.equal(syncStandaloneAgentAppViewerWebviewBounds(surface), false);
+  assert.deepEqual(webview.style, { height: "150px", width: "300px" });
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentAppViewerLayout.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentAppViewerLayout.ts
@@ -1,0 +1,24 @@
+const workspaceAppWebviewSelector = 'webview[data-browser-node-webview="true"]';
+
+export interface StandaloneAgentAppViewerSurface {
+  clientHeight: number;
+  clientWidth: number;
+  querySelector(selectors: string): {
+    style: { height: string; width: string };
+  } | null;
+}
+
+export function syncStandaloneAgentAppViewerWebviewBounds(
+  surface: StandaloneAgentAppViewerSurface
+): boolean {
+  const width = Math.round(surface.clientWidth);
+  const height = Math.round(surface.clientHeight);
+  const webview = surface.querySelector(workspaceAppWebviewSelector);
+  if (!webview || width <= 0 || height <= 0) return false;
+
+  const nextWidth = `${width}px`;
+  const nextHeight = `${height}px`;
+  if (webview.style.width !== nextWidth) webview.style.width = nextWidth;
+  if (webview.style.height !== nextHeight) webview.style.height = nextHeight;
+  return true;
+}


### PR DESCRIPTION
## What changed

- backport #2504 to `release/0818`
- keep standalone Agent app webviews synchronized with their right-sidebar bounds
- reclaim the conversation-rail width budget after automatic rail collapse

## Why

AI Office apps could retain stale/default Electron webview bounds and be clipped in the standalone Agent right sidebar. The release branch also continued reserving width for an automatically collapsed conversation rail.

## Validation

- cherry-pick applied without conflicts
- focused standalone app viewer layout tests: 2/2 passed
- diff check passed

Mainline validation is recorded in #2504, including Desktop typecheck, production build, Windows Electron E2E, and full PR CI.
