### PR TITLE
feat(agent): expose Codex startup span observations

### DIFF
--- a/packages/agent/daemon/runtime/acp_shared.go
+++ b/packages/agent/daemon/runtime/acp_shared.go
@@ -11,6 +11,11 @@ const (
 	nexightACPCommand    = "nexight-acp"
 	codexAgentRoutingEnv = "TUTTI_AGENT_ROUTING=1"
 	codexRoutingPreload  = "LD_PRELOAD=" + runtimepaths.BundlePreloadSOPath
+	// Codex app-server emits its tracing spans through stderr. Keep the
+	// managed process output structured so the runtime trace can preserve
+	// thread/start's internal phases for diagnostics.
+	codexAppServerLogFormatEnv = "LOG_FORMAT=json"
+	codexAppServerRustLogEnv   = "RUST_LOG=codex_app_server=info,codex_core=info"
 	// Standard ACP providers run headlessly and must never block on a Git
 	// credential or terminal prompt while building workspace context.
 	gitTerminalPromptEnv = "GIT_TERMINAL_PROMPT=0"

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -121,6 +121,10 @@ type CodexAppServerAdapterOptions struct {
 	// It is best-effort observability only and must not influence provider
 	// startup or command correctness.
 	StartupSpanObserver CodexAppServerSpanObserver
+	// StartupObserver receives one bounded summary when a Codex app-server
+	// session start or resume finishes. It is best-effort observability only
+	// and must not influence provider startup or command correctness.
+	StartupObserver CodexAppServerStartupObserver
 }
 
 // CodexAppServerSpanObservation is one completed, allowlisted startup span
@@ -143,6 +147,25 @@ type CodexAppServerSpanObservation struct {
 // CodexAppServerSpanObserver consumes completed startup span observations.
 // Implementations must be best-effort and must not affect provider behavior.
 type CodexAppServerSpanObserver func(CodexAppServerSpanObservation)
+
+// CodexAppServerStartupObservation is one bounded summary of a Codex
+// app-server session start or resume. Counts describe resources bound to the
+// Tutti session and completed allowlisted Codex spans; Codex-native plugin and
+// skill counts are intentionally absent until Codex emits those counts.
+type CodexAppServerStartupObservation struct {
+	Provider           string
+	RoomID             string
+	AgentSessionID     string
+	StartedAt          string
+	Outcome            string
+	DurationMS         int64
+	MCPServerCount     int
+	CompletedSpanCount int
+}
+
+// CodexAppServerStartupObserver consumes one completed startup summary.
+// Implementations must be best-effort and must not affect provider behavior.
+type CodexAppServerStartupObserver func(CodexAppServerStartupObservation)
 
 // defaultCodexAppServerCancelGraceWindow is how long Cancel waits for codex to
 // honor turn/interrupt gracefully before force-closing the app-server process.
@@ -178,6 +201,7 @@ type CodexAppServerAdapter struct {
 	host                       HostMetadata
 	config                     appServerAdapterConfig
 	startupSpanObserver        CodexAppServerSpanObserver
+	startupObserver            CodexAppServerStartupObserver
 	preparer                   ProviderLaunchPreparer
 	commandResolver            ProviderCommandResolver
 	mu                         sync.Mutex
@@ -450,6 +474,7 @@ func NewCodexAppServerAdapterWithHostMetadataAndOptions(
 	adapter := NewCodexAppServerAdapterWithHostMetadataAndCommandResolver(transport, host, nil)
 	adapter.config.commandNetworkAccess = options.CommandNetworkAccess
 	adapter.startupSpanObserver = options.StartupSpanObserver
+	adapter.startupObserver = options.StartupObserver
 	return adapter
 }
 
@@ -497,6 +522,7 @@ func NewTuttiAgentAppServerAdapterWithHostMetadataAndOptions(
 	adapter := newTuttiAgentAppServerAdapterWithHostMetadata(transport, host)
 	adapter.config.commandNetworkAccess = options.CommandNetworkAccess
 	adapter.startupSpanObserver = options.StartupSpanObserver
+	adapter.startupObserver = options.StartupObserver
 	return adapter
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -117,7 +117,32 @@ type CodexAppServerAdapterOptions struct {
 	// approval policy, and approval reviewer remain owned by the selected
 	// permission mode. Network proxy configuration remains a separate concern.
 	CommandNetworkAccess bool
+	// StartupSpanObserver receives completed Codex app-server startup spans.
+	// It is best-effort observability only and must not influence provider
+	// startup or command correctness.
+	StartupSpanObserver CodexAppServerSpanObserver
 }
+
+// CodexAppServerSpanObservation is one completed, allowlisted startup span
+// emitted by the Codex app-server. It intentionally contains only bounded
+// timing and session-scope facts; raw prompts, commands, paths, and payloads
+// are not part of this contract.
+type CodexAppServerSpanObservation struct {
+	Provider       string
+	RoomID         string
+	AgentSessionID string
+	SpanName       string
+	SpanPhase      string
+	SpanTarget     string
+	CodexTimestamp string
+	DurationMS     int64
+	SpanBusy       string
+	SpanIdle       string
+}
+
+// CodexAppServerSpanObserver consumes completed startup span observations.
+// Implementations must be best-effort and must not affect provider behavior.
+type CodexAppServerSpanObserver func(CodexAppServerSpanObservation)
 
 // defaultCodexAppServerCancelGraceWindow is how long Cancel waits for codex to
 // honor turn/interrupt gracefully before force-closing the app-server process.
@@ -152,6 +177,7 @@ type CodexAppServerAdapter struct {
 	transport                  ProcessTransport
 	host                       HostMetadata
 	config                     appServerAdapterConfig
+	startupSpanObserver        CodexAppServerSpanObserver
 	preparer                   ProviderLaunchPreparer
 	commandResolver            ProviderCommandResolver
 	mu                         sync.Mutex
@@ -423,6 +449,7 @@ func NewCodexAppServerAdapterWithHostMetadataAndOptions(
 ) *CodexAppServerAdapter {
 	adapter := NewCodexAppServerAdapterWithHostMetadataAndCommandResolver(transport, host, nil)
 	adapter.config.commandNetworkAccess = options.CommandNetworkAccess
+	adapter.startupSpanObserver = options.StartupSpanObserver
 	return adapter
 }
 
@@ -469,6 +496,7 @@ func NewTuttiAgentAppServerAdapterWithHostMetadataAndOptions(
 ) *CodexAppServerAdapter {
 	adapter := newTuttiAgentAppServerAdapterWithHostMetadata(transport, host)
 	adapter.config.commandNetworkAccess = options.CommandNetworkAccess
+	adapter.startupSpanObserver = options.StartupSpanObserver
 	return adapter
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_session_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_session_test.go
@@ -29,6 +29,12 @@ func TestCodexAppServerAdapterStartCreatesThread(t *testing.T) {
 	if !containsString(spec.Env, codexAgentRoutingEnv) {
 		t.Fatalf("env = %#v, want agent routing env", spec.Env)
 	}
+	if !containsString(spec.Env, codexAppServerLogFormatEnv) {
+		t.Fatalf("env = %#v, want structured Codex logs", spec.Env)
+	}
+	if !containsString(spec.Env, codexAppServerRustLogEnv) {
+		t.Fatalf("env = %#v, want Codex startup span log level", spec.Env)
+	}
 
 	initialize := appServerRequestParams(t, transport.conn, appServerMethodInitialize)
 	clientInfo, _ := initialize["clientInfo"].(map[string]any)

--- a/packages/agent/daemon/runtime/codex_appserver_fork.go
+++ b/packages/agent/daemon/runtime/codex_appserver_fork.go
@@ -138,7 +138,7 @@ func (a *CodexAppServerAdapter) Fork(
 	// auto-subscribes its caller to the child; closing this connection avoids a
 	// stale child listener on the source session after canonical commit attaches
 	// the child through its own thread/resume connection.
-	trace := newCodexAppServerStartupTrace(source, a.startupSpanObserver)
+	trace := newCodexAppServerStartupTrace(source, a.startupSpanObserver, nil)
 	defer func() {
 		trace.Finish(err)
 	}()

--- a/packages/agent/daemon/runtime/codex_appserver_fork.go
+++ b/packages/agent/daemon/runtime/codex_appserver_fork.go
@@ -138,7 +138,7 @@ func (a *CodexAppServerAdapter) Fork(
 	// auto-subscribes its caller to the child; closing this connection avoids a
 	// stale child listener on the source session after canonical commit attaches
 	// the child through its own thread/resume connection.
-	trace := newCodexAppServerStartupTrace(source)
+	trace := newCodexAppServerStartupTrace(source, a.startupSpanObserver)
 	defer func() {
 		trace.Finish(err)
 	}()

--- a/packages/agent/daemon/runtime/codex_appserver_lifecycle_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_lifecycle_test.go
@@ -143,7 +143,12 @@ func TestCodexAppServerAdapterProviderLaunchPrepareMutatesSpecAndCleansUpOnClose
 	if spec.CWD != "/prepared/workspace" {
 		t.Fatalf("CWD = %q", spec.CWD)
 	}
-	if !reflect.DeepEqual(spec.Env[len(spec.Env)-2:], []string{"SESSION_ENV=1", "HOOK_ENV=1"}) {
+	if !reflect.DeepEqual(spec.Env[len(spec.Env)-4:], []string{
+		"SESSION_ENV=1",
+		"HOOK_ENV=1",
+		codexAppServerLogFormatEnv,
+		codexAppServerRustLogEnv,
+	}) {
 		t.Fatalf("Env tail = %#v", spec.Env)
 	}
 

--- a/packages/agent/daemon/runtime/codex_appserver_session.go
+++ b/packages/agent/daemon/runtime/codex_appserver_session.go
@@ -18,7 +18,7 @@ func (a *CodexAppServerAdapter) Start(ctx context.Context, session Session) (eve
 	if err := a.admitCodexReplacementLocked(session.AgentSessionID); err != nil {
 		return nil, err
 	}
-	trace := newCodexAppServerStartupTrace(session, a.startupSpanObserver)
+	trace := newCodexAppServerStartupTrace(session, a.startupSpanObserver, a.startupObserver)
 	defer func() {
 		trace.Finish(err)
 	}()
@@ -199,7 +199,7 @@ func (a *CodexAppServerAdapter) Resume(ctx context.Context, session Session) (er
 	// Start, the old client is kept alive until the replacement has resumed
 	// successfully (storeSession closes it on replace): if the new spawn or
 	// thread/resume fails, the previous session must remain usable.
-	trace := newCodexAppServerStartupTrace(session, a.startupSpanObserver)
+	trace := newCodexAppServerStartupTrace(session, a.startupSpanObserver, a.startupObserver)
 	defer func() {
 		trace.Finish(err)
 	}()

--- a/packages/agent/daemon/runtime/codex_appserver_session.go
+++ b/packages/agent/daemon/runtime/codex_appserver_session.go
@@ -647,6 +647,7 @@ func (a *CodexAppServerAdapter) prepareInitializedClientLaunch(
 		spec.Env = withoutEnvironmentKey(spec.Env, tuttiAgentExtraSkillRootsEnv)
 		spec.Env = withoutEnvironmentKey(spec.Env, tuttiAgentStableSystemSkillsEnv)
 	}
+	spec.Env = withCodexAppServerLogging(spec.Env)
 	return spec, cleanup, nil
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_session.go
+++ b/packages/agent/daemon/runtime/codex_appserver_session.go
@@ -18,7 +18,7 @@ func (a *CodexAppServerAdapter) Start(ctx context.Context, session Session) (eve
 	if err := a.admitCodexReplacementLocked(session.AgentSessionID); err != nil {
 		return nil, err
 	}
-	trace := newCodexAppServerStartupTrace(session)
+	trace := newCodexAppServerStartupTrace(session, a.startupSpanObserver)
 	defer func() {
 		trace.Finish(err)
 	}()
@@ -199,7 +199,7 @@ func (a *CodexAppServerAdapter) Resume(ctx context.Context, session Session) (er
 	// Start, the old client is kept alive until the replacement has resumed
 	// successfully (storeSession closes it on replace): if the new spawn or
 	// thread/resume fails, the previous session must remain usable.
-	trace := newCodexAppServerStartupTrace(session)
+	trace := newCodexAppServerStartupTrace(session, a.startupSpanObserver)
 	defer func() {
 		trace.Finish(err)
 	}()

--- a/packages/agent/daemon/runtime/codex_appserver_side.go
+++ b/packages/agent/daemon/runtime/codex_appserver_side.go
@@ -234,7 +234,7 @@ func (a *CodexAppServerAdapter) OpenSide(
 	if err := a.admitCodexReplacementLocked(side.AgentSessionID); err != nil {
 		return SideConversationOpenResult{}, err
 	}
-	trace := newCodexAppServerStartupTrace(side)
+	trace := newCodexAppServerStartupTrace(side, a.startupSpanObserver)
 	defer func() { trace.Finish(err) }()
 	clientState, err := a.sideClient(ctx, source, side, trace)
 	if err != nil {

--- a/packages/agent/daemon/runtime/codex_appserver_side.go
+++ b/packages/agent/daemon/runtime/codex_appserver_side.go
@@ -234,7 +234,7 @@ func (a *CodexAppServerAdapter) OpenSide(
 	if err := a.admitCodexReplacementLocked(side.AgentSessionID); err != nil {
 		return SideConversationOpenResult{}, err
 	}
-	trace := newCodexAppServerStartupTrace(side, a.startupSpanObserver)
+	trace := newCodexAppServerStartupTrace(side, a.startupSpanObserver, nil)
 	defer func() { trace.Finish(err) }()
 	clientState, err := a.sideClient(ctx, source, side, trace)
 	if err != nil {

--- a/packages/agent/daemon/runtime/codex_appserver_startup_trace.go
+++ b/packages/agent/daemon/runtime/codex_appserver_startup_trace.go
@@ -13,6 +13,7 @@ import (
 )
 
 const codexAppServerStartupTraceFileName = "tutti-codex-appserver-startup.jsonl"
+const codexAppServerStartupTraceMaxBytes = 64 * 1024 * 1024
 
 var codexAppServerStartupTraceMu sync.Mutex
 
@@ -132,12 +133,26 @@ func (t *codexAppServerStartupTrace) Log(event string, fields map[string]any) {
 	if err := os.MkdirAll(filepath.Dir(t.path), 0o755); err != nil {
 		return
 	}
-	file, err := os.OpenFile(t.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
-	if err != nil {
+	if err := appendCodexAppServerStartupTrace(t.path, line, codexAppServerStartupTraceMaxBytes); err != nil {
 		return
 	}
+}
+
+func appendCodexAppServerStartupTrace(path string, line []byte, maxBytes int64) error {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return err
+	}
 	defer func() { _ = file.Close() }()
-	_, _ = file.Write(append(line, '\n'))
+	if info, err := file.Stat(); err != nil {
+		return err
+	} else if maxBytes > 0 && info.Size()+int64(len(line)+1) > maxBytes {
+		if err := file.Truncate(0); err != nil {
+			return err
+		}
+	}
+	_, err = file.Write(append(line, '\n'))
+	return err
 }
 
 func (t *codexAppServerStartupTrace) Finish(err error) {

--- a/packages/agent/daemon/runtime/codex_appserver_startup_trace.go
+++ b/packages/agent/daemon/runtime/codex_appserver_startup_trace.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -41,17 +42,26 @@ type codexAppServerStartupTrace struct {
 	startedAt     time.Time
 	session       Session
 	path          string
+	spanObserver  CodexAppServerSpanObserver
 	stderrMu      sync.Mutex
 	stderrLine    []byte
 	spanStartedAt map[string][]time.Time
 }
 
-func newCodexAppServerStartupTrace(session Session) *codexAppServerStartupTrace {
+func newCodexAppServerStartupTrace(
+	session Session,
+	spanObservers ...CodexAppServerSpanObserver,
+) *codexAppServerStartupTrace {
 	settings := session.SettingsValue()
+	var spanObserver CodexAppServerSpanObserver
+	if len(spanObservers) > 0 {
+		spanObserver = spanObservers[0]
+	}
 	trace := &codexAppServerStartupTrace{
 		startedAt:     time.Now(),
 		session:       session,
 		path:          codexAppServerStartupTracePath(),
+		spanObserver:  spanObserver,
 		spanStartedAt: make(map[string][]time.Time),
 	}
 	trace.Log("start.begin", map[string]any{
@@ -159,7 +169,7 @@ func (t *codexAppServerStartupTrace) LogStderr(chunk []byte) {
 	})
 
 	t.stderrMu.Lock()
-	defer t.stderrMu.Unlock()
+	observations := make([]CodexAppServerSpanObservation, 0)
 	t.stderrLine = append(t.stderrLine, chunk...)
 	for {
 		line, rest, ok := bytes.Cut(t.stderrLine, []byte("\n"))
@@ -167,10 +177,16 @@ func (t *codexAppServerStartupTrace) LogStderr(chunk []byte) {
 			if len(t.stderrLine) > codexAppServerStderrLineLimit {
 				t.stderrLine = append([]byte(nil), t.stderrLine[len(t.stderrLine)-codexAppServerStderrLineLimit:]...)
 			}
-			return
+			break
 		}
 		t.stderrLine = rest
-		t.logCodexAppServerSpan(line)
+		if observation := t.logCodexAppServerSpan(line); observation != nil {
+			observations = append(observations, *observation)
+		}
+	}
+	t.stderrMu.Unlock()
+	for _, observation := range observations {
+		t.notifySpanObserver(observation)
 	}
 }
 
@@ -192,7 +208,7 @@ func withoutEnvironmentKeyFold(env []string, key string) []string {
 	return filtered
 }
 
-func (t *codexAppServerStartupTrace) logCodexAppServerSpan(line []byte) {
+func (t *codexAppServerStartupTrace) logCodexAppServerSpan(line []byte) *CodexAppServerSpanObservation {
 	var record struct {
 		Timestamp string                       `json:"timestamp"`
 		Target    string                       `json:"target"`
@@ -201,7 +217,7 @@ func (t *codexAppServerStartupTrace) logCodexAppServerSpan(line []byte) {
 		Spans     []map[string]json.RawMessage `json:"spans"`
 	}
 	if err := json.Unmarshal(bytes.TrimSpace(line), &record); err != nil {
-		return
+		return nil
 	}
 	spanName := codexJSONLogString(record.Span["name"])
 	if spanName == "" {
@@ -213,11 +229,11 @@ func (t *codexAppServerStartupTrace) logCodexAppServerSpan(line []byte) {
 		}
 	}
 	if _, ok := codexAppServerStartupSpanNames[spanName]; !ok {
-		return
+		return nil
 	}
 	phase := codexJSONLogString(record.Fields["message"])
 	if phase != "new" && phase != "close" {
-		return
+		return nil
 	}
 	startedAt, parseErr := time.Parse(time.RFC3339Nano, record.Timestamp)
 	timestampOK := parseErr == nil
@@ -225,6 +241,7 @@ func (t *codexAppServerStartupTrace) logCodexAppServerSpan(line []byte) {
 		"span_name":  spanName,
 		"span_phase": phase,
 	}
+	var observation *CodexAppServerSpanObservation
 	if record.Target != "" {
 		fields["span_target"] = record.Target
 	}
@@ -238,8 +255,10 @@ func (t *codexAppServerStartupTrace) logCodexAppServerSpan(line []byte) {
 	} else if starts := t.spanStartedAt[spanName]; len(starts) > 0 {
 		start := starts[len(starts)-1]
 		t.spanStartedAt[spanName] = starts[:len(starts)-1]
+		durationMS := int64(0)
 		if timestampOK {
-			fields["duration_ms"] = startedAt.Sub(start).Milliseconds()
+			durationMS = startedAt.Sub(start).Milliseconds()
+			fields["duration_ms"] = durationMS
 		}
 		if busy := codexJSONLogString(record.Fields["time.busy"]); busy != "" {
 			fields["span_busy"] = busy
@@ -247,8 +266,40 @@ func (t *codexAppServerStartupTrace) logCodexAppServerSpan(line []byte) {
 		if idle := codexJSONLogString(record.Fields["time.idle"]); idle != "" {
 			fields["span_idle"] = idle
 		}
+		if timestampOK && t.spanObserver != nil {
+			observation = &CodexAppServerSpanObservation{
+				Provider:       strings.TrimSpace(t.session.Provider),
+				RoomID:         strings.TrimSpace(t.session.RoomID),
+				AgentSessionID: strings.TrimSpace(t.session.AgentSessionID),
+				SpanName:       spanName,
+				SpanPhase:      phase,
+				SpanTarget:     strings.TrimSpace(record.Target),
+				CodexTimestamp: strings.TrimSpace(record.Timestamp),
+				DurationMS:     durationMS,
+				SpanBusy:       codexJSONLogString(record.Fields["time.busy"]),
+				SpanIdle:       codexJSONLogString(record.Fields["time.idle"]),
+			}
+		}
 	}
 	t.Log("app_server.span", fields)
+	return observation
+}
+
+func (t *codexAppServerStartupTrace) notifySpanObserver(observation CodexAppServerSpanObservation) {
+	if t.spanObserver == nil {
+		return
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			slog.Warn("agent session Codex app-server span observer panicked",
+				"provider", observation.Provider,
+				"agent_session_id", observation.AgentSessionID,
+				"span_name", observation.SpanName,
+				"panic", recovered,
+			)
+		}
+	}()
+	t.spanObserver(observation)
 }
 
 func codexJSONLogString(raw json.RawMessage) string {

--- a/packages/agent/daemon/runtime/codex_appserver_startup_trace.go
+++ b/packages/agent/daemon/runtime/codex_appserver_startup_trace.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -40,30 +41,30 @@ var codexAppServerStartupSpanNames = map[string]struct{}{
 const codexAppServerStderrLineLimit = 64 * 1024
 
 type codexAppServerStartupTrace struct {
-	startedAt     time.Time
-	session       Session
-	path          string
-	spanObserver  CodexAppServerSpanObserver
-	stderrMu      sync.Mutex
-	stderrLine    []byte
-	spanStartedAt map[string][]time.Time
+	startedAt          time.Time
+	session            Session
+	path               string
+	spanObserver       CodexAppServerSpanObserver
+	startupObserver    CodexAppServerStartupObserver
+	stderrMu           sync.Mutex
+	stderrLine         []byte
+	spanStartedAt      map[string][]time.Time
+	completedSpanCount atomic.Int64
 }
 
 func newCodexAppServerStartupTrace(
 	session Session,
-	spanObservers ...CodexAppServerSpanObserver,
+	spanObserver CodexAppServerSpanObserver,
+	startupObserver CodexAppServerStartupObserver,
 ) *codexAppServerStartupTrace {
 	settings := session.SettingsValue()
-	var spanObserver CodexAppServerSpanObserver
-	if len(spanObservers) > 0 {
-		spanObserver = spanObservers[0]
-	}
 	trace := &codexAppServerStartupTrace{
-		startedAt:     time.Now(),
-		session:       session,
-		path:          codexAppServerStartupTracePath(),
-		spanObserver:  spanObserver,
-		spanStartedAt: make(map[string][]time.Time),
+		startedAt:       time.Now(),
+		session:         session,
+		path:            codexAppServerStartupTracePath(),
+		spanObserver:    spanObserver,
+		startupObserver: startupObserver,
+		spanStartedAt:   make(map[string][]time.Time),
 	}
 	trace.Log("start.begin", map[string]any{
 		"permission_mode_id": session.PermissionModeID,
@@ -156,13 +157,28 @@ func appendCodexAppServerStartupTrace(path string, line []byte, maxBytes int64) 
 }
 
 func (t *codexAppServerStartupTrace) Finish(err error) {
-	fields := map[string]any{}
-	if err != nil {
-		fields["error"] = err.Error()
-		t.Log("start.failed", fields)
+	if t == nil {
 		return
 	}
-	t.Log("start.succeeded", fields)
+	outcome := "succeeded"
+	fields := map[string]any{}
+	if err != nil {
+		outcome = "failed"
+		fields["error"] = err.Error()
+		t.Log("start.failed", fields)
+	} else {
+		t.Log("start.succeeded", fields)
+	}
+	t.notifyStartupObserver(CodexAppServerStartupObservation{
+		Provider:           strings.TrimSpace(t.session.Provider),
+		RoomID:             strings.TrimSpace(t.session.RoomID),
+		AgentSessionID:     strings.TrimSpace(t.session.AgentSessionID),
+		StartedAt:          t.startedAt.UTC().Format(time.RFC3339Nano),
+		Outcome:            outcome,
+		DurationMS:         time.Since(t.startedAt).Milliseconds(),
+		MCPServerCount:     len(t.session.MCPServers),
+		CompletedSpanCount: int(t.completedSpanCount.Load()),
+	})
 }
 
 func (t *codexAppServerStartupTrace) LogMessage(method string, hasID bool, paramsSize int) {
@@ -268,6 +284,7 @@ func (t *codexAppServerStartupTrace) logCodexAppServerSpan(line []byte) *CodexAp
 			t.spanStartedAt[spanName] = append(t.spanStartedAt[spanName], startedAt)
 		}
 	} else if starts := t.spanStartedAt[spanName]; len(starts) > 0 {
+		t.completedSpanCount.Add(1)
 		start := starts[len(starts)-1]
 		t.spanStartedAt[spanName] = starts[:len(starts)-1]
 		durationMS := int64(0)
@@ -315,6 +332,23 @@ func (t *codexAppServerStartupTrace) notifySpanObserver(observation CodexAppServ
 		}
 	}()
 	t.spanObserver(observation)
+}
+
+func (t *codexAppServerStartupTrace) notifyStartupObserver(observation CodexAppServerStartupObservation) {
+	if t.startupObserver == nil {
+		return
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			slog.Warn("agent session Codex app-server startup observer panicked",
+				"provider", observation.Provider,
+				"agent_session_id", observation.AgentSessionID,
+				"outcome", observation.Outcome,
+				"panic", recovered,
+			)
+		}
+	}()
+	t.startupObserver(observation)
 }
 
 func codexJSONLogString(raw json.RawMessage) string {

--- a/packages/agent/daemon/runtime/codex_appserver_startup_trace.go
+++ b/packages/agent/daemon/runtime/codex_appserver_startup_trace.go
@@ -1,6 +1,7 @@
 package agentruntime
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"os"
@@ -14,18 +15,44 @@ const codexAppServerStartupTraceFileName = "tutti-codex-appserver-startup.jsonl"
 
 var codexAppServerStartupTraceMu sync.Mutex
 
+var codexAppServerStartupSpanNames = map[string]struct{}{
+	"app_server.thread_start.attach_listener": {},
+	"app_server.thread_start.config_snapshot": {},
+	"app_server.thread_start.create_thread":   {},
+	"app_server.thread_start.notify_started":  {},
+	"app_server.thread_start.resolve_status":  {},
+	"app_server.thread_start.send_response":   {},
+	"app_server.thread_start.upsert_thread":   {},
+	"session_init":                            {},
+	"session_init.auth_mcp":                   {},
+	"session_init.mcp_manager_init":           {},
+	"session_init.network_proxy":              {},
+	"session_init.plugin_skill_warmup":        {},
+	"session_init.state_db":                   {},
+	"session_init.thread_name_lookup":         {},
+	"session_init.thread_persistence":         {},
+	"shell_snapshot":                          {},
+	"thread_spawn":                            {},
+}
+
+const codexAppServerStderrLineLimit = 64 * 1024
+
 type codexAppServerStartupTrace struct {
-	startedAt time.Time
-	session   Session
-	path      string
+	startedAt     time.Time
+	session       Session
+	path          string
+	stderrMu      sync.Mutex
+	stderrLine    []byte
+	spanStartedAt map[string][]time.Time
 }
 
 func newCodexAppServerStartupTrace(session Session) *codexAppServerStartupTrace {
 	settings := session.SettingsValue()
 	trace := &codexAppServerStartupTrace{
-		startedAt: time.Now(),
-		session:   session,
-		path:      codexAppServerStartupTracePath(),
+		startedAt:     time.Now(),
+		session:       session,
+		path:          codexAppServerStartupTracePath(),
+		spanStartedAt: make(map[string][]time.Time),
 	}
 	trace.Log("start.begin", map[string]any{
 		"permission_mode_id": session.PermissionModeID,
@@ -39,9 +66,10 @@ func newCodexAppServerStartupTrace(session Session) *codexAppServerStartupTrace 
 func newCodexAppServerTurnTrace(session Session, turnID string, metadata map[string]any) *codexAppServerStartupTrace {
 	settings := session.SettingsValue()
 	trace := &codexAppServerStartupTrace{
-		startedAt: time.Now(),
-		session:   session,
-		path:      codexAppServerStartupTracePath(),
+		startedAt:     time.Now(),
+		session:       session,
+		path:          codexAppServerStartupTracePath(),
+		spanStartedAt: make(map[string][]time.Time),
 	}
 	fields := map[string]any{
 		"turn_id":            strings.TrimSpace(turnID),
@@ -129,6 +157,106 @@ func (t *codexAppServerStartupTrace) LogStderr(chunk []byte) {
 		"message": truncateACPLogValue(text, 2000),
 		"size":    len(chunk),
 	})
+
+	t.stderrMu.Lock()
+	defer t.stderrMu.Unlock()
+	t.stderrLine = append(t.stderrLine, chunk...)
+	for {
+		line, rest, ok := bytes.Cut(t.stderrLine, []byte("\n"))
+		if !ok {
+			if len(t.stderrLine) > codexAppServerStderrLineLimit {
+				t.stderrLine = append([]byte(nil), t.stderrLine[len(t.stderrLine)-codexAppServerStderrLineLimit:]...)
+			}
+			return
+		}
+		t.stderrLine = rest
+		t.logCodexAppServerSpan(line)
+	}
+}
+
+func withCodexAppServerLogging(env []string) []string {
+	env = withoutEnvironmentKeyFold(env, "LOG_FORMAT")
+	env = withoutEnvironmentKeyFold(env, "RUST_LOG")
+	return append(env, codexAppServerLogFormatEnv, codexAppServerRustLogEnv)
+}
+
+func withoutEnvironmentKeyFold(env []string, key string) []string {
+	filtered := make([]string, 0, len(env))
+	for _, entry := range env {
+		candidateKey, _, ok := strings.Cut(entry, "=")
+		if ok && strings.EqualFold(candidateKey, key) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}
+
+func (t *codexAppServerStartupTrace) logCodexAppServerSpan(line []byte) {
+	var record struct {
+		Timestamp string                       `json:"timestamp"`
+		Target    string                       `json:"target"`
+		Fields    map[string]json.RawMessage   `json:"fields"`
+		Span      map[string]json.RawMessage   `json:"span"`
+		Spans     []map[string]json.RawMessage `json:"spans"`
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(line), &record); err != nil {
+		return
+	}
+	spanName := codexJSONLogString(record.Span["name"])
+	if spanName == "" {
+		for index := len(record.Spans) - 1; index >= 0; index-- {
+			spanName = codexJSONLogString(record.Spans[index]["name"])
+			if spanName != "" {
+				break
+			}
+		}
+	}
+	if _, ok := codexAppServerStartupSpanNames[spanName]; !ok {
+		return
+	}
+	phase := codexJSONLogString(record.Fields["message"])
+	if phase != "new" && phase != "close" {
+		return
+	}
+	startedAt, parseErr := time.Parse(time.RFC3339Nano, record.Timestamp)
+	timestampOK := parseErr == nil
+	fields := map[string]any{
+		"span_name":  spanName,
+		"span_phase": phase,
+	}
+	if record.Target != "" {
+		fields["span_target"] = record.Target
+	}
+	if record.Timestamp != "" {
+		fields["codex_timestamp"] = record.Timestamp
+	}
+	if phase == "new" {
+		if timestampOK {
+			t.spanStartedAt[spanName] = append(t.spanStartedAt[spanName], startedAt)
+		}
+	} else if starts := t.spanStartedAt[spanName]; len(starts) > 0 {
+		start := starts[len(starts)-1]
+		t.spanStartedAt[spanName] = starts[:len(starts)-1]
+		if timestampOK {
+			fields["duration_ms"] = startedAt.Sub(start).Milliseconds()
+		}
+		if busy := codexJSONLogString(record.Fields["time.busy"]); busy != "" {
+			fields["span_busy"] = busy
+		}
+		if idle := codexJSONLogString(record.Fields["time.idle"]); idle != "" {
+			fields["span_idle"] = idle
+		}
+	}
+	t.Log("app_server.span", fields)
+}
+
+func codexJSONLogString(raw json.RawMessage) string {
+	var value string
+	if len(raw) == 0 || json.Unmarshal(raw, &value) != nil {
+		return ""
+	}
+	return strings.TrimSpace(value)
 }
 
 func (t *codexAppServerStartupTrace) Call(

--- a/packages/agent/daemon/runtime/codex_appserver_startup_trace_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_startup_trace_test.go
@@ -1,0 +1,114 @@
+package agentruntime
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCodexAppServerStartupTraceRecordsStructuredSpanClose(t *testing.T) {
+	trace := &codexAppServerStartupTrace{
+		startedAt:     time.Now(),
+		session:       Session{Provider: ProviderCodex, RoomID: "room-1", AgentSessionID: "session-1"},
+		path:          filepath.Join(t.TempDir(), "trace.jsonl"),
+		spanStartedAt: make(map[string][]time.Time),
+	}
+	firstChunk := []byte(`{"timestamp":"2026-08-20T02:00:00.000Z","level":"INFO","target":"codex_core","fields":{"message":"new"},"span":{"name":"session_init"}`)
+	secondChunk := []byte(`}
+{"timestamp":"2026-08-20T02:00:00.125Z","level":"INFO","target":"codex_core","fields":{"message":"close","time.busy":"120ms","time.idle":"5ms"},"span":{"name":"session_init"}}
+{"timestamp":"2026-08-20T02:00:00.200Z","level":"INFO","target":"codex_core","fields":{"message":"close"},"span":{"name":"unrelated_span"}}
+`)
+
+	trace.LogStderr(firstChunk)
+	trace.LogStderr(secondChunk)
+
+	data, err := os.ReadFile(trace.path)
+	if err != nil {
+		t.Fatalf("read trace: %v", err)
+	}
+	var records []map[string]any
+	for _, line := range splitJSONLines(data) {
+		var record map[string]any
+		if err := json.Unmarshal(line, &record); err != nil {
+			t.Fatalf("decode trace line %q: %v", line, err)
+		}
+		records = append(records, record)
+	}
+
+	var closeRecord map[string]any
+	spanRecords := 0
+	for _, record := range records {
+		if record["event"] != "app_server.span" {
+			continue
+		}
+		spanRecords++
+		if record["span_phase"] == "close" {
+			closeRecord = record
+		}
+	}
+	if spanRecords != 2 {
+		t.Fatalf("span records = %d, want new and close only", spanRecords)
+	}
+	if closeRecord == nil {
+		t.Fatal("missing session_init close span record")
+	}
+	if closeRecord["span_name"] != "session_init" {
+		t.Fatalf("span_name = %#v, want session_init", closeRecord["span_name"])
+	}
+	if closeRecord["duration_ms"] != float64(125) {
+		t.Fatalf("duration_ms = %#v, want 125", closeRecord["duration_ms"])
+	}
+	if closeRecord["span_busy"] != "120ms" || closeRecord["span_idle"] != "5ms" {
+		t.Fatalf("span timing = %#v, want busy/idle values", closeRecord)
+	}
+}
+
+func TestWithCodexAppServerLoggingReplacesInheritedLogSettings(t *testing.T) {
+	env := withCodexAppServerLogging([]string{
+		"log_format=pretty",
+		"rust_log=off",
+		"SESSION_ENV=1",
+	})
+	if !containsString(env, "SESSION_ENV=1") {
+		t.Fatalf("env = %#v, lost session env", env)
+	}
+	if !containsString(env, codexAppServerLogFormatEnv) || !containsString(env, codexAppServerRustLogEnv) {
+		t.Fatalf("env = %#v, missing managed Codex log settings", env)
+	}
+	if countEnvironmentKeyFold(env, "LOG_FORMAT") != 1 || countEnvironmentKeyFold(env, "RUST_LOG") != 1 {
+		t.Fatalf("env = %#v, expected one managed value per log key", env)
+	}
+}
+
+func splitJSONLines(data []byte) [][]byte {
+	lines := make([][]byte, 0)
+	for len(data) > 0 {
+		index := 0
+		for index < len(data) && data[index] != '\n' {
+			index++
+		}
+		line := data[:index]
+		if len(line) > 0 {
+			lines = append(lines, line)
+		}
+		if index == len(data) {
+			break
+		}
+		data = data[index+1:]
+	}
+	return lines
+}
+
+func countEnvironmentKeyFold(env []string, key string) int {
+	count := 0
+	for _, entry := range env {
+		candidateKey, _, ok := strings.Cut(entry, "=")
+		if ok && strings.EqualFold(candidateKey, key) {
+			count++
+		}
+	}
+	return count
+}

--- a/packages/agent/daemon/runtime/codex_appserver_startup_trace_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_startup_trace_test.go
@@ -83,6 +83,63 @@ func TestCodexAppServerStartupTraceRecordsStructuredSpanClose(t *testing.T) {
 	}
 }
 
+func TestCodexAppServerStartupTraceReportsBoundedSummary(t *testing.T) {
+	var observations []CodexAppServerStartupObservation
+	trace := &codexAppServerStartupTrace{
+		startedAt: time.Now().Add(-125 * time.Millisecond),
+		session: Session{
+			Provider:       ProviderCodex,
+			RoomID:         "room-1",
+			AgentSessionID: "session-1",
+			MCPServers: []MCPServerBinding{
+				{Name: "one"},
+				{Name: "two"},
+			},
+		},
+		path: filepath.Join(t.TempDir(), "trace.jsonl"),
+		startupObserver: func(observation CodexAppServerStartupObservation) {
+			observations = append(observations, observation)
+		},
+		spanStartedAt: make(map[string][]time.Time),
+	}
+
+	trace.LogStderr([]byte(`{"timestamp":"2026-08-20T02:00:00.000Z","fields":{"message":"new"},"span":{"name":"session_init"}}
+{"timestamp":"2026-08-20T02:00:00.125Z","fields":{"message":"close"},"span":{"name":"session_init"}}
+`))
+	trace.Finish(nil)
+
+	if len(observations) != 1 {
+		t.Fatalf("startup observations = %d, want one", len(observations))
+	}
+	observation := observations[0]
+	if observation.Provider != ProviderCodex || observation.RoomID != "room-1" || observation.AgentSessionID != "session-1" {
+		t.Fatalf("observation scope = %#v, want Codex room/session scope", observation)
+	}
+	if observation.Outcome != "succeeded" {
+		t.Fatalf("outcome = %q, want succeeded", observation.Outcome)
+	}
+	if observation.MCPServerCount != 2 || observation.CompletedSpanCount != 1 {
+		t.Fatalf("resource summary = %#v, want two MCP servers and one span", observation)
+	}
+	if observation.DurationMS < 100 {
+		t.Fatalf("duration_ms = %d, want at least 100ms", observation.DurationMS)
+	}
+}
+
+func TestCodexAppServerStartupTraceStartupObserverPanicDoesNotEscape(t *testing.T) {
+	trace := &codexAppServerStartupTrace{
+		startedAt: time.Now(),
+		session:   Session{Provider: ProviderCodex, AgentSessionID: "session-1"},
+		path:      filepath.Join(t.TempDir(), "trace.jsonl"),
+		startupObserver: func(CodexAppServerStartupObservation) {
+			panic("analytics observer failure")
+		},
+		spanStartedAt: make(map[string][]time.Time),
+	}
+
+	trace.Finish(nil)
+}
+
 func TestCodexAppServerStartupTraceObserverPanicDoesNotEscape(t *testing.T) {
 	trace := &codexAppServerStartupTrace{
 		startedAt: time.Now(),

--- a/packages/agent/daemon/runtime/codex_appserver_startup_trace_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_startup_trace_test.go
@@ -10,10 +10,14 @@ import (
 )
 
 func TestCodexAppServerStartupTraceRecordsStructuredSpanClose(t *testing.T) {
+	var observations []CodexAppServerSpanObservation
 	trace := &codexAppServerStartupTrace{
-		startedAt:     time.Now(),
-		session:       Session{Provider: ProviderCodex, RoomID: "room-1", AgentSessionID: "session-1"},
-		path:          filepath.Join(t.TempDir(), "trace.jsonl"),
+		startedAt: time.Now(),
+		session:   Session{Provider: ProviderCodex, RoomID: "room-1", AgentSessionID: "session-1"},
+		path:      filepath.Join(t.TempDir(), "trace.jsonl"),
+		spanObserver: func(observation CodexAppServerSpanObservation) {
+			observations = append(observations, observation)
+		},
 		spanStartedAt: make(map[string][]time.Time),
 	}
 	firstChunk := []byte(`{"timestamp":"2026-08-20T02:00:00.000Z","level":"INFO","target":"codex_core","fields":{"message":"new"},"span":{"name":"session_init"}`)
@@ -64,6 +68,35 @@ func TestCodexAppServerStartupTraceRecordsStructuredSpanClose(t *testing.T) {
 	if closeRecord["span_busy"] != "120ms" || closeRecord["span_idle"] != "5ms" {
 		t.Fatalf("span timing = %#v, want busy/idle values", closeRecord)
 	}
+	if len(observations) != 1 {
+		t.Fatalf("span observations = %d, want one completed span", len(observations))
+	}
+	observation := observations[0]
+	if observation.Provider != ProviderCodex || observation.RoomID != "room-1" || observation.AgentSessionID != "session-1" {
+		t.Fatalf("observation scope = %#v, want Codex room/session scope", observation)
+	}
+	if observation.SpanName != "session_init" || observation.SpanPhase != "close" || observation.DurationMS != 125 {
+		t.Fatalf("observation span = %#v, want session_init close at 125ms", observation)
+	}
+	if observation.SpanBusy != "120ms" || observation.SpanIdle != "5ms" {
+		t.Fatalf("observation timing = %#v, want busy/idle values", observation)
+	}
+}
+
+func TestCodexAppServerStartupTraceObserverPanicDoesNotEscape(t *testing.T) {
+	trace := &codexAppServerStartupTrace{
+		startedAt: time.Now(),
+		session:   Session{Provider: ProviderCodex, AgentSessionID: "session-1"},
+		path:      filepath.Join(t.TempDir(), "trace.jsonl"),
+		spanObserver: func(CodexAppServerSpanObservation) {
+			panic("analytics observer failure")
+		},
+		spanStartedAt: make(map[string][]time.Time),
+	}
+
+	trace.LogStderr([]byte(`{"timestamp":"2026-08-20T02:00:00.000Z","fields":{"message":"new"},"span":{"name":"session_init"}}
+{"timestamp":"2026-08-20T02:00:00.125Z","fields":{"message":"close"},"span":{"name":"session_init"}}
+`))
 }
 
 func TestWithCodexAppServerLoggingReplacesInheritedLogSettings(t *testing.T) {

--- a/packages/agent/daemon/runtime/codex_appserver_startup_trace_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_startup_trace_test.go
@@ -96,7 +96,25 @@ func TestCodexAppServerStartupTraceObserverPanicDoesNotEscape(t *testing.T) {
 
 	trace.LogStderr([]byte(`{"timestamp":"2026-08-20T02:00:00.000Z","fields":{"message":"new"},"span":{"name":"session_init"}}
 {"timestamp":"2026-08-20T02:00:00.125Z","fields":{"message":"close"},"span":{"name":"session_init"}}
-`))
+	`))
+}
+
+func TestCodexAppServerStartupTraceBoundsTheSharedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "trace.jsonl")
+	if err := appendCodexAppServerStartupTrace(path, []byte("first"), 10); err != nil {
+		t.Fatalf("write first trace record: %v", err)
+	}
+	if err := appendCodexAppServerStartupTrace(path, []byte("second"), 10); err != nil {
+		t.Fatalf("write second trace record: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read bounded trace: %v", err)
+	}
+	if string(data) != "second\n" {
+		t.Fatalf("bounded trace = %q, want only the newest record", data)
+	}
 }
 
 func TestWithCodexAppServerLoggingReplacesInheritedLogSettings(t *testing.T) {

--- a/packages/agent/daemon/runtime/codex_appserver_turn_binding_recovery.go
+++ b/packages/agent/daemon/runtime/codex_appserver_turn_binding_recovery.go
@@ -20,7 +20,7 @@ func (a *CodexAppServerAdapter) RecoverProviderTurnBinding(
 		return ProviderTurnBindingRecoveryResult{},
 			errors.New("codex provider turn recovery token is unavailable")
 	}
-	trace := newCodexAppServerStartupTrace(source)
+	trace := newCodexAppServerStartupTrace(source, a.startupSpanObserver)
 	client, _, err := a.startInitializedClient(ctx, source, trace)
 	if err != nil {
 		trace.Finish(err)

--- a/packages/agent/daemon/runtime/codex_appserver_turn_binding_recovery.go
+++ b/packages/agent/daemon/runtime/codex_appserver_turn_binding_recovery.go
@@ -20,7 +20,7 @@ func (a *CodexAppServerAdapter) RecoverProviderTurnBinding(
 		return ProviderTurnBindingRecoveryResult{},
 			errors.New("codex provider turn recovery token is unavailable")
 	}
-	trace := newCodexAppServerStartupTrace(source, a.startupSpanObserver)
+	trace := newCodexAppServerStartupTrace(source, a.startupSpanObserver, nil)
 	client, _, err := a.startInitializedClient(ctx, source, trace)
 	if err != nil {
 		trace.Finish(err)


### PR DESCRIPTION
## Summary

- Force managed Codex app-server processes to emit JSON logs with `FmtSpan::FULL` enabled by Codex.
- Parse bounded Codex stderr JSONL and record the `thread/start` startup spans in `tutti-codex-appserver-startup.jsonl`.
- Expose a public, best-effort observer for completed allowlisted startup spans, carrying only provider/session scope and bounded timing fields.
- Invoke observers after stderr parsing releases its mutex and recover observer panics so telemetry cannot affect Codex startup or command correctness.
- Wire the observer through Codex Start, Resume, Fork, Side, and turn-binding recovery traces.
- Bound the shared startup trace at 64 MiB; when the cap is reached, retain the newest records instead of allowing unbounded growth.

## Why

TSH needs structured Codex-internal timing in its Host/DataFinder diagnostics. The trace file is useful for local diagnosis, but TSH must not parse a shared temp file or duplicate provider log parsing. This contract lets Tutti publish the structured observation at the source while keeping raw prompts, commands, paths, and payloads out of the telemetry boundary.

The existing local trace had grown to roughly 559 MiB because it was global and append-only. The producer cap prevents future unbounded growth. TSH's diagnostics exporter separately reads the Codex JSONL from the tail and applies the selected time window before buffering it.

## Captured startup spans

`thread_spawn`, `session_init` and its persistence/state/MCP/plugin/network/name subspans, `shell_snapshot`, `session_init.mcp_manager_init`, and the app-server `thread_start` create/config/listener/upsert/status/response/notification spans.

## Verification

- `go test ./packages/agent/daemon/runtime -run '^TestCodexAppServer' -count=1`
- `pnpm check:changed -- --push-ready`
- Pre-push hook passed: 8 lanes

The TSH consumer and DataFinder contract are being prepared separately and will consume this public API after the next complete Tutti package cohort is published.