### PR TITLE
Fix missing stable desktop changelog entries

### DIFF
--- a/.github/workflows/desktop-release-changelog-repair.yml
+++ b/.github/workflows/desktop-release-changelog-repair.yml
@@ -1,0 +1,178 @@
+name: Repair Desktop Release Changelog
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Published stable GitHub release tag to restore, such as v0.2.27
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: desktop-release-promotion
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  repair:
+    name: Restore Stable Changelog Entry
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      TUTTI_ARTIFACTS_AWS_ROLE_ARN: ${{ vars.TUTTI_ARTIFACTS_AWS_ROLE_ARN }}
+      TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET }}
+      TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX }}
+
+    steps:
+      - name: Checkout release tooling
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+
+      - name: Validate published stable release
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          release_tag="${INPUT_RELEASE_TAG}"
+          if [[ ! "${release_tag}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "release_tag must identify a stable vX.Y.Z release." >&2
+            exit 1
+          fi
+
+          gh release view "${release_tag}" \
+            --json assets,isDraft,isPrerelease,tagName,targetCommitish > release.json
+          if [[ "$(jq -r .tagName release.json)" != "${release_tag}" ]]; then
+            echo "GitHub release tag does not match ${release_tag}." >&2
+            exit 1
+          fi
+          if [[ "$(jq -r .isDraft release.json)" != "false" || "$(jq -r .isPrerelease release.json)" != "false" ]]; then
+            echo "Only a published stable GitHub release can repair the public changelog." >&2
+            exit 1
+          fi
+          if ! jq -e '.assets[] | select(.name == "release-summary.json")' release.json >/dev/null; then
+            echo "GitHub release ${release_tag} is missing release-summary.json." >&2
+            exit 1
+          fi
+          if ! jq -e '.assets[] | select(.name == "SHA256SUMS.txt")' release.json >/dev/null; then
+            echo "GitHub release ${release_tag} is missing SHA256SUMS.txt." >&2
+            exit 1
+          fi
+
+          git fetch --force origin "refs/tags/${release_tag}:refs/tags/${release_tag}"
+          release_target="$(git rev-list -n 1 "${release_tag}")"
+          echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
+          echo "release_target=${release_target}" >> "$GITHUB_OUTPUT"
+
+      - name: Download staged release summary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.release.outputs.release_tag }}
+        run: |
+          mkdir -p release-assets
+          gh release download "${RELEASE_TAG}" \
+            --pattern release-summary.json \
+            --pattern SHA256SUMS.txt \
+            --dir release-assets
+
+      - name: Verify staged release summary checksum
+        run: |
+          cd release-assets
+          grep -E '^[0-9a-f]{64}  release-summary\.json$' SHA256SUMS.txt | sha256sum --check --strict
+
+      - name: Validate staged release summary
+        env:
+          RELEASE_CHANNEL: stable
+          RELEASE_TAG: ${{ steps.release.outputs.release_tag }}
+          RELEASE_TARGET: ${{ steps.release.outputs.release_target }}
+        run: node apps/desktop/scripts/validate-release-summary.mjs release-assets/release-summary.json
+
+      - name: Install AWS CLI
+        run: |
+          if ! command -v aws >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends unzip
+            case "$(uname -m)" in
+              x86_64) awscli_arch="x86_64" ;;
+              aarch64|arm64) awscli_arch="aarch64" ;;
+              *)
+                echo "Unsupported architecture for AWS CLI installer: $(uname -m)" >&2
+                exit 1
+                ;;
+            esac
+            curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${awscli_arch}.zip" -o /tmp/awscliv2.zip
+            unzip -q /tmp/awscliv2.zip -d /tmp
+            sudo /tmp/aws/install --update
+          fi
+          aws --version
+
+      - name: Validate AWS S3 release asset configuration
+        run: |
+          missing=()
+          for name in AWS_REGION TUTTI_ARTIFACTS_AWS_ROLE_ARN TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("$name")
+            fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            echo "Missing required AWS S3 release asset configuration: ${missing[*]}" >&2
+            exit 1
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.TUTTI_ARTIFACTS_AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Repair stable changelog metadata
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.release_tag }}
+        run: |
+          prefix="${TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX%/}"
+          changelog_uri="s3://${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}/${prefix}/changelog.json"
+          aws s3 cp "${changelog_uri}" existing-changelog.json
+          node apps/desktop/scripts/upsert-release-changelog.mjs \
+            existing-changelog.json \
+            release-assets/release-summary.json \
+            changelog.json
+          node - <<'NODE'
+          const fs = require("node:fs");
+          const before = JSON.parse(fs.readFileSync("existing-changelog.json", "utf8"));
+          const after = JSON.parse(fs.readFileSync("changelog.json", "utf8"));
+          const releaseTag = process.env.RELEASE_TAG;
+          const existingTags = new Set(before.entries.map((entry) => entry.tag));
+          const repairedEntries = after.entries.filter((entry) => entry.tag === releaseTag);
+          if (repairedEntries.length !== 1) {
+            throw new Error(`Expected exactly one repaired ${releaseTag} changelog entry.`);
+          }
+          for (const tag of existingTags) {
+            if (!after.entries.some((entry) => entry.tag === tag)) {
+              throw new Error(`Repair removed existing changelog entry ${tag}.`);
+            }
+          }
+          const expectedCount = before.entries.length + (existingTags.has(releaseTag) ? 0 : 1);
+          if (after.entries.length !== expectedCount) {
+            throw new Error(`Expected ${expectedCount} changelog entries after repair, found ${after.entries.length}.`);
+          }
+          NODE
+          aws s3 cp changelog.json "${changelog_uri}" \
+            --content-type "application/json" \
+            --cache-control "public, max-age=60"
+
+      - name: Verify repaired changelog metadata
+        run: |
+          prefix="${TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX%/}"
+          changelog_uri="s3://${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}/${prefix}/changelog.json"
+          aws s3 cp "${changelog_uri}" published-changelog.json
+          cmp changelog.json published-changelog.json

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -419,6 +419,14 @@ https://<asset-base-url>/changelog.json
 
 `changelog.json` is updated only for stable releases. RC and beta builds can still generate per-run summaries for Feishu and GitHub Release notes, but they should not appear on the public changelog feed unless that policy is changed explicitly.
 
+If a published stable release is missing from the aggregate feed, use the
+manual `Repair Desktop Release Changelog` workflow with that exact stable tag.
+The repair reads the checksummed `release-summary.json` attached to the
+published GitHub Release, validates that its tag and target commit still match,
+and upserts only that entry under the same `desktop-release-promotion`
+concurrency lock used by normal promotion. It must not republish the GitHub
+Release, upload immutable installers, or move any stable/RC/beta pointer.
+
 ## Draft Promotion
 
 External publication is owned by `.github/workflows/desktop-release-promote.yml`. RC and beta builds may call it automatically. A stable candidate must be submitted manually from the Feishu link and then pass the `desktop-stable-release` GitHub Environment approval.

--- a/docs/conventions/troubleshooting/desktop-release.md
+++ b/docs/conventions/troubleshooting/desktop-release.md
@@ -2,6 +2,37 @@
 
 [Back to troubleshooting index](./README.md)
 
+### A published stable release is missing from the public changelog
+
+- Symptom:
+  The stable GitHub Release and its installers are public, but
+  `https://tutti.sh/changelog` skips that version and the aggregate
+  `changelog.json` does not contain its tag.
+- Quick checks:
+  Inspect the public `changelog.json`, then confirm the GitHub Release is a
+  published non-prerelease with a `release-summary.json` asset. Check the
+  original promotion run's `Update stable changelog metadata` step and any
+  later release or recovery runs that rewrote the mutable aggregate.
+- Root cause:
+  The public page renders the release-owned aggregate rather than deriving
+  entries from GitHub on each request. If that mutable aggregate loses an
+  entry, later releases preserve the incomplete baseline even though the
+  missing release and its immutable summary remain valid.
+- Fix:
+  Run `Repair Desktop Release Changelog` with the exact missing stable tag.
+  The workflow validates the published release and summary, preserves every
+  existing entry, and upserts the missing summary without moving release
+  pointers or republishing assets. Do not rerun promotion for an older stable
+  tag because its rollback guard correctly rejects moving the public channel
+  behind the current release.
+- Validation:
+  Confirm the workflow's S3 round-trip verification passes, then verify the
+  public aggregate and `https://tutti.sh/changelog` both contain the restored
+  version after the configured cache window.
+- References:
+  [.github/workflows/desktop-release-changelog-repair.yml](../../../.github/workflows/desktop-release-changelog-repair.yml)
+  [upsert-release-changelog.mjs](../../../apps/desktop/scripts/upsert-release-changelog.mjs)
+
 ### Packaged Tutti starts but external shells cannot find `tutti`
 
 - Symptom:

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -16,6 +16,10 @@ const promoteWorkflowPath = new URL(
   "../../.github/workflows/desktop-release-promote.yml",
   import.meta.url
 );
+const changelogRepairWorkflowPath = new URL(
+  "../../.github/workflows/desktop-release-changelog-repair.yml",
+  import.meta.url
+);
 const buildScriptPath = new URL(
   "../../tools/scripts/build-desktop-package.sh",
   import.meta.url
@@ -730,6 +734,40 @@ test("desktop release workflow generates summaries and stable changelog metadata
     releaseWorkflows,
     /RELEASE_SUMMARY_PATH:\s+release-summary\/release-summary\.json/
   );
+});
+
+test("desktop changelog repair restores one published stable summary without moving release pointers", async () => {
+  const repairWorkflow = await readFile(changelogRepairWorkflowPath, "utf8");
+
+  assert.match(repairWorkflow, /workflow_dispatch:/);
+  assert.match(repairWorkflow, /release_tag:/);
+  assert.match(
+    repairWorkflow,
+    /permissions:\s*\n\s*contents:\s*read\s*\n\s*id-token:\s*write/
+  );
+  assert.match(repairWorkflow, /group:\s*desktop-release-promotion/);
+  assert.match(
+    repairWorkflow,
+    /\^v\(0\|\[1-9\]\[0-9\]\*\)\\\.\(0\|\[1-9\]\[0-9\]\*\)\\\.\(0\|\[1-9\]\[0-9\]\*\)\$/
+  );
+  assert.match(repairWorkflow, /isDraft/);
+  assert.match(repairWorkflow, /isPrerelease/);
+  assert.match(repairWorkflow, /--pattern release-summary\.json/);
+  assert.match(repairWorkflow, /--pattern SHA256SUMS\.txt/);
+  assert.match(repairWorkflow, /sha256sum --check --strict/);
+  assert.match(
+    repairWorkflow,
+    /apps\/desktop\/scripts\/validate-release-summary\.mjs/
+  );
+  assert.match(
+    repairWorkflow,
+    /apps\/desktop\/scripts\/upsert-release-changelog\.mjs/
+  );
+  assert.match(repairWorkflow, /Repair removed existing changelog entry/);
+  assert.match(repairWorkflow, /cmp changelog\.json published-changelog\.json/);
+  assert.doesNotMatch(repairWorkflow, /latest\.json/);
+  assert.doesNotMatch(repairWorkflow, /gh release edit/);
+  assert.doesNotMatch(repairWorkflow, /aws s3 sync/);
 });
 
 test("desktop promotion consumes the checksummed summary staged with the draft", async () => {


### PR DESCRIPTION
## 背景

官网 changelog 的发布数据源缺少已发布的稳定版 v0.2.27。旧稳定版不能安全重跑完整 promotion，因为版本回退保护会阻止它覆盖当前 v0.2.28 指针。

## 改动

- 新增手动 `Repair Desktop Release Changelog` 工作流
- 仅接受已发布、非 prerelease 的稳定版 SemVer tag
- 下载并校验 Release 附带的 `release-summary.json` 与 `SHA256SUMS.txt`
- 在 `desktop-release-promotion` 并发锁下只 upsert `changelog.json`
- 验证既有条目未丢失，并从 S3 回读比对发布结果
- 明确禁止该工作流移动 latest 指针、重发 Release 或同步安装包
- 补充发布规范、排障文档和防回归测试

## 验证

- `node --test tools/scripts/desktop-release-config.test.mjs`（49/49）
- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready`

## Windows 影响

无平台运行时影响；改动仅涉及 GitHub Actions 中的发布元数据修复。