### PR TITLE
fix(workspace-files): keep Agent context menu actions clickable on Windows

### DIFF
--- a/.changeset/workspace-file-context-menu-pointer-actions.md
+++ b/.changeset/workspace-file-context-menu-pointer-actions.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/workspace-file-manager": patch
+---
+
+Keep Agent-mode viewport context-menu actions interactive on Windows by activating them on pointer down outside native drag regions, starting actions before the menu closes, and refreshing action callbacks when the right-click target changes.

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerContextMenu.render.test.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerContextMenu.render.test.tsx
@@ -1,0 +1,212 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkspaceFileManagerSession } from "../services/workspaceFileManagerService.interface.ts";
+import type { WorkspaceFileEntry } from "../services/workspaceFileManagerTypes.ts";
+
+const contextMenuView = vi.hoisted(() => ({
+  contextMenu: null as {
+    entry: WorkspaceFileEntry;
+    x: number;
+    y: number;
+  } | null,
+  currentDirectoryPath: "/workspace",
+  isBusy: false,
+  isLoading: false,
+  isMutating: false
+}));
+
+vi.mock("./useWorkspaceFileManagerService.ts", () => ({
+  useWorkspaceFileManagerContextMenuView: () => ({
+    state: {},
+    view: contextMenuView
+  })
+}));
+
+import { WorkspaceFileManagerContextMenu } from "./WorkspaceFileManagerContextMenu.tsx";
+import { WorkspaceFileManagerContextMenuContainer } from "./WorkspaceFileManagerContextMenuContainer.tsx";
+
+describe("WorkspaceFileManagerContextMenu", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let previousActEnvironment: boolean | undefined;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+    previousActEnvironment = (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT;
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    document
+      .querySelectorAll("[data-workspace-file-manager-context-menu]")
+      .forEach((menu) => menu.remove());
+    contextMenuView.contextMenu = null;
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+  });
+
+  it("activates a viewport action on pointer down before closing the menu", async () => {
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <WorkspaceFileManagerContextMenu
+          contextMenu={{ x: 20, y: 20 }}
+          contextMenuRef={{ current: null }}
+          items={[
+            {
+              type: "item",
+              id: "open",
+              label: "Open",
+              onSelect
+            }
+          ]}
+          positionMode="viewport"
+          onClose={onClose}
+        />
+      );
+    });
+
+    const action =
+      document.querySelector<HTMLButtonElement>('[role="menuitem"]');
+    expect(action).not.toBeNull();
+
+    await act(async () => {
+      action?.dispatchEvent(
+        new MouseEvent("pointerdown", {
+          bubbles: true,
+          button: 0,
+          cancelable: true
+        })
+      );
+    });
+
+    expect(onSelect).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(onSelect.mock.invocationCallOrder[0]).toBeLessThan(
+      onClose.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY
+    );
+
+    await act(async () => {
+      action?.click();
+    });
+    expect(onSelect).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("keeps viewport actions activatable without a preceding pointer event", async () => {
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <WorkspaceFileManagerContextMenu
+          contextMenu={{ x: 20, y: 20 }}
+          contextMenuRef={{ current: null }}
+          items={[
+            {
+              type: "item",
+              id: "open",
+              label: "Open",
+              onSelect
+            }
+          ]}
+          positionMode="viewport"
+          onClose={onClose}
+        />
+      );
+    });
+
+    await act(async () => {
+      document.querySelector<HTMLButtonElement>('[role="menuitem"]')?.click();
+    });
+
+    expect(onSelect).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("uses actions resolved for the latest right-click target", async () => {
+    const firstEntry = createEntry("first");
+    const secondEntry = createEntry("second");
+    const selectedPaths: string[] = [];
+    const closeContextMenu = vi.fn();
+    const session = {
+      closeContextMenu,
+      store: {
+        locationSections: [],
+        searchQuery: "",
+        selectedLocationId: null
+      }
+    } as unknown as WorkspaceFileManagerSession;
+    const resolveContextMenu = vi.fn((request) => {
+      const path =
+        request.target.kind === "blank" ? null : request.target.entry.path;
+      return [
+        {
+          type: "item" as const,
+          id: "open",
+          label: "Open",
+          onSelect: () => {
+            if (path) selectedPaths.push(path);
+          }
+        }
+      ];
+    });
+    const renderMenu = () => (
+      <WorkspaceFileManagerContextMenuContainer
+        resolveContextMenu={resolveContextMenu}
+        session={session}
+      />
+    );
+
+    contextMenuView.contextMenu = { entry: firstEntry, x: 20, y: 20 };
+    await act(async () => {
+      root.render(renderMenu());
+    });
+
+    contextMenuView.contextMenu = { entry: secondEntry, x: 40, y: 40 };
+    await act(async () => {
+      root.render(renderMenu());
+    });
+
+    const action =
+      document.querySelector<HTMLButtonElement>('[role="menuitem"]');
+    await act(async () => {
+      action?.dispatchEvent(
+        new MouseEvent("pointerdown", {
+          bubbles: true,
+          button: 0,
+          cancelable: true
+        })
+      );
+    });
+
+    expect(resolveContextMenu).toHaveBeenCalledTimes(2);
+    expect(selectedPaths).toEqual([secondEntry.path]);
+    expect(closeContextMenu).toHaveBeenCalledOnce();
+  });
+});
+
+function createEntry(name: string): WorkspaceFileEntry {
+  return {
+    hasChildren: true,
+    kind: "directory",
+    mtimeMs: null,
+    name,
+    path: `/workspace/${name}`,
+    sizeBytes: null
+  };
+}

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerContextMenu.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerContextMenu.tsx
@@ -107,7 +107,7 @@ export function WorkspaceFileManagerContextMenu({
       className={cn(
         // `is-open` keeps host CSS that keys off the class (not only data-state)
         // from leaving the surface at opacity:0.
-        "is-open w-[220px] overflow-visible p-1",
+        "is-open nodrag w-[220px] overflow-visible p-1 [-webkit-app-region:no-drag]",
         positionMode === "viewport" ? "fixed" : "absolute"
       )}
       role="menu"
@@ -126,7 +126,12 @@ export function WorkspaceFileManagerContextMenu({
       }}
     >
       {items.map((item) => (
-        <ContextMenuItemRenderer key={item.id} item={item} onClose={onClose} />
+        <ContextMenuItemRenderer
+          activateOnPointerDown={positionMode === "viewport"}
+          key={item.id}
+          item={item}
+          onClose={onClose}
+        />
       ))}
     </MenuSurface>
   );
@@ -163,8 +168,9 @@ function ContextMenuItemRenderer({
           icon={item.icon ?? <LaunchIcon className="size-4" />}
           label={item.label}
           onClick={() => {
+            const selection = item.onSelect();
             onClose();
-            void item.onSelect();
+            void selection;
           }}
         />
       );

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerContextMenuContainer.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerContextMenuContainer.tsx
@@ -27,13 +27,27 @@ export function WorkspaceFileManagerContextMenuContainer({
   const [items, setItems] = useState<
     readonly WorkspaceFileManagerContextMenuItem[]
   >([]);
+  const resolvedRequestKeyRef = useRef<string | null>(null);
 
   const contextMenuX = view.contextMenu?.x;
   const contextMenuY = view.contextMenu?.y;
   const contextMenuEntryPath = view.contextMenu?.entry?.path ?? null;
+  const contextMenuRequestKey =
+    contextMenuX === undefined || contextMenuY === undefined
+      ? null
+      : [
+          contextMenuEntryPath ?? "<blank>",
+          view.currentDirectoryPath,
+          contextMenuX,
+          contextMenuY,
+          view.isBusy,
+          view.isLoading,
+          view.isMutating
+        ].join("\u0000");
 
   useLayoutEffect(() => {
-    if (contextMenuX === undefined || contextMenuY === undefined) {
+    if (contextMenuRequestKey === null) {
+      resolvedRequestKeyRef.current = null;
       setItems((current) => (current.length === 0 ? current : []));
       return;
     }
@@ -44,8 +58,14 @@ export function WorkspaceFileManagerContextMenuContainer({
     });
     const resolved = resolveContextMenu(request);
     if (!isPromiseLike(resolved)) {
+      const matchesResolvedRequest =
+        resolvedRequestKeyRef.current === contextMenuRequestKey;
+      resolvedRequestKeyRef.current = contextMenuRequestKey;
       setItems((current) =>
-        areContextMenuItemsEquivalent(current, resolved) ? current : resolved
+        matchesResolvedRequest &&
+        areContextMenuItemsEquivalent(current, resolved)
+          ? current
+          : resolved
       );
       return;
     }
@@ -54,7 +74,11 @@ export function WorkspaceFileManagerContextMenuContainer({
     setItems((current) => (current.length === 0 ? current : []));
     void resolved.then((nextItems) => {
       if (!cancelled) {
+        const matchesResolvedRequest =
+          resolvedRequestKeyRef.current === contextMenuRequestKey;
+        resolvedRequestKeyRef.current = contextMenuRequestKey;
         setItems((current) =>
+          matchesResolvedRequest &&
           areContextMenuItemsEquivalent(current, nextItems)
             ? current
             : nextItems
@@ -68,6 +92,7 @@ export function WorkspaceFileManagerContextMenuContainer({
     // object every render and would retrigger setItems forever.
   }, [
     contextMenuEntryPath,
+    contextMenuRequestKey,
     contextMenuX,
     contextMenuY,
     resolveContextMenu,


### PR DESCRIPTION
## What changed

- Activate Agent-mode viewport context-menu actions on pointer down and explicitly exclude the menu from Electron native drag regions.
- Start an action before closing the menu so Windows cannot discard the click during portal teardown.
- Refresh resolved menu callbacks when the right-click target/request changes while retaining structural deduplication for the same request.
- Add behavioral coverage for pointerdown/click deduplication, keyboard/synthetic click activation, action-before-close ordering, and callback refresh across targets.

## Root cause

The portaled Agent-mode menu relied on the later `click` event while living near a draggable Electron title region. On Windows the pointer sequence could be intercepted or the menu could close before the action ran. Separately, structural item deduplication could retain the previous target's callback when two menus had identical labels and ids.

## Validation

- `pnpm --filter @tutti-os/workspace-file-manager test` — Node 136/136; Vitest 24/24.
- `pnpm --filter @tutti-os/workspace-file-manager typecheck`.
- `pnpm --filter @tutti-os/workspace-file-manager build`.
- Changed-file `oxlint`.
- Renderer boundary, AgentGUI degradation, Electron runtime boundary, CSS/backdrop, and runtime image budget checks.
- Full `dev-gui` flow built the current worktree daemon and launched a responsive `Tutti Dev` window on Windows.
- Independent subagent review: no blockers.

## Known repository/tooling baseline

The global hook's UI metadata lane currently fails on unchanged `origin/main` because `cn` is listed in UI metadata but is not re-exported from `@tutti-os/ui-system/utils`. The Windows package-pack lane also loses JSON quoting for `--packages-json`. The relevant package build and all other changed/staged lanes above passed.

## Risk

Physical menu input automation was unavailable under the desktop driver's input policy, so the Windows event sequence is covered by component behavior tests plus successful Electron launch. A resolver that changes only callback identity while every request-key field and menu structure remain identical retains the existing callback; normal reopen and target/state/coordinate changes refresh it.
