### PR TITLE
Fix changelog repairs to use reviewed release notes

### DIFF
--- a/.github/workflows/desktop-release-changelog-repair.yml
+++ b/.github/workflows/desktop-release-changelog-repair.yml
@@ -97,6 +97,19 @@ jobs:
           RELEASE_TARGET: ${{ steps.release.outputs.release_target }}
         run: node apps/desktop/scripts/validate-release-summary.mjs release-assets/release-summary.json
 
+      - name: Build approved summary from current release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_CHANNEL: stable
+          RELEASE_TAG: ${{ steps.release.outputs.release_tag }}
+          RELEASE_TARGET: ${{ steps.release.outputs.release_target }}
+        run: |
+          gh release view "${RELEASE_TAG}" --json body --jq .body > approved-release-body.md
+          node apps/desktop/scripts/extract-approved-release-summary.mjs \
+            approved-release-body.md \
+            release-assets/release-summary.json \
+            approved-release-summary.json
+
       - name: Install AWS CLI
         run: |
           if ! command -v aws >/dev/null 2>&1; then
@@ -144,7 +157,7 @@ jobs:
           aws s3 cp "${changelog_uri}" existing-changelog.json
           node apps/desktop/scripts/upsert-release-changelog.mjs \
             existing-changelog.json \
-            release-assets/release-summary.json \
+            approved-release-summary.json \
             changelog.json
           node - <<'NODE'
           const fs = require("node:fs");

--- a/apps/desktop/scripts/upsert-release-summary.mjs
+++ b/apps/desktop/scripts/upsert-release-summary.mjs
@@ -112,8 +112,13 @@ function parseLocaleSection(sectionBody, title, nextTitle = null) {
     if (line.startsWith("#### ")) {
       current = { title: line.slice(5).trim(), items: [] };
       sections.push(current);
-    } else if (line.startsWith("- ") && current) {
-      current.items.push(line.slice(2).trim());
+    } else if (
+      current &&
+      line &&
+      !line.startsWith("#") &&
+      !line.startsWith("<!--")
+    ) {
+      current.items.push(line.startsWith("- ") ? line.slice(2).trim() : line);
     }
   }
   const validSections = sections.filter(

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -421,11 +421,14 @@ https://<asset-base-url>/changelog.json
 
 If a published stable release is missing from the aggregate feed, use the
 manual `Repair Desktop Release Changelog` workflow with that exact stable tag.
-The repair reads the checksummed `release-summary.json` attached to the
-published GitHub Release, validates that its tag and target commit still match,
-and upserts only that entry under the same `desktop-release-promotion`
-concurrency lock used by normal promotion. It must not republish the GitHub
-Release, upload immutable installers, or move any stable/RC/beta pointer.
+The repair validates the checksummed `release-summary.json` attached to the
+published GitHub Release for its tag, target commit, and comparison metadata,
+then rebuilds the public summary from the current human-reviewed Release Notes
+section. This keeps later editorial corrections authoritative without mutating
+the staged candidate asset. It upserts only that entry under the same
+`desktop-release-promotion` concurrency lock used by normal promotion and must
+not republish the GitHub Release, upload immutable installers, or move any
+stable/RC/beta pointer.
 
 ## Draft Promotion
 

--- a/docs/conventions/troubleshooting/desktop-release.md
+++ b/docs/conventions/troubleshooting/desktop-release.md
@@ -20,11 +20,12 @@
   missing release and its immutable summary remain valid.
 - Fix:
   Run `Repair Desktop Release Changelog` with the exact missing stable tag.
-  The workflow validates the published release and summary, preserves every
-  existing entry, and upserts the missing summary without moving release
-  pointers or republishing assets. Do not rerun promotion for an older stable
-  tag because its rollback guard correctly rejects moving the public channel
-  behind the current release.
+  The workflow validates the published release and staged summary metadata,
+  rebuilds the public entry from the current human-reviewed Release Notes,
+  preserves every existing entry, and upserts the corrected summary without
+  moving release pointers or republishing assets. Do not rerun promotion for an
+  older stable tag because its rollback guard correctly rejects moving the
+  public channel behind the current release.
 - Validation:
   Confirm the workflow's S3 round-trip verification passes, then verify the
   public aggregate and `https://tutti.sh/changelog` both contain the restored

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -780,9 +780,18 @@ test("desktop changelog repair restores one published stable summary without mov
     repairWorkflow,
     /apps\/desktop\/scripts\/validate-release-summary\.mjs/
   );
+  assert.match(repairWorkflow, /gh release view .* --json body --jq \.body/);
+  assert.match(
+    repairWorkflow,
+    /apps\/desktop\/scripts\/extract-approved-release-summary\.mjs/
+  );
   assert.match(
     repairWorkflow,
     /apps\/desktop\/scripts\/upsert-release-changelog\.mjs/
+  );
+  assert.match(
+    repairWorkflow,
+    /existing-changelog\.json[\s\\]*approved-release-summary\.json[\s\\]*changelog\.json/
   );
   assert.match(repairWorkflow, /Repair removed existing changelog entry/);
   assert.match(repairWorkflow, /cmp changelog\.json published-changelog\.json/);

--- a/tools/scripts/desktop-release-summary.test.mjs
+++ b/tools/scripts/desktop-release-summary.test.mjs
@@ -210,6 +210,37 @@ test("approved summary is parsed from the human review instead of generated sugg
   assert.equal(approved.generatedAt, "2026-08-17T01:00:00.000Z");
 });
 
+test("approved summary accepts reviewed items written as plain Markdown lines", () => {
+  const body = [
+    REVIEW_START,
+    "## Release Notes",
+    "### 中文",
+    "人工确认标题",
+    "#### 功能变更",
+    "默认开启快捷提示词管理",
+    "支持会话分叉",
+    "### English",
+    "Reviewed headline",
+    "#### Feature Changes",
+    "Quick prompt management is enabled by default",
+    "Conversation forking is supported",
+    REVIEW_END
+  ].join("\n");
+  const approved = buildApprovedReleaseSummary({
+    body,
+    generatedSummary: validReleaseSummary()
+  });
+
+  assert.deepEqual(approved.zh.sections[0].items, [
+    "默认开启快捷提示词管理",
+    "支持会话分叉"
+  ]);
+  assert.deepEqual(approved.en.sections[0].items, [
+    "Quick prompt management is enabled by default",
+    "Conversation forking is supported"
+  ]);
+});
+
 test("desktop release summary trims only generated notes at GitHub's body limit", () => {
   const oversizedNotes = [
     "## What's Changed",


### PR DESCRIPTION
## 背景

v0.2.27 的 GitHub Release 正文已经人工移除 side conversation 等旧内容，但其 `release-summary.json` 附件仍保留生成阶段的旧摘要。此前 changelog repair 直接使用该附件，导致旧文案重新进入官网。

## 改动

- repair 工作流继续用 checksummed `release-summary.json` 校验 tag、commit 和 compare 元数据
- 公开文案改从当前 GitHub Release 的 human-reviewed Release Notes 管理区提取
- 支持人工审核区中不带列表符号的逐行条目，完整保留 v0.2.27 当前英文 Feature Changes
- changelog upsert 改用提取后的 approved summary
- 更新发布规范、排障文档和防回归测试

## 验证

- 使用线上 v0.2.27 Release 正文和附件本地提取，确认不再包含 side conversation、connector access、GitHub clone、device-code/QR-code 文案
- `node --test tools/scripts/desktop-release-summary.test.mjs tools/scripts/desktop-release-config.test.mjs`（67/67）
- `pnpm check:changed`（8 lanes）
- pre-push `pnpm check:changed -- --push-ready`（9 lanes）

## Windows 影响

无桌面运行时影响；仅修改发布摘要解析与 changelog 修复工作流。