### PR TITLE
fix(release): keep promotion links canonical

### DIFF
--- a/.github/workflows/desktop-release-promote.yml
+++ b/.github/workflows/desktop-release-promote.yml
@@ -72,7 +72,6 @@ jobs:
       release_prerelease: ${{ steps.release.outputs.release_prerelease }}
       release_tag: ${{ steps.release.outputs.release_tag }}
       release_target: ${{ steps.release.outputs.release_target }}
-      release_url: ${{ steps.release.outputs.release_url }}
       release_version: ${{ steps.release.outputs.release_version }}
       source_ref: ${{ steps.release.outputs.source_ref }}
 
@@ -199,7 +198,6 @@ jobs:
             fi
           fi
 
-          release_url="$(jq -r .html_url release.json)"
           echo "approval_digest=${approval_digest}" >> "$GITHUB_OUTPUT"
           echo "release_already_published=${release_already_published}" >> "$GITHUB_OUTPUT"
           echo "release_candidate_id=${release_candidate_id}" >> "$GITHUB_OUTPUT"
@@ -210,7 +208,6 @@ jobs:
           echo "release_prerelease=${release_prerelease}" >> "$GITHUB_OUTPUT"
           echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
           echo "release_target=${release_target}" >> "$GITHUB_OUTPUT"
-          echo "release_url=${release_url}" >> "$GITHUB_OUTPUT"
           echo "release_version=${release_version}" >> "$GITHUB_OUTPUT"
           echo "source_ref=${source_ref}" >> "$GITHUB_OUTPUT"
 
@@ -230,7 +227,7 @@ jobs:
     if: ${{ always() && needs.resolve.result == 'success' && (needs.approve-stable.result == 'success' || needs.approve-stable.result == 'skipped') }}
     runs-on: ubuntu-latest
     outputs:
-      release_url: ${{ needs.resolve.outputs.release_url }}
+      release_url: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ needs.resolve.outputs.release_tag }}
     env:
       AWS_REGION: ${{ vars.AWS_REGION }}
       TUTTI_ARTIFACTS_AWS_ROLE_ARN: ${{ vars.TUTTI_ARTIFACTS_AWS_ROLE_ARN }}

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -612,6 +612,27 @@ test("desktop promotion notification tolerates skipped optional approval", async
   assert.match(notifyJob, /needs\.promote\.result\s*==\s*'success'/);
 });
 
+test("desktop promotion sends the canonical tag URL instead of a transient draft URL", async () => {
+  const promoteWorkflow = await readFile(promoteWorkflowPath, "utf8");
+
+  assert.match(
+    promoteWorkflow,
+    /release_url:\s+\${{\s*github\.server_url\s*}}\/\${{\s*github\.repository\s*}}\/releases\/tag\/\${{\s*needs\.resolve\.outputs\.release_tag\s*}}/
+  );
+  assert.doesNotMatch(
+    promoteWorkflow,
+    /release_url="\$\(jq -r \.html_url release\.json\)"/
+  );
+  assert.doesNotMatch(
+    promoteWorkflow,
+    /release_url:\s+\${{\s*needs\.resolve\.outputs\.release_url\s*}}/
+  );
+  assert.match(
+    promoteWorkflow,
+    /RELEASE_URL:\s+\${{\s*needs\.promote\.outputs\.release_url\s*}}/
+  );
+});
+
 test("desktop release workflow can mirror release assets to S3 and upsert direct download links", async () => {
   const workflow = await readFile(workflowPath, "utf8");
   const promoteWorkflow = await readFile(promoteWorkflowPath, "utf8");


### PR DESCRIPTION
## Summary
- stop carrying the transient Draft Release `html_url` through promotion outputs
- construct the notification URL from the repository and final release tag
- add a regression check that rejects the old `untagged-*` output path

## Root cause
The reviewed stable promotion captured `.html_url` while the release was still a draft. GitHub returned an `untagged-*` URL, which became invalid after the draft was attached to the stable tag and published.

## Test evidence
- Protected contract or prior failure: formal release cards must link to `/releases/tag/<tag>`, never the transient draft URL
- Credible faulty implementation / negative control: the new test failed against the pre-fix `.html_url` and `needs.resolve.outputs.release_url` wiring
- Existing coverage gap: staging covered canonical candidate URLs, but promotion notification output was not protected
- Owning seam and test level: release workflow repository contract test
- Observable outcomes and important non-effects: canonical URL is exported; transient draft URL is absent; notification still consumes the promote output
- Blocking lane: `pnpm check:changed` and pre-push `pnpm check:changed -- --push-ready` (5/5 lanes)
- Platform impact: platform-neutral GitHub Actions expression; no Windows/POSIX behavior difference

## Documentation impact
No durable documentation change is required; this restores the documented release-link behavior.