### PR TITLE
fix(release): backport Agent workspace regressions

### DIFF
--- a/.changeset/agent-windows-system-actions-and-layout.md
+++ b/.changeset/agent-windows-system-actions-and-layout.md
@@ -1,0 +1,8 @@
+---
+"@tutti-os/agent-gui": patch
+"@tutti-os/desktop": patch
+---
+
+Expose Desktop update checks and developer-log export from Agent mode, normalize
+Windows workspace paths before file clipboard writes, and keep standalone app
+webviews attached to their live sidebar height while switching tool tabs.

--- a/apps/desktop/src/main/host/clipboardFilePaths.test.ts
+++ b/apps/desktop/src/main/host/clipboardFilePaths.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildWindowsFileDropBuffer,
+  normalizeClipboardFilePaths
+} from "./clipboardFilePaths.ts";
+
+test("normalizes workspace API drive paths before Windows clipboard access", () => {
+  assert.deepEqual(
+    normalizeClipboardFilePaths(
+      [" /C:/Users/15514/Documents/tutti ", "C:/Users/15514/Documents/tutti"],
+      "win32"
+    ),
+    ["C:\\Users\\15514\\Documents\\tutti"]
+  );
+});
+
+test("preserves absolute POSIX clipboard paths", () => {
+  assert.deepEqual(
+    normalizeClipboardFilePaths([" /Users/test/Documents/tutti "], "darwin"),
+    ["/Users/test/Documents/tutti"]
+  );
+});
+
+test("builds a wide Windows DROPFILES payload", () => {
+  const buffer = buildWindowsFileDropBuffer([
+    "C:\\Users\\15514\\Documents\\tutti",
+    "D:\\Shared\\notes.txt"
+  ]);
+
+  assert.equal(buffer.readUInt32LE(0), 20);
+  assert.equal(buffer.readInt32LE(4), 0);
+  assert.equal(buffer.readInt32LE(8), 0);
+  assert.equal(buffer.readInt32LE(12), 0);
+  assert.equal(buffer.readInt32LE(16), 1);
+  assert.equal(
+    buffer.subarray(20).toString("utf16le"),
+    "C:\\Users\\15514\\Documents\\tutti\0D:\\Shared\\notes.txt\0\0"
+  );
+  assert.deepEqual(buffer.subarray(-4), Buffer.alloc(4));
+});

--- a/apps/desktop/src/main/host/clipboardFilePaths.ts
+++ b/apps/desktop/src/main/host/clipboardFilePaths.ts
@@ -1,0 +1,37 @@
+import path from "node:path";
+
+export function normalizeClipboardFilePaths(
+  filePaths: readonly string[],
+  platform: NodeJS.Platform = process.platform
+): string[] {
+  const pathApi = platform === "win32" ? path.win32 : path.posix;
+  return [
+    ...new Set(
+      filePaths
+        .map((filePath) => filePath.trim())
+        .filter(Boolean)
+        .map((filePath) =>
+          platform === "win32" && /^\/[A-Za-z]:[\\/]/u.test(filePath)
+            ? filePath.slice(1)
+            : filePath
+        )
+        .map((filePath) => pathApi.resolve(filePath))
+    )
+  ];
+}
+
+export function buildWindowsFileDropBuffer(
+  filePaths: readonly string[]
+): Buffer {
+  const widePaths =
+    filePaths.map((filePath) => `${path.win32.resolve(filePath)}\0`).join("") +
+    "\0";
+  const pathsBuffer = Buffer.from(widePaths, "utf16le");
+  const header = Buffer.alloc(20);
+  header.writeUInt32LE(20, 0);
+  header.writeInt32LE(0, 4);
+  header.writeInt32LE(0, 8);
+  header.writeInt32LE(0, 12);
+  header.writeInt32LE(1, 16);
+  return Buffer.concat([header, pathsBuffer]);
+}

--- a/apps/desktop/src/main/host/clipboardFiles.ts
+++ b/apps/desktop/src/main/host/clipboardFiles.ts
@@ -4,6 +4,10 @@ import path from "node:path";
 import { clipboard, nativeImage } from "electron";
 import { writeImageToClipboardWriter } from "./clipboardImageWriter.ts";
 import { buildFilenamesPlist } from "./clipboardFilePlist.ts";
+import {
+  buildWindowsFileDropBuffer,
+  normalizeClipboardFilePaths
+} from "./clipboardFilePaths.ts";
 
 type SystemClipboardWriter = Pick<
   typeof clipboard,
@@ -35,14 +39,7 @@ export function writeFilesToSystemClipboard(
   filePaths: readonly string[],
   deps: SystemClipboardDependencies = {}
 ): void {
-  const normalizedPaths = [
-    ...new Set(
-      filePaths
-        .map((filePath) => filePath.trim())
-        .filter(Boolean)
-        .map((filePath) => path.resolve(filePath))
-    )
-  ];
+  const normalizedPaths = normalizeClipboardFilePaths(filePaths);
   if (normalizedPaths.length === 0) {
     throw new Error("clipboard file paths are required");
   }
@@ -69,26 +66,12 @@ export function writeFilesToSystemClipboard(
     clipboardWriter.clear();
     clipboardWriter.writeBuffer(
       "CF_HDROP",
-      buildCFHDropBuffer(normalizedPaths)
+      buildWindowsFileDropBuffer(normalizedPaths)
     );
     return;
   }
 
   throw new Error("clipboard file copy is unsupported on this platform");
-}
-
-function buildCFHDropBuffer(filePaths: readonly string[]): Buffer {
-  const widePaths =
-    filePaths.map((filePath) => `${path.win32.resolve(filePath)}\0`).join("") +
-    "\0";
-  const pathsBuffer = Buffer.from(widePaths, "utf16le");
-  const header = Buffer.alloc(20);
-  header.writeUInt32LE(20, 0);
-  header.writeUInt32LE(1, 4);
-  header.writeUInt32LE(0, 8);
-  header.writeInt32LE(0, 12);
-  header.writeInt32LE(0, 16);
-  return Buffer.concat([header, pathsBuffer]);
 }
 
 function isPathWithinRoot(rootPath: string, candidatePath: string): boolean {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentConfigSystemActions.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentConfigSystemActions.tsx
@@ -1,0 +1,112 @@
+import {
+  DownloadIcon,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  RefreshIcon
+} from "@tutti-os/ui-system";
+import { useAppUpdateService } from "@renderer/features/app-update";
+import { useTranslation } from "@renderer/i18n";
+import { useWorkspaceSettingsService } from "../../workspace-workbench/ui/useWorkspaceSettingsService";
+
+const actionClassName =
+  "nodrag flex h-7 w-full items-center gap-2 rounded-[6px] px-2 text-[13px] text-[var(--text-primary)] transition-colors hover:bg-[var(--transparency-hover)] hover:text-[var(--text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-focus)] disabled:text-[var(--text-tertiary)] [-webkit-app-region:no-drag]";
+
+export function DesktopAgentConfigSystemActions(): React.JSX.Element {
+  const { t } = useTranslation();
+  const { service: appUpdateService, state: appUpdateState } =
+    useAppUpdateService();
+  const { service: settingsService, state: settingsState } =
+    useWorkspaceSettingsService();
+
+  const exportLogs = (input: {
+    includeAgentSessions: boolean;
+    scope: "recent-10-minutes" | "recent-3-days";
+  }): void => {
+    void settingsService.exportDeveloperLogs(input);
+  };
+
+  return (
+    <div className="flex min-w-0 flex-col gap-1">
+      <button
+        className={actionClassName}
+        data-testid="agent-gui-config-check-updates"
+        disabled={appUpdateState.isActing}
+        onClick={() => void appUpdateService.checkForUpdates()}
+        type="button"
+      >
+        <RefreshIcon aria-hidden="true" className="size-4" />
+        <span>
+          {appUpdateState.isActing
+            ? t("updates.checkingTitle")
+            : t("desktop.menu.checkForUpdates")}
+        </span>
+      </button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            className={actionClassName}
+            data-testid="agent-gui-config-export-logs"
+            disabled={settingsState.developerLogs.exporting}
+            type="button"
+          >
+            <DownloadIcon aria-hidden="true" className="size-4" />
+            <span>{t("workspace.settings.developer.exportLogs")}</span>
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="start"
+          className="w-64"
+          side="right"
+          style={{ zIndex: "calc(var(--z-panel-popover) + 1)" }}
+        >
+          <DropdownMenuItem
+            onSelect={() =>
+              exportLogs({
+                includeAgentSessions: false,
+                scope: "recent-10-minutes"
+              })
+            }
+          >
+            {t("workspace.settings.developer.exportRecentTenMinutesLogsOnly")}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() =>
+              exportLogs({
+                includeAgentSessions: true,
+                scope: "recent-10-minutes"
+              })
+            }
+          >
+            {t(
+              "workspace.settings.developer.exportRecentTenMinutesLogsWithSessions"
+            )}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() =>
+              exportLogs({
+                includeAgentSessions: false,
+                scope: "recent-3-days"
+              })
+            }
+          >
+            {t("workspace.settings.developer.exportRecentThreeDaysLogsOnly")}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() =>
+              exportLogs({
+                includeAgentSessions: true,
+                scope: "recent-3-days"
+              })
+            }
+          >
+            {t(
+              "workspace.settings.developer.exportRecentThreeDaysLogsWithSessions"
+            )}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -72,6 +72,7 @@ import { resolveDesktopAgentGUIEmbeddedDesktopSize } from "./desktopAgentGUIEmbe
 import { scheduleDesktopAgentGUIWorkbenchHydration } from "./desktopAgentGUIWorkbenchHydration.ts";
 import { resolveDesktopAgentGUIWorkbenchBodyVisibility } from "./desktopAgentGUIWorkbenchVisibility.ts";
 import { useDesktopAgentConfigCommerce } from "./useDesktopAgentConfigCommerce.tsx";
+import { DesktopAgentConfigSystemActions } from "./DesktopAgentConfigSystemActions.tsx";
 import { hasDesktopLocalTuttiAgent } from "./desktopAgentConfigCommerceContext.ts";
 import { useDesktopAgentGUIComposerFooterAccessory } from "./useDesktopAgentGUIComposerFooterAccessory.tsx";
 import { useDesktopAgentGUIOpenSessionComposerRequest } from "./useDesktopAgentGUIOpenSessionComposerRequest.ts";
@@ -96,6 +97,10 @@ import {
 const EMPTY_AGENT_SESSION_LAUNCH_MODES_BY_PROJECT_SECTION_KEY: Readonly<
   Record<string, AgentGUISessionLaunchMode>
 > = Object.freeze({});
+
+const renderDesktopAgentConfigSystemActions: NonNullable<
+  AgentGUIProps["renderSlots"]["agentConfigSystemActions"]
+> = () => <DesktopAgentConfigSystemActions />;
 
 const AgentSessionReplayNodeReadiness = lazy(() =>
   import("../../agent-session-replay/ui/AgentSessionReplayNodeReadiness.tsx").then(
@@ -699,6 +704,7 @@ function DesktopAgentGUISurfaceImpl({
     },
     renderSlots: {
       agentConfigAccount: renderAgentConfigAccount,
+      agentConfigSystemActions: renderDesktopAgentConfigSystemActions,
       composerFooterAccessory: renderComposerFooterAccessory,
       sidebarFooter: renderSidebarFooter
     }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/useStableDesktopAgentGUIHostProps.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/useStableDesktopAgentGUIHostProps.test.ts
@@ -45,6 +45,7 @@ test("React Compiler preserves field-keyed Agent GUI host projections", async ()
   assert.match(compiled, /nextHostActions\.onAgentConfigMenuOpen/);
   assert.match(compiled, /nextHostActions\.onOpenConversationWindow/);
   assert.match(compiled, /nextRenderSlots\.agentConfigAccount/);
+  assert.match(compiled, /nextRenderSlots\.agentConfigSystemActions/);
 });
 
 test("forwards the explicitly selected project directory capability", () => {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/useStableDesktopAgentGUIHostProps.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/useStableDesktopAgentGUIHostProps.ts
@@ -56,7 +56,10 @@ export type DesktopAgentGUIHostProps = {
   >;
   renderSlots: Pick<
     AgentGUIProps["renderSlots"],
-    "agentConfigAccount" | "composerFooterAccessory" | "sidebarFooter"
+    | "agentConfigAccount"
+    | "agentConfigSystemActions"
+    | "composerFooterAccessory"
+    | "sidebarFooter"
   >;
 };
 
@@ -144,6 +147,7 @@ export function useStableDesktopAgentGUIHostProps({
     },
     renderSlots: {
       agentConfigAccount: nextRenderSlots.agentConfigAccount,
+      agentConfigSystemActions: nextRenderSlots.agentConfigSystemActions,
       composerFooterAccessory: nextRenderSlots.composerFooterAccessory,
       sidebarFooter: nextRenderSlots.sidebarFooter
     }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentAppViewerLayout.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentAppViewerLayout.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { syncStandaloneAgentAppViewerWebviewBounds } from "./standaloneAgentAppViewerLayout.ts";
 
-test("standalone Agent app viewer gives the Electron webview explicit host bounds", () => {
+test("standalone Agent app viewer keeps the Electron webview bound to its live host", () => {
   const webview = { style: { height: "150px", width: "300px" } };
   const surface = {
     clientHeight: 468,
@@ -11,7 +11,12 @@ test("standalone Agent app viewer gives the Electron webview explicit host bound
   };
 
   assert.equal(syncStandaloneAgentAppViewerWebviewBounds(surface), true);
-  assert.deepEqual(webview.style, { height: "468px", width: "796px" });
+  assert.deepEqual(webview.style, { height: "100%", width: "100%" });
+
+  surface.clientHeight = 620;
+  surface.clientWidth = 1040;
+  assert.equal(syncStandaloneAgentAppViewerWebviewBounds(surface), true);
+  assert.deepEqual(webview.style, { height: "100%", width: "100%" });
 });
 
 test("standalone Agent app viewer waits until its hidden surface has layout bounds", () => {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentAppViewerLayout.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentAppViewerLayout.ts
@@ -16,8 +16,11 @@ export function syncStandaloneAgentAppViewerWebviewBounds(
   const webview = surface.querySelector(workspaceAppWebviewSelector);
   if (!webview || width <= 0 || height <= 0) return false;
 
-  const nextWidth = `${width}px`;
-  const nextHeight = `${height}px`;
+  // Keep the guest attached to the live host bounds. Writing a transient pixel
+  // height while tabs are switching can freeze Electron's webview at its
+  // intermediate/default height even after the sidebar finishes laying out.
+  const nextWidth = "100%";
+  const nextHeight = "100%";
   if (webview.style.width !== nextWidth) webview.style.width = nextWidth;
   if (webview.style.height !== nextHeight) webview.style.height = nextHeight;
   return true;

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.status.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.status.spec.tsx
@@ -210,6 +210,27 @@ describe("AgentGUINode status controller integration", () => {
     });
   });
 
+  it("renders Host system actions in the all-provider config menu", () => {
+    mockViewModel = createViewModel({
+      conversationFilter: { kind: "all" }
+    });
+    const renderAgentConfigSystemActions = vi.fn(() => (
+      <div data-testid="host-system-actions">Host system actions</div>
+    ));
+
+    render(
+      <AgentGUINode
+        {...createProps()}
+        renderSlots={{
+          agentConfigSystemActions: renderAgentConfigSystemActions
+        }}
+      />
+    );
+
+    expect(renderAgentConfigSystemActions).toHaveBeenCalledOnce();
+    expect(latestViewProps().agentConfigSystemActionsContent).toBeTruthy();
+  });
+
   it("does not project status from the previous target after a target switch", () => {
     mockViewModel = createViewModel();
     let observer: AgentStatusStreamObserver | null = null;
@@ -456,6 +477,7 @@ describe("AgentGUINode status controller integration", () => {
 
 interface CapturedViewProps {
   agentConfigAccountContent?: React.ReactNode;
+  agentConfigSystemActionsContent?: React.ReactNode;
   onAgentConfigMenuOpen?: () => void;
   onAgentConfigMenuClose?: () => void;
   providerAuthAccountLabels?: Partial<Record<string, string>>;

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -152,6 +152,7 @@ export const AgentGUINode = memo(function AgentGUINode({
   } = hostActions;
   const {
     agentConfigAccount: renderAgentConfigAccount,
+    agentConfigSystemActions: renderAgentConfigSystemActions,
     agentTargetInfo: renderAgentTargetInfo,
     composerFooterAccessory: renderComposerFooterAccessory,
     projectDirectoryPickerHeaderActions:
@@ -398,6 +399,8 @@ export const AgentGUINode = memo(function AgentGUINode({
   const agentConfigAccountContent = agentConfigMenuContext
     ? (renderAgentConfigAccount?.(agentConfigMenuContext) ?? null)
     : null;
+  const agentConfigSystemActionsContent =
+    renderAgentConfigSystemActions?.() ?? null;
 
   return (
     <AgentGUIMentionServiceBoundary
@@ -511,6 +514,7 @@ export const AgentGUINode = memo(function AgentGUINode({
                 controllerRailStatus?.resolvedEmpty ?? false
               }
               agentConfigAccountContent={agentConfigAccountContent}
+              agentConfigSystemActionsContent={agentConfigSystemActionsContent}
               providerAuthAccountLabels={effectiveProviderAuthAccountLabels}
               onAgentConfigMenuClose={handleAgentConfigMenuClose}
               onAgentConfigMenuOpen={handleAgentConfigMenuOpen}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
@@ -259,6 +259,8 @@ export interface AgentGUINodeRenderSlots {
    * Returning null preserves AgentGUI's provider account and quota content.
    */
   agentConfigAccount?: (context: AgentGUIAgentConfigMenuContext) => ReactNode;
+  /** Optional Host-owned system actions appended to the Agent config menu. */
+  agentConfigSystemActions?: () => ReactNode;
   projectDirectoryPickerHeaderActions?: ReferenceSourcePickerProps["renderHeaderActions"];
   projectSelectOptions?: AgentProjectDropdownOptions;
   referencePickerSidebarActions?: (
@@ -500,6 +502,7 @@ export function areAgentGUINodePropsEqual(
     pa.onEngagementEvent === na.onEngagementEvent &&
     pa.onConversationRailLayoutChange === na.onConversationRailLayoutChange &&
     ps.agentConfigAccount === ns.agentConfigAccount &&
+    ps.agentConfigSystemActions === ns.agentConfigSystemActions &&
     ps.agentTargetInfo === ns.agentTargetInfo &&
     ps.composerFooterAccessory === ns.composerFooterAccessory &&
     ps.providerRailEmpty === ns.providerRailEmpty &&

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -113,6 +113,7 @@ export function AgentGUINodeView({
   slashStatusUsageErrorMessage = null,
   slashStatusUsageAttempted = false,
   agentConfigAccountContent,
+  agentConfigSystemActionsContent,
   onAgentConfigMenuClose,
   onAgentConfigMenuOpen,
   onAgentUsageRefresh,
@@ -613,6 +614,7 @@ export function AgentGUINodeView({
                   providerLabel={railConfigTarget?.label}
                   providerAuthAccountLabel={effectiveProviderAuthAccountLabel}
                   accountContent={agentConfigAccountContent}
+                  systemActionsContent={agentConfigSystemActionsContent}
                   onAgentConfigMenuClose={onAgentConfigMenuClose}
                   onAgentConfigMenuOpen={onAgentConfigMenuOpen}
                   onAgentUsageRefresh={onAgentUsageRefresh}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.spec.tsx
@@ -27,6 +27,36 @@ const labels = {
 } as unknown as AgentGUIViewLabels;
 
 describe("AgentGUIConfigMenu", () => {
+  it("keeps Host system actions interactive after Agent settings", () => {
+    const onSystemAction = vi.fn();
+    render(
+      <AgentGUIConfigMenu
+        environmentSetupVisible={false}
+        labels={labels}
+        providerScopedActionsVisible
+        slashStatusLimits={[]}
+        slashStatusLimitsLoading={false}
+        slashStatusLimitsResolvedEmpty={false}
+        slashStatusUsageCapturedAtUnixMs={null}
+        slashStatusUsageDidFail={false}
+        slashStatusUsageAttempted={false}
+        systemActionsContent={
+          <button type="button" onClick={onSystemAction}>
+            Check for updates
+          </button>
+        }
+        onOpenAgentEnvSetup={vi.fn()}
+        onOpenAgentSettings={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "More" }));
+    fireEvent.click(screen.getByRole("button", { name: "Check for updates" }));
+
+    expect(onSystemAction).toHaveBeenCalledOnce();
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+  });
+
   it("replaces provider quota chrome only when the Host supplies account content", () => {
     const onOpen = vi.fn();
     render(

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.tsx
@@ -12,6 +12,7 @@ import type { AgentGUIViewLabels } from "../AgentGUINodeView";
 
 interface AgentGUIConfigMenuProps {
   accountContent?: ReactNode;
+  systemActionsContent?: ReactNode;
   environmentSetupVisible: boolean;
   labels: AgentGUIViewLabels;
   providerScopedActionsVisible: boolean;
@@ -40,6 +41,7 @@ export function AgentGUIConfigAccountFallbackSuppressed(): null {
 
 export function AgentGUIConfigMenu({
   accountContent,
+  systemActionsContent,
   environmentSetupVisible,
   labels,
   providerScopedActionsVisible,
@@ -115,6 +117,7 @@ export function AgentGUIConfigMenu({
         align="end"
         className="w-[300px] max-w-[calc(100vw-32px)] gap-3 p-1 text-xs"
         data-testid="agent-gui-config-menu"
+        style={{ zIndex: "var(--z-panel-popover)" }}
       >
         <div className="flex min-w-0 flex-col gap-1">
           {hasAccountContent ? (
@@ -265,6 +268,14 @@ export function AgentGUIConfigMenu({
               <span>{labels.agentSettingsMenu}</span>
             </button>
           </div>
+          {systemActionsContent ? (
+            <>
+              <div className="px-2">
+                <span className="block h-px bg-[var(--border-1)]" />
+              </div>
+              {systemActionsContent}
+            </>
+          ) : null}
         </div>
       </PopoverContent>
     </Popover>

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
@@ -633,6 +633,8 @@ export interface AgentGUINodeViewProps extends AgentGUIComposerExternalPromptPro
   slashStatusUsageAttempted?: boolean;
   /** Host-rendered account/Commerce chrome for the exact selected target. */
   agentConfigAccountContent?: ReactNode;
+  /** Host-rendered system actions appended to the Agent config menu. */
+  agentConfigSystemActionsContent?: ReactNode;
   onAgentConfigMenuClose?: () => void;
   onAgentConfigMenuOpen?: () => void;
   /** Forces a fresh usage probe from the config menu's refresh control. */


### PR DESCRIPTION
## Summary
Backport of #2524 to `release/0818`:
- fix Windows File panel copy paths and wide `CF_HDROP` payload
- add Agent-mode check-update and export-log actions
- keep standalone Agent app webviews at live host height after browser/app tab switches

## Verification
- cherry-pick applied cleanly to current `origin/release/0818`
- source PR #2524 passed all CI, including Windows x64 package, Typecheck, all TypeScript test shards, lint, package pack, and review gate
- local source-branch validation included `make dev-gui`, Desktop 10/10 focused tests, Agent GUI 23/23 tests, both package typechecks, and Desktop production build
- release backport `git diff HEAD^ --check` passed