### PR TITLE
feat(device-link): add exact retirement handles

### DIFF
--- a/packages/device-link/README.md
+++ b/packages/device-link/README.md
@@ -72,6 +72,14 @@ waits for accepted stream handlers to finish. Link observations carry a
 per-connection sequence; projections must ignore older deliveries and treat
 `disconnected` as terminal for that globally comparable connection ID.
 
+Lifecycle controllers that cannot wait for transport I/O use `Retire` or
+`RetireAll`. These methods synchronously advance admission generations, revoke
+incoming handlers, and remove the exact old link, then return immutable
+`Retirement` handles for physical close outside the controller lock. A delayed
+retirement close never looks up a key again and therefore cannot close a newer
+link registered for the same opaque key. `Invalidate` and `InvalidateAll`
+remain synchronous compatibility wrappers.
+
 Tutti's `mobileremote` Desktop owner is the first production adapter: it keeps
 pairing, identity proof, rendezvous, and Agent framing in `tuttid`, while the
 shared manager owns the authenticated link and incoming stream lifecycle.

--- a/packages/device-link/linkmanager/manager.go
+++ b/packages/device-link/linkmanager/manager.go
@@ -83,6 +83,27 @@ const (
 	RegisterKeptExisting RegisterDisposition = "kept_existing"
 )
 
+// Retirement owns one exact link that has already been removed from Manager
+// authority. Close never looks the link up by key, so a delayed physical close
+// cannot affect a replacement registered for the same key.
+type Retirement struct {
+	once     sync.Once
+	close    func() error
+	closeErr error
+}
+
+func (r *Retirement) Close() error {
+	if r == nil {
+		return nil
+	}
+	r.once.Do(func() {
+		if r.close != nil {
+			r.closeErr = r.close()
+		}
+	})
+	return r.closeErr
+}
+
 type Manager[K comparable, M any] struct {
 	cfg ManagerConfig[K, M]
 
@@ -128,7 +149,9 @@ type managedLink[K comparable, M any] struct {
 	eventSequence  uint64
 	disconnected   bool
 	closed         bool
+	revokeOnce     sync.Once
 	closeOnce      sync.Once
+	closeErr       error
 }
 
 type EstablishFunc[K comparable, M any] func(context.Context, *Admission[K, M]) (Registration[K, M], error)
@@ -258,7 +281,7 @@ func (m *Manager[K, M]) Register(
 		admission.globalGeneration != m.globalGeneration ||
 		admission.keyGeneration != m.keyGenerations[admission.key] {
 		m.mu.Unlock()
-		incoming.closeTransport()
+		_ = incoming.closeTransport()
 		return "", ErrAdmissionInvalidated
 	}
 	admission.used = true
@@ -268,7 +291,7 @@ func (m *Manager[K, M]) Register(
 		withinCollisionWindow := age >= 0 && age <= m.cfg.CollisionWindow
 		if !withinCollisionWindow || existing.connectionID <= incoming.connectionID {
 			m.mu.Unlock()
-			incoming.closeTransport()
+			_ = incoming.closeTransport()
 			return RegisterKeptExisting, nil
 		}
 		replaced = existing
@@ -283,7 +306,7 @@ func (m *Manager[K, M]) Register(
 
 	if replaced != nil {
 		m.notify(replaced, LinkDisconnected)
-		replaced.closeTransport()
+		_ = replaced.closeTransport()
 	}
 	m.notify(incoming, LinkReady)
 	go m.acceptStreams(incoming)
@@ -392,9 +415,12 @@ func (m *Manager[K, M]) OpenOrConnect(
 	}
 }
 
-func (m *Manager[K, M]) Invalidate(key K) {
+// Retire advances the exact key generation, rejects in-flight admissions, and
+// removes the current link without waiting for transport I/O. The returned
+// handle owns only the removed link and may be closed asynchronously.
+func (m *Manager[K, M]) Retire(key K) Retirement {
 	if m == nil {
-		return
+		return Retirement{}
 	}
 	var closing *managedLink[K, M]
 	var cancelAdmissions []context.CancelCauseFunc
@@ -421,15 +447,30 @@ func (m *Manager[K, M]) Invalidate(key K) {
 		cancel(ErrAdmissionInvalidated)
 	}
 	if closing != nil {
+		closing.revokeHandlers()
 		m.notify(closing, LinkDisconnected)
-		closing.closeTransport()
+		return Retirement{close: closing.closeTransport}
 	}
+	return Retirement{}
 }
 
-// InvalidateAll advances the manager generation, cancels every in-flight
-// admission, and closes all pooled links. The manager remains reusable.
+func (m *Manager[K, M]) Invalidate(key K) {
+	retirement := m.Retire(key)
+	_ = retirement.Close()
+}
+
+// RetireAll advances the manager generation, cancels every in-flight
+// admission, and removes all pooled links without waiting for transport I/O.
+// The manager remains reusable and every returned handle owns one exact old
+// link.
+func (m *Manager[K, M]) RetireAll() []Retirement {
+	return m.retireAll(false)
+}
+
+// InvalidateAll preserves the legacy synchronous cleanup contract. Lifecycle
+// callers that must remain live across a blocked Link.Close use RetireAll.
 func (m *Manager[K, M]) InvalidateAll() {
-	m.invalidateAll(false)
+	closeRetirements(m.RetireAll())
 }
 
 // SetEnabled atomically pauses or resumes admission. Disabling advances the
@@ -489,14 +530,14 @@ func (m *Manager[K, M]) SetEnabled(enabled bool) error {
 	}
 	for _, link := range closing {
 		m.notify(link, LinkDisconnected)
-		link.closeTransport()
+		_ = link.closeTransport()
 	}
 	return nil
 }
 
 // BeginQuiescence permanently closes admission and cancels all stream handlers.
 func (m *Manager[K, M]) BeginQuiescence() {
-	m.invalidateAll(true)
+	closeRetirements(m.retireAll(true))
 }
 
 func (m *Manager[K, M]) WaitForQuiescence(ctx context.Context) error {
@@ -521,9 +562,9 @@ func (m *Manager[K, M]) WaitForQuiescence(ctx context.Context) error {
 	}
 }
 
-func (m *Manager[K, M]) invalidateAll(permanent bool) {
+func (m *Manager[K, M]) retireAll(permanent bool) []Retirement {
 	if m == nil {
-		return
+		return nil
 	}
 	var closing []*managedLink[K, M]
 	var cancelAdmissions []context.CancelCauseFunc
@@ -556,8 +597,19 @@ func (m *Manager[K, M]) invalidateAll(permanent bool) {
 		cancel(ErrAdmissionInvalidated)
 	}
 	for _, link := range closing {
+		link.revokeHandlers()
 		m.notify(link, LinkDisconnected)
-		link.closeTransport()
+	}
+	retirements := make([]Retirement, 0, len(closing))
+	for _, link := range closing {
+		retirements = append(retirements, Retirement{close: link.closeTransport})
+	}
+	return retirements
+}
+
+func closeRetirements(retirements []Retirement) {
+	for index := range retirements {
+		_ = retirements[index].Close()
 	}
 }
 
@@ -613,7 +665,7 @@ func (m *Manager[K, M]) remove(link *managedLink[K, M]) {
 	if removedCurrent {
 		m.notify(link, LinkDisconnected)
 	}
-	link.closeTransport()
+	_ = link.closeTransport()
 }
 
 func (m *Manager[K, M]) notify(link *managedLink[K, M], state LinkState) {
@@ -721,18 +773,31 @@ func (m *Manager[K, M]) expireIdle(link *managedLink[K, M], generation uint64) {
 	link.idleTimer = nil
 	m.mu.Unlock()
 	m.notify(link, LinkDisconnected)
-	link.closeTransport()
+	_ = link.closeTransport()
 }
 
-func (link *managedLink[K, M]) closeTransport() {
-	link.closeOnce.Do(func() {
+func (link *managedLink[K, M]) revokeHandlers() {
+	if link == nil {
+		return
+	}
+	link.revokeOnce.Do(func() {
 		if link.cancelHandlers != nil {
 			link.cancelHandlers()
 		}
+	})
+}
+
+func (link *managedLink[K, M]) closeTransport() error {
+	if link == nil {
+		return nil
+	}
+	link.closeOnce.Do(func() {
+		link.revokeHandlers()
 		if link.link != nil {
-			_ = link.link.Close()
+			link.closeErr = link.link.Close()
 		}
 	})
+	return link.closeErr
 }
 
 type managedStream struct {

--- a/packages/device-link/linkmanager/manager_test.go
+++ b/packages/device-link/linkmanager/manager_test.go
@@ -14,6 +14,27 @@ type testMetadata struct {
 	Peer string
 }
 
+type blockingCloseLink struct {
+	*fakeLink
+	closeStarted chan struct{}
+	releaseClose chan struct{}
+	startOnce    sync.Once
+}
+
+func newBlockingCloseLink() *blockingCloseLink {
+	return &blockingCloseLink{
+		fakeLink:     newFakeLink(),
+		closeStarted: make(chan struct{}),
+		releaseClose: make(chan struct{}),
+	}
+}
+
+func (link *blockingCloseLink) Close() error {
+	link.startOnce.Do(func() { close(link.closeStarted) })
+	<-link.releaseClose
+	return link.fakeLink.Close()
+}
+
 func TestManagerReusesLinkAndExpiresOnlyAfterLastStreamCloses(t *testing.T) {
 	t.Parallel()
 	manager := NewManager[string, testMetadata](ManagerConfig[string, testMetadata]{
@@ -60,6 +81,85 @@ func TestManagerRejectsLateLinkAfterGenerationInvalidation(t *testing.T) {
 		t.Fatalf("late link close=%d ready=%v", link.closeCount.Load(), manager.Ready("peer"))
 	}
 	admission.Close()
+}
+
+func TestManagerRetireDoesNotMakeReplacementWaitForOldClose(t *testing.T) {
+	t.Parallel()
+	manager := NewManager[string, testMetadata](ManagerConfig[string, testMetadata]{
+		IdleGrace: time.Minute,
+	})
+	old := newBlockingCloseLink()
+	registerTestLink(t, manager, "peer", "old", old, nil)
+
+	retired := manager.Retire("peer")
+	if manager.Ready("peer") {
+		t.Fatal("retired link remained ready")
+	}
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- retired.Close() }()
+	select {
+	case <-old.closeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("old physical close did not start")
+	}
+
+	replacement := newFakeLink()
+	registerTestLink(t, manager, "peer", "replacement", replacement, nil)
+	if !manager.Ready("peer") {
+		t.Fatal("replacement did not become ready while old close was blocked")
+	}
+	stream, err := manager.OpenStream(context.Background(), "peer")
+	if err != nil {
+		t.Fatalf("OpenStream through replacement: %v", err)
+	}
+	_ = stream.Close()
+
+	close(old.releaseClose)
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("old retirement close: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("old retirement close did not finish")
+	}
+	if !manager.Ready("peer") {
+		t.Fatal("late old close removed the replacement")
+	}
+	if replacement.closeCount.Load() != 0 {
+		t.Fatalf("late old close closed replacement %d times", replacement.closeCount.Load())
+	}
+	manager.Invalidate("peer")
+}
+
+func TestManagerRetireAllReturnsExactIndependentHandles(t *testing.T) {
+	t.Parallel()
+	manager := NewManager[string, testMetadata](ManagerConfig[string, testMetadata]{
+		IdleGrace: time.Minute,
+	})
+	first := newFakeLink()
+	second := newFakeLink()
+	registerTestLink(t, manager, "first", "first-old", first, nil)
+	registerTestLink(t, manager, "second", "second-old", second, nil)
+
+	retirements := manager.RetireAll()
+	if len(retirements) != 2 {
+		t.Fatalf("RetireAll returned %d handles, want 2", len(retirements))
+	}
+	if manager.Ready("first") || manager.Ready("second") {
+		t.Fatal("RetireAll left an old link ready")
+	}
+	replacement := newFakeLink()
+	registerTestLink(t, manager, "first", "first-new", replacement, nil)
+	for index := range retirements {
+		if err := retirements[index].Close(); err != nil {
+			t.Fatalf("close retirement: %v", err)
+		}
+	}
+	if !manager.Ready("first") || replacement.closeCount.Load() != 0 {
+		t.Fatal("retired handle affected the replacement")
+	}
+	manager.Invalidate("first")
 }
 
 func TestManagerRejectsLinkAfterAdmissionContextCancellation(t *testing.T) {


### PR DESCRIPTION
## Summary

- add exact `Retirement` handles for device-link manager entries
- synchronously revoke admission and remove the captured link without waiting for transport I/O
- keep delayed physical close scoped to the captured link so replacements for the same key remain live
- retain `Invalidate` and `InvalidateAll` as compatibility wrappers

## Lifecycle contract

This supports the desktopd lifecycle contract: retire exact generation under the state lock, publish the replacement, then dispose the captured old handle outside the lock.

## Validation

- `go test ./packages/device-link/... -count=1`
- `go test -race ./packages/device-link/linkmanager -count=1`
- package-scoped golangci-lint
- `pnpm check:changed -- --push-ready`

The full changed-aware run still reports unrelated existing failures in `packages/auth/bridge-go` and `services/tuttid/service/workspace`; those files are outside this change.