### PR TITLE
docs: Point the session-replay references at the moved state.go

### DIFF
--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -4703,7 +4703,7 @@ permanently ambiguous`. Provider status may already be `active` while the
   tool-owned nested argument, and prove the source Agent graph remains
   unchanged.
 - References:
-  [state.go](../../../services/tuttid/biz/agentsessionreplay/state.go)
+  [state.go](../../../packages/agent/session-replay/state.go)
   [agent_session_replay_state.go](../../../services/tuttid/data/workspace/agent_session_replay_state.go)
 
 ### Cassette replay loses the provider session before the second stimulus
@@ -4955,13 +4955,13 @@ permanently ambiguous`. Provider status may already be `active` while the
   state can never hold.
 - Fix:
   Register message-content `attachmentId` values as alpha-equivalent
-  identities in `registerReplayIDs` (`services/tuttid/biz/agentsessionreplay/state.go`),
+  identities in `registerReplayIDs` (`packages/agent/session-replay/state.go`),
   like session/turn/message IDs.
 - Validation:
   `TestCompareTuttiReplayStateTreatsAttachmentIDsAsAlphaEquivalent` in
   `state_test.go`; a full record→replay of an image-input cassette passes.
 - References:
-  [state.go](../../../services/tuttid/biz/agentsessionreplay/state.go)
+  [state.go](../../../packages/agent/session-replay/state.go)
 
 ### Replay transport mismatch on Goal Control `operationId`
 
@@ -4981,7 +4981,7 @@ permanently ambiguous`. Provider status may already be `active` while the
   `TestCompareTuttiReplayStateTreatsGoalControlOperationIDsAsAlphaEquivalent`;
   record→audit→replay of `l01_codex` (`l01`) passes.
 - References:
-  [state.go](../../../services/tuttid/biz/agentsessionreplay/state.go)
+  [state.go](../../../packages/agent/session-replay/state.go)
   `tutti-agent-session-replay-cases/cases/l01/scenario.mjs`
 
 ### Project-session replay never shows the restored session in the rail


### PR DESCRIPTION
Four references in `docs/conventions/troubleshooting/agent-session-lifecycle.md` point at
`services/tuttid/biz/agentsessionreplay/state.go`. `582f56586`
("refactor(agent-session-replay): extract shared packages", 2026-08-03) moved it to
`packages/agent/session-replay/state.go`, which is where it is today.

| line | form |
|---|---|
| 4706 | `[state.go](../../../services/tuttid/biz/agentsessionreplay/state.go)` |
| 4958 | inline, in the Fix for "Attachment identifiers are runtime-generated" |
| 4964 | link |
| 4984 | link |

Three of the four render as markdown links that resolve nowhere. The directory
`services/tuttid/biz/agentsessionreplay/` does still exist, holding `facade.go`, which is
probably why this survived a read.

Four lines, one file, no prose changes.

## What is deliberately not in this

`docs/conventions/troubleshooting/mobile.md:242` names
`apps/mobile/src/services/workspaceActivityCommandAdapter.ts`, gone in `c1214cc8b`
("refactor(agent): unify desktop and mobile effect execution"). `apps/mobile/src/services/`
now holds `mobileAgentActivityMapping.ts` and `mobileAgentActivityReconcileExecutor.ts`, which
look related, and I am not going to guess which one that reference should become. Say which
and it is a follow-up, or the line comes out.

Part of #2468.

Found by [docproof](https://github.com/melbinjp/docproof), which resolves documented paths
against the repository and its git history.
