### PR TITLE
fix(connector): keep one authorization round until cancel

### DIFF
--- a/docs/architecture/connector.md
+++ b/docs/architecture/connector.md
@@ -593,10 +593,13 @@ synchronizing -> materializing -> ready`; failure is terminal and disposes
   host keeps the mutation request open until runtime work completes; the local
   projection is cleared on both success and failure and never replaces daemon
   installation truth
-- every new user authorization action creates a new `clientRequestId` and sends
-  `replacementPolicy=replace_active`; continuation polling within that action
-  reuses the same identity, while a superseded renderer Promise cannot retain
-  the Connector mutation token
+- the first user authorization action stays in flight until it completes or
+  the user Cancels; a second Authorize click joins that Promise and must not
+  create another `clientRequestId` or send `replace_active`. After Cancel, the
+  next Authorize is a new action: it creates a new `clientRequestId` and sends
+  `replacementPolicy=replace_active`. Continuation polling within one action
+  reuses the same identity. A canceled renderer Promise cannot retain the
+  Connector mutation token
 - event refreshes are coalesced, daemon reconnect performs a full reload, and
   accepted commands are followed through the operation endpoint or events
 - hosts gate connector-market transport through `canRequest`; Tutti binds it to
@@ -667,10 +670,14 @@ open the blocked-state dialog. Only one dialog host is mounted at a time, so
 the catalog keeps the full settings content width and never leaves an empty
 right column.
 
-Closing an authorization dialog only dismisses presentation. The explicit
-Cancel action calls the Host cancellation command. Reopening an unconnected
-Connector starts a new replace-active attempt, so a hidden or stuck renderer
-request cannot lock later authorization actions.
+Closing an authorization dialog while a request is in flight does not start a
+new session and does not dismiss the modal; the user must finish the provider
+flow or use Cancel. Browser OAuth keeps the in-flight footer on authorizing
+and does not surface Continue for a synthesized `external_link` view; the
+Start command already opened that URL. Cancel calls the Host cancellation
+command, then the next Authorize is a new replace-active attempt. A leftover
+pending session without an in-flight renderer request also shows Authorize,
+not a second Start disguised as Continue.
 
 ## Local OpenAPI Reuse
 

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -141,7 +141,7 @@ App Center, workspace-app lifecycle, App Factory, file references, and File Mana
 
 Connector catalog, installation, account authorization, and runtime convergence.
 
-- [Authorization stays loading and reopening cannot start a new attempt](./connector-market.md#authorization-stays-loading-and-reopening-cannot-start-a-new-attempt)
+- [A second authorize click starts another OAuth session](./connector-market.md#a-second-authorize-click-starts-another-oauth-session)
 - [OAuth finishes in the browser but does not return to the initiating desktop build](./connector-market.md#oauth-finishes-in-the-browser-but-does-not-return-to-the-initiating-desktop-build)
 - [Composer install stays spinning on an OAuth remote connector](./connector-market.md#composer-install-stays-spinning-on-an-oauth-remote-connector)
 

--- a/docs/conventions/troubleshooting/connector-market.md
+++ b/docs/conventions/troubleshooting/connector-market.md
@@ -1,43 +1,39 @@
 # Connector Market Troubleshooting
 
-### Authorization stays loading and reopening cannot start a new attempt
+### A second authorize click starts another OAuth session
 
 **Symptoms**
 
-- the authorization button may remain on its initial loading state before a URL
-  is returned
-- the local Start operation is already `completed` while its private session
-  receipt is still unresolved
-- the account authorization projection remains `disconnected` until the OAuth
-  callback is observed
-- closing and reopening the dialog appears to reuse the old request or reports
-  that another Connector operation is in progress
+- the first Authorize click already opened the provider tab
+- a second click, Continue, or dialog dismiss-and-reopen starts
+  `replace_active` and tombstones the first session
+- the first Google or provider tab later returns an empty 403 after Complete
+  already succeeded for the replacement session
+- the authorization button looks clickable again while the renderer Promise is
+  still waiting
 
 **Check**
 
-Trace four states separately: the renderer request identity, the durable Start
-operation, its private authorization-session receipt, and the provider process.
-A
-completed Start operation means the external session was created; it does not
-mean the provider authorization is terminal. Confirm that a redirect session
-returns `pending` to the caller even when the durable projection has not changed
-yet. Within one action, confirm that continuation uses one `clientRequestId`.
-For a new user action, confirm that the request carries
-`replacementPolicy=replace_active`, the prior receipt moves through `canceling`
-to `superseded`, and the old Broker/DWS process exits before the replacement is
-launched. If no initial event is returned, verify that the new request cancels
-the active Host-owned Begin instead of waiting behind its authorization lane.
+Trace the renderer Promise separately from the Host Start. While
+`authorizationInFlight` is set and the attempt is not canceled, a second
+`beginAuthorization` must return that Promise and must not increment Host
+starts. The dialog Authorize control stays disabled on
+`actionWaitingAuthorization`; browser OAuth must not swap that control for
+Continue when Start returns a synthesized `external_link` view. Only Cancel
+ends the round. After Cancel, the
+next Authorize may send `replacementPolicy=replace_active` with a new
+`clientRequestId`. Continuation polling inside the same action still reuses one
+identity. Do not re-relay a provider `code` after Complete.
 
 **Rule**
 
-Keep the account projection as durable authorization truth. Preserve the
-current session's `pending` state only in the Start command result so shared
-clients continue that idempotent session. A new user action is different from a
-continuation: it must use Host-owned replace-active semantics. Fence late
-observations by the durable receipt, require provider cancellation and process
-exit confirmation, then create the replacement. Do not persist a synthetic
-connected projection, infer success from the Start operation's terminal state,
-or let the renderer race separate cancel and start calls.
+One user authorization action stays active until it completes or the user
+Cancels. A second click is not a new user action. Keep the account projection
+as durable authorization truth, and keep `pending` only in the Start command
+result so shared clients continue that idempotent session. `replace_active` is
+for an explicit new round after Cancel or after the previous action finished,
+not for a repeated Authorize while the first Promise is still live. Do not
+cancel the in-flight renderer Promise just because the user clicked again.
 
 ### OAuth finishes in the browser but does not return to the initiating desktop build
 

--- a/packages/connector/renderer/src/application/services/connectorMarketService.test.ts
+++ b/packages/connector/renderer/src/application/services/connectorMarketService.test.ts
@@ -1244,12 +1244,8 @@ test("forwards a user-provided secret only to the authorization mutation", async
   service.dispose();
 });
 
-test("a new authorization command supersedes the previous caller", async () => {
+test("a second authorization command joins the in-flight attempt", async () => {
   const firstAuthorization =
-    deferred<
-      Awaited<ReturnType<ConnectorMarketBackend["beginAuthorization"]>>
-    >();
-  const secondAuthorization =
     deferred<
       Awaited<ReturnType<ConnectorMarketBackend["beginAuthorization"]>>
     >();
@@ -1264,9 +1260,7 @@ test("a new authorization command supersedes the previous caller", async () => {
       beginAuthorization: async (request) => {
         requests.push(request);
         authorizationAttempts += 1;
-        return authorizationAttempts === 1
-          ? firstAuthorization.promise
-          : secondAuthorization.promise;
+        return firstAuthorization.promise;
       }
     }),
     createRequestId: () => `authorization-${++requestIds}`
@@ -1275,8 +1269,77 @@ test("a new authorization command supersedes the previous caller", async () => {
 
   const first = service.beginAuthorization("notion");
   const second = service.beginAuthorization("notion");
+  assert.equal(second, first);
   const connected = connector("notion", 2);
   connected.authorization = { state: "connected" };
+  firstAuthorization.resolve({
+    connector: connected,
+    operation: {
+      ...operation("start_authorization", 2),
+      connectorKey: "notion",
+      state: "completed"
+    },
+    revision: 2
+  });
+  await first;
+  await second;
+
+  assert.equal(authorizationAttempts, 1);
+  assert.equal(requestIds, 1);
+  assert.deepEqual(
+    requests.map(({ clientRequestId, replacementPolicy }) => ({
+      clientRequestId,
+      replacementPolicy
+    })),
+    [
+      {
+        clientRequestId: "authorization-1",
+        replacementPolicy: "replace_active"
+      }
+    ]
+  );
+  assert.deepEqual(service.dataStore.authorizingConnectorKeys, {});
+  service.dispose();
+});
+
+test("a new authorization command starts only after the user cancels", async () => {
+  const firstAuthorization =
+    deferred<
+      Awaited<ReturnType<ConnectorMarketBackend["beginAuthorization"]>>
+    >();
+  const secondAuthorization =
+    deferred<
+      Awaited<ReturnType<ConnectorMarketBackend["beginAuthorization"]>>
+    >();
+  let authorizationAttempts = 0;
+  let requestIds = 0;
+  const requests: ConnectorAuthorizationInput[] = [];
+  const initial = connector("notion", 1);
+  initial.authorization = { state: "disconnected" };
+  const connected = connector("notion", 2);
+  connected.authorization = { state: "connected" };
+  const service = new ConnectorMarketService({
+    backend: backendWith({
+      getSnapshot: async () => snapshot(1, [initial]),
+      beginAuthorization: async (request) => {
+        requests.push(request);
+        authorizationAttempts += 1;
+        return authorizationAttempts === 1
+          ? firstAuthorization.promise
+          : secondAuthorization.promise;
+      },
+      cancelAuthorization: async () => undefined
+    }),
+    createRequestId: () => `authorization-${++requestIds}`
+  });
+  await service.ensureLoaded();
+
+  const first = service.beginAuthorization("notion");
+  await waitFor(() => authorizationAttempts === 1);
+  await service.cancelAuthorization("notion");
+  const second = service.beginAuthorization("notion");
+  assert.notEqual(second, first);
+  await waitFor(() => authorizationAttempts === 2);
   secondAuthorization.resolve({
     connector: connected,
     operation: {

--- a/packages/connector/renderer/src/application/services/connectorMarketService.ts
+++ b/packages/connector/renderer/src/application/services/connectorMarketService.ts
@@ -448,9 +448,10 @@ export class ConnectorMarketService implements IConnectorMarketService {
     if (this.disposed || !this.canRequest()) {
       return Promise.resolve();
     }
-    const previousAttempt = this.authorizationAttempts.get(connectorKey);
-    if (previousAttempt) {
-      previousAttempt.canceled = true;
+    const inFlight = this.authorizationInFlight.get(connectorKey);
+    const currentAttempt = this.authorizationAttempts.get(connectorKey);
+    if (inFlight && currentAttempt && !currentAttempt.canceled) {
+      return inFlight;
     }
     let authorization!: Promise<void>;
     authorization = this.runAuthorization(connectorKey, secret).finally(() => {

--- a/packages/connector/renderer/src/ui/dialogs/ConnectorAuthorizationDialog.tsx
+++ b/packages/connector/renderer/src/ui/dialogs/ConnectorAuthorizationDialog.tsx
@@ -76,6 +76,8 @@ export function ConnectorAuthorizationDialog({
   });
   const currentView =
     authorizationView ?? (resolved.kind === "form" ? resolved.view : null);
+  const showAuthorizationView =
+    currentView !== null && currentView.view.type !== "external_link";
 
   const handleInteractionEvent = (event: AuthorizationEventEnvelopeV1) => {
     if (!currentView) return;
@@ -109,7 +111,10 @@ export function ConnectorAuthorizationDialog({
   };
 
   return (
-    <DialogContent className="max-h-[min(720px,calc(100vh-32px))] overflow-y-auto sm:max-w-[420px]">
+    <DialogContent
+      aria-busy={authorizing}
+      className="max-h-[min(720px,calc(100vh-32px))] overflow-y-auto sm:max-w-[420px]"
+    >
       <DialogHeader className="gap-3 px-5 pt-4 text-center">
         <div className="gap-3 flex items-center justify-center">
           <span className="flex size-12 items-center justify-center rounded-xl bg-[var(--transparency-block)] text-[var(--accent)]">
@@ -140,7 +145,7 @@ export function ConnectorAuthorizationDialog({
         />
       </div>
 
-      {currentView ? (
+      {showAuthorizationView && currentView ? (
         <AuthorizationRenderer
           busy={authorizationView ? false : authorizing || pending}
           labels={{
@@ -187,12 +192,10 @@ export function ConnectorAuthorizationDialog({
             type="button"
             onClick={() => void onAuthorize()}
           >
-            {authorizing && !pending ? <Spinner size={14} /> : null}
-            {authorizing && pending
+            {authorizing ? <Spinner size={14} /> : null}
+            {authorizing
               ? i18n.t("actionWaitingAuthorization")
-              : pending
-                ? i18n.t("actionContinueAuthorization")
-                : i18n.t("actionAuthorize")}
+              : i18n.t("actionAuthorize")}
           </Button>
         </DialogFooter>
       )}

--- a/packages/connector/renderer/src/ui/dialogs/ConnectorMarketDialogs.spec.tsx
+++ b/packages/connector/renderer/src/ui/dialogs/ConnectorMarketDialogs.spec.tsx
@@ -1,5 +1,11 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { proxy } from "valtio";
 
@@ -108,5 +114,85 @@ describe("ConnectorMarketDialogs", () => {
     fireEvent.click(screen.getByRole("button", { name: "actionTry" }));
     expect(closeDialog).toHaveBeenCalledTimes(1);
     expect(onTryConnector).toHaveBeenCalledWith("gmail");
+  });
+
+  it("keeps one authorization action until the user finishes or cancels", async () => {
+    const viewState = proxy(
+      emptyView({
+        ...authorizationDialog,
+        authorizing: true,
+        pending: true,
+        authorizationView: {
+          protocol: "tutti.connector.authorization.view.v1",
+          viewId: "gmail-oauth",
+          view: {
+            type: "external_link",
+            url: "https://accounts.google.com/o/oauth2/auth"
+          }
+        }
+      })
+    );
+    const closeDialog = vi.fn();
+    const beginAuthorization = vi.fn(async () => undefined);
+    const cancelAuthorization = vi.fn(async () => undefined);
+    const root = {
+      market: {
+        beginAuthorization,
+        cancelAuthorization,
+        dataStore: proxy({
+          pendingUninstallNotificationsByOperationId: {}
+        })
+      },
+      uiState: {
+        closeDialog,
+        dataStore: proxy({
+          dialog: { connectorKey: "gmail", kind: "connector" },
+          query: "",
+          scope: {},
+          started: true
+        })
+      },
+      view: { dataStore: viewState }
+    } as unknown as IConnectorMarketRoot;
+
+    const { rerender } = render(
+      <ConnectorMarketRootProvider i18n={i18n} root={root}>
+        <ConnectorMarketDialogs />
+      </ConnectorMarketRootProvider>
+    );
+
+    const waiting = screen.getByRole("button", {
+      name: "actionWaitingAuthorization"
+    });
+    expect(waiting).toBeDisabled();
+    expect(
+      screen.queryByRole("button", { name: "actionContinueAuthorization" })
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(waiting);
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(beginAuthorization).not.toHaveBeenCalled();
+    expect(closeDialog).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "cancel" }));
+    expect(cancelAuthorization).toHaveBeenCalledWith("gmail");
+    await waitFor(() => expect(closeDialog).toHaveBeenCalledTimes(1));
+
+    viewState.dialog = {
+      ...authorizationDialog,
+      authorizing: false,
+      pending: true
+    };
+    rerender(
+      <ConnectorMarketRootProvider i18n={i18n} root={root}>
+        <ConnectorMarketDialogs />
+      </ConnectorMarketRootProvider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "actionAuthorize" }));
+    expect(beginAuthorization).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByRole("button", { name: "actionContinueAuthorization" })
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/connector/renderer/src/ui/dialogs/ConnectorMarketDialogs.tsx
+++ b/packages/connector/renderer/src/ui/dialogs/ConnectorMarketDialogs.tsx
@@ -172,7 +172,11 @@ export function ConnectorMarketDialogs() {
         <Dialog
           open
           onOpenChange={(open) => {
-            if (open || (dialog.kind === "installation" && dialog.installing)) {
+            if (
+              open ||
+              (dialog.kind === "installation" && dialog.installing) ||
+              (dialog.kind === "authorization" && dialog.authorizing)
+            ) {
               return;
             }
             uiState.closeDialog();

--- a/packages/connector/renderer/src/ui/i18n/connectorMarketI18n.ts
+++ b/packages/connector/renderer/src/ui/i18n/connectorMarketI18n.ts
@@ -44,7 +44,7 @@ const connectorMarketEn = {
   actionUpdate: "Update",
   actionUpdateAuthorization: "Reauthorize",
   actionUpdating: "Updating…",
-  actionWaitingAuthorization: "Waiting for authorization…",
+  actionWaitingAuthorization: "Authorizing",
   blockedDescription:
     "This connector cannot be used in the current environment",
   blockedTitle: "Connector unavailable",
@@ -169,7 +169,7 @@ const connectorMarketZhCN = {
   actionUpdate: "更新",
   actionUpdateAuthorization: "重新授权",
   actionUpdating: "更新中…",
-  actionWaitingAuthorization: "等待授权…",
+  actionWaitingAuthorization: "授权中",
   blockedDescription: "当前环境无法使用这个连接器",
   blockedTitle: "连接器不可用",
   cancel: "取消",


### PR DESCRIPTION
## Summary

A second Authorize click during an in-flight browser OAuth round was starting `replace_active` and swapping the waiting footer for Continue. That tombstoned the first Google session, so a leftover tab or callback refresh later returned an empty 403.

Keep the first round until it completes or the user Cancels: join in-flight `beginAuthorization`, keep the dialog on disabled **授权中**, and do not surface Continue for a synthesized `external_link` view. After Cancel, the next Authorize is a new replace-active round.

## Verification

- Reproduced on Google Slides: first Authorize opened the provider tab; the dialog then showed clickable Continue instead of waiting.
- Service test: a second `beginAuthorization` while in flight does not start Host again; a new Start is allowed only after Cancel.
- Dialog test: an in-flight `external_link` view stays on `actionWaitingAuthorization` and does not offer Continue.

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

Made with [Cursor](https://cursor.com)