### PR TITLE
fix(connector): stop proxy-env install storms and catalog-wide snapshot failures

### DIFF
--- a/packages/agent/daemon/runtime/connector_process_transport.go
+++ b/packages/agent/daemon/runtime/connector_process_transport.go
@@ -21,6 +21,11 @@ const (
 	connectorFDEnvPrefix        = "TUTTI_CONNECTOR_FD_"
 )
 
+// ErrProcessSpecInvalid marks a deterministic connector process contract
+// violation. The same spec can never succeed on retry, so callers must map it
+// to a terminal failure instead of scheduling another attempt.
+var ErrProcessSpecInvalid = errors.New("connector process spec is invalid")
+
 type connectorProcessTransport struct {
 	stdoutLimit int64
 	stderrLimit int64
@@ -176,26 +181,26 @@ func connectorTreeInventoryDigest(root string) (string, error) {
 
 func validateConnectorProcessSpec(spec ProcessSpec) error {
 	if len(spec.Command) == 0 || strings.TrimSpace(spec.Command[0]) == "" {
-		return errors.New("connector process command is required")
+		return fmt.Errorf("%w: connector process command is required", ErrProcessSpecInvalid)
 	}
 	if !filepath.IsAbs(spec.Command[0]) {
-		return errors.New("connector process executable must be absolute")
+		return fmt.Errorf("%w: connector process executable must be absolute", ErrProcessSpecInvalid)
 	}
 	if spec.ExecutableIdentity == nil || strings.TrimSpace(spec.ExecutableIdentity.SHA256) == "" || spec.ExecutableIdentity.SizeBytes <= 0 {
-		return errors.New("connector process executable identity is required")
+		return fmt.Errorf("%w: connector process executable identity is required", ErrProcessSpecInvalid)
 	}
 	environmentKeys := make(map[string]struct{}, len(spec.Env))
 	for _, item := range spec.Env {
 		key, _, ok := strings.Cut(item, "=")
 		if !ok || !validConnectorEnvironmentKey(key) {
-			return errors.New("connector process environment entries must be explicit key=value pairs")
+			return fmt.Errorf("%w: connector process environment entries must be explicit key=value pairs", ErrProcessSpecInvalid)
 		}
 		if strings.HasPrefix(strings.ToUpper(key), connectorFDEnvPrefix) {
-			return fmt.Errorf("connector process environment key %q uses a host-reserved prefix", key)
+			return fmt.Errorf("%w: connector process environment key %q uses a host-reserved prefix", ErrProcessSpecInvalid, key)
 		}
 		normalizedKey := strings.ToUpper(key)
 		if _, exists := environmentKeys[normalizedKey]; exists {
-			return fmt.Errorf("connector process environment key %q is duplicated", key)
+			return fmt.Errorf("%w: connector process environment key %q is duplicated", ErrProcessSpecInvalid, key)
 		}
 		environmentKeys[normalizedKey] = struct{}{}
 	}
@@ -224,13 +229,13 @@ func addSensitiveInheritedFiles(cmd *exec.Cmd, spec *ProcessSpec) error {
 	for _, inherited := range spec.SensitiveInheritedFiles {
 		key := strings.ToUpper(strings.TrimSpace(inherited.DescriptorEnvKey))
 		if inherited.File == nil || strings.TrimSpace(inherited.Purpose) == "" {
-			return errors.New("connector sensitive inherited file and purpose are required")
+			return fmt.Errorf("%w: connector sensitive inherited file and purpose are required", ErrProcessSpecInvalid)
 		}
 		if !strings.HasPrefix(key, connectorFDEnvPrefix) || strings.ContainsAny(key, "=\x00") {
-			return fmt.Errorf("connector sensitive descriptor environment key %q is invalid", inherited.DescriptorEnvKey)
+			return fmt.Errorf("%w: connector sensitive descriptor environment key %q is invalid", ErrProcessSpecInvalid, inherited.DescriptorEnvKey)
 		}
 		if _, exists := seen[key]; exists {
-			return fmt.Errorf("connector sensitive descriptor environment key %q is duplicated", key)
+			return fmt.Errorf("%w: connector sensitive descriptor environment key %q is duplicated", ErrProcessSpecInvalid, key)
 		}
 		seen[key] = struct{}{}
 		cmd.ExtraFiles = append(cmd.ExtraFiles, inherited.File)

--- a/packages/agent/daemon/runtime/connector_process_transport_test.go
+++ b/packages/agent/daemon/runtime/connector_process_transport_test.go
@@ -2,6 +2,7 @@ package agentruntime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -24,6 +25,20 @@ func TestConnectorProcessFixture(_ *testing.T) {
 		_, _ = fmt.Sscanf(fd, "%d", &descriptor)
 		secret, _ := io.ReadAll(os.NewFile(uintptr(descriptor), "credential"))
 		fmt.Printf(" credential=%s", secret)
+	}
+}
+
+func TestValidateConnectorProcessSpecMarksContractViolationInvalid(t *testing.T) {
+	err := validateConnectorProcessSpec(ProcessSpec{
+		Command:            []string{"/usr/bin/node"},
+		ExecutableIdentity: &ExecutableIdentity{SHA256: "abc", SizeBytes: 1},
+		Env: []string{
+			"HTTP_PROXY=http://127.0.0.1:7897",
+			"http_proxy=http://127.0.0.1:7897",
+		},
+	})
+	if !errors.Is(err, ErrProcessSpecInvalid) {
+		t.Fatalf("err = %v, want ErrProcessSpecInvalid", err)
 	}
 }
 

--- a/packages/connector/daemon/application/operation_recovery.go
+++ b/packages/connector/daemon/application/operation_recovery.go
@@ -7,7 +7,31 @@ import (
 	"time"
 )
 
-const operationRecoveryScanInterval = 500 * time.Millisecond
+const (
+	operationRecoveryScanInterval = 500 * time.Millisecond
+	operationRetryBaseDelay       = 500 * time.Millisecond
+	operationRetryMaxDelay        = 60 * time.Second
+	operationRetryMaxShift        = 8
+)
+
+// operationRetryDelay spaces out repeated attempts for the same operation. The
+// scan interval stays a latency hint for fresh work; without this delay a
+// permanently failing effect would be replayed twice per second and would
+// broadcast one market-changed event per replay.
+func operationRetryDelay(attempt int) time.Duration {
+	if attempt <= 1 {
+		return 0
+	}
+	shift := attempt - 2
+	if shift > operationRetryMaxShift {
+		return operationRetryMaxDelay
+	}
+	delay := operationRetryBaseDelay << shift
+	if delay > operationRetryMaxDelay {
+		return operationRetryMaxDelay
+	}
+	return delay
+}
 
 // runOperationRecoveryWorker is the durable-operation anti-entropy loop.
 // Scheduling is only a latency hint: accepted/running work is rediscovered
@@ -33,7 +57,12 @@ func (host *Host) scheduleRecoverableOperations(ctx context.Context) error {
 		return err
 	}
 	var scheduleErr error
+	now := time.Now().UTC()
 	for _, operation := range operations {
+		if delay := operationRetryDelay(int(operation.Attempt)); delay > 0 &&
+			!operation.UpdatedAt.IsZero() && now.Sub(operation.UpdatedAt) < delay {
+			continue
+		}
 		if err := host.scheduler.Schedule(ctx, operation.OperationID); err != nil {
 			scheduleErr = errors.Join(scheduleErr, err)
 		}

--- a/packages/connector/daemon/application/operation_recovery_test.go
+++ b/packages/connector/daemon/application/operation_recovery_test.go
@@ -43,6 +43,52 @@ func TestOperationRecoveryReschedulesDurableRunningWorkAfterWakeLoss(t *testing.
 	}
 }
 
+func TestOperationRecoveryDelaysRecentHighAttemptWork(t *testing.T) {
+	ctx := context.Background()
+	store, err := marketdata.Open(ctx, filepath.Join(t.TempDir(), "tuttid.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	operation := market.Operation{
+		OperationID: "install-retry", ClientRequestID: "request-retry", ConnectorKey: "github",
+		Kind: market.OperationKindInstall, State: market.OperationStateRunning, Stage: market.OperationStageInstalling,
+		Attempt: 6, CreatedAt: time.Now().UTC().Add(-time.Minute), UpdatedAt: time.Now().UTC(),
+	}
+	if err := store.Transaction(ctx, func(tx market.Transaction) error {
+		return tx.SaveOperation(operation)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	executor := &recordingOperationExecutor{}
+	scheduler := NewOperationScheduler(ctx)
+	if err := scheduler.Bind(executor); err != nil {
+		t.Fatal(err)
+	}
+	host := &Host{repository: store, scheduler: scheduler}
+	if err := host.scheduleRecoverableOperations(ctx); err != nil {
+		t.Fatal(err)
+	}
+	scheduler.Wait()
+	if calls := executor.operationIDs(); len(calls) != 0 {
+		t.Fatalf("recent high-attempt operation scheduled = %#v", calls)
+	}
+
+	operation.UpdatedAt = time.Now().UTC().Add(-2 * time.Minute)
+	if err := store.Transaction(ctx, func(tx market.Transaction) error {
+		return tx.SaveOperation(operation)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := host.scheduleRecoverableOperations(ctx); err != nil {
+		t.Fatal(err)
+	}
+	scheduler.Wait()
+	if calls := executor.operationIDs(); len(calls) != 1 || calls[0] != operation.OperationID {
+		t.Fatalf("recovered operations = %#v", calls)
+	}
+}
+
 type recordingOperationExecutor struct {
 	mu    sync.Mutex
 	calls []string

--- a/packages/connector/daemon/core/application.go
+++ b/packages/connector/daemon/core/application.go
@@ -175,8 +175,11 @@ func publicSnapshot(snapshot Snapshot, scope OperationScope) (Snapshot, error) {
 		if connectorRemovedFromCatalog(connector) {
 			continue
 		}
+		// A single historical or malformed release must not remove the whole
+		// catalog from every reader. Hidden connectors also hide their
+		// operations below, exactly like delisted ones.
 		if err := ValidateReleaseShape(connector.Release); err != nil {
-			return Snapshot{}, fmt.Errorf("validate connector %q release: %w", connector.Key, err)
+			continue
 		}
 		visibleConnectorKeys[connector.Key] = struct{}{}
 		connectors = append(connectors, connector)

--- a/packages/connector/daemon/core/application_execution.go
+++ b/packages/connector/daemon/core/application_execution.go
@@ -149,7 +149,8 @@ func (application *Application) executeInstall(ctx context.Context, operation Op
 		Release:     release,
 	})
 	if installErr != nil {
-		return NewDomainError(ErrorCodeInstallFailed, "connector release installation failed", true, installErr)
+		return NewDomainError(ErrorCodeInstallFailed, "connector release installation failed",
+			!errors.Is(installErr, ErrPermanentInstallFailure), installErr)
 	}
 	if err := validateReleaseInstallationReceipt(operation, release, installed); err != nil {
 		return err
@@ -183,7 +184,8 @@ func (application *Application) executeInstall(ctx context.Context, operation Op
 		OperationID: operation.OperationID, Scope: operation.Scope, Generation: operation.HostGeneration,
 		Release: release, Receipt: installed,
 	}); err != nil {
-		return NewDomainError(ErrorCodeInstallFailed, "connector release installation commit failed", true, err)
+		return NewDomainError(ErrorCodeInstallFailed, "connector release installation commit failed",
+			!errors.Is(err, ErrPermanentInstallFailure), err)
 	}
 	if err := application.prepareInstallRuntimeDesired(ctx, operation.OperationID, release, binding); err != nil {
 		return err
@@ -243,7 +245,8 @@ func (application *Application) executeUninstall(ctx context.Context, operation 
 		Generation:  operation.HostGeneration,
 		Release:     release,
 	}); err != nil {
-		return NewDomainError(ErrorCodeInstallFailed, "connector release cleanup failed", true, err)
+		return NewDomainError(ErrorCodeInstallFailed, "connector release cleanup failed",
+			!errors.Is(err, ErrPermanentInstallFailure), err)
 	}
 	return application.completeUninstall(ctx, operation.OperationID)
 }

--- a/packages/connector/daemon/core/application_test.go
+++ b/packages/connector/daemon/core/application_test.go
@@ -23,28 +23,22 @@ func TestApplicationPublicReadsRejectObsoleteConnectorIcon(t *testing.T) {
 		CatalogSnapshot{},
 	)
 
-	for _, test := range []struct {
-		name string
-		read func() error
-	}{
-		{name: "snapshot", read: func() error {
-			_, err := application.Snapshot(context.Background())
-			return err
-		}},
-		{name: "scoped snapshot", read: func() error {
-			_, err := application.SnapshotForScope(context.Background(), OperationScope{AccountID: "account-1"})
-			return err
-		}},
-		{name: "connector", read: func() error {
-			_, err := application.GetConnector(context.Background(), connector.Key)
-			return err
-		}},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			if err := test.read(); err == nil || !strings.Contains(err.Error(), "iconUrl") {
-				t.Fatalf("public read error = %v, want iconUrl rejection", err)
-			}
-		})
+	snapshot, err := application.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("snapshot failed because of one invalid release: %v", err)
+	}
+	if len(snapshot.Connectors) != 0 {
+		t.Fatalf("snapshot connectors = %#v, want hidden", snapshot.Connectors)
+	}
+	scoped, err := application.SnapshotForScope(context.Background(), OperationScope{AccountID: "account-1"})
+	if err != nil {
+		t.Fatalf("scoped snapshot failed because of one invalid release: %v", err)
+	}
+	if len(scoped.Connectors) != 0 {
+		t.Fatalf("scoped snapshot connectors = %#v, want hidden", scoped.Connectors)
+	}
+	if _, err := application.GetConnector(context.Background(), connector.Key); err == nil || !strings.Contains(err.Error(), "iconUrl") {
+		t.Fatalf("GetConnector() error = %v, want iconUrl rejection", err)
 	}
 }
 
@@ -112,6 +106,36 @@ func TestApplicationPublicReadsHideRemovedCatalogConnectorBeforeValidation(t *te
 	}
 	if _, err := repository.Connector(context.Background(), removed.Key); err != nil {
 		t.Fatalf("removed connector durable evidence was deleted: %v", err)
+	}
+}
+
+func TestApplicationPublicReadsHideInvalidReleaseWithoutFailingSnapshot(t *testing.T) {
+	invalid := testConnector("invalid-icon")
+	invalid.Release.Manifest.IconURL = "data:image/png;base64,iVBORw0KGgo="
+	visible := testConnector("visible")
+	repository := newMemoryRepository(invalid, visible)
+	application := newTestApplication(t, repository, &memoryScheduler{}, &memoryInstallRuntime{}, CatalogSnapshot{})
+
+	for _, read := range []struct {
+		name string
+		load func() (Snapshot, error)
+	}{
+		{name: "snapshot", load: func() (Snapshot, error) {
+			return application.Snapshot(context.Background())
+		}},
+		{name: "scoped snapshot", load: func() (Snapshot, error) {
+			return application.SnapshotForScope(context.Background(), OperationScope{AccountID: "account-1"})
+		}},
+	} {
+		t.Run(read.name, func(t *testing.T) {
+			snapshot, err := read.load()
+			if err != nil {
+				t.Fatalf("snapshot failed because of one invalid release: %v", err)
+			}
+			if len(snapshot.Connectors) != 1 || snapshot.Connectors[0].Key != visible.Key {
+				t.Fatalf("connectors = %#v, want only the valid one", snapshot.Connectors)
+			}
+		})
 	}
 }
 
@@ -370,6 +394,43 @@ func TestApplicationExecutesAcceptedInstall(t *testing.T) {
 		convergence.Observed.DesiredGeneration != convergence.Desired.Generation ||
 		convergence.Observed.BootEpoch != application.config.BootEpoch {
 		t.Fatalf("post-install runtime convergence = %#v", convergence)
+	}
+}
+
+func TestApplicationMarksPermanentInstallFailureNonRetryable(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		err       error
+		retryable bool
+	}{
+		{name: "transient", err: errors.New("network down"), retryable: true},
+		{name: "permanent", err: fmt.Errorf("%w: boom", ErrPermanentInstallFailure), retryable: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			repository := newMemoryRepository(testConnector("github"))
+			application := newTestApplication(
+				t,
+				repository,
+				&memoryScheduler{},
+				&memoryInstallRuntime{installationErr: test.err},
+				CatalogSnapshot{},
+			)
+			accepted, err := application.Install(context.Background(), ConnectorMutation{
+				Mutation:     Mutation{ClientRequestID: "request-" + test.name, ExpectedRevision: 0},
+				ConnectorKey: "github",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = application.ExecuteOperation(context.Background(), accepted.Operation.OperationID)
+			var domainError *DomainError
+			if !errors.As(err, &domainError) || domainError.Code != ErrorCodeInstallFailed {
+				t.Fatalf("err = %v", err)
+			}
+			if domainError.Retryable != test.retryable {
+				t.Fatalf("retryable = %v, want %v", domainError.Retryable, test.retryable)
+			}
+		})
 	}
 }
 
@@ -2418,6 +2479,7 @@ type memoryInstallRuntime struct {
 	installationResult      ReleaseInstallationObservation
 	installationInspectErr  error
 	installationCommitErr   error
+	installationErr         error
 	reconcileErrors         map[string]error
 }
 
@@ -2493,6 +2555,9 @@ func (host *memoryInstallRuntime) InstallRelease(
 	ctx context.Context,
 	request InstallReleaseRequest,
 ) (ReleaseInstallationReceipt, error) {
+	if host.installationErr != nil {
+		return ReleaseInstallationReceipt{}, host.installationErr
+	}
 	prepared, err := host.Prepare(ctx, PrepareArtifactRequest(request))
 	if err != nil {
 		return ReleaseInstallationReceipt{}, err

--- a/packages/connector/daemon/core/errors.go
+++ b/packages/connector/daemon/core/errors.go
@@ -8,6 +8,10 @@ import (
 var (
 	ErrNotFound           = errors.New("connector market resource not found")
 	ErrOperationLeaseLost = errors.New("connector market operation lease lost")
+	// ErrPermanentInstallFailure marks an installation failure that cannot succeed
+	// on retry, such as a rejected process contract or a malformed release. The
+	// recovery scanner must not reschedule an operation that failed this way.
+	ErrPermanentInstallFailure = errors.New("connector installation cannot be retried")
 )
 
 type ErrorCode string

--- a/packages/connector/runtime/node_package_installer.go
+++ b/packages/connector/runtime/node_package_installer.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -306,6 +307,9 @@ func (installer *NodePackageInstaller) runManagedNode(ctx context.Context, resol
 		Command: append([]string{node.Path}, args...), Env: env,
 		ExecutableIdentity: &agentruntime.ExecutableIdentity{SHA256: node.SHA256, SizeBytes: node.SizeBytes}})
 	if err != nil {
+		if errors.Is(err, agentruntime.ErrProcessSpecInvalid) {
+			return fmt.Errorf("%w: %w", market.ErrPermanentInstallFailure, err)
+		}
 		return err
 	}
 	defer connection.Close()
@@ -366,6 +370,11 @@ func uniquePaths(values []string) []string {
 	return result
 }
 
+// allowedNodePackageInstallEnvironment projects the inherited environment onto
+// the installer allow-list. Keys are folded case-insensitively and emitted in
+// one canonical upper-case form: the connector process contract rejects two
+// entries that differ only by case, so POSIX hosts exporting both HTTP_PROXY
+// and http_proxy must not produce two entries here.
 func allowedNodePackageInstallEnvironment(environment []string) []string {
 	allowed := map[string]struct{}{
 		"ALL_PROXY": {}, "COMSPEC": {}, "HTTP_PROXY": {}, "HTTPS_PROXY": {},
@@ -373,15 +382,26 @@ func allowedNodePackageInstallEnvironment(environment []string) []string {
 		"NODE_EXTRA_CA_CERTS": {}, "PATHEXT": {}, "SSL_CERT_DIR": {}, "SSL_CERT_FILE": {},
 		"SYSTEMROOT": {},
 	}
-	result := make([]string, 0, len(allowed))
+	values := make(map[string]string, len(allowed))
 	for _, item := range environment {
-		key, _, ok := strings.Cut(item, "=")
+		key, value, ok := strings.Cut(item, "=")
 		if !ok {
 			continue
 		}
-		if _, ok := allowed[strings.ToUpper(key)]; ok {
-			result = append(result, item)
+		canonical := strings.ToUpper(key)
+		if _, permitted := allowed[canonical]; !permitted {
+			continue
 		}
+		values[canonical] = value
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	result := make([]string, 0, len(keys))
+	for _, key := range keys {
+		result = append(result, key+"="+values[key])
 	}
 	return result
 }

--- a/packages/connector/runtime/node_package_installer_test.go
+++ b/packages/connector/runtime/node_package_installer_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"sync"
@@ -287,4 +288,34 @@ func containsEnvironmentKey(environment []string, expected string) bool {
 		}
 	}
 	return false
+}
+
+func TestAllowedNodePackageInstallEnvironmentFoldsProxyKeyCase(t *testing.T) {
+	got := allowedNodePackageInstallEnvironment([]string{
+		"PATH=/usr/bin",
+		"http_proxy=http://127.0.0.1:7897",
+		"HTTP_PROXY=http://127.0.0.1:7897",
+		"https_proxy=http://127.0.0.1:7897",
+		"HTTPS_PROXY=http://127.0.0.1:7897",
+		"no_proxy=localhost",
+	})
+	want := []string{
+		"HTTPS_PROXY=http://127.0.0.1:7897",
+		"HTTP_PROXY=http://127.0.0.1:7897",
+		"NO_PROXY=localhost",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("environment = %#v, want %#v", got, want)
+	}
+}
+
+func TestAllowedNodePackageInstallEnvironmentKeepsLastValueForFoldedKey(t *testing.T) {
+	got := allowedNodePackageInstallEnvironment([]string{
+		"http_proxy=http://first.invalid:1",
+		"HTTP_PROXY=http://second.invalid:2",
+	})
+	want := []string{"HTTP_PROXY=http://second.invalid:2"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("environment = %#v, want %#v", got, want)
+	}
 }


### PR DESCRIPTION
## Summary

Hosts that export both `HTTP_PROXY` and `http_proxy` (POSIX convention) cannot install `node_package` connectors. The installer allow-list folded keys for matching but kept both entries; the process contract then rejected the spec as duplicated. That failure was marked retryable, so the 500ms recovery scanner replayed it continuously and published `connector-market-changed` on every attempt.

A second all-or-nothing path made one historical release with a `data:` icon fail the entire public snapshot, so the catalog disappeared instead of hiding the invalid row.

This change:

- emits one canonical upper-case env entry per allow-listed key (last value wins)
- wraps process-spec contract violations as `ErrProcessSpecInvalid` / `ErrPermanentInstallFailure` so install/commit/cleanup map them to non-retryable failures
- spaces remaining recoverable retries with exponential backoff
- hides a single invalid release from `publicSnapshot` instead of failing the catalog; `GetConnector` still rejects that key

TSH Desktop follow-up (catalog ingest skip + last-good UI) waits until this ships as a Tutti cohort and TSH upgrades atomically.

## Verification

Reproduced on TSH Desktop against Tutti `0.0.400`:

- `connector process environment key "http_proxy" is duplicated` on every install retry
- `iconUrl must be a safe HTTPS URL` taking down the whole snapshot
- thousands of `connector market operation failed` lines at ~500ms

Targeted tests added for env folding, permanent vs transient install errors, recovery delay, and snapshot hide. Manual Desktop reinstall still needs the published cohort.

## Fallback Three Questions

- Source: retryable install effects plus the 500ms recovery scan, and persisted releases that no longer pass `ValidateReleaseShape`.
- Why can it not be fixed at that source? Transient install failures still need recovery after a dropped wake. Historical local releases cannot be rewritten by a catalog republish on the first read.
- Removal condition: delete the scan-side delay once operations persist `next_attempt_at` themselves. Delete snapshot hiding once hosts no longer store presentation-invalid historical releases.

## Checklist

- [ ] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.
- [x] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
