### PR TITLE
fix(release): upload draft assets by release id

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -701,7 +701,9 @@ jobs:
                 gh api --method DELETE "repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}"
               done
           fi
-          gh release upload "${TUTTI_DESKTOP_RELEASE_CANDIDATE_TAG}" release-assets/*
+          node apps/desktop/scripts/upload-github-release-assets.mjs \
+            staged-release.json \
+            release-assets
           echo "release_id=$(jq -r .id staged-release.json)" >> "$GITHUB_OUTPUT"
 
       - name: Install AWS CLI

--- a/apps/desktop/scripts/upload-github-release-assets.mjs
+++ b/apps/desktop/scripts/upload-github-release-assets.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+import { createReadStream } from "node:fs";
+import { readdir, readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+function resolveUploadUrl(template, assetName) {
+  const url = new URL(template.replace(/\{.*$/, ""));
+  url.searchParams.set("name", assetName);
+  return url;
+}
+
+async function uploadReleaseAssets({
+  releasePath,
+  assetsDirectory,
+  token,
+  fetchImpl = fetch
+}) {
+  if (!token) throw new Error("GH_TOKEN is required to upload release assets");
+
+  const release = JSON.parse(await readFile(releasePath, "utf8"));
+  if (!release.id || typeof release.upload_url !== "string") {
+    throw new Error("GitHub release response is missing id or upload_url");
+  }
+
+  const entries = await readdir(assetsDirectory, { withFileTypes: true });
+  const assetNames = entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .sort();
+  if (assetNames.length === 0) {
+    throw new Error(`No release assets found in ${assetsDirectory}`);
+  }
+
+  for (const assetName of assetNames) {
+    const assetPath = path.join(assetsDirectory, assetName);
+    const assetStat = await stat(assetPath);
+    const uploadUrl = resolveUploadUrl(release.upload_url, assetName);
+    const response = await fetchImpl(uploadUrl, {
+      method: "POST",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "Content-Length": String(assetStat.size),
+        "Content-Type": "application/octet-stream",
+        "X-GitHub-Api-Version": "2022-11-28"
+      },
+      body: createReadStream(assetPath),
+      duplex: "half"
+    });
+    if (!response.ok) {
+      const detail = (await response.text()).trim();
+      throw new Error(
+        `Failed to upload ${assetName} to GitHub release ${release.id}: ${response.status}${detail ? ` ${detail}` : ""}`
+      );
+    }
+    console.log(`Uploaded ${assetName} to GitHub release ${release.id}`);
+  }
+
+  return { releaseId: String(release.id), assetNames };
+}
+
+async function main() {
+  const [releasePath, assetsDirectory] = process.argv.slice(2);
+  if (!releasePath || !assetsDirectory) {
+    throw new Error(
+      "Usage: upload-github-release-assets.mjs <release-json> <assets-directory>"
+    );
+  }
+  await uploadReleaseAssets({
+    releasePath,
+    assetsDirectory,
+    token: process.env.GH_TOKEN
+  });
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  void main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}
+
+export { resolveUploadUrl, uploadReleaseAssets };

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -484,7 +484,9 @@ test("desktop release workflow passes tsh-aligned Feishu card context", async ()
   );
   assert.ok(
     workflow.indexOf("name: Resolve current stable GitHub draft URL") >
-      workflow.indexOf("name: Update release notes with summary and direct downloads"),
+      workflow.indexOf(
+        "name: Update release notes with summary and direct downloads"
+      ),
     "the candidate draft URL should be refreshed after release notes are updated"
   );
   assert.match(
@@ -855,6 +857,8 @@ test("stable candidates require environment approval and bind the reviewed notes
   const promoteWorkflow = await readFile(promoteWorkflowPath, "utf8");
 
   assert.match(workflow, /build-release-candidate-manifest\.mjs/);
+  assert.match(workflow, /upload-github-release-assets\.mjs/);
+  assert.doesNotMatch(workflow, /gh release upload/);
   assert.match(workflow, /release_candidate_tag="candidate-\$\{release_tag\}"/);
   assert.match(workflow, /releases\/assets\/\$\{asset_id\}/);
   assert.match(

--- a/tools/scripts/desktop-release-upload.test.mjs
+++ b/tools/scripts/desktop-release-upload.test.mjs
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  resolveUploadUrl,
+  uploadReleaseAssets
+} from "../../apps/desktop/scripts/upload-github-release-assets.mjs";
+
+test("release asset upload uses the REST upload URL returned for the release", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "desktop-release-upload-"));
+  const releasePath = path.join(dir, "release.json");
+  const assetsDirectory = path.join(dir, "assets");
+  await mkdir(assetsDirectory);
+  await writeFile(
+    releasePath,
+    JSON.stringify({
+      id: 42,
+      upload_url:
+        "https://uploads.github.test/repos/tutti-os/tutti/releases/42/assets{?name,label}"
+    })
+  );
+  await writeFile(path.join(assetsDirectory, "b file.zip"), "second");
+  await writeFile(path.join(assetsDirectory, "a.dmg"), "first");
+
+  const requests = [];
+  const fetchImpl = async (url, init) => {
+    const chunks = [];
+    for await (const chunk of init.body) chunks.push(chunk);
+    requests.push({
+      url: String(url),
+      method: init.method,
+      headers: init.headers,
+      body: Buffer.concat(chunks).toString("utf8")
+    });
+    return new Response(null, { status: 201 });
+  };
+
+  try {
+    const result = await uploadReleaseAssets({
+      releasePath,
+      assetsDirectory,
+      token: "test-token",
+      fetchImpl
+    });
+
+    assert.deepEqual(result, {
+      releaseId: "42",
+      assetNames: ["a.dmg", "b file.zip"]
+    });
+    assert.deepEqual(
+      requests.map(({ url, body }) => ({ url, body })),
+      [
+        {
+          url: "https://uploads.github.test/repos/tutti-os/tutti/releases/42/assets?name=a.dmg",
+          body: "first"
+        },
+        {
+          url: "https://uploads.github.test/repos/tutti-os/tutti/releases/42/assets?name=b+file.zip",
+          body: "second"
+        }
+      ]
+    );
+    for (const request of requests) {
+      assert.equal(request.method, "POST");
+      assert.equal(request.headers.Authorization, "Bearer test-token");
+      assert.equal(request.headers["Content-Type"], "application/octet-stream");
+      assert.equal(
+        request.headers["Content-Length"],
+        String(request.body.length)
+      );
+    }
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+});
+
+test("release asset upload reports the release id and failed asset", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "desktop-release-upload-"));
+  const releasePath = path.join(dir, "release.json");
+  await writeFile(
+    releasePath,
+    JSON.stringify({
+      id: 99,
+      upload_url:
+        "https://uploads.github.test/repos/tutti-os/tutti/releases/99/assets{?name,label}"
+    })
+  );
+  await writeFile(path.join(dir, "broken.zip"), "payload");
+
+  try {
+    await assert.rejects(
+      uploadReleaseAssets({
+        releasePath,
+        assetsDirectory: dir,
+        token: "test-token",
+        fetchImpl: async () => new Response("upstream failure", { status: 502 })
+      }),
+      /Failed to upload broken\.zip to GitHub release 99: 502 upstream failure/
+    );
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+});
+
+test("release upload URL preserves the endpoint and encodes the asset name", () => {
+  assert.equal(
+    resolveUploadUrl(
+      "https://uploads.github.com/releases/7/assets{?name,label}",
+      "Tutti Setup.exe"
+    ).href,
+    "https://uploads.github.com/releases/7/assets?name=Tutti+Setup.exe"
+  );
+});


### PR DESCRIPTION
## Summary
- upload stable-candidate assets through the exact REST upload URL returned by GitHub
- avoid the draft tag re-lookup that failed with `release not found`
- add behavior coverage for URL encoding, streaming uploads, and failures

## Verification
- `node --test tools/scripts/desktop-release-upload.test.mjs tools/scripts/desktop-release-config.test.mjs tools/scripts/desktop-release-candidate.test.mjs tools/scripts/desktop-release-candidate-e2e.test.mjs` (58 passed)
- oxlint on changed JS/MJS files
- oxfmt/prettier checks
- desktop-release.yml parsed with yaml

Failed run addressed: https://github.com/tutti-os/tutti/actions/runs/32289130869