### PR TITLE
fix(agent-gui): load capabilities for dollar skill queries

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -168,12 +168,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     hiddenMentionFilterIds = EMPTY_HIDDEN_MENTION_FILTER_IDS
   } = props;
   const slashCapabilitiesRefreshedSessionRef = useRef<string | null>(null);
-  const handleDraftContentChange = useComposerDraftCapabilitiesRequest({
-    agentSessionId,
-    onDraftContentChange,
-    onRetryComposerOptions,
-    provider
-  });
+  const editorHandleRef = useRef<AgentRichTextEditorHandle | null>(null);
   const {
     canQueueWhileBusy,
     editorDisabled: disabled,
@@ -244,6 +239,21 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     useState<AgentFileMentionSuggestionState | null>(null);
   const selectedProjectPath =
     composerSettings.selectedProjectPath?.trim() ?? "";
+  const capabilitiesScopeKey = [
+    workspaceId,
+    agentSessionId ?? "",
+    provider,
+    selectedAgentTarget?.agentTargetId?.trim() ||
+      selectedAgentTarget?.targetId.trim() ||
+      "",
+    selectedProjectPath || workspacePath?.trim() || ""
+  ].join("\u0000");
+  const handleDraftContentChange = useComposerDraftCapabilitiesRequest({
+    capabilitiesScopeKey,
+    editorHandleRef,
+    onDraftContentChange,
+    onRetryComposerOptions
+  });
   const [isSelectedProjectMissing, setIsSelectedProjectMissing] =
     useScopedProjectMissingState(selectedProjectPath);
   const [isSlashStatusPanelOpen, setIsSlashStatusPanelOpen] = useState(false);
@@ -324,7 +334,6 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
       referenceProvenanceFilters,
       hiddenMentionFilterIds
     );
-  const editorHandleRef = useRef<AgentRichTextEditorHandle | null>(null);
   const wasActiveRef = useRef(isActive);
   const lastComposerFocusRequestRef = useRef<number | null>(null);
   const autoMentionHighlightedKeyRef = useRef<string | null>(null);
@@ -387,14 +396,15 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
   useEffect(() => {
     setHighlightedIndex(0);
     refreshComposerSlashCapabilities({
-      agentSessionId,
+      capabilitiesScopeKey,
       isPaletteOpen,
       onRetryComposerOptions,
       refreshedSessionRef: slashCapabilitiesRefreshedSessionRef,
+      skillQuery: skillQueryMatch?.query ?? null,
       slashQuery
     });
   }, [
-    agentSessionId,
+    capabilitiesScopeKey,
     isPaletteOpen,
     onRetryComposerOptions,
     skillQueryMatch?.prefix,

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerDraftCapabilitiesRequest.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerDraftCapabilitiesRequest.spec.tsx
@@ -1,0 +1,124 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentRichTextEditorHandle } from "../agentRichText/AgentRichTextEditor";
+import { buildAgentComposerDraft } from "../model/agentComposerDraft";
+import { useComposerDraftCapabilitiesRequest } from "./useComposerDraftCapabilitiesRequest";
+
+describe("useComposerDraftCapabilitiesRequest", () => {
+  it.each(["/", "$"])(
+    "requests provider capabilities for a %s palette query",
+    (trigger) => {
+      const onDraftContentChange = vi.fn();
+      const onRetryComposerOptions = vi.fn();
+      const { result } = renderHook(() =>
+        useComposerDraftCapabilitiesRequest({
+          capabilitiesScopeKey: "draft\u0000codex\u0000local:codex",
+          editorHandleRef: { current: null },
+          onDraftContentChange,
+          onRetryComposerOptions
+        })
+      );
+      const draft = buildAgentComposerDraft({ prompt: trigger });
+
+      act(() => result.current(draft, "draft-scope"));
+
+      expect(onRetryComposerOptions).toHaveBeenCalledOnce();
+      expect(onRetryComposerOptions).toHaveBeenCalledWith({
+        section: "capabilities"
+      });
+      expect(onDraftContentChange).toHaveBeenCalledWith(draft, "draft-scope");
+    }
+  );
+
+  it("does not request provider capabilities for ordinary text", () => {
+    const onDraftContentChange = vi.fn();
+    const onRetryComposerOptions = vi.fn();
+    const { result } = renderHook(() =>
+      useComposerDraftCapabilitiesRequest({
+        capabilitiesScopeKey: "draft\u0000codex\u0000local:codex",
+        editorHandleRef: { current: null },
+        onDraftContentChange,
+        onRetryComposerOptions
+      })
+    );
+
+    act(() =>
+      result.current(buildAgentComposerDraft({ prompt: "hello" }), "draft")
+    );
+
+    expect(onRetryComposerOptions).not.toHaveBeenCalled();
+    expect(onDraftContentChange).toHaveBeenCalledOnce();
+  });
+
+  it("requests capabilities for a query before trailing draft text", () => {
+    const onRetryComposerOptions = vi.fn();
+    const { result } = renderHook(() =>
+      useComposerDraftCapabilitiesRequest({
+        capabilitiesScopeKey: "draft\u0000codex\u0000local:codex",
+        editorHandleRef: {
+          current: {
+            getPromptTextBeforeSelection: () => "Please $"
+          } as AgentRichTextEditorHandle
+        },
+        onDraftContentChange: vi.fn(),
+        onRetryComposerOptions
+      })
+    );
+
+    act(() =>
+      result.current(
+        buildAgentComposerDraft({ prompt: "Please $ review this" }),
+        "draft"
+      )
+    );
+
+    expect(onRetryComposerOptions).toHaveBeenCalledWith({
+      section: "capabilities"
+    });
+  });
+
+  it("requests capabilities again when a dollar query is reopened", () => {
+    const onRetryComposerOptions = vi.fn();
+    const { result } = renderHook(() =>
+      useComposerDraftCapabilitiesRequest({
+        capabilitiesScopeKey: "draft\u0000codex\u0000local:codex",
+        editorHandleRef: { current: null },
+        onDraftContentChange: vi.fn(),
+        onRetryComposerOptions
+      })
+    );
+
+    act(() =>
+      result.current(buildAgentComposerDraft({ prompt: "$" }), "draft")
+    );
+    act(() =>
+      result.current(buildAgentComposerDraft({ prompt: "hello" }), "draft")
+    );
+    act(() =>
+      result.current(buildAgentComposerDraft({ prompt: "$" }), "draft")
+    );
+
+    expect(onRetryComposerOptions).toHaveBeenCalledTimes(2);
+  });
+
+  it("requests capabilities again for a new target and project scope", () => {
+    const onRetryComposerOptions = vi.fn();
+    let capabilitiesScopeKey = "workspace-agent:a\u0000/workspace/a";
+    const { result, rerender } = renderHook(() =>
+      useComposerDraftCapabilitiesRequest({
+        capabilitiesScopeKey,
+        editorHandleRef: { current: null },
+        onDraftContentChange: vi.fn(),
+        onRetryComposerOptions
+      })
+    );
+    const draft = buildAgentComposerDraft({ prompt: "$" });
+
+    act(() => result.current(draft, "draft"));
+    capabilitiesScopeKey = "workspace-agent:b\u0000/workspace/b";
+    rerender();
+    act(() => result.current(draft, "draft"));
+
+    expect(onRetryComposerOptions).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerDraftCapabilitiesRequest.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerDraftCapabilitiesRequest.ts
@@ -1,34 +1,49 @@
 import { useCallback, useRef } from "react";
+import type { AgentRichTextEditorHandle } from "../agentRichText/AgentRichTextEditor";
 import { agentComposerDraftPrompt } from "../model/agentComposerDraft";
+import { getAgentComposerTriggerQueryMatch } from "../model/agentComposerTriggerQueries";
 import type { AgentComposerProps } from "./AgentComposer.types";
 
 interface UseComposerDraftCapabilitiesRequestOptions {
-  agentSessionId: string | null;
+  capabilitiesScopeKey: string;
+  editorHandleRef: { current: AgentRichTextEditorHandle | null };
   onDraftContentChange: AgentComposerProps["onDraftContentChange"];
   onRetryComposerOptions: AgentComposerProps["onRetryComposerOptions"];
-  provider: string;
 }
 
 export function useComposerDraftCapabilitiesRequest({
-  agentSessionId,
+  capabilitiesScopeKey,
+  editorHandleRef,
   onDraftContentChange,
-  onRetryComposerOptions,
-  provider
+  onRetryComposerOptions
 }: UseComposerDraftCapabilitiesRequestOptions): AgentComposerProps["onDraftContentChange"] {
   const requestedKeyRef = useRef<string | null>(null);
 
   return useCallback(
     (nextDraft, sourceScopeKey) => {
-      const nextPrompt = agentComposerDraftPrompt(nextDraft).trimStart();
-      if (onRetryComposerOptions && nextPrompt.startsWith("/")) {
-        const requestKey = `${provider}:${agentSessionId ?? "draft"}`;
-        if (requestedKeyRef.current !== requestKey) {
-          requestedKeyRef.current = requestKey;
+      const promptBeforeSelection =
+        editorHandleRef.current?.getPromptTextBeforeSelection() ?? "";
+      const nextPrompt = (
+        promptBeforeSelection || agentComposerDraftPrompt(nextDraft)
+      ).trimStart();
+      if (
+        onRetryComposerOptions &&
+        getAgentComposerTriggerQueryMatch(nextPrompt)
+      ) {
+        if (requestedKeyRef.current !== capabilitiesScopeKey) {
+          requestedKeyRef.current = capabilitiesScopeKey;
           onRetryComposerOptions({ section: "capabilities" });
         }
+      } else {
+        requestedKeyRef.current = null;
       }
       onDraftContentChange(nextDraft, sourceScopeKey);
     },
-    [agentSessionId, onDraftContentChange, onRetryComposerOptions, provider]
+    [
+      capabilitiesScopeKey,
+      editorHandleRef,
+      onDraftContentChange,
+      onRetryComposerOptions
+    ]
   );
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerSlashCapabilitiesRefresh.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerSlashCapabilitiesRefresh.spec.tsx
@@ -2,16 +2,20 @@ import { describe, expect, it, vi } from "vitest";
 import { refreshComposerSlashCapabilities } from "./useComposerSlashCapabilitiesRefresh";
 
 describe("refreshComposerSlashCapabilities", () => {
-  it("refreshes capabilities again when slash search is reopened", () => {
+  it.each([
+    { name: "slash", skillQuery: null, slashQuery: "" },
+    { name: "skill", skillQuery: "", slashQuery: null }
+  ])("refreshes capabilities again when $name search is reopened", (query) => {
     const onRetryComposerOptions = vi.fn();
     const refreshedSessionRef = { current: null as string | null };
     const refresh = (isPaletteOpen: boolean): void =>
       refreshComposerSlashCapabilities({
-        agentSessionId: "session-1",
+        capabilitiesScopeKey: "session-1\u0000target-a\u0000/workspace/a",
         isPaletteOpen,
         onRetryComposerOptions,
         refreshedSessionRef,
-        slashQuery: ""
+        skillQuery: query.skillQuery,
+        slashQuery: query.slashQuery
       });
 
     refresh(true);
@@ -25,6 +29,25 @@ describe("refreshComposerSlashCapabilities", () => {
     });
 
     refresh(true);
+    expect(onRetryComposerOptions).toHaveBeenCalledTimes(2);
+  });
+
+  it("refreshes an open skill query when its target scope changes", () => {
+    const onRetryComposerOptions = vi.fn();
+    const refreshedSessionRef = { current: null as string | null };
+    const refresh = (capabilitiesScopeKey: string): void =>
+      refreshComposerSlashCapabilities({
+        capabilitiesScopeKey,
+        isPaletteOpen: true,
+        onRetryComposerOptions,
+        refreshedSessionRef,
+        skillQuery: "",
+        slashQuery: null
+      });
+
+    refresh("draft\u0000target-a\u0000/workspace/a");
+    refresh("draft\u0000target-b\u0000/workspace/b");
+
     expect(onRetryComposerOptions).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerSlashCapabilitiesRefresh.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerSlashCapabilitiesRefresh.ts
@@ -1,15 +1,17 @@
 import type { AgentComposerProps } from "./AgentComposer.types";
 
 export function refreshComposerSlashCapabilities(input: {
-  agentSessionId: string | null;
+  capabilitiesScopeKey: string;
   isPaletteOpen: boolean;
   onRetryComposerOptions: AgentComposerProps["onRetryComposerOptions"];
   refreshedSessionRef: { current: string | null };
+  skillQuery: string | null;
   slashQuery: string | null;
 }): void {
   const refreshKey =
-    input.isPaletteOpen && input.slashQuery !== null
-      ? input.agentSessionId
+    input.isPaletteOpen &&
+    (input.slashQuery !== null || input.skillQuery !== null)
+      ? input.capabilitiesScopeKey
       : null;
   if (refreshKey === null) {
     input.refreshedSessionRef.current = null;


### PR DESCRIPTION
## Summary

Typing `$` in a cold Composer shows no Skills because only `/` requests the capability catalog. Typing `/` first loads the catalog and makes a later `$` query work.

This change uses the Palette's existing caret-relative trigger parser to request capabilities for both `/` and `$`. It also refreshes restored or reopened `$` queries and scopes request deduplication to the current workspace, session, provider, Agent Target, and working directory.

Fixes #2638.

## Verification

Validation recorded for `b28489112b` against unmodified `main@404a084f7`:

- Before the fix, the focused regression passes for `/` and ordinary text but fails for `$`. After the fix, all 9 focused tests pass, including restored/reopened queries and changes to Agent Target or project scope.
- GUI A/B: before the fix, cold `$` is empty until `/` loads the catalog; after the fix, cold `$` shows Skills directly.
- Full AgentGUI suite: 3,119 tests passed. `pnpm check:changed -- --base upstream/main --push-ready`: 12 lanes passed. Provider-strategy and AgentGUI degradation checks passed.

The change stays in the existing Composer request and refresh helpers, with no new timer, subscription, or cache. AgentComposer exports and Host contracts are unchanged. The logic is platform-neutral; no Windows-specific behavior changes. No documentation update is needed because this restores the existing `$` contract.

## Checklist

- [x] This PR does not change session, turn, goal, or runtime-operation lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed. (No update required; this restores an existing contract.)
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. (Not applicable.)
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
