### PR TITLE
fix(agent): keep Codex alive when optional MCP fails

### DIFF
--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -1540,21 +1540,28 @@ inline data URL instead`. Claude or standard ACP may instead receive no
   App-server notifications and the response for their triggering RPC have no
   safe application-order guarantee. Waiting only on the response leaves the
   lifecycle call blocked when Codex has already published the authoritative
-  thread snapshot. Required MCP startup failure is also a terminal lifecycle
-  fact, but it can arrive without stderr or a response. Child terminal
-  notifications can arrive before `receiverThreadIds` registers their thread;
-  dropping those unknown-thread terminal events loses the only completion fact.
+  thread snapshot. A required MCP failure is terminal only when Codex reports
+  it through the lifecycle RPC itself. MCP stderr and startup-status
+  notifications are diagnostic state, not independent lifecycle failures:
+  optional MCP startup can fail while the Codex session is still usable. Child
+  terminal notifications can arrive before `receiverThreadIds` registers their
+  thread; dropping those unknown-thread terminal events loses the only
+  completion fact.
 - Fix:
   Complete only the active method-matched `thread/start` or `thread/resume` wait
-  from a valid `thread/started` snapshot. Schedule the structured MCP failure
-  after a short response grace window so a normal response wins the race. Keep
-  ordinary foreign-thread progress dropped, but retain a bounded terminal
-  notification until child registration and replay it with child identity.
+  from a valid `thread/started` snapshot. Do not fail that wait from MCP stderr
+  or `mcpServer/startupStatus/updated`; record the warning and keep the session
+  alive. A real Codex lifecycle RPC error, process exit, or transport error
+  remains terminal and is still propagated. Keep ordinary foreign-thread
+  progress dropped, but retain a bounded terminal notification until child
+  registration and replay it with child identity. Warnings without a `turnId`
+  use a session audit event instead of a turn-scoped message.
   Keep confirmed provider turn-id fences; only the existing unconfirmed steer
   stub and goal-adopted exceptions may settle from a different or empty id.
 - Validation:
-  Run the notification-only Start/Resume wire test, the MCP failed-status
-  response-grace tests, and the child terminal-before-registration replay test.
+  Run the notification-only Start/Resume wire test, the delayed MCP
+  failed-status tests, the turnless warning projection test, and
+  the child terminal-before-registration replay test.
   Run the focused app-server suite with `-race` and the full
   `go test ./packages/agent/daemon/runtime` package suite.
 - References:

--- a/packages/agent/daemon/runtime/acp_client.go
+++ b/packages/agent/daemon/runtime/acp_client.go
@@ -394,25 +394,6 @@ func (c *acpClient) unregisterCall(id int64, active *acpActiveHandler) {
 	c.mu.Unlock()
 }
 
-// failActiveHandler wakes the lifecycle RPC currently waiting for a provider
-// response without terminating the underlying process. The caller owns the
-// decision to retain or close that process after the typed failure is returned.
-func (c *acpClient) failActiveHandler(err error) {
-	if c == nil || err == nil {
-		return
-	}
-	c.mu.Lock()
-	active := c.active
-	c.mu.Unlock()
-	if active == nil {
-		return
-	}
-	select {
-	case active.errors <- err:
-	default:
-	}
-}
-
 // completeActiveHandler supplies a synthetic success result to the active
 // request when the provider emits an authoritative lifecycle notification but
 // loses the matching JSON-RPC response. The method fence prevents an

--- a/packages/agent/daemon/runtime/codex_appserver_client.go
+++ b/packages/agent/daemon/runtime/codex_appserver_client.go
@@ -29,7 +29,7 @@ type codexAppServerClient struct {
 	// through the typed schema parse (telemetry only).
 	parsedNotificationMethods sync.Map
 	mcpFailureMu              sync.Mutex
-	mcpFailureScheduled       bool
+	mcpFailureObserved        bool
 }
 
 type codexAppServerCaller struct {
@@ -101,11 +101,11 @@ func (c *codexAppServerClient) observeMCPStderr(chunk []byte) {
 	diagnostics := c.raw.Diagnostics()
 	detail := diagnostics.StderrTail
 	failure := codexMCPServerStartupFailureFromStderr(detail)
-	c.scheduleMCPFailure(failure, "stderr")
+	c.observeMCPFailure(failure, "stderr")
 }
 
 func (c *codexAppServerClient) observeMCPStartupStatus(status map[string]any) {
-	c.scheduleMCPFailure(codexMCPServerStartupFailureFromStatus(status), "notification")
+	c.observeMCPFailure(codexMCPServerStartupFailureFromStatus(status), "notification")
 }
 
 func (c *codexAppServerClient) completeThreadLifecycleFromNotification(thread map[string]any) {
@@ -124,33 +124,27 @@ func (c *codexAppServerClient) completeThreadLifecycleFromNotification(thread ma
 	c.raw.completeActiveHandler(appServerMethodThreadResume, result)
 }
 
-func (c *codexAppServerClient) scheduleMCPFailure(failure error, source string) {
+// observeMCPFailure records provider-owned MCP state without changing the
+// lifecycle result of an unrelated app-server RPC. Codex treats MCP servers
+// as optional unless its own lifecycle response says otherwise; stderr and
+// startup-status notifications do not carry enough authority to close the
+// Codex session.
+func (c *codexAppServerClient) observeMCPFailure(failure error, source string) {
 	if c == nil || failure == nil {
 		return
 	}
 	c.mcpFailureMu.Lock()
-	if c.mcpFailureScheduled {
+	if c.mcpFailureObserved {
 		c.mcpFailureMu.Unlock()
 		return
 	}
-	c.mcpFailureScheduled = true
+	c.mcpFailureObserved = true
 	c.mcpFailureMu.Unlock()
 	slog.Warn("agent session Codex MCP server startup failed",
 		"event", "agent_session.codex.mcp.startup_failed",
 		"source", source,
 		"error", failure.Error(),
-		"grace_ms", defaultCodexAppServerMCPFailureGraceWindow.Milliseconds(),
 	)
-	time.AfterFunc(defaultCodexAppServerMCPFailureGraceWindow, func() {
-		c.failActiveCall(failure)
-	})
-}
-
-func (c *codexAppServerClient) failActiveCall(err error) {
-	if c == nil || c.raw == nil {
-		return
-	}
-	c.raw.failActiveHandler(err)
 }
 
 func (c *codexAppServerClient) Close() error {

--- a/packages/agent/daemon/runtime/codex_appserver_lifecycle_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_lifecycle_test.go
@@ -391,44 +391,7 @@ func TestCodexAppServerAdapterResumeThreadFailureKeepsPreviousSessionLive(t *tes
 	}
 }
 
-func TestCodexAppServerAdapterResumeMCPAuthFailureDoesNotBecomeLifecycleTimeout(t *testing.T) {
-	t.Parallel()
-
-	transport := &multiProcAppServerTransport{}
-	adapter := NewCodexAppServerAdapter(transport)
-	session := testAppServerSession()
-	if _, err := adapter.Start(context.Background(), session); err != nil {
-		t.Fatalf("Start: %v", err)
-	}
-	transport.setConfigure(func(server *fakeCodexAppServer) {
-		server.mcpAuthStderrOnResume = true
-	})
-	session.ProviderSessionID = "codex-thread-1"
-	startedAt := time.Now()
-	err := adapter.Resume(context.Background(), session)
-	if err == nil {
-		t.Fatal("Resume with MCP auth failure should error")
-	}
-	if elapsed := time.Since(startedAt); elapsed >= 3*time.Second {
-		t.Fatalf("Resume took %s; MCP failure became a lifecycle timeout", elapsed)
-	}
-	var mcpErr *codexMCPServerStartupError
-	if !errors.As(err, &mcpErr) {
-		t.Fatalf("Resume error = %v, want codexMCPServerStartupError", err)
-	}
-	if mcpErr.FailureReason != "reauthenticationRequired" {
-		t.Fatalf("MCP failure reason = %q, want reauthenticationRequired", mcpErr.FailureReason)
-	}
-	spawned, live := transport.snapshot()
-	if spawned != 2 || len(live) != 1 || live[0] != transport.conn(0) {
-		t.Fatalf("spawned=%d live=%d, want only the original process live after failed resume", spawned, len(live))
-	}
-	if !adapter.HasLiveSession(session) {
-		t.Fatal("HasLiveSession = false: MCP startup failure must preserve the previous session")
-	}
-}
-
-func TestCodexAppServerAdapterResumeResponseWinsMCPAuthGraceRace(t *testing.T) {
+func TestCodexAppServerAdapterResumeMCPAuthFailureDoesNotBlockLifecycle(t *testing.T) {
 	t.Parallel()
 
 	transport := &multiProcAppServerTransport{}
@@ -440,39 +403,74 @@ func TestCodexAppServerAdapterResumeResponseWinsMCPAuthGraceRace(t *testing.T) {
 	transport.setConfigure(func(server *fakeCodexAppServer) {
 		server.mcpAuthStderrOnResume = true
 		server.mcpAuthStderrResumeResponse = true
+		server.mcpFailureResponseDelay = 1100 * time.Millisecond
 	})
 	session.ProviderSessionID = "codex-thread-1"
-	if err := adapter.Resume(context.Background(), session); err != nil {
-		t.Fatalf("Resume response lost the MCP grace race: %v", err)
+	startedAt := time.Now()
+	err := adapter.Resume(context.Background(), session)
+	if err != nil {
+		t.Fatalf("Resume with optional MCP auth failure: %v", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed >= 3*time.Second {
+		t.Fatalf("Resume took %s; MCP failure blocked lifecycle", elapsed)
 	}
 	spawned, live := transport.snapshot()
 	if spawned != 2 || len(live) != 1 || live[0] != transport.conn(1) {
 		t.Fatalf("spawned=%d live=%d, want only the resumed process live", spawned, len(live))
 	}
+	if !adapter.HasLiveSession(session) {
+		t.Fatal("HasLiveSession = false after optional MCP startup failure")
+	}
 }
 
-func TestCodexAppServerAdapterMCPStartupStatusFailureDoesNotBecomeLifecycleTimeout(t *testing.T) {
+func TestCodexAppServerAdapterStartMCPAuthFailureDoesNotBlockLifecycle(t *testing.T) {
+	t.Parallel()
+
+	transport := &multiProcAppServerTransport{}
+	adapter := NewCodexAppServerAdapter(transport)
+	transport.setConfigure(func(server *fakeCodexAppServer) {
+		server.mcpAuthStderrOnStart = true
+		server.mcpAuthStderrStartResponse = true
+		server.mcpFailureResponseDelay = 1100 * time.Millisecond
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if _, err := adapter.Start(ctx, testAppServerSession()); err != nil {
+		t.Fatalf("Start with optional MCP auth failure: %v", err)
+	}
+	spawned, live := transport.snapshot()
+	if spawned != 1 || len(live) != 1 || live[0] != transport.conn(0) {
+		t.Fatalf("spawned=%d live=%d, want the started process to remain live", spawned, len(live))
+	}
+}
+
+func TestCodexAppServerAdapterMCPStartupStatusFailureDoesNotBlockLifecycle(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		configure   func(*fakeCodexAppServer)
-		resume      bool
-		wantOldLive bool
+		name          string
+		configure     func(*fakeCodexAppServer)
+		resume        bool
+		wantLiveIndex int
 	}{
 		{
 			name: "start",
 			configure: func(server *fakeCodexAppServer) {
 				server.mcpStartupStatusFailedOnStart = true
+				server.mcpStartupStatusFailureResponse = true
+				server.mcpFailureResponseDelay = 1100 * time.Millisecond
 			},
+			wantLiveIndex: 0,
 		},
 		{
 			name: "resume",
 			configure: func(server *fakeCodexAppServer) {
 				server.mcpStartupStatusFailedOnResume = true
+				server.mcpStartupStatusFailureResponse = true
+				server.mcpFailureResponseDelay = 1100 * time.Millisecond
 			},
-			resume:      true,
-			wantOldLive: true,
+			resume:        true,
+			wantLiveIndex: 1,
 		},
 	}
 
@@ -498,30 +496,22 @@ func TestCodexAppServerAdapterMCPStartupStatusFailureDoesNotBecomeLifecycleTimeo
 			} else {
 				_, err = adapter.Start(ctx, session)
 			}
-			if err == nil {
-				t.Fatal("MCP startup status failure unexpectedly succeeded")
+			if err != nil {
+				t.Fatalf("MCP startup status failure blocked lifecycle: %v", err)
 			}
 			if elapsed := time.Since(startedAt); elapsed >= 3*time.Second {
-				t.Fatalf("lifecycle call took %s; MCP failure became a timeout: %v", elapsed, err)
-			}
-			var mcpErr *codexMCPServerStartupError
-			if !errors.As(err, &mcpErr) {
-				t.Fatalf("lifecycle error = %v, want codexMCPServerStartupError", err)
-			}
-			if mcpErr.Name != "figma" || mcpErr.FailureReason != "reauthenticationRequired" ||
-				mcpErr.Detail != "MCP server requires authentication" {
-				t.Fatalf("MCP error = %#v, want structured notification fields", mcpErr)
+				t.Fatalf("lifecycle call took %s; MCP failure blocked lifecycle", elapsed)
 			}
 			spawned, live := transport.snapshot()
-			if test.wantOldLive {
-				if spawned != 2 || len(live) != 1 || live[0] != transport.conn(0) {
-					t.Fatalf("spawned=%d live=%d, want only the original process live after failed resume", spawned, len(live))
-				}
-				if !adapter.HasLiveSession(session) {
-					t.Fatal("HasLiveSession = false: failed resume must preserve the previous session")
-				}
-			} else if spawned != 1 || len(live) != 0 {
-				t.Fatalf("spawned=%d live=%d, want failed start process closed", spawned, len(live))
+			wantSpawned := 1
+			if test.resume {
+				wantSpawned = 2
+			}
+			if spawned != wantSpawned || len(live) != 1 || live[0] != transport.conn(test.wantLiveIndex) {
+				t.Fatalf("spawned=%d live=%d, want process %d to remain live", spawned, len(live), test.wantLiveIndex)
+			}
+			if !adapter.HasLiveSession(session) {
+				t.Fatal("HasLiveSession = false after optional MCP startup failure")
 			}
 		})
 	}

--- a/packages/agent/daemon/runtime/codex_appserver_mcp.go
+++ b/packages/agent/daemon/runtime/codex_appserver_mcp.go
@@ -3,17 +3,9 @@ package agentruntime
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
-
-// defaultCodexAppServerMCPFailureGraceWindow gives the app-server a short
-// chance to finish an in-flight lifecycle response after rmcp or app-server
-// reports a fatal MCP startup failure. A broken MCP worker must not turn into
-// the generic 30-second thread/start or thread/resume timeout, while a response
-// already in flight still wins the race.
-const defaultCodexAppServerMCPFailureGraceWindow = time.Second
 
 type codexMCPServerStartupError struct {
 	Name          string
@@ -110,10 +102,21 @@ func codexMCPServerStartupWarningEvent(
 	detail = limitVisibleErrorDetail(cleanVisibleErrorText(detail))
 
 	title := fmt.Sprintf("MCP server %s startup failed", name)
+	messageID := "mcp-startup-warning:" + strings.TrimSpace(session.AgentSessionID) + ":" + name
 	metadata := map[string]any{
-		"messageId": "mcp-startup-warning:" + strings.TrimSpace(session.AgentSessionID) + ":" + name,
+		"messageId": messageID,
 		"code":      "mcp_server_startup_failed",
 		"retryable": false,
+	}
+	if strings.TrimSpace(turnID) == "" {
+		metadata["kind"] = "agent_system_notice"
+		metadata["noticeKind"] = "warning"
+		metadata["severity"] = "warning"
+		metadata["title"] = title
+		if detail != "" {
+			metadata["detail"] = detail
+		}
+		return newSessionAuditEventWithID(session, messageID, RoleAssistant, title, metadata)
 	}
 	return appServerSystemNoticeEvent(session, turnID, "warning", title, detail, metadata)
 }

--- a/packages/agent/daemon/runtime/codex_appserver_mcp_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_mcp_test.go
@@ -133,6 +133,9 @@ func TestCodexAppServerReducerProjectsMCPStartupStatus(t *testing.T) {
 			}
 			metadata := event.Payload.Metadata
 			if asString(metadata["kind"]) == "agent_system_notice" {
+				if event.Type != activityshared.EventSessionAudit || event.Payload.TurnID != "" {
+					t.Fatalf("turnless MCP warning event = %#v, want session audit without turnId", event)
+				}
 				if asString(metadata["noticeKind"]) != "warning" ||
 					asString(metadata["severity"]) != "warning" ||
 					asString(metadata["detail"]) != "MCP server requires authentication" ||
@@ -147,5 +150,23 @@ func TestCodexAppServerReducerProjectsMCPStartupStatus(t *testing.T) {
 		case <-deadline:
 			t.Fatalf("MCP startup status/warning projection missing: status=%t warning=%t", statusFound, warningFound)
 		}
+	}
+}
+
+func TestCodexAppServerStartupWarningKeepsTurnScopedProjection(t *testing.T) {
+	adapter, _, session := startedAppServerAdapter(t)
+	appSession := adapter.getSession(session.AgentSessionID)
+	if appSession == nil {
+		t.Fatal("missing app-server session")
+	}
+
+	event := codexMCPServerStartupWarningEvent(appSession.client, session, "turn-1", map[string]any{
+		"name":          "figma",
+		"status":        "failed",
+		"failureReason": "reauthenticationRequired",
+		"error":         "MCP server requires authentication",
+	})
+	if event.Type != activityshared.EventMessageAppended || event.Payload.TurnID != "turn-1" {
+		t.Fatalf("turn-scoped MCP warning event = %#v, want message on turn-1", event)
 	}
 }

--- a/packages/agent/daemon/runtime/codex_appserver_scripted_session_rpc_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_scripted_session_rpc_test.go
@@ -33,8 +33,11 @@ type scriptedSessionState struct {
 	threadName                      string
 	replayTokenUsageOnResume        bool
 	threadResumeError               bool
+	mcpAuthStderrOnStart            bool
 	mcpAuthStderrOnResume           bool
+	mcpAuthStderrStartResponse      bool
 	mcpAuthStderrResumeResponse     bool
+	mcpFailureResponseDelay         time.Duration
 	mcpStartupStatusFailedOnStart   bool
 	mcpStartupStatusFailedOnResume  bool
 	mcpStartupStatusFailureResponse bool
@@ -205,8 +208,11 @@ func (s *fakeCodexAppServer) handleSessionRPC(message scriptedAppServerMessage) 
 	case appServerMethodThreadStart, appServerMethodThreadResume:
 		s.mu.Lock()
 		threadResumeError := s.threadResumeError && message.Method == appServerMethodThreadResume
+		mcpAuthStderrOnStart := s.mcpAuthStderrOnStart && message.Method == appServerMethodThreadStart
 		mcpAuthStderrOnResume := s.mcpAuthStderrOnResume && message.Method == appServerMethodThreadResume
+		mcpAuthStderrStartResponse := s.mcpAuthStderrStartResponse && message.Method == appServerMethodThreadStart
 		mcpAuthStderrResumeResponse := s.mcpAuthStderrResumeResponse && message.Method == appServerMethodThreadResume
+		mcpFailureResponseDelay := s.mcpFailureResponseDelay
 		mcpStartupStatusFailed := (s.mcpStartupStatusFailedOnStart && message.Method == appServerMethodThreadStart) ||
 			(s.mcpStartupStatusFailedOnResume && message.Method == appServerMethodThreadResume)
 		mcpStartupStatusFailureResponse := s.mcpStartupStatusFailureResponse
@@ -215,9 +221,12 @@ func (s *fakeCodexAppServer) handleSessionRPC(message scriptedAppServerMessage) 
 		threadStartedResponse := s.threadStartedResponse
 		replayTokenUsage := s.replayTokenUsageOnResume && message.Method == appServerMethodThreadResume
 		s.mu.Unlock()
-		if mcpAuthStderrOnResume {
+		mcpAuthStderr := mcpAuthStderrOnStart || mcpAuthStderrOnResume
+		mcpAuthStderrResponse := (mcpAuthStderrOnStart && mcpAuthStderrStartResponse) ||
+			(mcpAuthStderrOnResume && mcpAuthStderrResumeResponse)
+		if mcpAuthStderr {
 			s.sendStderr([]byte(`rmcp::transport::worker: worker quit with fatal: Transport channel closed, when AuthRequired(AuthRequiredError { www_authenticate_header: "Bearer resource_metadata=\"https://mcp.figma.com/.well-known/oauth-protected-resource\",scope=\"mcp:connect\"" })`))
-			if !mcpAuthStderrResumeResponse {
+			if !mcpAuthStderrResponse {
 				return true
 			}
 		}
@@ -260,7 +269,7 @@ func (s *fakeCodexAppServer) handleSessionRPC(message scriptedAppServerMessage) 
 				},
 			})
 		}
-		s.sendJSON(map[string]any{
+		response := map[string]any{
 			"id": message.ID,
 			"result": map[string]any{
 				"thread":          map[string]any{"id": "codex-thread-1"},
@@ -271,7 +280,15 @@ func (s *fakeCodexAppServer) handleSessionRPC(message scriptedAppServerMessage) 
 				"sandbox":         map[string]any{"type": "workspaceWrite"},
 				"modelProvider":   "openai",
 			},
-		})
+		}
+		if (mcpAuthStderr || mcpStartupStatusFailed) && mcpFailureResponseDelay > 0 {
+			go func() {
+				time.Sleep(mcpFailureResponseDelay)
+				s.sendJSON(response)
+			}()
+			return true
+		}
+		s.sendJSON(response)
 		if !threadStarted {
 			s.notify(appServerNotifyThreadStarted, map[string]any{
 				"thread": map[string]any{"id": "codex-thread-1"},


### PR DESCRIPTION
## Summary
- Keep Codex app-server Start/Resume independent from optional MCP stderr and startup-status failures.
- Preserve real Codex lifecycle RPC, process, and transport errors as terminal.
- Project turnless MCP warnings as session audit events and add regression coverage.

## Tests
- `pnpm check:changed -- --push-ready` (pre-push, 8 lanes)
- `go test ./packages/agent/daemon/runtime -count=1`
- Focused runtime tests with `-race`

## Notes
- This PR changes Tutti only; no TSH dependency update is included.
