### PR TITLE
fix(connector): keep token input after authorize

### DIFF
--- a/docs/architecture/connector.md
+++ b/docs/architecture/connector.md
@@ -657,9 +657,13 @@ open it.
 
 Connector details are represented by one modal state machine, never by a fixed
 right-hand pane. An uninstalled connector opens an installation confirmation.
-An unconnected installed connector opens the authorization dialog; an
-authorized connector opens the management dialog. Blocked releases open the
-blocked-state dialog. Only one dialog host is mounted at a time, so
+An unconnected installed connector opens the authorization dialog. The token
+form keeps typed secrets after submit so a failed or in-flight attempt does
+not force the user to re-enter them. Completing authorization in that dialog
+keeps the modal open and advances it to the management dialog, where
+disconnect and try remain available. An already authorized connector opens
+the management dialog directly. Blocked releases
+open the blocked-state dialog. Only one dialog host is mounted at a time, so
 the catalog keeps the full settings content width and never leaves an empty
 right column.
 

--- a/packages/connector/renderer/src/application/services/view/connectorMarketViewBuilder.test.ts
+++ b/packages/connector/renderer/src/application/services/view/connectorMarketViewBuilder.test.ts
@@ -186,6 +186,18 @@ test("keeps connector details open through installation and advances to authoriz
       : undefined,
     "https://work.weixin.qq.com/ai/qc/c?s=opaque"
   );
+
+  delete market.pendingAuthorizationsByConnectorKey[connector.key];
+  delete market.authorizingConnectorKeys[connector.key];
+  delete market.authorizationViewsByConnectorKey[connector.key];
+  connector.authorization = { state: "connected" };
+  market.connectorsByKey[connector.key] = connector;
+  const connected = buildConnectorMarketView(market, dialogState).dialog;
+  assert.equal(connected?.kind, "management");
+  assert.equal(
+    connected?.kind === "management" && connected.canAuthorize,
+    true
+  );
 });
 
 test("preserves the connector authorization interaction for the dialog", () => {

--- a/packages/connector/renderer/src/ui/authorization/AuthorizationViewRenderer.spec.tsx
+++ b/packages/connector/renderer/src/ui/authorization/AuthorizationViewRenderer.spec.tsx
@@ -1,0 +1,61 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthorizationViewEnvelopeV1 } from "@tutti-os/connector-contracts/authorization/v1";
+
+import { DefaultAuthorizationViewRenderer } from "./AuthorizationViewRenderer.tsx";
+
+afterEach(cleanup);
+
+const labels = {
+  activate: "Continue",
+  cancel: "Cancel",
+  qrCodeAlt: "Authorization QR code",
+  refresh: "Refresh",
+  retry: "Retry",
+  submit: "Authorize",
+  unsupportedField: "Unsupported"
+};
+
+const secretFormView: AuthorizationViewEnvelopeV1 = {
+  protocol: "tutti.connector.authorization.view.v1",
+  viewId: "form-1",
+  view: {
+    type: "form",
+    fields: [
+      {
+        type: "secret",
+        name: "secret",
+        label: "Access token",
+        placeholder: "Paste token",
+        required: true
+      }
+    ]
+  }
+};
+
+describe("DefaultAuthorizationViewRenderer", () => {
+  it("keeps the typed secret after authorize so a failed attempt can retry", () => {
+    const onEvent = vi.fn();
+    render(
+      <DefaultAuthorizationViewRenderer
+        busy={false}
+        labels={labels}
+        view={secretFormView}
+        onEvent={onEvent}
+      />
+    );
+
+    const input = screen.getByLabelText(/Access token/);
+    fireEvent.change(input, { target: { value: "pat_keep_me" } });
+    fireEvent.click(screen.getByRole("button", { name: "Authorize" }));
+
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent.mock.calls[0]?.[0]).toMatchObject({
+      viewId: "form-1",
+      event: { type: "submit", values: { secret: "pat_keep_me" } }
+    });
+    expect(screen.getByLabelText(/Access token/)).toHaveValue("pat_keep_me");
+  });
+});

--- a/packages/connector/renderer/src/ui/authorization/AuthorizationViewRenderer.tsx
+++ b/packages/connector/renderer/src/ui/authorization/AuthorizationViewRenderer.tsx
@@ -188,9 +188,7 @@ function AuthorizationFormRenderer({
   const submit = (event: FormEvent) => {
     event.preventDefault();
     if (canSubmit) {
-      const submitEvent = createAuthorizationSubmitEvent(view.viewId, values);
-      setValues(initialFormValues(view.view.fields));
-      onEvent(submitEvent);
+      onEvent(createAuthorizationSubmitEvent(view.viewId, values));
     }
   };
 

--- a/packages/connector/renderer/src/ui/dialogs/ConnectorMarketDialogs.spec.tsx
+++ b/packages/connector/renderer/src/ui/dialogs/ConnectorMarketDialogs.spec.tsx
@@ -1,0 +1,112 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { proxy } from "valtio";
+
+import type { IConnectorMarketRoot } from "../../application/services/core/connectorMarketRoot.interface.ts";
+import type {
+  ConnectorAuthorizationDialogView,
+  ConnectorManagementDialogView,
+  ConnectorMarketViewState
+} from "../../application/services/view/connectorMarketViewTypes.ts";
+import { ConnectorMarketRootProvider } from "../ConnectorMarketServicesContext.tsx";
+import type { ConnectorMarketI18nRuntime } from "../i18n/connectorMarketI18n.ts";
+import { ConnectorMarketDialogs } from "./ConnectorMarketDialogs.tsx";
+
+afterEach(cleanup);
+
+const i18n = {
+  has: () => true,
+  t: (key: string) => key,
+  tFirst: (keys: readonly string[]) => keys[0] ?? ""
+} as ConnectorMarketI18nRuntime;
+
+const authorizationDialog: ConnectorAuthorizationDialogView = {
+  authorizationKind: "oauth2",
+  authorizing: false,
+  brokeredAuthorization: false,
+  connectorKey: "gmail",
+  description: "Gmail tools",
+  displayName: "Gmail",
+  iconUrl: "/gmail.png",
+  kind: "authorization",
+  pending: false,
+  permissions: []
+};
+
+const managementDialog: ConnectorManagementDialogView = {
+  canAuthorize: true,
+  canUninstall: true,
+  connectorKey: "gmail",
+  description: "Gmail tools",
+  details: [],
+  displayName: "Gmail",
+  iconUrl: "/gmail.png",
+  kind: "management",
+  permissions: []
+};
+
+function emptyView(
+  dialog: ConnectorMarketViewState["dialog"]
+): ConnectorMarketViewState {
+  return {
+    cardsByKey: {},
+    catalogError: null,
+    dialog,
+    refreshing: false,
+    sections: [],
+    status: "ready"
+  };
+}
+
+describe("ConnectorMarketDialogs", () => {
+  it("keeps the dialog open after authorization so disconnect and try stay available", async () => {
+    const viewState = proxy(emptyView(authorizationDialog));
+    const closeDialog = vi.fn();
+    const onTryConnector = vi.fn();
+    const root = {
+      market: {
+        beginAuthorization: vi.fn(async () => {
+          viewState.dialog = managementDialog;
+        }),
+        dataStore: proxy({
+          pendingUninstallNotificationsByOperationId: {}
+        })
+      },
+      uiState: {
+        closeDialog,
+        dataStore: proxy({
+          dialog: { connectorKey: "gmail", kind: "connector" },
+          query: "",
+          scope: {},
+          started: true
+        })
+      },
+      view: { dataStore: viewState }
+    } as unknown as IConnectorMarketRoot;
+
+    render(
+      <ConnectorMarketRootProvider
+        i18n={i18n}
+        onTryConnector={onTryConnector}
+        root={root}
+      >
+        <ConnectorMarketDialogs />
+      </ConnectorMarketRootProvider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "actionAuthorize" }));
+
+    expect(
+      await screen.findByRole("button", { name: "actionTry" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "actionDisconnect" })
+    ).toBeInTheDocument();
+    expect(closeDialog).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "actionTry" }));
+    expect(closeDialog).toHaveBeenCalledTimes(1);
+    expect(onTryConnector).toHaveBeenCalledWith("gmail");
+  });
+});

--- a/packages/connector/renderer/src/ui/dialogs/ConnectorMarketDialogs.tsx
+++ b/packages/connector/renderer/src/ui/dialogs/ConnectorMarketDialogs.tsx
@@ -48,7 +48,6 @@ export function ConnectorMarketDialogs() {
         .beginAuthorization(connectorKey, secret)
         .then(() => {
           setShowSuccessToast("authorize");
-          uiState.closeDialog();
         })
         .catch((error: unknown) => {
           if (
@@ -71,7 +70,7 @@ export function ConnectorMarketDialogs() {
           }
         });
     },
-    [i18n, market, onError, uiState]
+    [i18n, market, onError]
   );
 
   useEffect(() => {
@@ -112,7 +111,7 @@ export function ConnectorMarketDialogs() {
   // Hide management dialog when showing success toast
   const shouldHideDialog =
     dialog?.kind === "management" &&
-    Boolean(showSuccessToast || uninstallSuccess);
+    (showSuccessToast === "install" || Boolean(uninstallSuccess));
 
   const cancelAuthorizationDialog = () => {
     if (dialog?.kind !== "authorization") {


### PR DESCRIPTION
## Summary

Clicking Authorize on a connector token form immediately cleared the secret field. A failed or still-running attempt then forced the user to paste the token again.

Keep the typed secret after submit, and leave the connector modal open on the management view after a successful authorization so disconnect and try remain available.

## Verification

- Reproduced on the authorization form: submitting a token emptied the Access token input while the submit event still carried the secret.
- After the fix, the same submit keeps the typed token in the input and still emits the submit event.
- Added `AuthorizationViewRenderer.spec.tsx` for secret preservation and `ConnectorMarketDialogs.spec.tsx` for the post-success management dialog.

## Checklist

- [ ] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.


Made with [Cursor](https://cursor.com)