### PR TITLE
fix(connector): center token authorization form actions

### DIFF
--- a/packages/connector/renderer/src/ui/authorization/AuthorizationViewRenderer.tsx
+++ b/packages/connector/renderer/src/ui/authorization/AuthorizationViewRenderer.tsx
@@ -216,7 +216,7 @@ function AuthorizationFormRenderer({
           }
         />
       ))}
-      <DialogFooter>
+      <DialogFooter className="pt-1 sm:justify-center">
         <Button
           disabled={busy}
           size="dialog"


### PR DESCRIPTION
## Summary

- Center Cancel/Connect on the API-token authorization form so they match the OAuth/QR footer alignment.
- The token form used `DialogFooter`'s default `sm:justify-end`, which put the actions on the right while other authorization views stay centered.

## Verification

- Presentation-only className change; no logic or behavior change.
- Local `pnpm check:changed -- --push-ready` passed on push (11 lanes).
- Windows: CSS flex alignment only; no OS-specific path, process, or filesystem behavior.

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed (none needed).
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

Made with [Cursor](https://cursor.com)