### PR TITLE
fix(connector): complete oauth remote install and reuse activation tools

### DIFF
--- a/docs/architecture/connector-remote-mcp.md
+++ b/docs/architecture/connector-remote-mcp.md
@@ -183,7 +183,13 @@ LegacyMCPClient
 - 不持久化或按 TTL 缓存 Tool 列表；每次 `tools/list` 和 `tools/call` 都以当前下游列表为准；
 - 原子替换生成 `Mcp-Param-*` Header 所需的 Tool Schema，已删除 Tool 不得残留。
 
-远程 Route Builder 调用 `server/discover` 和 `tools/list`，然后通过现有本地 Connector MCP Surface 发布带 Connector Namespace 的 Tool。调用 Gateway 时不得发送 `initialize` 或 `notifications/initialized`。
+远程 Route Builder 每次激活都调用 `server/discover`。同一进程内、同一授权身份
+（account、connector、release digest、本地 connection id、`connectionVersion`、
+`serverRevision`）的成功 `tools/list` 可以由 `ImplementationHost` 复用，避免
+Bootstrap 重建 Route 时重复探测；身份变化必须重新列出。该内存表没有 TTL，不写入
+SQLite，`Host.Close` 时丢弃，且不得缓存空列表、非法契约或 428/`-33001`/`-33002`。
+它只服务 Route 激活校验，不是 Agent 可见列表。调用 Gateway 时不得发送
+`initialize` 或 `notifications/initialized`。
 
 ## 授权与 Runtime Reconcile
 
@@ -204,7 +210,7 @@ sequenceDiagram
     G-->>T: revision + connected + connectionVersion
     T->>T: 原子保存账号级授权投影
     T->>R: 调度持久化 Reconcile
-    R->>G: server/discover + tools/list
+    R->>G: server/discover; tools/list unless same-boot identity hits Host memory
     R->>A: 发布或移除 Connector Route
 ```
 
@@ -223,7 +229,7 @@ sequenceDiagram
 - Active Default Connection 发生变化；
 - 已安装的 Connector Release 发生变化。
 
-生产环境 Composition Root 必须提供 `AuthorizationProjections` 和 `AccountRuntimeBindingResolver`。没有 Active Authorized Account Binding 的远程 Connector 必须处于 Disabled 状态，不得向 Agent 发布 Route。
+生产环境 Composition Root 必须提供 `AuthorizationProjections` 和 `AccountRuntimeBindingResolver`。没有 Active Authorized Account Binding 的远程 Connector 必须处于 Disabled 状态，不得向 Agent 发布 Route。安装阶段的 enabled Reconcile 若收到 HTTP 428 或 JSON-RPC `-33001`/`-33002`，必须写成过期投影并重规划 Disabled Desired，而不是把 428 当作可重试的安装失败。安装是设备事实；未授权的远程 Connector 可以已安装，但不向 Agent 发布 Route。
 
 ## Tool 生命周期
 
@@ -231,11 +237,11 @@ sequenceDiagram
 2. 授权阶段在 `tsh-server` 建立或更新账号级 Connection。
 3. Runtime Reconcile 判断远程 Route 是否启用。
 4. `server/discover` 在不访问上游 MCP 的情况下确认 Gateway 协议和公开能力。
-5. `tools/list` 返回当前 Connection 可用的 Tool；Tutti 使用 Connector Namespace 注册这些 Tool。
+5. `tools/list` 返回当前 Connection 可用的 Tool；同一授权身份在本进程内可复用上次成功的激活结果。Tutti 使用 Connector Namespace 注册这些 Tool。
 6. `tools/call` 携带已安装的 Connector Version 和当前 Tutti Session 转发给 Gateway。
 7. 授权失效时，通过同一个 Reconcile 流程移除或禁用 Route。
 
-Tool 不做本地业务缓存：Agent 的 `tools/list` 逐页直取下游；`tools/call` 只定位可能拥有该 Namespace 的 Connector，重新读取其当前 Tool 契约后调用，避免无关 Connector 超时阻塞。Route 安装时的 Tool 只用于启动校验，不作为 Agent 可见列表的真相。
+Agent 可见的 Tool 不做本地业务缓存：Agent 的 `tools/list` 逐页直取下游；`tools/call` 只定位可能拥有该 Namespace 的 Connector，重新读取其当前 Tool 契约后调用，避免无关 Connector 超时阻塞。Route 激活时的内存复用只跳过启动探测，不作为 Agent 可见列表的真相，也不得用 TTL 或 SQLite 代替下游当前列表。
 
 ## 端到端工作流程
 

--- a/docs/architecture/connector.md
+++ b/docs/architecture/connector.md
@@ -69,7 +69,12 @@ filter so installed connectors remain in their server-owned sections.
 Installation is a device fact. Authorization is an account projection. A
 Connector may therefore be installed while inactive for the current account;
 authorization completion or expiry schedules a normal durable runtime
-reconcile without changing installed truth. Every durable lifecycle command
+reconcile without changing installed truth. Remote MCP HTTP 428 and JSON-RPC
+`-33001`/`-33002` during an enabled reconcile are authorization-required
+observations, not retryable install failures. Core persists an expired account
+projection, replans `RuntimeDesired` as disabled, and lets
+`awaitRuntimeDesired` converge that inactive generation so the install
+operation can complete. Every durable lifecycle command
 freezes its `accountId` in `OperationScope`, while short-lived artifact and
 credential grants are passed only through execution ports and are never
 serialized into SQLite.
@@ -340,6 +345,10 @@ accepted -> deactivating(Desired=disabled) -> Observed(disabled)
          -> removing -> absent -> completed
 ```
 
+An authorization-required observation still completes install after the
+disabled generation is Observed. Install completion does not require an
+enabled Agent route.
+
 These are short database transactions separated by idempotent external
 effects, not one long transaction. Every external effect is preceded by a
 durable phase/receipt. A retryable error leaves the Operation non-terminal and
@@ -430,7 +439,10 @@ For account-scoped runtimes, `AccountRuntimeBindingResolver` maps `none`
 authorization to an always-active device connection. OAuth/API-key connectors
 remain inactive until the current account projection is `connected`; only then
 does the resolver request a one-shot credential-broker grant. `expired`,
-`disconnected`, and missing projections reconcile inactive. Daemon or guest
+`disconnected`, and missing projections reconcile inactive. If an enabled
+reconcile observes authorization-required from the remote MCP before the
+projection has expired, Core writes `expired` and replans inactive instead of
+leaving the install or convergence row retrying 428. Daemon or guest
 restart uses `BootstrapForScope` to rebuild the same projection explicitly.
 
 An enabled Runtime Reconcile returns one identity-fenced receipt containing
@@ -485,6 +497,9 @@ authentication only through a host-supplied request authorizer. Neither an API
 key submitted by the user nor the product account session is copied into the
 runtime VM. Remote MCP execution follows the product host's authenticated
 relay, while the VM receives only the non-credential runtime route identity.
+Route activation may reuse a same-process `tools/list` for an unchanged
+authorization identity; Agent-visible lists stay live and are never persisted
+or TTL-cached.
 Remote authorization replacement propagates the explicit replacement policy to
 Start and uses the session-scoped control-plane Cancel endpoint when a receipt
 already exists. This covers both a returned session and an interrupted initial
@@ -611,7 +626,10 @@ has observed its latest desired generation as enabled and ready; `starting`,
 projection retain the legacy authorization-based presentation. AgentGUI maps
 its provider-neutral capability options into that projection and retains only
 placement plus its Tutti Mode fallback. Selecting one item emits a semantic
-connector-open intent. The host
+connector-open intent. Composer “install” waits on the durable install
+operation; authorization-required remote MCP must complete that operation
+with an inactive route so the trigger can move from install to authorize
+instead of spinning. The host
 executes `openConnectorMarketDialog(root, connectorKey)`, which waits for the
 authoritative market view, rejects invalid or unknown keys, and then advances
 the package-owned dialog state machine. Before applying the bounded quick-list

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -141,8 +141,9 @@ App Center, workspace-app lifecycle, App Factory, file references, and File Mana
 
 Connector catalog, installation, account authorization, and runtime convergence.
 
-- [OAuth opens once, then the desktop stays disconnected or a second attempt supersedes the first](./connector-market.md#oauth-opens-once-then-the-desktop-stays-disconnected-or-a-second-attempt-supersedes-the-first)
+- [Authorization stays loading and reopening cannot start a new attempt](./connector-market.md#authorization-stays-loading-and-reopening-cannot-start-a-new-attempt)
 - [OAuth finishes in the browser but does not return to the initiating desktop build](./connector-market.md#oauth-finishes-in-the-browser-but-does-not-return-to-the-initiating-desktop-build)
+- [Composer install stays spinning on an OAuth remote connector](./connector-market.md#composer-install-stays-spinning-on-an-oauth-remote-connector)
 
 ## [Toolchain, Browser, And Terminal](./toolchain-browser-terminal.md)
 

--- a/docs/conventions/troubleshooting/connector-market.md
+++ b/docs/conventions/troubleshooting/connector-market.md
@@ -54,3 +54,20 @@ Inspect the server-owned authorization bridge URL before it leaves the renderer.
 **Rule**
 
 The initiating desktop build owns the callback environment. Do not infer a production or development desktop scheme from the authorization website hostname. Web code must accept only the exact supported `open` routes and keep the legacy client marker solely as compatibility for already released clients.
+
+### Composer install stays spinning on an OAuth remote connector
+
+**Symptoms**
+
+- composer connector menu “install” keeps a spinner for minutes
+- daemon logs repeat `list connector MCP tools: MCP Streamable HTTP request failed: status 428`
+- the install operation stays `running` with rising `attempt` and retryable `connector_install_failed`
+- after enough retries the connector may still become `installed` while the account projection is `expired` and runtime desired is disabled
+
+**Check**
+
+Separate device installation from account authorization. Confirm the connector is remote Streamable HTTP plus oauth2, and that enabled runtime reconcile called `tools/list` before any user authorization. The composer trigger waits for the durable install operation, not for an enabled Agent route. `awaitRuntimeDesired` must be able to converge a disabled generation after an authorization-required observation.
+
+**Rule**
+
+HTTP 428 and JSON-RPC `-33001`/`-33002` are authorization-required, not retryable install failure. Persist an expired account projection, replan `RuntimeDesired` enabled=false, and complete install once that inactive generation is Observed. Do not keep the install operation retrying 428, and do not require a connected route before installation may become a device fact.

--- a/packages/connector/daemon/core/account_runtime_binding.go
+++ b/packages/connector/daemon/core/account_runtime_binding.go
@@ -64,7 +64,7 @@ func (resolver AccountRuntimeBindingResolver) ResolveRuntimeBinding(
 		return RuntimeBinding{}, invalidOperationReceipt("authorization projection identity does not match runtime scope")
 	}
 	if remote && !projection.ServerSynchronized {
-		return RuntimeBinding{ConnectionID: connectionID, Enabled: false, AuthorizationState: AuthorizationStateDisconnected}, nil
+		return projectionRuntimeBinding(connectionID, false, AuthorizationStateDisconnected, projection, nil), nil
 	}
 	// Remote routes have a stable account+connector identity. The server's
 	// connectionId is diagnostic authorization state and can change when a
@@ -76,24 +76,24 @@ func (resolver AccountRuntimeBindingResolver) ResolveRuntimeBinding(
 		return RuntimeBinding{}, invalidOperationReceipt("authorization projection connection id is invalid")
 	}
 	if projection.State != AuthorizationStateConnected {
-		return RuntimeBinding{ConnectionID: connectionID, Enabled: false, AuthorizationState: projection.State}, nil
+		return projectionRuntimeBinding(connectionID, false, projection.State, projection, nil), nil
 	}
 	if request.Purpose == RuntimeBindingPurposePlan || request.Purpose == RuntimeBindingPurposeDeactivate {
 		// Planning persists only non-secret intent. Reconcile resolves a fresh,
 		// one-shot credential grant immediately before the host call.
-		return RuntimeBinding{ConnectionID: connectionID, Enabled: true, AuthorizationState: projection.State}, nil
+		return projectionRuntimeBinding(connectionID, true, projection.State, projection, nil), nil
 	}
 	managed := request.Release.Manifest.Implementation.ManagedStdio
 	if remote {
 		// Remote MCP routes authenticate to tsh-server with the Tutti account
 		// session. Provider credentials never cross the daemon boundary.
-		return RuntimeBinding{ConnectionID: connectionID, Enabled: true, AuthorizationState: projection.State}, nil
+		return projectionRuntimeBinding(connectionID, true, projection.State, projection, nil), nil
 	}
 	if managed != nil && managed.CredentialBroker != nil {
 		// Connector-owned credential brokers persist their own account binding
 		// inside the managed VM user home. They do not consume a Server-issued
 		// credential grant when the active CLI/MCP route is reconciled.
-		return RuntimeBinding{ConnectionID: connectionID, Enabled: true, AuthorizationState: projection.State}, nil
+		return projectionRuntimeBinding(connectionID, true, projection.State, projection, nil), nil
 	}
 	if resolver.Credentials == nil {
 		return RuntimeBinding{}, NewDomainError(ErrorCodeUnavailable, "credential broker grant issuer is not registered", true, nil)
@@ -106,7 +106,24 @@ func (resolver AccountRuntimeBindingResolver) ResolveRuntimeBinding(
 	if len(grant) == 0 {
 		return RuntimeBinding{}, invalidOperationReceipt("credential broker grant issuer returned an empty grant")
 	}
-	return RuntimeBinding{ConnectionID: connectionID, Enabled: true, AuthorizationState: projection.State, CredentialBrokerGrant: grant}, nil
+	return projectionRuntimeBinding(connectionID, true, projection.State, projection, grant), nil
+}
+
+func projectionRuntimeBinding(
+	connectionID string,
+	enabled bool,
+	state AuthorizationState,
+	projection AuthorizationProjection,
+	grant []byte,
+) RuntimeBinding {
+	return RuntimeBinding{
+		ConnectionID:          connectionID,
+		Enabled:               enabled,
+		AuthorizationState:    state,
+		ConnectionVersion:     projection.ConnectionVersion,
+		ServerRevision:        projection.ServerRevision,
+		CredentialBrokerGrant: grant,
+	}
 }
 
 func DeviceRuntimeConnectionID(connectorKey string) string {

--- a/packages/connector/daemon/core/account_runtime_binding_test.go
+++ b/packages/connector/daemon/core/account_runtime_binding_test.go
@@ -109,7 +109,7 @@ func TestAccountRuntimeBindingResolverUsesServerConnectionForRemoteMCPWithoutGra
 	release.Manifest.AuthorizationKind = "api_key"
 	projections := &authorizationProjectionStoreStub{projection: AuthorizationProjection{
 		AccountID: "account-1", ConnectorKey: "tencent-docs", ConnectionID: "server-connection", State: AuthorizationStateConnected,
-		ServerSynchronized: true,
+		ConnectionVersion: 3, ServerRevision: 12, ServerSynchronized: true,
 	}}
 	binding, err := (AccountRuntimeBindingResolver{Projections: projections}).ResolveRuntimeBinding(context.Background(), RuntimeBindingRequest{
 		Scope: OperationScope{AccountID: "account-1"}, Connector: Connector{Key: "tencent-docs"}, Release: release,
@@ -117,7 +117,8 @@ func TestAccountRuntimeBindingResolverUsesServerConnectionForRemoteMCPWithoutGra
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !binding.Enabled || binding.ConnectionID != AccountRuntimeConnectionID("account-1", "tencent-docs") || len(binding.CredentialBrokerGrant) != 0 {
+	if !binding.Enabled || binding.ConnectionID != AccountRuntimeConnectionID("account-1", "tencent-docs") ||
+		binding.ConnectionVersion != 3 || binding.ServerRevision != 12 || len(binding.CredentialBrokerGrant) != 0 {
 		t.Fatalf("binding = %#v", binding)
 	}
 }

--- a/packages/connector/daemon/core/application_runtime_authorization.go
+++ b/packages/connector/daemon/core/application_runtime_authorization.go
@@ -1,0 +1,133 @@
+package host
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// replanRuntimeAfterAuthorizationRequired keeps device installation truth and
+// turns a remote authorization-required observation into inactive runtime
+// intent. Install and later convergence can then complete without retrying MCP
+// 428 as install failure.
+func (application *Application) replanRuntimeAfterAuthorizationRequired(
+	ctx context.Context,
+	convergence RuntimeConvergence,
+	connector Connector,
+	release Release,
+) error {
+	scope := convergence.Desired.Scope
+	if application.config.AuthorizationProjections != nil && strings.TrimSpace(scope.AccountID) != "" {
+		projection := AuthorizationProjection{
+			AccountID:    scope.AccountID,
+			ConnectorKey: connector.Key,
+			ConnectionID: strings.TrimSpace(convergence.Desired.ConnectionID),
+			State:        AuthorizationStateExpired,
+			UpdatedAt:    application.config.Now().UTC(),
+		}
+		if current, err := application.config.AuthorizationProjections.AuthorizationProjection(
+			ctx, scope.AccountID, connector.Key,
+		); err == nil {
+			if strings.TrimSpace(current.ConnectionID) != "" {
+				projection.ConnectionID = strings.TrimSpace(current.ConnectionID)
+			}
+			projection.ConnectorVersion = current.ConnectorVersion
+			projection.ServerSynchronized = current.ServerSynchronized
+			projection.ConnectionVersion = current.ConnectionVersion
+			projection.ServerRevision = current.ServerRevision
+		}
+		if err := application.saveAuthorizationProjection(ctx, ConnectorMutation{
+			ConnectorKey: connector.Key,
+			AccountID:    scope.AccountID,
+		}, projection); err != nil {
+			return err
+		}
+	}
+	binding := RuntimeBinding{
+		ConnectionID:       convergence.Desired.ConnectionID,
+		Enabled:            false,
+		AuthorizationState: AuthorizationStateExpired,
+	}
+	_, err := application.saveRuntimeDesired(
+		ctx, scope, connector.Key, release.ReleaseDigest, binding, false, nil, nil,
+	)
+	return err
+}
+
+func (application *Application) inspectRuntimeAuthorization(
+	ctx context.Context,
+	convergence RuntimeConvergence,
+	connector Connector,
+) (Connector, error) {
+	if connector.Release.Manifest.Implementation.ManagedStdio == nil ||
+		connector.Release.Manifest.AuthorizationKind == "none" {
+		return connector, nil
+	}
+	inspector, ok := application.config.Authorization.(AuthorizationInspector)
+	if !ok {
+		return connector, nil
+	}
+	observation, err := inspector.InspectAuthorization(ctx, AuthorizationInspectRequest{
+		Scope: convergence.Desired.Scope, Connector: connector,
+		AuthorizationGeneration: convergence.Desired.Generation,
+		DesktopBootEpoch:        application.config.BootEpoch,
+		StateRevision:           connector.Revision,
+	})
+	if err != nil {
+		return Connector{}, fmt.Errorf("inspect connector authorization: %w", err)
+	}
+	if observation.ConnectorKey != "" && observation.ConnectorKey != connector.Key ||
+		observation.ReleaseDigest != "" && observation.ReleaseDigest != connector.Release.ReleaseDigest {
+		return Connector{}, invalidOperationReceipt("authorization inspector returned a mismatched observation")
+	}
+	var state AuthorizationState
+	switch observation.State {
+	case AuthorizationObservationConnected:
+		state = AuthorizationStateConnected
+	case AuthorizationObservationDisconnected:
+		state = AuthorizationStateDisconnected
+	case AuthorizationObservationExpired:
+		state = AuthorizationStateExpired
+	case AuthorizationObservationFailed:
+		state = AuthorizationStateFailed
+	case AuthorizationObservationPending:
+		state = AuthorizationStatePending
+	default:
+		return Connector{}, invalidOperationReceipt("authorization inspector returned an invalid state")
+	}
+	if connector.Authorization.State != state || connector.Authorization.FailureCode != observation.FailureCode {
+		err = application.config.Repository.Transaction(ctx, func(tx Transaction) error {
+			stored, txErr := tx.Connector(connector.Key)
+			if txErr != nil {
+				return txErr
+			}
+			revision := tx.AdvanceRevision()
+			stored.Authorization = Authorization{State: state, FailureCode: strings.TrimSpace(observation.FailureCode)}
+			stored.Revision = revision
+			if txErr := tx.SaveConnector(stored); txErr != nil {
+				return txErr
+			}
+			return tx.EnqueueConnectorMarketChanged(ChangedEvent{ConnectorKey: stored.Key, Revision: revision})
+		})
+		if err != nil {
+			return Connector{}, err
+		}
+		connector.Authorization = Authorization{State: state, FailureCode: strings.TrimSpace(observation.FailureCode)}
+	}
+	if application.config.AuthorizationProjections != nil && strings.TrimSpace(convergence.Desired.Scope.AccountID) != "" {
+		connectionID := strings.TrimSpace(observation.ConnectionID)
+		if state == AuthorizationStateConnected && connectionID == "" {
+			return Connector{}, invalidOperationReceipt("connected authorization inspection returned no connection id")
+		}
+		if err := application.saveAuthorizationProjection(ctx, ConnectorMutation{
+			ConnectorKey: connector.Key, AccountID: convergence.Desired.Scope.AccountID,
+		}, AuthorizationProjection{
+			AccountID: convergence.Desired.Scope.AccountID, ConnectorKey: connector.Key,
+			ConnectionID: connectionID, State: state, FailureCode: observation.FailureCode,
+			UpdatedAt: application.config.Now().UTC(),
+		}); err != nil {
+			return Connector{}, err
+		}
+	}
+	return connector, nil
+}

--- a/packages/connector/daemon/core/application_runtime_convergence.go
+++ b/packages/connector/daemon/core/application_runtime_convergence.go
@@ -409,9 +409,16 @@ func (application *Application) ConvergeRuntime(
 	receipt, err := application.reconcileRuntime(executionContext, RuntimeReconcileRequest{
 		OperationID: operationID, Scope: convergence.Desired.Scope, ConnectionID: binding.ConnectionID,
 		Connector: connector, Enabled: binding.Enabled, Generation: generation,
+		ConnectionVersion:     binding.ConnectionVersion,
+		ServerRevision:        binding.ServerRevision,
 		CredentialBrokerGrant: binding.CredentialBrokerGrant,
 	})
 	if err != nil {
+		if authorizationRequiredError(err) {
+			return application.replanRuntimeAfterAuthorizationRequired(
+				context.WithoutCancel(ctx), convergence, connector, release,
+			)
+		}
 		return application.retryRuntimeConvergence(ctx, convergence,
 			NewDomainError(ErrorCodeInstallFailed, "connector runtime could not be reconciled", true, err))
 	}
@@ -446,84 +453,6 @@ func (application *Application) completeRuntimeConvergence(
 		convergence.LastErrorCode = ""
 		convergence.LastError = ""
 	})
-}
-
-func (application *Application) inspectRuntimeAuthorization(
-	ctx context.Context,
-	convergence RuntimeConvergence,
-	connector Connector,
-) (Connector, error) {
-	if connector.Release.Manifest.Implementation.ManagedStdio == nil ||
-		connector.Release.Manifest.AuthorizationKind == "none" {
-		return connector, nil
-	}
-	inspector, ok := application.config.Authorization.(AuthorizationInspector)
-	if !ok {
-		return connector, nil
-	}
-	observation, err := inspector.InspectAuthorization(ctx, AuthorizationInspectRequest{
-		Scope: convergence.Desired.Scope, Connector: connector,
-		AuthorizationGeneration: convergence.Desired.Generation,
-		DesktopBootEpoch:        application.config.BootEpoch,
-		StateRevision:           connector.Revision,
-	})
-	if err != nil {
-		return Connector{}, fmt.Errorf("inspect connector authorization: %w", err)
-	}
-	if observation.ConnectorKey != "" && observation.ConnectorKey != connector.Key ||
-		observation.ReleaseDigest != "" && observation.ReleaseDigest != connector.Release.ReleaseDigest {
-		return Connector{}, invalidOperationReceipt("authorization inspector returned a mismatched observation")
-	}
-	var state AuthorizationState
-	switch observation.State {
-	case AuthorizationObservationConnected:
-		state = AuthorizationStateConnected
-	case AuthorizationObservationDisconnected:
-		state = AuthorizationStateDisconnected
-	case AuthorizationObservationExpired:
-		state = AuthorizationStateExpired
-	case AuthorizationObservationFailed:
-		state = AuthorizationStateFailed
-	case AuthorizationObservationPending:
-		state = AuthorizationStatePending
-	default:
-		return Connector{}, invalidOperationReceipt("authorization inspector returned an invalid state")
-	}
-	if connector.Authorization.State != state || connector.Authorization.FailureCode != observation.FailureCode {
-		err = application.config.Repository.Transaction(ctx, func(tx Transaction) error {
-			stored, txErr := tx.Connector(connector.Key)
-			if txErr != nil {
-				return txErr
-			}
-			revision := tx.AdvanceRevision()
-			stored.Authorization = Authorization{State: state, FailureCode: strings.TrimSpace(observation.FailureCode)}
-			stored.Revision = revision
-			if txErr := tx.SaveConnector(stored); txErr != nil {
-				return txErr
-			}
-			return tx.EnqueueConnectorMarketChanged(ChangedEvent{ConnectorKey: stored.Key, Revision: revision})
-		})
-		if err != nil {
-			return Connector{}, err
-		}
-		connector.Authorization = Authorization{State: state, FailureCode: strings.TrimSpace(observation.FailureCode)}
-	}
-	if application.config.AuthorizationProjections != nil && strings.TrimSpace(convergence.Desired.Scope.AccountID) != "" {
-		connectionID := strings.TrimSpace(observation.ConnectionID)
-		if state == AuthorizationStateConnected && connectionID == "" {
-			return Connector{}, invalidOperationReceipt("connected authorization inspection returned no connection id")
-		}
-		if err := application.saveAuthorizationProjection(ctx, ConnectorMutation{
-			ConnectorKey: connector.Key, AccountID: convergence.Desired.Scope.AccountID,
-		}, AuthorizationProjection{
-			AccountID: convergence.Desired.Scope.AccountID, ConnectorKey: connector.Key,
-			ConnectionID: connectionID, State: state, FailureCode: observation.FailureCode,
-			UpdatedAt: application.config.Now().UTC(),
-		}); err != nil {
-			return Connector{}, err
-		}
-	}
-	return connector, nil
 }
 
 func (application *Application) runtimeConnectorAndRelease(
@@ -598,8 +527,7 @@ func (application *Application) saveRuntimeDesired(
 		if err != nil {
 			return err
 		}
-		if connector.Installation.State != InstallationStateInstalled ||
-			connector.Installation.InstalledReleaseDigest != releaseDigest {
+		if !runtimeDesiredTargetMatches(connector, releaseDigest) {
 			return NewDomainError(ErrorCodeRevisionConflict, "installed connector changed while planning runtime", true, nil)
 		}
 		if mutation != nil {
@@ -710,6 +638,17 @@ func runtimeDesiredMatchesBinding(desired RuntimeDesired, releaseDigest string, 
 func runtimeBindingMatchesDesired(binding RuntimeBinding, desired RuntimeDesired) bool {
 	return desired.ReleaseDigest != "" && desired.Enabled == binding.Enabled &&
 		desired.ConnectionID == strings.TrimSpace(binding.ConnectionID) && desired.AuthorizationState == binding.AuthorizationState
+}
+
+func runtimeDesiredTargetMatches(connector Connector, releaseDigest string) bool {
+	releaseDigest = strings.TrimSpace(releaseDigest)
+	if connector.Installation.State == InstallationStateInstalled &&
+		connector.Installation.InstalledReleaseDigest == releaseDigest {
+		return true
+	}
+	return (connector.Installation.State == InstallationStateInstalling ||
+		connector.Installation.State == InstallationStateUpdating) &&
+		connector.Installation.CandidateReleaseDigest == releaseDigest
 }
 
 func runtimeActivationEnabled(desired RuntimeDesired) bool {

--- a/packages/connector/daemon/core/application_runtime_convergence_test.go
+++ b/packages/connector/daemon/core/application_runtime_convergence_test.go
@@ -206,6 +206,146 @@ func TestUpdateKeepsCurrentReleaseUntilCandidateRuntimeIsObserved(t *testing.T) 
 	}
 }
 
+func TestInstallCompletesWhenEnabledRuntimeRequiresAuthorization(t *testing.T) {
+	connector := testRemoteAuthorizedConnector("gmail")
+	connector.Installation = Installation{State: InstallationStateNotInstalled}
+	repository := newMemoryRepository(connector)
+	runtime := &memoryInstallRuntime{enabledReconcileErrors: map[string]error{
+		connector.Key: NewDomainError(
+			ErrorCodeAuthorizationFailed,
+			"connector authorization is required",
+			false,
+			errors.New("list connector MCP tools: MCP Streamable HTTP request failed: status 428"),
+		),
+	}}
+	projections := &recordingAuthorizationProjectionStore{projection: AuthorizationProjection{
+		AccountID: "account-1", ConnectorKey: connector.Key, ConnectionID: "server-connection",
+		State: AuthorizationStateConnected, ServerSynchronized: true,
+	}}
+	readiness := NewAuthorizationReadinessGate()
+	readiness.SetReady("account-1", true)
+	application := newTestApplication(t, repository, &memoryScheduler{}, runtime, CatalogSnapshot{})
+	application.config.AuthorizationProjections = projections
+	application.config.RuntimeBindings = AccountRuntimeBindingResolver{
+		Projections: projections, Readiness: readiness,
+	}
+	application.config.ImplementationRegistry = NewImplementationRegistry(map[string]ImplementationValidator{
+		ImplementationKindRemoteStreamableHTTP: nil,
+	})
+
+	accepted, err := application.Install(context.Background(), ConnectorMutation{
+		Mutation: Mutation{ClientRequestID: "install-gmail"}, ConnectorKey: connector.Key, AccountID: "account-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := application.ExecuteOperation(context.Background(), accepted.Operation.OperationID); err != nil {
+		t.Fatalf("install error = %v", err)
+	}
+	stored, err := repository.Connector(context.Background(), connector.Key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	operation, err := repository.Operation(context.Background(), accepted.Operation.OperationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	convergence, err := repository.RuntimeConvergence(context.Background(), OperationScope{AccountID: "account-1"}, connector.Key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Installation.State != InstallationStateInstalled ||
+		operation.State != OperationStateCompleted ||
+		projections.projection.State != AuthorizationStateExpired ||
+		convergence.Desired.Enabled ||
+		convergence.Desired.AuthorizationState != AuthorizationStateExpired ||
+		convergence.Observed.DesiredGeneration != convergence.Desired.Generation ||
+		runtime.lastReconcile.Enabled {
+		t.Fatalf(
+			"auth-required install left spinner debt: connector=%#v operation=%#v projection=%#v desired=%#v observed=%#v lastReconcile=%#v",
+			stored.Installation, operation, projections.projection, convergence.Desired, convergence.Observed, runtime.lastReconcile,
+		)
+	}
+}
+
+func TestRuntimeConvergenceForwardsAuthorizationIdentityToRemoteReconcile(t *testing.T) {
+	connector := testRemoteAuthorizedConnector("gmail")
+	repository := newMemoryRepository(connector)
+	runtime := &memoryInstallRuntime{}
+	projections := &recordingAuthorizationProjectionStore{projection: AuthorizationProjection{
+		AccountID: "account-1", ConnectorKey: connector.Key, ConnectionID: "server-connection",
+		State: AuthorizationStateConnected, ServerSynchronized: true,
+		ConnectionVersion: 3, ServerRevision: 12,
+	}}
+	readiness := NewAuthorizationReadinessGate()
+	readiness.SetReady("account-1", true)
+	application := newTestApplication(t, repository, &memoryScheduler{}, runtime, CatalogSnapshot{})
+	application.config.AuthorizationProjections = projections
+	application.config.RuntimeBindings = AccountRuntimeBindingResolver{
+		Projections: projections, Readiness: readiness,
+	}
+	if _, err := application.EnsureRuntimeDesired(context.Background(), OperationScope{AccountID: "account-1"}, connector.Key); err != nil {
+		t.Fatal(err)
+	}
+	if err := application.ConvergeRuntime(context.Background(), OperationScope{AccountID: "account-1"}, connector.Key); err != nil {
+		t.Fatal(err)
+	}
+	if runtime.lastReconcile.ConnectionVersion != 3 || runtime.lastReconcile.ServerRevision != 12 ||
+		!runtime.lastReconcile.Enabled {
+		t.Fatalf("reconcile identity = %#v", runtime.lastReconcile)
+	}
+}
+
+func TestRuntimeConvergenceAuthorizationRequiredReplansInactiveRuntime(t *testing.T) {
+	connector := testRemoteAuthorizedConnector("gmail")
+	repository := newMemoryRepository(connector)
+	runtime := &memoryInstallRuntime{enabledReconcileErrors: map[string]error{
+		connector.Key: NewDomainError(
+			ErrorCodeAuthorizationFailed,
+			"connector authorization is required",
+			false,
+			errors.New("list connector MCP tools: MCP Streamable HTTP request failed: status 428"),
+		),
+	}}
+	projections := &recordingAuthorizationProjectionStore{projection: AuthorizationProjection{
+		AccountID: "account-1", ConnectorKey: connector.Key, ConnectionID: "server-connection",
+		State: AuthorizationStateConnected, ServerSynchronized: true,
+	}}
+	readiness := NewAuthorizationReadinessGate()
+	readiness.SetReady("account-1", true)
+	application := newTestApplication(t, repository, &memoryScheduler{}, runtime, CatalogSnapshot{})
+	application.config.AuthorizationProjections = projections
+	application.config.RuntimeBindings = AccountRuntimeBindingResolver{
+		Projections: projections, Readiness: readiness,
+	}
+	if _, err := application.EnsureRuntimeDesired(context.Background(), OperationScope{AccountID: "account-1"}, connector.Key); err != nil {
+		t.Fatal(err)
+	}
+	if err := application.ConvergeRuntime(context.Background(), OperationScope{AccountID: "account-1"}, connector.Key); err != nil {
+		t.Fatalf("first converge error = %v", err)
+	}
+	if err := application.ConvergeRuntime(context.Background(), OperationScope{AccountID: "account-1"}, connector.Key); err != nil {
+		t.Fatalf("disabled converge error = %v", err)
+	}
+	stored, err := repository.RuntimeConvergence(context.Background(), OperationScope{AccountID: "account-1"}, connector.Key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Attempt != 0 || stored.LastErrorCode != "" || stored.Desired.Enabled ||
+		stored.Desired.AuthorizationState != AuthorizationStateExpired ||
+		stored.Observed.DesiredGeneration != stored.Desired.Generation ||
+		projections.projection.State != AuthorizationStateExpired {
+		t.Fatalf("authorization-required convergence = %#v projection=%#v", stored, projections.projection)
+	}
+	connectorAfter, err := repository.Connector(context.Background(), connector.Key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if connectorAfter.Installation.State != InstallationStateInstalled {
+		t.Fatalf("installation changed after authorization-required runtime: %#v", connectorAfter.Installation)
+	}
+}
+
 func TestAuthorizedUpdateInspectsPreparedCandidateBeforePromotion(t *testing.T) {
 	connector := testManagedAuthorizedConnector("lark-cli")
 	connector.Authorization = Authorization{State: AuthorizationStateConnected}

--- a/packages/connector/daemon/core/application_runtime_execution.go
+++ b/packages/connector/daemon/core/application_runtime_execution.go
@@ -23,6 +23,8 @@ func (application *Application) executeRuntimeReconcile(ctx context.Context, ope
 	receipt, err := application.reconcileRuntime(ctx, RuntimeReconcileRequest{
 		OperationID: operation.OperationID, Scope: operation.Scope, ConnectionID: binding.ConnectionID,
 		Connector: connector, Enabled: binding.Enabled, Generation: operation.HostGeneration,
+		ConnectionVersion:     binding.ConnectionVersion,
+		ServerRevision:        binding.ServerRevision,
 		CredentialBrokerGrant: binding.CredentialBrokerGrant,
 	})
 	if err != nil {

--- a/packages/connector/daemon/core/application_test.go
+++ b/packages/connector/daemon/core/application_test.go
@@ -2357,6 +2357,27 @@ func testConnector(key string) Connector {
 	}
 }
 
+func testRemoteAuthorizedConnector(key string) Connector {
+	connector := testConnector(key)
+	connector.Release.Manifest.AuthorizationKind = "oauth2"
+	connector.Release.Manifest.RequiredCapabilities = []string{"tools"}
+	connector.Release.Manifest.Implementation = Implementation{
+		Kind: ImplementationKindRemoteStreamableHTTP,
+		RemoteStreamableHTTP: &RemoteStreamableHTTPImplementation{
+			ProtocolVersion:     "2026-07-28",
+			BindingRef:          key + ".primary",
+			ContractVersion:     1,
+			BindingContractHash: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+	}
+	connector.Authorization = Authorization{State: AuthorizationStateDisconnected}
+	connector.Installation = Installation{
+		State: InstallationStateInstalled, InstalledVersion: connector.Release.Version,
+		InstalledReleaseID: connector.Release.ReleaseID, InstalledReleaseDigest: connector.Release.ReleaseDigest,
+	}
+	return connector
+}
+
 func testManagedAuthorizedConnector(key string) Connector {
 	connector := testConnector(key)
 	connector.Release.Manifest.AuthorizationKind = "oauth2"
@@ -2481,6 +2502,7 @@ type memoryInstallRuntime struct {
 	installationCommitErr   error
 	installationErr         error
 	reconcileErrors         map[string]error
+	enabledReconcileErrors  map[string]error
 }
 
 func (host *memoryInstallRuntime) Reconcile(_ context.Context, request RuntimeReconcileRequest) (RuntimeReceipt, error) {
@@ -2488,6 +2510,11 @@ func (host *memoryInstallRuntime) Reconcile(_ context.Context, request RuntimeRe
 	host.reconcileRequests = append(host.reconcileRequests, request)
 	host.lastReconcile = request
 	host.lastCredentialGrant = string(request.CredentialBrokerGrant)
+	if request.Enabled {
+		if err := host.enabledReconcileErrors[request.Connector.Key]; err != nil {
+			return RuntimeReceipt{}, err
+		}
+	}
 	if err := host.reconcileErrors[request.Connector.Key]; err != nil {
 		return RuntimeReceipt{}, err
 	}

--- a/packages/connector/daemon/core/errors.go
+++ b/packages/connector/daemon/core/errors.go
@@ -77,3 +77,8 @@ func isRetryableError(err error) bool {
 	var domainError *DomainError
 	return errors.As(err, &domainError) && domainError.Retryable
 }
+
+func authorizationRequiredError(err error) bool {
+	var domainError *DomainError
+	return errors.As(err, &domainError) && domainError.Code == ErrorCodeAuthorizationFailed
+}

--- a/packages/connector/daemon/core/ports.go
+++ b/packages/connector/daemon/core/ports.go
@@ -277,6 +277,11 @@ type RuntimeReconcileRequest struct {
 	Connector    Connector
 	Enabled      bool
 	Generation   HostGeneration
+	// ConnectionVersion and ServerRevision identify the current account
+	// authorization generation for remote MCP route activation. They are not
+	// Agent-visible cache keys.
+	ConnectionVersion uint64
+	ServerRevision    uint64
 	// CredentialBrokerGrant is a one-shot authority passed directly to the
 	// runtime adapter. Implementations must not log or persist it.
 	CredentialBrokerGrant []byte
@@ -321,9 +326,14 @@ const (
 )
 
 type RuntimeBinding struct {
-	ConnectionID          string
-	Enabled               bool
-	AuthorizationState    AuthorizationState
+	ConnectionID       string
+	Enabled            bool
+	AuthorizationState AuthorizationState
+	// ConnectionVersion and ServerRevision are the account-authorization
+	// identity for one remote route. Runtime adapters may key in-process
+	// bootstrap evidence on them; they are not serialized into Desired.
+	ConnectionVersion     uint64
+	ServerRevision        uint64
 	CredentialBrokerGrant []byte
 }
 

--- a/packages/connector/runtime/implementationhost/host.go
+++ b/packages/connector/runtime/implementationhost/host.go
@@ -101,6 +101,7 @@ type Host struct {
 	mcpRegistry            *MCPRegistry
 	registry               *RouteRegistry
 	binDir                 string
+	remoteMCPTools         *remoteMCPToolCache
 }
 
 type connectorRoute struct {
@@ -185,6 +186,7 @@ func New(config Config) (*Host, error) {
 		mcpRegistry:            config.MCP,
 		registry:               config.Registry,
 		binDir:                 config.BinDir,
+		remoteMCPTools:         newRemoteMCPToolCache(),
 	}
 	host.authorizationProvider = newManagedCredentialAuthorizationProvider(host)
 	return host, nil
@@ -259,7 +261,7 @@ func (host *Host) Reconcile(ctx context.Context, request ReconcileRequest) (mark
 		route.executionRoot, route.installedRoot = executionRoot, installedRoot
 	}
 	if err != nil {
-		return market.RuntimeReceipt{}, err
+		return market.RuntimeReceipt{}, wrapRemoteMCPAuthorizationError(err)
 	}
 	route.displayName = runtimeRequest.Connector.Release.Manifest.DisplayName
 	route.description = runtimeRequest.Connector.Release.Manifest.Description
@@ -323,7 +325,12 @@ func (*Host) validateAuthorization(request market.RuntimeReconcileRequest) error
 			return nil
 		}
 		if request.Connector.Authorization.State != market.AuthorizationStateConnected {
-			return errors.New("authorized remote connector is not connected")
+			return market.NewDomainError(
+				market.ErrorCodeAuthorizationFailed,
+				"authorized remote connector is not connected",
+				false,
+				nil,
+			)
 		}
 		return nil
 	}
@@ -338,7 +345,12 @@ func (*Host) validateAuthorization(request market.RuntimeReconcileRequest) error
 		return errors.New("authorized connector credential broker binding is unavailable")
 	}
 	if request.Connector.Authorization.State != market.AuthorizationStateConnected {
-		return errors.New("authorized managed connector is not connected")
+		return market.NewDomainError(
+			market.ErrorCodeAuthorizationFailed,
+			"authorized managed connector is not connected",
+			false,
+			nil,
+		)
 	}
 	return nil
 }
@@ -370,6 +382,7 @@ func (host *Host) Close() error {
 		route.Fence()
 		errs = append(errs, route.Close(deadline))
 	}
+	host.remoteMCPTools.clear()
 	return errors.Join(errs...)
 }
 

--- a/packages/connector/runtime/implementationhost/mcp_authorization.go
+++ b/packages/connector/runtime/implementationhost/mcp_authorization.go
@@ -1,0 +1,43 @@
+package implementationhost
+
+import (
+	"errors"
+	"net/http"
+
+	market "github.com/tutti-os/tutti/packages/connector/daemon/core"
+	"github.com/tutti-os/tutti/packages/connector/runtime/mcp"
+)
+
+const (
+	mcpAuthorizationRequiredCode = -33001
+	mcpAuthorizationExpiredCode  = -33002
+)
+
+func wrapRemoteMCPAuthorizationError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var domain *market.DomainError
+	if errors.As(err, &domain) && domain.Code == market.ErrorCodeAuthorizationFailed {
+		return err
+	}
+	if !remoteMCPAuthorizationRequired(err) {
+		return err
+	}
+	return market.NewDomainError(
+		market.ErrorCodeAuthorizationFailed,
+		"connector authorization is required",
+		false,
+		err,
+	)
+}
+
+func remoteMCPAuthorizationRequired(err error) bool {
+	var rpcErr *mcp.RPCError
+	if errors.As(err, &rpcErr) &&
+		(rpcErr.Code == mcpAuthorizationRequiredCode || rpcErr.Code == mcpAuthorizationExpiredCode) {
+		return true
+	}
+	var httpErr *mcp.ModernHTTPError
+	return errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusPreconditionRequired
+}

--- a/packages/connector/runtime/implementationhost/mcp_authorization_test.go
+++ b/packages/connector/runtime/implementationhost/mcp_authorization_test.go
@@ -1,0 +1,31 @@
+package implementationhost
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	market "github.com/tutti-os/tutti/packages/connector/daemon/core"
+	"github.com/tutti-os/tutti/packages/connector/runtime/mcp"
+)
+
+func TestWrapRemoteMCPAuthorizationErrorMapsPreconditionRequired(t *testing.T) {
+	cause := &mcp.ModernHTTPError{
+		StatusCode: http.StatusPreconditionRequired,
+		Cause:      &mcp.RPCError{Code: -33001, Message: "authorization required"},
+	}
+	err := wrapRemoteMCPAuthorizationError(cause)
+	var domain *market.DomainError
+	if !errors.As(err, &domain) || domain.Code != market.ErrorCodeAuthorizationFailed || domain.Retryable {
+		t.Fatalf("error = %#v", err)
+	}
+}
+
+func TestWrapRemoteMCPAuthorizationErrorLeavesTransientFailures(t *testing.T) {
+	cause := &mcp.ModernHTTPError{StatusCode: http.StatusBadGateway}
+	err := wrapRemoteMCPAuthorizationError(cause)
+	var domain *market.DomainError
+	if err != cause || errors.As(err, &domain) {
+		t.Fatalf("error = %#v", err)
+	}
+}

--- a/packages/connector/runtime/implementationhost/mcp_registry.go
+++ b/packages/connector/runtime/implementationhost/mcp_registry.go
@@ -291,7 +291,8 @@ func routeMCPCaller(route *connectorRoute) mcpCaller {
 
 func (registry *MCPRegistry) observeAuthorizationError(err error) {
 	var rpcErr *connectormcp.RPCError
-	if !errors.As(err, &rpcErr) || (rpcErr.Code != -33001 && rpcErr.Code != -33002) {
+	if !errors.As(err, &rpcErr) ||
+		(rpcErr.Code != mcpAuthorizationRequiredCode && rpcErr.Code != mcpAuthorizationExpiredCode) {
 		return
 	}
 	registry.mu.RLock()

--- a/packages/connector/runtime/implementationhost/mcp_routes.go
+++ b/packages/connector/runtime/implementationhost/mcp_routes.go
@@ -33,12 +33,17 @@ func (host *Host) buildRemoteRoute(ctx context.Context, request market.RuntimeRe
 	closeClient := func() { _ = client.Close(context.Background()) }
 	if _, err := client.Call(ctx, "server/discover", map[string]any{}); err != nil {
 		closeClient()
-		return nil, fmt.Errorf("discover remote connector MCP: %w", err)
+		return nil, wrapRemoteMCPAuthorizationError(fmt.Errorf("discover remote connector MCP: %w", err))
 	}
-	tools, err := listModernMCPTools(ctx, client)
-	if err != nil {
-		closeClient()
-		return nil, err
+	cacheKey := remoteMCPToolCacheKeyFrom(request)
+	tools, cached := host.remoteMCPTools.lookup(cacheKey)
+	if !cached {
+		var err error
+		tools, err = listModernMCPTools(ctx, client)
+		if err != nil {
+			closeClient()
+			return nil, wrapRemoteMCPAuthorizationError(err)
+		}
 	}
 	for _, tool := range tools {
 		if err := client.RegisterTool(tool.Name, tool.InputSchema); err != nil {
@@ -50,6 +55,9 @@ func (host *Host) buildRemoteRoute(ctx context.Context, request market.RuntimeRe
 	if err := host.registerMCPTools(route, client, tools); err != nil {
 		closeClient()
 		return nil, err
+	}
+	if !cached {
+		host.remoteMCPTools.store(cacheKey, tools)
 	}
 	route.remoteMCP = client
 	return route, nil

--- a/packages/connector/runtime/implementationhost/remote_mcp_client_factory_test.go
+++ b/packages/connector/runtime/implementationhost/remote_mcp_client_factory_test.go
@@ -3,6 +3,8 @@ package implementationhost
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"net/http"
 	"reflect"
 	"testing"
 
@@ -24,11 +26,15 @@ type remoteMCPClientStub struct {
 	calls      []string
 	registered []string
 	closed     bool
+	listErr    error
 }
 
 func (client *remoteMCPClientStub) Call(_ context.Context, method string, _ any) (json.RawMessage, error) {
 	client.calls = append(client.calls, method)
 	if method == "tools/list" {
+		if client.listErr != nil {
+			return nil, client.listErr
+		}
 		return json.RawMessage(`{"resultType":"complete","tools":[{"name":"search","description":"Search","inputSchema":{"type":"object"}}]}`), nil
 	}
 	return json.RawMessage(`{"resultType":"complete"}`), nil
@@ -82,4 +88,125 @@ func TestBuildRemoteRouteUsesProductClientFactoryWithLifecycleIdentity(t *testin
 		t.Fatalf("remote client bootstrap = provenance:%s@%s route:%v calls:%#v registered:%#v",
 			route.connectorKey, route.connectorVersion, route.remoteMCP == client, client.calls, client.registered)
 	}
+}
+
+func TestBuildRemoteRouteReusesInProcessToolsListForSameAuthorizationIdentity(t *testing.T) {
+	client := &remoteMCPClientStub{}
+	host := &Host{
+		remoteMCPClientFactory: &remoteMCPFactoryRecorder{client: client},
+		remoteMCPTools:         newRemoteMCPToolCache(),
+	}
+	request := testRemoteMCPRouteRequest("documents", 3, 12)
+	if _, err := host.buildRemoteRoute(context.Background(), request); err != nil {
+		t.Fatal(err)
+	}
+	request.Generation.Generation++
+	if _, err := host.buildRemoteRoute(context.Background(), request); err != nil {
+		t.Fatal(err)
+	}
+	if got := countRemoteMCPCalls(client.calls, "tools/list"); got != 1 {
+		t.Fatalf("tools/list calls = %d, want 1; calls=%#v", got, client.calls)
+	}
+	if got := countRemoteMCPCalls(client.calls, "server/discover"); got != 2 {
+		t.Fatalf("server/discover calls = %d, want 2; calls=%#v", got, client.calls)
+	}
+}
+
+func TestBuildRemoteRouteReloadsToolsListWhenAuthorizationIdentityChanges(t *testing.T) {
+	client := &remoteMCPClientStub{}
+	host := &Host{
+		remoteMCPClientFactory: &remoteMCPFactoryRecorder{client: client},
+		remoteMCPTools:         newRemoteMCPToolCache(),
+	}
+	request := testRemoteMCPRouteRequest("documents", 3, 12)
+	if _, err := host.buildRemoteRoute(context.Background(), request); err != nil {
+		t.Fatal(err)
+	}
+	request.ConnectionVersion = 4
+	if _, err := host.buildRemoteRoute(context.Background(), request); err != nil {
+		t.Fatal(err)
+	}
+	if got := countRemoteMCPCalls(client.calls, "tools/list"); got != 2 {
+		t.Fatalf("tools/list calls = %d, want 2; calls=%#v", got, client.calls)
+	}
+}
+
+func TestBuildRemoteRouteDoesNotCacheAuthorizationRequiredToolsList(t *testing.T) {
+	client := &remoteMCPClientStub{listErr: &mcp.ModernHTTPError{
+		StatusCode: http.StatusPreconditionRequired,
+		Cause:      &mcp.RPCError{Code: -33001, Message: "authorization required"},
+	}}
+	host := &Host{
+		remoteMCPClientFactory: &remoteMCPFactoryRecorder{client: client},
+		remoteMCPTools:         newRemoteMCPToolCache(),
+	}
+	request := testRemoteMCPRouteRequest("gmail", 3, 12)
+	if _, err := host.buildRemoteRoute(context.Background(), request); err == nil {
+		t.Fatal("expected authorization-required tools/list to fail")
+	}
+	client.listErr = nil
+	if _, err := host.buildRemoteRoute(context.Background(), request); err != nil {
+		t.Fatal(err)
+	}
+	if got := countRemoteMCPCalls(client.calls, "tools/list"); got != 2 {
+		t.Fatalf("failed tools/list was cached: calls=%#v", client.calls)
+	}
+}
+
+func TestBuildRemoteRouteMapsAuthorizationRequired(t *testing.T) {
+	client := &remoteMCPClientStub{listErr: &mcp.ModernHTTPError{
+		StatusCode: http.StatusPreconditionRequired,
+		Cause:      &mcp.RPCError{Code: -33001, Message: "authorization required"},
+	}}
+	host := &Host{remoteMCPClientFactory: &remoteMCPFactoryRecorder{client: client}}
+	implementation := market.RemoteStreamableHTTPImplementation{
+		ProtocolVersion: mcp.ModernProtocolVersion, BindingRef: "gmail.primary", ContractVersion: 1,
+		BindingContractHash: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+	}
+	_, err := host.buildRemoteRoute(context.Background(), market.RuntimeReconcileRequest{
+		OperationID: "operation-1", ConnectionID: "connection-1", Scope: market.OperationScope{AccountID: "account-1"},
+		Connector: market.Connector{Key: "gmail", Release: market.Release{
+			Version: "0.1.3", ReleaseDigest: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+			Manifest: market.Manifest{Implementation: market.Implementation{
+				Kind: market.ImplementationKindRemoteStreamableHTTP, RemoteStreamableHTTP: &implementation,
+			}},
+		}},
+		Generation: market.HostGeneration{BootEpoch: "boot-1", Generation: 1},
+	})
+	var domain *market.DomainError
+	if !errors.As(err, &domain) || domain.Code != market.ErrorCodeAuthorizationFailed || domain.Retryable {
+		t.Fatalf("buildRemoteRoute error = %#v", err)
+	}
+	if !client.closed {
+		t.Fatal("authorization-required discover/list left the remote MCP client open")
+	}
+}
+
+func testRemoteMCPRouteRequest(connectorKey string, connectionVersion, serverRevision uint64) market.RuntimeReconcileRequest {
+	implementation := market.RemoteStreamableHTTPImplementation{
+		ProtocolVersion: mcp.ModernProtocolVersion, BindingRef: connectorKey + ".primary", ContractVersion: 1,
+		BindingContractHash: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+	}
+	return market.RuntimeReconcileRequest{
+		OperationID: "operation-1", ConnectionID: "connection-1", Scope: market.OperationScope{AccountID: "account-1"},
+		Connector: market.Connector{Key: connectorKey, Release: market.Release{
+			Version: "1.2.3", ReleaseDigest: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+			Manifest: market.Manifest{Implementation: market.Implementation{
+				Kind: market.ImplementationKindRemoteStreamableHTTP, RemoteStreamableHTTP: &implementation,
+			}},
+		}},
+		Generation:        market.HostGeneration{BootEpoch: "boot-1", Generation: 1},
+		ConnectionVersion: connectionVersion,
+		ServerRevision:    serverRevision,
+	}
+}
+
+func countRemoteMCPCalls(calls []string, method string) int {
+	count := 0
+	for _, call := range calls {
+		if call == method {
+			count++
+		}
+	}
+	return count
 }

--- a/packages/connector/runtime/implementationhost/remote_mcp_tool_cache.go
+++ b/packages/connector/runtime/implementationhost/remote_mcp_tool_cache.go
@@ -1,0 +1,87 @@
+package implementationhost
+
+import (
+	"strings"
+	"sync"
+
+	market "github.com/tutti-os/tutti/packages/connector/daemon/core"
+)
+
+// remoteMCPToolCache keeps successful route-activation tools/list results in
+// process memory. It is not Agent-visible truth and has no TTL; identity
+// changes miss, and the Host drops the table on Close.
+type remoteMCPToolCache struct {
+	mu    sync.RWMutex
+	tools map[remoteMCPToolCacheKey][]mcpTool
+}
+
+type remoteMCPToolCacheKey struct {
+	accountID         string
+	connectorKey      string
+	releaseDigest     string
+	connectionID      string
+	connectionVersion uint64
+	serverRevision    uint64
+}
+
+func newRemoteMCPToolCache() *remoteMCPToolCache {
+	return &remoteMCPToolCache{tools: make(map[remoteMCPToolCacheKey][]mcpTool)}
+}
+
+func remoteMCPToolCacheKeyFrom(request market.RuntimeReconcileRequest) remoteMCPToolCacheKey {
+	return remoteMCPToolCacheKey{
+		accountID:         strings.TrimSpace(request.Scope.AccountID),
+		connectorKey:      strings.TrimSpace(request.Connector.Key),
+		releaseDigest:     strings.TrimSpace(request.Connector.Release.ReleaseDigest),
+		connectionID:      strings.TrimSpace(request.ConnectionID),
+		connectionVersion: request.ConnectionVersion,
+		serverRevision:    request.ServerRevision,
+	}
+}
+
+func (key remoteMCPToolCacheKey) complete() bool {
+	return key.accountID != "" && key.connectorKey != "" && key.releaseDigest != "" && key.connectionID != ""
+}
+
+func (cache *remoteMCPToolCache) lookup(key remoteMCPToolCacheKey) ([]mcpTool, bool) {
+	if cache == nil || !key.complete() {
+		return nil, false
+	}
+	cache.mu.RLock()
+	defer cache.mu.RUnlock()
+	tools, ok := cache.tools[key]
+	if !ok {
+		return nil, false
+	}
+	return cloneMCPTools(tools), true
+}
+
+func (cache *remoteMCPToolCache) store(key remoteMCPToolCacheKey, tools []mcpTool) {
+	if cache == nil || !key.complete() || len(tools) == 0 {
+		return
+	}
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	cache.tools[key] = cloneMCPTools(tools)
+}
+
+func (cache *remoteMCPToolCache) clear() {
+	if cache == nil {
+		return
+	}
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	cache.tools = make(map[remoteMCPToolCacheKey][]mcpTool)
+}
+
+func cloneMCPTools(tools []mcpTool) []mcpTool {
+	cloned := make([]mcpTool, len(tools))
+	for index, tool := range tools {
+		cloned[index] = mcpTool{
+			Name:        tool.Name,
+			Description: tool.Description,
+			InputSchema: cloneJSONMap(tool.InputSchema),
+		}
+	}
+	return cloned
+}


### PR DESCRIPTION
## Summary

Composer “install” on OAuth remote connectors (for example Gmail) stayed spinning because enabled runtime reconcile treated Gateway HTTP `428` / JSON-RPC `-33001`/`-33002` as retryable install failure. Install is a device fact; it should complete with an inactive route and let the user authorize next.

The same remote route builder also called `tools/list` on every generation rebuild. Same-boot Bootstrap was paying that cost repeatedly even when the account authorization identity had not changed.

This change maps authorization-required MCP errors to a non-retryable domain error, persists an expired projection, and replans `RuntimeDesired` as disabled so `awaitRuntimeDesired` can finish. Route activation may reuse an in-process `tools/list` for the same account, connector, release digest, connection id, `connectionVersion`, and `serverRevision`. `server/discover` still runs every time. Agent-visible `tools/list` / `tools/call` stay live. Empty, invalid, and authorization-required lists are not cached, and the table is dropped on `Host.Close`.

## Verification

- `TestInstallCompletesWhenEnabledRuntimeRequiresAuthorization` and `TestRuntimeConvergenceAuthorizationRequiredReplansInactiveRuntime` complete install/convergence with an inactive desired generation after 428.
- `TestBuildRemoteRouteReusesInProcessToolsListForSameAuthorizationIdentity` keeps a second same-identity activation to one `tools/list` and two `server/discover` calls.
- Skipping cache lookup makes that reuse test fail (`tools/list` count becomes 2).
- Identity change and 428-then-success both force a fresh `tools/list`.
- `pnpm check:changed -- --push-ready` passed locally before push.

## Fallback Three Questions

- Source: route-activation `tools/list` during same-boot generation rebuilds, and HTTP 428 during an enabled install/reconcile before the user has authorized.
- Why can it not be fixed at that source: Agent-visible tool lists must stay live against the current Connection. Route activation still needs a successful tool contract to register the route, and Gateway 428 is a valid pre-authorization observation, not a missing local cache.
- Removal condition: delete the memory table if route activation no longer needs `tools/list`, or if Bootstrap stops rebuilding routes that already hold that contract. Delete the 428 replan if install no longer waits on enabled runtime convergence.

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

Made with [Cursor](https://cursor.com)