### PR TITLE
fix(agent-gui): open message center sessions across agents

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionActivation.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionActivation.test.ts
@@ -19,7 +19,10 @@ function agentActivityRuntimeWithActivation(
   return {
     getSessionEngine(workspaceId) {
       onWorkspace?.(workspaceId);
-      return { activateSession } as AgentSessionEngine;
+      return {
+        activateSession,
+        getSnapshot: () => ({ sessionLifecycle: { sessionsById: {} } })
+      } as unknown as AgentSessionEngine;
     }
   };
 }
@@ -27,12 +30,18 @@ function agentActivityRuntimeWithActivation(
 test("resolveDesktopAgentGUIOpenSessionActivation extracts valid open-session requests", () => {
   assert.deepEqual(
     resolveDesktopAgentGUIOpenSessionActivation({
-      payload: { agentSessionId: " session-1 " },
+      payload: {
+        agentSessionId: " session-1 ",
+        agentTargetId: " local:claude-code ",
+        provider: "claude-code"
+      },
       sequence: 7,
       type: desktopAgentGUIOpenSessionActivationType
     }),
     {
       agentSessionId: "session-1",
+      agentTargetId: "local:claude-code",
+      provider: "claude-code",
       sequence: 7
     }
   );
@@ -47,7 +56,7 @@ test("resolveDesktopAgentGUIOpenSessionActivation extracts valid open-session re
   );
 });
 
-test("consumeDesktopAgentGUIOpenSessionActivation activates and selects the requested session once", () => {
+test("consumeDesktopAgentGUIOpenSessionActivation admits and forwards an exact cross-Agent session once", () => {
   const activated: unknown[] = [];
   const engineWorkspaceIds: string[] = [];
   const cleared: unknown[] = [];
@@ -70,11 +79,16 @@ test("consumeDesktopAgentGUIOpenSessionActivation activates and selects the requ
 
   const consumed = consumeDesktopAgentGUIOpenSessionActivation({
     activation: {
-      payload: { agentSessionId: "session-2" },
+      payload: {
+        agentSessionId: "session-2",
+        agentTargetId: "local:claude-code",
+        provider: "claude-code"
+      },
       sequence: 11,
       type: desktopAgentGUIOpenSessionActivationType
     },
     agentActivityRuntime,
+    agentDirectoryStatus: "ready",
     clearNodeActivation: (nodeId, sequence) => {
       cleared.push({ nodeId, sequence });
     },
@@ -90,6 +104,8 @@ test("consumeDesktopAgentGUIOpenSessionActivation activates and selects the requ
       stateChanges.push(state);
     },
     provider: "codex",
+    resolveAgentTargetProvider: (agentTargetId) =>
+      agentTargetId === "local:claude-code" ? "claude-code" : null,
     workspaceId: "workspace-1",
     updateNodeState: (updater) => {
       nodeState = updater(nodeState);
@@ -102,6 +118,8 @@ test("consumeDesktopAgentGUIOpenSessionActivation activates and selects the requ
   assert.deepEqual(openSessionRequests, [
     {
       agentSessionId: "session-2",
+      agentTargetId: "local:claude-code",
+      provider: "claude-code",
       sequence: 11
     }
   ]);
@@ -113,14 +131,10 @@ test("consumeDesktopAgentGUIOpenSessionActivation activates and selects the requ
     }
   ]);
   assert.deepEqual(engineWorkspaceIds, ["workspace-1"]);
-  assert.equal(nodeState.lastActiveAgentSessionId, "session-2");
-  assert.deepEqual(stateChanges, [
-    {
-      conversationRailCollapsed: false,
-      conversationRailWidthPx: null,
-      lastActiveAgentSessionId: "session-2"
-    }
-  ]);
+  assert.equal(nodeState.agentTargetId, undefined);
+  assert.equal(nodeState.lastActiveAgentSessionId, "session-1");
+  assert.equal(nodeState.provider, "codex");
+  assert.deepEqual(stateChanges, []);
 
   const replayed = consumeDesktopAgentGUIOpenSessionActivation({
     activation: {
@@ -129,6 +143,7 @@ test("consumeDesktopAgentGUIOpenSessionActivation activates and selects the requ
       type: desktopAgentGUIOpenSessionActivationType
     },
     agentActivityRuntime,
+    agentDirectoryStatus: "ready",
     handledSequence: 11,
     markHandled: (sequence) => {
       handled.push(sequence);
@@ -155,6 +170,8 @@ test("consumeDesktopAgentGUIOpenSessionActivation activates and selects the requ
   assert.deepEqual(openSessionRequests, [
     {
       agentSessionId: "session-2",
+      agentTargetId: "local:claude-code",
+      provider: "claude-code",
       sequence: 11
     }
   ]);
@@ -175,6 +192,7 @@ test("consumeDesktopAgentGUIOpenSessionActivation clears stale cross-provider ta
       type: desktopAgentGUIOpenSessionActivationType
     },
     agentActivityRuntime,
+    agentDirectoryStatus: "ready",
     handledSequence: null,
     markHandled: () => {},
     nodeId: "node-1",
@@ -194,9 +212,10 @@ test("consumeDesktopAgentGUIOpenSessionActivation clears stale cross-provider ta
   assert.equal(nodeState.agentTargetId, null);
 });
 
-test("consumeDesktopAgentGUIOpenSessionActivation leaves rejected admission settlement to the engine", () => {
+test("consumeDesktopAgentGUIOpenSessionActivation leaves state untouched when admission rejects", () => {
   const activated: unknown[] = [];
   const openSessionRequests: unknown[] = [];
+  const rejections: unknown[] = [];
   let nodeState: DesktopAgentGUINodeState = {
     provider: "codex",
     lastActiveAgentSessionId: "session-1"
@@ -213,11 +232,15 @@ test("consumeDesktopAgentGUIOpenSessionActivation leaves rejected admission sett
       type: desktopAgentGUIOpenSessionActivationType
     },
     agentActivityRuntime,
+    agentDirectoryStatus: "ready",
     handledSequence: null,
     markHandled: () => {},
     nodeId: "node-1",
     onOpenSessionRequest: (request) => {
       openSessionRequests.push(request);
+    },
+    onOpenSessionRejected: (request, reason) => {
+      rejections.push({ request, reason });
     },
     onStateChange: () => {},
     provider: "codex",
@@ -227,14 +250,18 @@ test("consumeDesktopAgentGUIOpenSessionActivation leaves rejected admission sett
     }
   });
 
-  assert.equal(consumed, true);
-  assert.deepEqual(openSessionRequests, [
+  assert.equal(consumed, false);
+  assert.deepEqual(openSessionRequests, []);
+  assert.equal(nodeState.lastActiveAgentSessionId, "session-1");
+  assert.deepEqual(rejections, [
     {
-      agentSessionId: "missing-session",
-      sequence: 12
+      reason: "session-activation-rejected",
+      request: {
+        agentSessionId: "missing-session",
+        sequence: 12
+      }
     }
   ]);
-  assert.equal(nodeState.lastActiveAgentSessionId, "missing-session");
   assert.deepEqual(activated, [
     {
       agentSessionId: "missing-session",

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionActivation.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionActivation.ts
@@ -1,9 +1,15 @@
-import type { AgentGUIRuntime } from "@tutti-os/agent-gui";
+import type {
+  AgentGUIAgentDirectoryStatus,
+  AgentGUIRuntime
+} from "@tutti-os/agent-gui";
+import { selectEngineSession } from "@tutti-os/agent-activity-core";
 import type { WorkbenchHostActivation } from "@tutti-os/workbench-surface";
 import {
   areDesktopAgentGUINodeStatesEqual,
   areDesktopAgentGUIWorkbenchStatesEqual,
   desktopAgentGUIOpenSessionActivationType,
+  isDesktopAgentGUIProvider,
+  normalizeDesktopAgentGUIProvider,
   normalizeDesktopAgentGUINodeState,
   projectDesktopAgentGUIWorkbenchState,
   type DesktopAgentGUINodeState,
@@ -18,20 +24,26 @@ import {
 export interface ConsumeDesktopAgentGUIOpenSessionActivationInput {
   activation: WorkbenchHostActivation | null;
   agentActivityRuntime: Pick<AgentGUIRuntime, "getSessionEngine">;
+  agentDirectoryStatus: AgentGUIAgentDirectoryStatus;
   clearNodeActivation?: (this: void, nodeId: string, sequence: number) => void;
   handledSequence: number | null;
   markHandled(this: void, sequence: number): void;
   nodeId: string;
   onOpenSessionRequest?(
     this: void,
-    request: { agentSessionId: string; sequence: number }
+    request: DesktopAgentGUIOpenSessionRequest
+  ): void;
+  onOpenSessionRejected?(
+    this: void,
+    request: DesktopAgentGUIOpenSessionRequest | null,
+    reason: DesktopAgentGUIOpenSessionRejectionReason
   ): void;
   onOpenSessionComposerRequest?(
     this: void,
     request: DesktopAgentGUIOpenSessionComposerRequest | null
   ): void;
   onStateChange(this: void, state: DesktopAgentGUIWorkbenchState): void;
-  provider: DesktopAgentGUIProvider;
+  provider: DesktopAgentGUIProvider | null;
   resolveAgentTargetProvider?(
     this: void,
     agentTargetId: string | null
@@ -43,14 +55,30 @@ export interface ConsumeDesktopAgentGUIOpenSessionActivationInput {
   ): void;
 }
 
+export interface DesktopAgentGUIOpenSessionRequest {
+  agentSessionId: string;
+  agentTargetId?: string | null;
+  provider?: DesktopAgentGUIProvider;
+  sequence: number;
+}
+
+export type DesktopAgentGUIOpenSessionRejectionReason =
+  | "agent-target-unavailable"
+  | "invalid-request"
+  | "provider-mismatch"
+  | "session-activation-rejected"
+  | "session-identity-mismatch";
+
 export function consumeDesktopAgentGUIOpenSessionActivation({
   activation,
   agentActivityRuntime,
+  agentDirectoryStatus,
   clearNodeActivation,
   handledSequence,
   markHandled,
   nodeId,
   onOpenSessionRequest,
+  onOpenSessionRejected,
   onOpenSessionComposerRequest,
   onStateChange,
   provider,
@@ -59,21 +87,85 @@ export function consumeDesktopAgentGUIOpenSessionActivation({
   updateNodeState
 }: ConsumeDesktopAgentGUIOpenSessionActivationInput): boolean {
   const request = resolveDesktopAgentGUIOpenSessionActivation(activation);
-  if (!request || handledSequence === request.sequence) {
+  if (!request) {
+    if (
+      activation?.type === desktopAgentGUIOpenSessionActivationType &&
+      handledSequence !== activation.sequence
+    ) {
+      markHandled(activation.sequence);
+      clearNodeActivation?.(nodeId, activation.sequence);
+      onOpenSessionRejected?.(null, "invalid-request");
+    }
+    return false;
+  }
+  if (handledSequence === request.sequence) {
     return false;
   }
 
-  markHandled(request.sequence);
-  clearNodeActivation?.(nodeId, request.sequence);
-  onOpenSessionRequest?.(request);
-  const composerRequest =
-    resolveDesktopAgentGUIOpenSessionComposerActivation(activation);
-  onOpenSessionComposerRequest?.(
-    composerRequest?.agentSessionId === request.agentSessionId
-      ? composerRequest
-      : null
+  const hasRequestedAgentTarget = Object.prototype.hasOwnProperty.call(
+    request,
+    "agentTargetId"
   );
-  agentActivityRuntime.getSessionEngine(workspaceId).activateSession({
+  const requestedAgentTargetId = request.agentTargetId?.trim() || null;
+  const resolvedTargetProvider = requestedAgentTargetId
+    ? (resolveAgentTargetProvider?.(requestedAgentTargetId) ?? null)
+    : null;
+  if (
+    requestedAgentTargetId &&
+    !resolvedTargetProvider &&
+    (agentDirectoryStatus === "idle" || agentDirectoryStatus === "loading")
+  ) {
+    return false;
+  }
+  if (requestedAgentTargetId && !resolvedTargetProvider) {
+    markHandled(request.sequence);
+    clearNodeActivation?.(nodeId, request.sequence);
+    onOpenSessionRejected?.(request, "agent-target-unavailable");
+    return false;
+  }
+  if (
+    requestedAgentTargetId &&
+    request.provider &&
+    resolvedTargetProvider !== request.provider
+  ) {
+    markHandled(request.sequence);
+    clearNodeActivation?.(nodeId, request.sequence);
+    onOpenSessionRejected?.(request, "provider-mismatch");
+    return false;
+  }
+  const sessionEngine = agentActivityRuntime.getSessionEngine(workspaceId);
+  const knownSession = selectEngineSession(
+    sessionEngine.getSnapshot(),
+    request.agentSessionId
+  );
+  const knownSessionTargetId = knownSession?.agentTargetId?.trim() || null;
+  const knownSessionProvider = knownSession?.provider.trim() || null;
+  if (
+    knownSession &&
+    ((hasRequestedAgentTarget &&
+      knownSessionTargetId !== requestedAgentTargetId) ||
+      (request.provider && knownSessionProvider !== request.provider))
+  ) {
+    markHandled(request.sequence);
+    clearNodeActivation?.(nodeId, request.sequence);
+    onOpenSessionRejected?.(request, "session-identity-mismatch");
+    return false;
+  }
+  const requestedProviderInput =
+    resolvedTargetProvider ?? request.provider ?? provider;
+  if (!requestedProviderInput) {
+    if (agentDirectoryStatus === "idle" || agentDirectoryStatus === "loading") {
+      return false;
+    }
+    markHandled(request.sequence);
+    clearNodeActivation?.(nodeId, request.sequence);
+    onOpenSessionRejected?.(request, "invalid-request");
+    return false;
+  }
+  const requestedProvider = normalizeDesktopAgentGUIProvider(
+    requestedProviderInput
+  );
+  const activationAccepted = sessionEngine.activateSession({
     agentSessionId: request.agentSessionId,
     mode: "existing",
     requestId: [
@@ -84,49 +176,65 @@ export function consumeDesktopAgentGUIOpenSessionActivation({
       request.sequence
     ].join(":")
   });
-  updateNodeState((current) => {
-    const currentAgentTargetId = current.agentTargetId?.trim() || null;
-    const currentAgentTargetProvider = currentAgentTargetId
-      ? (resolveAgentTargetProvider?.(currentAgentTargetId) ?? null)
-      : null;
-    const shouldClearAgentTarget =
-      currentAgentTargetProvider !== null &&
-      currentAgentTargetProvider !== provider;
-    const next = normalizeDesktopAgentGUINodeState(
-      {
-        ...current,
-        ...(shouldClearAgentTarget
-          ? {
-              agentTargetId: null
-            }
-          : {}),
-        lastActiveAgentSessionId: request.agentSessionId,
-        provider
-      },
-      provider
-    );
-    if (areDesktopAgentGUINodeStatesEqual(current, next)) {
-      return current;
-    }
+  if (!activationAccepted) {
+    markHandled(request.sequence);
+    clearNodeActivation?.(nodeId, request.sequence);
+    onOpenSessionRejected?.(request, "session-activation-rejected");
+    return false;
+  }
 
-    const currentWorkbenchState = projectDesktopAgentGUIWorkbenchState(current);
-    const nextWorkbenchState = projectDesktopAgentGUIWorkbenchState(next);
-    if (
-      !areDesktopAgentGUIWorkbenchStatesEqual(
-        currentWorkbenchState,
-        nextWorkbenchState
-      )
-    ) {
-      onStateChange(nextWorkbenchState);
-    }
-    return next;
-  });
+  markHandled(request.sequence);
+  clearNodeActivation?.(nodeId, request.sequence);
+  if (!hasRequestedAgentTarget) {
+    updateNodeState((current) => {
+      const currentAgentTargetId = current.agentTargetId?.trim() || null;
+      const currentAgentTargetProvider = currentAgentTargetId
+        ? (resolveAgentTargetProvider?.(currentAgentTargetId) ?? null)
+        : null;
+      const shouldClearAgentTarget =
+        currentAgentTargetProvider !== null &&
+        currentAgentTargetProvider !== requestedProvider;
+      const next = normalizeDesktopAgentGUINodeState(
+        {
+          ...current,
+          ...(shouldClearAgentTarget ? { agentTargetId: null } : {}),
+          lastActiveAgentSessionId: request.agentSessionId,
+          provider: requestedProvider
+        },
+        requestedProvider
+      );
+      if (areDesktopAgentGUINodeStatesEqual(current, next)) {
+        return current;
+      }
+
+      const currentWorkbenchState =
+        projectDesktopAgentGUIWorkbenchState(current);
+      const nextWorkbenchState = projectDesktopAgentGUIWorkbenchState(next);
+      if (
+        !areDesktopAgentGUIWorkbenchStatesEqual(
+          currentWorkbenchState,
+          nextWorkbenchState
+        )
+      ) {
+        onStateChange(nextWorkbenchState);
+      }
+      return next;
+    });
+  }
+  onOpenSessionRequest?.(request);
+  const composerRequest =
+    resolveDesktopAgentGUIOpenSessionComposerActivation(activation);
+  onOpenSessionComposerRequest?.(
+    composerRequest?.agentSessionId === request.agentSessionId
+      ? composerRequest
+      : null
+  );
   return true;
 }
 
 export function resolveDesktopAgentGUIOpenSessionActivation(
   activation: WorkbenchHostActivation | null
-): { agentSessionId: string; sequence: number } | null {
+): DesktopAgentGUIOpenSessionRequest | null {
   if (
     !activation ||
     activation.type !== desktopAgentGUIOpenSessionActivationType
@@ -134,26 +242,51 @@ export function resolveDesktopAgentGUIOpenSessionActivation(
     return null;
   }
 
-  const agentSessionId = agentSessionIdFromOpenSessionActivationPayload(
-    activation.payload
-  );
-  return agentSessionId
-    ? {
-        agentSessionId,
-        sequence: activation.sequence
-      }
-    : null;
+  const payload = openSessionActivationPayload(activation.payload);
+  return payload ? { ...payload, sequence: activation.sequence } : null;
 }
 
-function agentSessionIdFromOpenSessionActivationPayload(
+function openSessionActivationPayload(
   payload: unknown
-): string | null {
+): Omit<DesktopAgentGUIOpenSessionRequest, "sequence"> | null {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
     return null;
   }
-  const agentSessionId = (payload as { agentSessionId?: unknown })
-    .agentSessionId;
-  return typeof agentSessionId === "string" && agentSessionId.trim()
-    ? agentSessionId.trim()
-    : null;
+  const record = payload as Record<string, unknown>;
+  const agentSessionId = record.agentSessionId;
+  if (typeof agentSessionId !== "string" || !agentSessionId.trim()) {
+    return null;
+  }
+  const rawAgentTargetId = record.agentTargetId;
+  const hasAgentTargetId =
+    rawAgentTargetId !== undefined &&
+    Object.prototype.hasOwnProperty.call(record, "agentTargetId");
+  if (
+    hasAgentTargetId &&
+    rawAgentTargetId !== null &&
+    (typeof rawAgentTargetId !== "string" || !rawAgentTargetId.trim())
+  ) {
+    return null;
+  }
+  const rawProvider = record.provider;
+  if (
+    rawProvider !== undefined &&
+    (!isDesktopAgentGUIProvider(rawProvider) || !rawProvider.trim())
+  ) {
+    return null;
+  }
+  return {
+    agentSessionId: agentSessionId.trim(),
+    ...(hasAgentTargetId
+      ? {
+          agentTargetId:
+            typeof rawAgentTargetId === "string"
+              ? rawAgentTargetId.trim()
+              : null
+        }
+      : {}),
+    ...(typeof rawProvider === "string"
+      ? { provider: normalizeDesktopAgentGUIProvider(rawProvider) }
+      : {})
+  };
 }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionComposerActivation.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionComposerActivation.test.ts
@@ -16,8 +16,9 @@ test("source-session activation selects the exact session and requests a non-sub
         activateSession(input: unknown) {
           selected.push(input);
           return true;
-        }
-      } as AgentSessionEngine;
+        },
+        getSnapshot: () => ({ sessionLifecycle: { sessionsById: {} } })
+      } as unknown as AgentSessionEngine;
     }
   } as Pick<AgentGUIRuntime, "getSessionEngine">;
 
@@ -35,6 +36,7 @@ test("source-session activation selects the exact session and requests a non-sub
       type: desktopAgentGUIOpenSessionActivationType
     },
     agentActivityRuntime: runtime,
+    agentDirectoryStatus: "ready",
     handledSequence: null,
     markHandled() {},
     nodeId: "node-1",

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -396,12 +396,10 @@ function DesktopAgentGUISurfaceImpl({
     agentStatusSource
   );
   useEffect(() => {
-    if (!provider) {
-      return;
-    }
     consumeDesktopAgentGUIOpenSessionActivation({
       activation: surface.activation,
       agentActivityRuntime,
+      agentDirectoryStatus: agentDirectory.status,
       clearNodeActivation: surface.host.clearNodeActivation?.bind(surface.host),
       handledSequence: handledOpenSessionActivationSequenceRef.current,
       markHandled: (sequence) => {
@@ -409,27 +407,30 @@ function DesktopAgentGUISurfaceImpl({
       },
       nodeId: surface.nodeId,
       onOpenSessionRequest: setOpenSessionRequest,
+      onOpenSessionRejected: () =>
+        Toast.Error(
+          i18n.t("workspace.agentMessageCenter.openSessionUnavailable")
+        ),
       onOpenSessionComposerRequest: setOpenSessionComposerRequest,
       // Persistence is owned by handleUpdateNode (the single writer).
       onStateChange: DESKTOP_AGENT_GUI_NOOP,
       provider,
       resolveAgentTargetProvider: (agentTargetId) =>
-        resolveDesktopAgentGUIProviderForAgentTarget(
-          agentTargetId,
-          agents,
-          provider
-        ),
+        agents.find((agent) => agent.agentTargetId === agentTargetId)
+          ?.provider ?? null,
       workspaceId,
       updateNodeState: handleUpdateNode
     });
   }, [
     agentActivityRuntime,
+    agentDirectory.status,
     surface.activation,
     surface.host,
     surface.nodeId,
     handleUpdateNode,
     provider,
     agents,
+    i18n,
     workspaceId
   ]);
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchComposition.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchComposition.test.ts
@@ -130,7 +130,8 @@ test("workspace agent GUI session launches use container instances", () => {
   });
   assert.deepEqual(descriptor.activation, {
     payload: {
-      agentSessionId: "session-2"
+      agentSessionId: "session-2",
+      provider: "codex"
     },
     type: "agent-gui:open-session"
   });

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentGuiLaunchHandler.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/standaloneAgentGuiLaunchHandler.test.ts
@@ -48,6 +48,37 @@ test("standalone Agent session launches activate locally and clear an omitted ta
   assert.deepEqual(opened, []);
 });
 
+test("standalone Agent session launches preserve an explicit target in the current window", async () => {
+  const activations: unknown[] = [];
+  const opened: DesktopHostOpenAgentWindowInput[] = [];
+
+  await handleStandaloneAgentGuiLaunch(
+    {
+      agentSessionId: "session-agent-b",
+      agentTargetId: " local:agent-b ",
+      provider: "codex",
+      workspaceId: "workspace-1"
+    },
+    createContext({
+      activateAgentSession(input) {
+        activations.push(input);
+      },
+      async openAgentWindow(input) {
+        opened.push(input);
+      }
+    })
+  );
+
+  assert.deepEqual(activations, [
+    {
+      agentSessionId: "session-agent-b",
+      agentTargetId: "local:agent-b",
+      provider: "codex"
+    }
+  ]);
+  assert.deepEqual(opened, []);
+});
+
 test("standalone Agent draft launches open a new window with the complete bootstrap intent", async () => {
   const opened: DesktopHostOpenAgentWindowInput[] = [];
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentMessageCenterToolPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentMessageCenterToolPanel.tsx
@@ -14,7 +14,8 @@ import {
   useEngineSelector,
   workspaceAgentMessageCenterPromptStatus,
   WorkspaceAgentMessageCenterPanel,
-  type WorkspaceAgentMessageCenterModel
+  type WorkspaceAgentMessageCenterModel,
+  type WorkspaceAgentMessageCenterOpenChatInput
 } from "@tutti-os/agent-gui/agent-message-center";
 import type { I18nRuntime } from "@tutti-os/ui-i18n-runtime";
 import type { WorkspaceAgentActivityService } from "@renderer/features/workspace-agent";
@@ -30,7 +31,7 @@ interface StandaloneAgentMessageCenterToolPanelProps {
   open: boolean;
   workspaceId: string;
   onClose: () => void;
-  onOpenChat: (input: { agentSessionId: string; provider: string }) => void;
+  onOpenChat: (input: WorkspaceAgentMessageCenterOpenChatInput) => void;
 }
 
 export function StandaloneAgentMessageCenterToolPanel({
@@ -170,9 +171,9 @@ export function StandaloneAgentMessageCenterToolPanel({
     [activityService, workspaceId]
   );
   const handleOpenChat = useCallback(
-    (input: { agentSessionId: string; provider: string }) => {
-      onOpenChat(input);
+    (input: WorkspaceAgentMessageCenterOpenChatInput) => {
       onClose();
+      onOpenChat(input);
     },
     [onClose, onOpenChat]
   );

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebar.tsx
@@ -7,6 +7,7 @@ import {
   type ReactNode
 } from "react";
 import { selectWorkspaceAgentConsumerCounts } from "@tutti-os/agent-activity-core";
+import type { WorkspaceAgentMessageCenterOpenChatInput } from "@tutti-os/agent-gui/agent-message-center";
 import {
   AgentToolPanelIcon,
   AgentToolSidebar,
@@ -60,10 +61,9 @@ interface StandaloneAgentToolSidebarProps {
   issueManagerOpenRequest?: StandaloneAgentIssueManagerOpenRequest | null;
   mainContentMinWidthPx?: number;
   renderHeader: (layout: AgentToolSidebarHeaderLayout) => ReactNode;
-  onOpenMessageCenterChat: (input: {
-    agentSessionId: string;
-    provider: string;
-  }) => void;
+  onOpenMessageCenterChat: (
+    input: WorkspaceAgentMessageCenterOpenChatInput
+  ) => void;
   onAppsOpen: () => void;
   onAppendBrowserElementMention: (mention: string) => void;
   onBrowserElementError: (message: string) => void;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebarPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebarPanel.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, type ReactNode } from "react";
 import type { I18nRuntime } from "@tutti-os/ui-i18n-runtime";
 import type { AgentToolTab } from "@tutti-os/agent-gui/workbench/tool-sidebar";
+import type { WorkspaceAgentMessageCenterOpenChatInput } from "@tutti-os/agent-gui/agent-message-center";
 import type { AgentToolBrowserController } from "@tutti-os/agent-gui/workbench/tool-sidebar";
 import type {
   WorkbenchContribution,
@@ -100,10 +101,9 @@ export function StandaloneAgentToolSidebarPanel({
     controller: AgentToolBrowserController | null
   ) => void;
   onCloseMessageCenter: () => void;
-  onOpenMessageCenterChat: (input: {
-    agentSessionId: string;
-    provider: string;
-  }) => void;
+  onOpenMessageCenterChat: (
+    input: WorkspaceAgentMessageCenterOpenChatInput
+  ) => void;
   tab: AgentToolTab;
   setToolHost: (instanceId: string, host: WorkbenchHostHandle | null) => void;
   workspaceId: string;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
@@ -703,7 +703,6 @@ export function StandaloneAgentWindow({
     openFileInSidebar,
     runtimeApi: desktopApi.runtime,
     setActivation,
-    setNodeState,
     workspaceAgentActivityService,
     workspaceAppCenterService,
     workspaceId

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentMessageCenterAction.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentMessageCenterAction.tsx
@@ -15,7 +15,8 @@ import {
   WorkspaceAgentMessageCenterPanel,
   dispatchAgentPlanPromptAction,
   useEngineSelector,
-  type WorkspaceAgentMessageCenterModel
+  type WorkspaceAgentMessageCenterModel,
+  type WorkspaceAgentMessageCenterOpenChatInput
 } from "@tutti-os/agent-gui/agent-message-center";
 import {
   type AgentActivityMessage,
@@ -177,10 +178,11 @@ export function WorkspaceAgentMessageCenterAction({
   }, [workspace.id]);
 
   const openMessageCenterChat = useCallback(
-    (input: { agentSessionId: string; provider: string }) => {
+    (input: WorkspaceAgentMessageCenterOpenChatInput) => {
       const launchPromise = launchNode?.(
         createWorkspaceAgentGuiSessionLaunchRequest({
           agentSessionId: input.agentSessionId,
+          agentTargetId: input.agentTargetId,
           provider: input.provider
         })
       );
@@ -282,6 +284,7 @@ export function WorkspaceAgentMessageCenterAction({
         }
         openMessageCenterChat({
           agentSessionId: payload.agentSessionId,
+          agentTargetId: null,
           provider: payload.provider
         });
       }),

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useStandaloneAgentLaunchRouting.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useStandaloneAgentLaunchRouting.ts
@@ -22,8 +22,7 @@ import {
 import {
   desktopAgentGUIOpenSessionActivationType,
   normalizeDesktopAgentGUIProvider,
-  type DesktopAgentGUIProvider,
-  type DesktopAgentGUIWorkbenchState
+  type DesktopAgentGUIProvider
 } from "@renderer/features/workspace-agent/desktopAgentGUINodeState.ts";
 import { handleStandaloneAgentGuiLaunch } from "../services/standaloneAgentGuiLaunchHandler.ts";
 import type { StandaloneAgentIssueManagerOpenRequest } from "../services/standaloneAgentIssueManagerLaunch.ts";
@@ -50,7 +49,6 @@ interface StandaloneAgentLaunchRoutingInput {
   setActivation: Dispatch<
     SetStateAction<WorkbenchHostNodeBodyContext["activation"]>
   >;
-  setNodeState: Dispatch<SetStateAction<DesktopAgentGUIWorkbenchState>>;
   workspaceAgentActivityService: IWorkspaceAgentActivityService;
   workspaceAppCenterService: IWorkspaceAppCenterService;
   workspaceId: string;
@@ -66,7 +64,6 @@ export function useStandaloneAgentLaunchRouting({
   openFileInSidebar,
   runtimeApi,
   setActivation,
-  setNodeState,
   workspaceAgentActivityService,
   workspaceAppCenterService,
   workspaceId
@@ -99,15 +96,11 @@ export function useStandaloneAgentLaunchRouting({
       };
       provider: string;
     }) => {
-      setNodeState((current) => ({
-        ...current,
-        agentTargetId: input.agentTargetId,
-        lastActiveAgentSessionId: input.agentSessionId,
-        provider: normalizeDesktopAgentGUIProvider(input.provider)
-      }));
       setActivation({
         payload: {
           agentSessionId: input.agentSessionId,
+          agentTargetId: input.agentTargetId,
+          provider: normalizeDesktopAgentGUIProvider(input.provider),
           ...(input.composerAppend
             ? { composerAppend: input.composerAppend }
             : {})
@@ -116,7 +109,7 @@ export function useStandaloneAgentLaunchRouting({
         type: desktopAgentGUIOpenSessionActivationType
       });
     },
-    [setActivation, setNodeState]
+    [setActivation]
   );
   const handleOpenMessageCenterChat = useCallback(
     (input: WorkspaceAgentMessageCenterOpenChatInput) => {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useStandaloneAgentLaunchRouting.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useStandaloneAgentLaunchRouting.ts
@@ -8,6 +8,7 @@ import {
   type SetStateAction
 } from "react";
 import type { WorkbenchHostNodeBodyContext } from "@tutti-os/workbench-surface";
+import type { WorkspaceAgentMessageCenterOpenChatInput } from "@tutti-os/agent-gui/agent-message-center";
 import type { DesktopAgentDirectorySnapshot } from "@shared/contracts/agentDirectory.ts";
 import type { DesktopHostWindowApi, DesktopRuntimeApi } from "@preload/types";
 import type { IWorkspaceAppCenterService } from "@renderer/features/workspace-app-center";
@@ -73,10 +74,9 @@ export function useStandaloneAgentLaunchRouting({
   handleLinkAction: NonNullable<
     DesktopAgentGUIWorkbenchBodyProps["onLinkAction"]
   >;
-  handleOpenMessageCenterChat(input: {
-    agentSessionId: string;
-    provider: string;
-  }): void;
+  handleOpenMessageCenterChat(
+    input: WorkspaceAgentMessageCenterOpenChatInput
+  ): void;
   issueManagerOpenRequest: StandaloneAgentIssueManagerOpenRequest | null;
 } {
   const activationSequenceRef = useRef(1);
@@ -119,10 +119,15 @@ export function useStandaloneAgentLaunchRouting({
     [setActivation, setNodeState]
   );
   const handleOpenMessageCenterChat = useCallback(
-    (input: { agentSessionId: string; provider: string }) => {
-      handleActivateAgentSession({ ...input, agentTargetId: null });
+    (input: WorkspaceAgentMessageCenterOpenChatInput) => {
+      void requestWorkspaceAgentGuiLaunch({
+        agentSessionId: input.agentSessionId,
+        agentTargetId: input.agentTargetId,
+        provider: normalizeDesktopAgentGUIProvider(input.provider),
+        workspaceId
+      });
     },
-    [handleActivateAgentSession]
+    [workspaceId]
   );
 
   useEffect(

--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -416,6 +416,7 @@ export const en = {
     },
     agentMessageCenter: {
       openAria: "Open agent messages",
+      openSessionUnavailable: "Couldn't open this session",
       promptConstraintHeader: "Constraint",
       promptInputHeader: "Input",
       promptQuestion: "Add a response for the agent.",

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -408,6 +408,7 @@ export const zhCN = {
     },
     agentMessageCenter: {
       openAria: "打开 Agent 消息",
+      openSessionUnavailable: "无法打开此会话",
       promptConstraintHeader: "约束",
       promptInputHeader: "输入",
       promptQuestion: "为 Agent 添加回复。",

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2794,6 +2794,14 @@ AgentGUI, Message Center, dock/header, workspace window, and standalone Agent wi
 
 Opening a panel/window creates presentation state only. It does not clone a Session, copy engine entities, or start another event stream. Standalone tools are Desktop chrome, not AgentGUI lifecycle.
 
+The Message Center `Open session` action carries the canonical Session,
+Agent Target, and Provider identity together. In the standalone Agent window,
+the embedded panel closes first and delegates that identity to the existing
+workspace AgentGUI launch handler. A Session request without
+`openInNewWindow=true` activates the Session in the current Agent window and
+must not call the native window opener. Workspace-hosted Message Center actions
+reuse the existing Workbench node launch with the same identity tuple.
+
 Workbench previews must not mount a second AgentGUI tree. Genie capture prefers
 the host-provided native image and clones the visible node DOM into a texture
 only after native capture fails or exceeds its bounded wait. Electron hosts

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.draftMessageHelpers.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.draftMessageHelpers.spec.ts
@@ -13,11 +13,43 @@ import {
   clearSubmittedDraftIfUnchanged,
   deleteSubmittedDraftSnapshotsForScopes,
   deleteUnacceptedSubmittedDraftSnapshot,
+  normalizeAgentGUIOpenSessionRequest,
   toRuntimeSendContent
 } from "./agentGuiController.draftMessageHelpers";
 
 afterEach(() => {
   resetAgentCustomMentionKindsForTests();
+});
+
+describe("open-session request normalization", () => {
+  it("preserves the exact Agent target and Provider identity", () => {
+    expect(
+      normalizeAgentGUIOpenSessionRequest({
+        agentSessionId: " session-claude ",
+        agentTargetId: " local:claude-code ",
+        provider: "claude-code",
+        sequence: 7
+      } as never)
+    ).toEqual({
+      agentSessionId: "session-claude",
+      agentTargetId: "local:claude-code",
+      provider: "claude-code",
+      sequence: 7
+    });
+  });
+
+  it("keeps an explicitly undefined target compatible with legacy requests", () => {
+    expect(
+      normalizeAgentGUIOpenSessionRequest({
+        agentSessionId: "session-codex",
+        agentTargetId: undefined,
+        sequence: 8
+      })
+    ).toEqual({
+      agentSessionId: "session-codex",
+      sequence: 8
+    });
+  });
 });
 
 describe("runtime prompt materialization", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.draftMessageHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.draftMessageHelpers.ts
@@ -76,8 +76,12 @@ export {
 } from "./useAgentConversationMessagePaging";
 export interface AgentGUIOpenSessionRequest {
   agentSessionId: string;
+  agentTargetId?: string | null;
+  provider?: AgentGUIProvider;
   sequence: number;
 }
+
+export type AgentGUIOpenSessionSelectionOutcome = "rejected" | "selected";
 export function createPendingOptimisticTurnId(clientSubmitId: string): string {
   return `pending:${clientSubmitId}`;
 }
@@ -122,10 +126,54 @@ export function normalizeAgentGUIOpenSessionRequest(
   if (!agentSessionId || typeof request?.sequence !== "number") {
     return null;
   }
+  const record = request as unknown as Record<string, unknown>;
+  const rawAgentTargetId = record.agentTargetId;
+  const hasAgentTargetId =
+    rawAgentTargetId !== undefined &&
+    Object.prototype.hasOwnProperty.call(record, "agentTargetId");
+  if (
+    hasAgentTargetId &&
+    rawAgentTargetId !== null &&
+    (typeof rawAgentTargetId !== "string" || !rawAgentTargetId.trim())
+  ) {
+    return null;
+  }
+  const rawProvider = record.provider;
+  if (
+    rawProvider !== undefined &&
+    (typeof rawProvider !== "string" || !rawProvider.trim())
+  ) {
+    return null;
+  }
   return {
     agentSessionId,
+    ...(hasAgentTargetId
+      ? {
+          agentTargetId:
+            typeof rawAgentTargetId === "string"
+              ? rawAgentTargetId.trim()
+              : null
+        }
+      : {}),
+    ...(typeof rawProvider === "string"
+      ? { provider: rawProvider.trim() }
+      : {}),
     sequence: request.sequence
   };
+}
+
+export function resolveAgentGUIPendingOpenSessionRequestForRender(input: {
+  handledSequence: number | null;
+  openSessionRequest: AgentGUIOpenSessionRequest | null | undefined;
+  pendingOpenSessionRequest: AgentGUIOpenSessionRequest | null;
+}): AgentGUIOpenSessionRequest | null {
+  const normalizedOpenSessionRequest = normalizeAgentGUIOpenSessionRequest(
+    input.openSessionRequest
+  );
+  return normalizedOpenSessionRequest &&
+    normalizedOpenSessionRequest.sequence !== input.handledSequence
+    ? normalizedOpenSessionRequest
+    : input.pendingOpenSessionRequest;
 }
 
 export function numberValue(value: unknown): number | null {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationPresentation.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationPresentation.spec.tsx
@@ -283,6 +283,46 @@ describe("useAgentGUIConversationPresentation", () => {
     });
   });
 
+  it("does not let the previous Session overwrite a pending exact target", () => {
+    const conversation = createConversation();
+    const input = createInput(conversation);
+    const onDataChange = vi.fn();
+    input.data = {
+      agentTargetId: "target-claude",
+      lastActiveAgentSessionId: "session-claude",
+      provider: "claude-code"
+    };
+    input.dataRef = { current: input.data };
+    input.normalizedExplicitProviderTargets = [
+      {
+        agentTargetId: "target-1",
+        label: "Codex",
+        provider: "codex",
+        ref: { kind: "local", provider: "codex" },
+        targetId: "target-1"
+      },
+      {
+        agentTargetId: "target-claude",
+        label: "Claude Code",
+        provider: "claude-code",
+        ref: { kind: "local", provider: "claude-code" },
+        targetId: "target-claude"
+      }
+    ];
+    input.normalizedProviderTargets = input.normalizedExplicitProviderTargets;
+    input.onDataChangeRef = { current: onDataChange };
+    input.pendingOpenSessionRequest = {
+      agentSessionId: "session-claude",
+      agentTargetId: "target-claude",
+      provider: "claude-code",
+      sequence: 10
+    };
+
+    renderHook(() => useAgentGUIConversationPresentation(input));
+
+    expect(onDataChange).not.toHaveBeenCalled();
+  });
+
   it("keeps a hidden transient conversation out of the rail while presenting its identity", () => {
     const conversation = createConversation();
     const hiddenTransient: AgentGUIConversationSummary = {
@@ -365,6 +405,7 @@ function createInput(
     isSubmitting: true,
     normalizedExplicitProviderTargets: [],
     normalizedProviderTargets: [],
+    pendingOpenSessionRequest: null,
     onDataChangeRef: { current: vi.fn() },
     shouldUseStaticProviderTargets: false,
     transientConversation: null,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationPresentation.ts
@@ -18,7 +18,10 @@ import {
   conversationSummariesRenderEqual,
   stableConversationSummaryList
 } from "./agentGuiController.stableHelpers";
-import { conversationStatusFromAgentActivityDisplayStatus } from "./agentGuiController.draftMessageHelpers";
+import {
+  conversationStatusFromAgentActivityDisplayStatus,
+  type AgentGUIOpenSessionRequest
+} from "./agentGuiController.draftMessageHelpers";
 import { mergeVisibleConversations } from "./agentGuiController.conversationHelpers";
 import { rememberAgentGUIActiveConversation } from "../model/agentGuiSessionNavigationMemory";
 import { resolveConversationSummaryById } from "./useAgentConversationSelection";
@@ -42,6 +45,7 @@ interface UseAgentGUIConversationPresentationInput {
   isSubmitting: boolean;
   normalizedExplicitProviderTargets: readonly AgentGUIAgentTarget[];
   normalizedProviderTargets: readonly AgentGUIAgentTarget[];
+  pendingOpenSessionRequest: AgentGUIOpenSessionRequest | null;
   onDataChangeRef: CurrentValue<
     (updater: (current: AgentGUINodeData) => AgentGUINodeData) => void
   >;
@@ -168,6 +172,13 @@ export function useAgentGUIConversationPresentation(
     if (input.agentTargetsLoading || !input.activeConversationId) {
       return;
     }
+    if (
+      input.pendingOpenSessionRequest &&
+      input.pendingOpenSessionRequest.agentSessionId.trim() !==
+        input.activeConversationId
+    ) {
+      return;
+    }
     const summary = resolveConversationSummaryById(
       input.conversations,
       input.activeConversationId,
@@ -248,6 +259,7 @@ export function useAgentGUIConversationPresentation(
     input.normalizedExplicitProviderTargets,
     input.normalizedProviderTargets,
     input.onDataChangeRef,
+    input.pendingOpenSessionRequest,
     input.agentTargetsLoading,
     input.shouldUseStaticProviderTargets,
     input.transientConversation

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRouting.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRouting.spec.tsx
@@ -281,4 +281,55 @@ describe("useAgentGUIConversationRouting", () => {
 
     expect(setIntent).not.toHaveBeenCalledWith({ tag: "home" });
   });
+
+  it("routes an exact cross-Agent request through the target-aware owner", () => {
+    const sessionEngine = createAgentSessionEngine({
+      clock: { nowUnixMs: () => 1 },
+      commandPort: createTestEngineCommandPort({
+        execute: async () => undefined
+      }),
+      identity: { origin: "test", workspaceId: "workspace-1" },
+      scheduler: { schedule: () => ({ cancel() {} }) }
+    });
+    const openExternalSession = vi.fn(() => "selected" as const);
+    const selectConversation = vi.fn();
+
+    renderHook(() =>
+      useAgentGUIConversationRouting({
+        activeConversationIdRef: { current: "session-codex" },
+        agentTargetsLoading: false,
+        conversationListQuery: {},
+        conversations: [],
+        conversationsRef: { current: [] },
+        handledOpenSessionSequenceRef: { current: null },
+        hasLoadedConversations: true,
+        intent: {
+          id: "session-codex",
+          source: "user-selection",
+          tag: "active"
+        },
+        openExternalSession,
+        openSessionRequest: {
+          agentSessionId: "session-claude",
+          agentTargetId: "local:claude-code",
+          provider: "claude-code",
+          sequence: 8
+        },
+        pendingOpenSessionRequestRef: { current: null },
+        selectConversation,
+        sessionEngine,
+        setIntent: vi.fn(),
+        transientConversation: null,
+        workspaceId: "workspace-1"
+      })
+    );
+
+    expect(openExternalSession).toHaveBeenCalledWith({
+      agentSessionId: "session-claude",
+      agentTargetId: "local:claude-code",
+      provider: "claude-code",
+      sequence: 8
+    });
+    expect(selectConversation).not.toHaveBeenCalled();
+  });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRouting.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRouting.ts
@@ -9,6 +9,8 @@ import { useCallback, useEffect } from "react";
 import type { AgentGUIConversationSummary } from "../model/agentGuiConversationModel";
 import {
   normalizeAgentGUIOpenSessionRequest,
+  resolveAgentGUIPendingOpenSessionRequestForRender,
+  type AgentGUIOpenSessionSelectionOutcome,
   type AgentGUIOpenSessionRequest
 } from "./agentGuiController.draftMessageHelpers";
 import {
@@ -19,6 +21,7 @@ import {
 
 interface UseAgentGUIConversationRoutingInput {
   activeConversationIdRef: RefObject<string | null>;
+  agentTargetsLoading?: boolean;
   conversationListQuery: unknown | null;
   conversations: readonly AgentGUIConversationSummary[];
   conversationsRef: RefObject<AgentGUIConversationSummary[]>;
@@ -26,6 +29,9 @@ interface UseAgentGUIConversationRoutingInput {
   hasLoadedConversations: boolean;
   intent: ConversationIntent;
   openSessionRequest: AgentGUIOpenSessionRequest | null | undefined;
+  openExternalSession?(
+    request: AgentGUIOpenSessionRequest
+  ): AgentGUIOpenSessionSelectionOutcome;
   pendingOpenSessionRequestRef: RefObject<AgentGUIOpenSessionRequest | null>;
   selectConversation(
     agentSessionId: string,
@@ -39,9 +45,10 @@ interface UseAgentGUIConversationRoutingInput {
 
 export function useAgentGUIConversationRouting(
   input: UseAgentGUIConversationRoutingInput
-): void {
+): AgentGUIOpenSessionRequest | null {
   const {
     activeConversationIdRef,
+    agentTargetsLoading = false,
     conversationListQuery,
     conversations,
     conversationsRef,
@@ -49,6 +56,7 @@ export function useAgentGUIConversationRouting(
     hasLoadedConversations,
     intent,
     openSessionRequest,
+    openExternalSession,
     pendingOpenSessionRequestRef,
     selectConversation,
     sessionEngine,
@@ -56,6 +64,12 @@ export function useAgentGUIConversationRouting(
     transientConversation,
     workspaceId
   } = input;
+  const pendingOpenSessionRequestForRender =
+    resolveAgentGUIPendingOpenSessionRequestForRender({
+      handledSequence: handledOpenSessionSequenceRef.current,
+      openSessionRequest,
+      pendingOpenSessionRequest: pendingOpenSessionRequestRef.current
+    });
 
   const ensureTransientOpenSessionConversation = useCallback(
     (agentSessionId: string) => {
@@ -122,8 +136,21 @@ export function useAgentGUIConversationRouting(
     const resolveCanonicalId = (id: string) =>
       resolveConversationSummaryById(conversations, id, null) !== null;
     if (hasExplicitOpenSessionRequest) {
-      const requestedId = pendingOpenSessionRequest!.agentSessionId.trim();
+      const request = pendingOpenSessionRequest!;
+      const requestedId = request.agentSessionId.trim();
+      const hasExactTargetIdentity = Object.prototype.hasOwnProperty.call(
+        request,
+        "agentTargetId"
+      );
       if (!hasLoadedConversations) return;
+      if (hasExactTargetIdentity) {
+        if (request.agentTargetId !== null && agentTargetsLoading) return;
+        pendingOpenSessionRequestRef.current = null;
+        if (openExternalSession?.(request) === "selected") {
+          ensureTransientOpenSessionConversation(requestedId);
+        }
+        return;
+      }
       pendingOpenSessionRequestRef.current = null;
       selectConversation(requestedId, {
         reloadConversations: false,
@@ -174,13 +201,16 @@ export function useAgentGUIConversationRouting(
         return;
     }
   }, [
+    agentTargetsLoading,
     conversationListQuery,
     conversations,
     ensureTransientOpenSessionConversation,
     hasLoadedConversations,
     intent,
     openSessionRequest,
+    openExternalSession,
     selectConversation,
     transientConversation
   ]);
+  return pendingOpenSessionRequestForRender;
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -49,6 +49,7 @@ import { useAgentGUIComposerCapabilities } from "./useAgentGUIComposerCapabiliti
 import { useAgentGUIComposerOptionsSync } from "./useAgentGUIComposerOptionsSync";
 import { useAgentGUIControllerRefs } from "./useAgentGUIControllerRefs";
 import { useAgentGUIOperationActions } from "./useAgentGUIOperationActions";
+import { useAgentGUIProviderHome } from "./useAgentGUIProviderHome";
 import { useAgentGUIViewAssembly } from "./useAgentGUIViewAssembly";
 import { useAgentGUIProviderCatalogSelection } from "./useAgentGUIProviderCatalogSelection";
 import { useAgentGUISessionEngineState } from "./useAgentGUISessionEngineState";
@@ -549,8 +550,6 @@ export function useAgentGUINodeController({
     transientConversation,
     workspaceId
   });
-  const persistActiveConversation =
-    conversationSelection.persistActiveConversation;
   const selectConversation = conversationSelection.selectConversation;
   const syncConversationListProjection =
     conversationSelection.syncConversationListProjection;
@@ -614,8 +613,26 @@ export function useAgentGUINodeController({
     );
   }, [conversations.length, hasLoadedConversations, transientConversation]);
 
-  useAgentGUIConversationRouting({
+  const providerHome = useAgentGUIProviderHome({
+    ...providerCatalogSelection,
+    ...localState,
+    ...conversationList,
+    ...sessionEngineState,
+    ...controllerRefs,
+    ...conversationSelection,
+    agentActivityRuntime,
+    data,
+    defaultAgentTargetId,
+    isLoadingConversations,
+    providerReadinessGates,
+    sessionEngine,
+    transientConversation,
+    unactivate: activation.unactivate,
+    workspaceId
+  });
+  const pendingOpenSessionRequest = useAgentGUIConversationRouting({
     activeConversationIdRef,
+    agentTargetsLoading,
     conversationListQuery,
     conversations,
     conversationsRef,
@@ -623,6 +640,7 @@ export function useAgentGUINodeController({
     hasLoadedConversations,
     intent,
     openSessionRequest,
+    openExternalSession: providerHome.openExternalSession,
     pendingOpenSessionRequestRef,
     selectConversation,
     sessionEngine,
@@ -757,10 +775,11 @@ export function useAgentGUINodeController({
     normalizedComingSoonProviders,
     nodeId,
     operationActions,
-    persistActiveConversation,
+    pendingOpenSessionRequest,
     planImplementationTurnIdRef,
     providerRailMode,
     providerReadinessGates,
+    providerHome,
     targetConnectionSource,
     interactionReadinessSource,
     observationGapSource,
@@ -769,7 +788,6 @@ export function useAgentGUINodeController({
     sessionEngine,
     transientConversation,
     tuttiModeActivation,
-    unactivate: activation.unactivate,
     updateSelectedProjectPath,
     userProjects,
     workspaceId,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIProviderHome.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIProviderHome.spec.tsx
@@ -198,6 +198,56 @@ describe("useAgentGUIProviderHome", () => {
       "persisted-session"
     );
   });
+
+  it("switches Agent target and exact Session as one external-open selection", () => {
+    const codexTarget = target("codex", "agent:codex", "provider-target:codex");
+    const claudeTarget = target(
+      "claude-code",
+      "agent:claude-code",
+      "provider-target:claude-code"
+    );
+    const fixture = renderProviderHome({
+      activeConversationId: "codex-session",
+      conversations: [
+        conversation("codex-session", "codex", "agent:codex"),
+        conversation("claude-session", "claude-code", "agent:claude-code")
+      ],
+      data: {
+        agentTargetId: "agent:codex",
+        lastActiveAgentSessionId: "codex-session",
+        provider: "codex"
+      },
+      selectedTarget: codexTarget,
+      targets: [codexTarget, claudeTarget]
+    });
+
+    let outcome: string | null = null;
+    act(() => {
+      outcome = fixture.result.current.openExternalSession({
+        agentSessionId: "claude-session",
+        agentTargetId: "agent:claude-code",
+        provider: "claude-code",
+        sequence: 9
+      });
+    });
+
+    expect(outcome).toBe("selected");
+    expect(fixture.unactivate).toHaveBeenCalledWith("codex-session");
+    expect(fixture.setConversationFilter).toHaveBeenCalledWith({
+      kind: "agentTarget",
+      agentTargetId: "agent:claude-code"
+    });
+    expect(fixture.selectConversation).toHaveBeenCalledWith("claude-session", {
+      reloadConversations: false,
+      reveal: "external-open"
+    });
+    expect(fixture.getData()).toEqual(
+      expect.objectContaining({
+        agentTargetId: "agent:claude-code",
+        provider: "claude-code"
+      })
+    );
+  });
 });
 
 function renderProviderHome(input: {
@@ -336,7 +386,8 @@ function engine(
             item.id,
             {
               agentSessionId: item.id,
-              agentTargetId: item.agentTargetId
+              agentTargetId: item.agentTargetId,
+              provider: item.provider
             }
           ])
         )

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIProviderHome.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIProviderHome.ts
@@ -40,9 +40,14 @@ import {
   resolveAgentGUIProviderRailTargetSelection
 } from "./agentGuiController.providerHelpers";
 import { reportAgentGUIConversationFilterTargetUnresolved } from "./agentGuiController.reporting";
+import type {
+  AgentGUIOpenSessionRequest,
+  AgentGUIOpenSessionSelectionOutcome
+} from "./agentGuiController.draftMessageHelpers";
 import { isPendingNewConversationActivationForSession } from "./useAgentGUIActivation";
 import {
   resolveConversationSummaryById,
+  type AgentGUIConversationSelectionOptions,
   type ConversationIntent
 } from "./useAgentConversationSelection";
 
@@ -79,7 +84,7 @@ interface UseAgentGUIProviderHomeInput {
   selectedComposerTargetDataRef: CurrentValue<AgentGUIComposerTargetData>;
   selectConversation(
     agentSessionId: string,
-    options?: { reloadConversations?: boolean }
+    options?: AgentGUIConversationSelectionOptions
   ): void;
   sessionEngine: AgentSessionEngine;
   setActiveConversationId: Dispatch<SetStateAction<string | null>>;
@@ -279,6 +284,112 @@ export function useAgentGUIProviderHome(input: UseAgentGUIProviderHomeInput) {
     []
   );
 
+  const openExternalSession = useCallback(
+    (
+      request: AgentGUIOpenSessionRequest
+    ): AgentGUIOpenSessionSelectionOutcome => {
+      const current = inputRef.current;
+      const agentSessionId = request.agentSessionId.trim();
+      const hasAgentTargetId = Object.prototype.hasOwnProperty.call(
+        request,
+        "agentTargetId"
+      );
+      const agentTargetId = request.agentTargetId?.trim() || null;
+      const requestedProvider =
+        request.provider?.trim() || current.dataRef.current.provider;
+      if (!agentSessionId || !hasAgentTargetId || !requestedProvider) {
+        return "rejected";
+      }
+
+      const nextTarget = agentTargetId
+        ? resolveAgentGUIAgentTarget({
+            agentTargetId,
+            defaultAgentTargetId: current.defaultAgentTargetId,
+            provider: requestedProvider,
+            agentTargets: current.normalizedProviderTargets,
+            useStaticCatalog: current.shouldUseStaticProviderTargets
+          })
+        : null;
+      const knownSummary = resolveConversationSummaryById(
+        current.conversationsRef.current,
+        agentSessionId,
+        current.transientConversation
+      );
+      const knownSession = selectEngineSession(
+        current.sessionEngine.getSnapshot(),
+        agentSessionId
+      );
+      const knownAgentTargetId = knownSession
+        ? knownSession.agentTargetId?.trim() || null
+        : knownSummary
+          ? knownSummary.agentTargetId?.trim() || null
+          : undefined;
+      const knownProvider =
+        knownSession?.provider?.trim() || knownSummary?.provider?.trim() || "";
+      if (
+        (agentTargetId !== null && !nextTarget) ||
+        (nextTarget && nextTarget.provider !== requestedProvider) ||
+        (knownAgentTargetId !== undefined &&
+          knownAgentTargetId !== agentTargetId) ||
+        (knownProvider && knownProvider !== requestedProvider) ||
+        (agentTargetId === null &&
+          ((current.dataRef.current.agentTargetId?.trim() || null) !== null ||
+            current.dataRef.current.provider !== requestedProvider))
+      ) {
+        reportAgentGUIConversationFilterTargetUnresolved({
+          provider: requestedProvider,
+          agentTargetId: agentTargetId ?? "",
+          providerTargetCount: current.normalizedProviderTargets.length,
+          reason: "unresolved",
+          runtime: current.agentActivityRuntime,
+          workspaceId: current.workspaceId
+        });
+        return "rejected";
+      }
+
+      if (agentTargetId === null) {
+        if (current.conversationFilterRef.current.kind === "agentTarget") {
+          current.setConversationFilter({ kind: "all" });
+        }
+        current.selectConversation(agentSessionId, {
+          reloadConversations: false,
+          reveal: "external-open"
+        });
+        return "selected";
+      }
+      if (!nextTarget) return "rejected";
+
+      const currentAgentTargetId =
+        current.dataRef.current.agentTargetId?.trim() ||
+        current.effectiveSelectedProviderTarget.agentTargetId?.trim() ||
+        "";
+      const targetChanged =
+        currentAgentTargetId !== agentTargetId ||
+        current.dataRef.current.provider !== nextTarget.provider;
+      if (targetChanged) {
+        selectHomeComposerAgentTarget({
+          provider: nextTarget.provider,
+          agentTargetId
+        });
+      } else if (
+        current.conversationFilterRef.current.kind === "agentTarget" &&
+        current.conversationFilterRef.current.agentTargetId.trim() !==
+          agentTargetId
+      ) {
+        current.setConversationFilter({
+          kind: "agentTarget",
+          agentTargetId
+        });
+      }
+      current.selectConversation(agentSessionId, {
+        reloadConversations: false,
+        reveal: "external-open"
+      });
+      return "selected";
+    },
+    [selectHomeComposerAgentTarget]
+  );
+
   useEffect(() => {
     const effectiveAgentTargetId =
       input.effectiveSelectedProviderTarget.agentTargetId?.trim() ?? "";
@@ -446,6 +557,7 @@ export function useAgentGUIProviderHome(input: UseAgentGUIProviderHomeInput) {
   );
 
   return {
+    openExternalSession,
     resetHomeComposerAgentTargetToDefault,
     selectConversationFilterTarget,
     selectHomeComposerAgentTarget,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIViewAssembly.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIViewAssembly.ts
@@ -50,6 +50,7 @@ type SessionPresentationInput = Omit<
   | "serverInteractivePrompt"
 >;
 type ProviderHomeInput = Parameters<typeof useAgentGUIProviderHome>[0];
+type ProviderHome = ReturnType<typeof useAgentGUIProviderHome>;
 type OperationActions = ReturnType<typeof useAgentGUIOperationActions>;
 type ProviderCatalog = ReturnType<typeof useAgentGUIProviderCatalogSelection>;
 type LocalState = ReturnType<typeof useAgentGUILocalState>;
@@ -62,12 +63,12 @@ type UseAgentGUIViewAssemblyInput = ConversationPresentationInput &
   ConversationDetailInput &
   ComposerPresentationInput &
   SessionPresentationInput &
-  ProviderHomeInput &
   ProviderCatalog &
   LocalState &
   ComposerCapabilities &
   SessionDetailTransport &
   OperationActions & {
+    conversationFilter: ProviderHomeInput["conversationFilter"];
     nodeId?: string | null;
     operationActions: OperationActions;
     detailAvailability: AgentGUIDetailViewModel["availability"];
@@ -78,6 +79,9 @@ type UseAgentGUIViewAssemblyInput = ConversationPresentationInput &
       typeof useAgentGUIControllerActions
     >[0]["selectConversation"];
     providerRailMode: AgentGUIProviderRailMode | undefined;
+    providerReadinessGates: ProviderHomeInput["providerReadinessGates"];
+    providerHome: ProviderHome;
+    isLoadingConversations: ProviderHomeInput["isLoadingConversations"];
     tuttiModeActivation: ReturnType<typeof useAgentGUITuttiModeActivation>;
   };
 
@@ -218,10 +222,9 @@ export function useAgentGUIViewAssembly(input: UseAgentGUIViewAssemblyInput) {
     }
     return { ...activeConversation, needsUserAction: true };
   }, [activeConversation, session.pendingInteractivePrompt]);
-  const providerHome = useAgentGUIProviderHome(input);
   const controllerActions = useAgentGUIControllerActions({
     ...input.operationActions,
-    ...providerHome,
+    ...input.providerHome,
     loadOlderConversationMessages: input.loadOlderConversationMessages,
     selectConversation: input.selectConversation,
     setTuttiModeActive: input.tuttiModeActivation.setActive,

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterAttentionDeck.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterAttentionDeck.tsx
@@ -10,7 +10,10 @@ import { cn } from "@tutti-os/ui-system";
 import { useTranslation } from "../i18n/index";
 import type { WorkspaceLinkAction } from "../actions/workspaceLinkActions";
 import { WorkspaceAgentMessageCenterCard } from "./WorkspaceAgentMessageCenterCard";
-import type { WorkspaceAgentMessageCenterItem } from "./workspaceAgentMessageCenterModel";
+import type {
+  WorkspaceAgentMessageCenterItem,
+  WorkspaceAgentMessageCenterOpenChatInput
+} from "./workspaceAgentMessageCenterModel";
 
 const DECK_MAX_PEEK = 2;
 const DECK_NEW_CARD_COOLDOWN_MS = 500;
@@ -25,7 +28,7 @@ export interface WorkspaceAgentMessageCenterAttentionDeckProps {
     input: WorkspaceAgentMessageCenterAttentionDeckRenderCardInput
   ) => ReactNode;
   onLinkAction?: (action: WorkspaceLinkAction) => void;
-  onOpenChat: (input: { agentSessionId: string; provider: string }) => void;
+  onOpenChat: (input: WorkspaceAgentMessageCenterOpenChatInput) => void;
   onSubmitPrompt: (
     item: WorkspaceAgentMessageCenterItem,
     input: {

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.spec.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.spec.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import {
   createAgentSessionEngine,
   normalizeAgentActivitySession
@@ -72,6 +72,30 @@ describe("messageCenterStackPreviewNodes", () => {
       container.querySelector('[data-agent-mention-kind="workspace-app"]')
         ?.textContent
     ).toContain("AI 文档");
+  });
+});
+
+describe("WorkspaceAgentMessageCenterCard open session", () => {
+  it("forwards the canonical Agent target with the Session identity", () => {
+    const targetItem = item({ summary: "Ready" });
+    targetItem.agentTargetId = "local:agent-b";
+    const onOpenChat = vi.fn();
+
+    render(
+      <WorkspaceAgentMessageCenterCard
+        item={targetItem}
+        isSubmitting={false}
+        onOpenChat={onOpenChat}
+        onSubmitPrompt={() => undefined}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open session" }));
+    expect(onOpenChat).toHaveBeenCalledWith({
+      agentSessionId: "codex-1",
+      agentTargetId: "local:agent-b",
+      provider: "codex"
+    });
   });
 });
 

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
@@ -21,7 +21,8 @@ import { workspaceAgentActivityStatusLabel } from "../shared/workspaceAgentActiv
 import type { WorkspaceLinkAction } from "../actions/workspaceLinkActions";
 import {
   isWaitingMessageCenterItem,
-  type WorkspaceAgentMessageCenterItem
+  type WorkspaceAgentMessageCenterItem,
+  type WorkspaceAgentMessageCenterOpenChatInput
 } from "./workspaceAgentMessageCenterModel";
 import {
   LazyMessageCenterTooltip,
@@ -56,7 +57,7 @@ export interface WorkspaceAgentMessageCenterCardProps {
   showSummaryWithPrompt?: boolean;
   summaryAccessory?: ReactNode;
   onLinkAction?: (action: WorkspaceLinkAction) => void;
-  onOpenChat: (input: { agentSessionId: string; provider: string }) => void;
+  onOpenChat: (input: WorkspaceAgentMessageCenterOpenChatInput) => void;
   onSubmitPrompt: (input: {
     action?: string;
     optionId?: string;

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterIdentity.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterIdentity.tsx
@@ -23,7 +23,8 @@ import { userAvatarPlaceholderUrl } from "../shared/userAvatarPlaceholder";
 import {
   isWaitingMessageCenterItem,
   type WorkspaceAgentMessageCenterIdentity,
-  type WorkspaceAgentMessageCenterItem
+  type WorkspaceAgentMessageCenterItem,
+  type WorkspaceAgentMessageCenterOpenChatInput
 } from "./workspaceAgentMessageCenterModel";
 
 export function MessageCenterOpenChatButton({
@@ -38,7 +39,7 @@ export function MessageCenterOpenChatButton({
   alwaysVisible?: boolean;
   item: WorkspaceAgentMessageCenterItem;
   label: string;
-  onOpenChat: (input: { agentSessionId: string; provider: string }) => void;
+  onOpenChat: (input: WorkspaceAgentMessageCenterOpenChatInput) => void;
   provider: string;
 }): JSX.Element {
   "use memo";
@@ -65,6 +66,7 @@ export function MessageCenterOpenChatButton({
           onClick={() =>
             onOpenChat({
               agentSessionId: item.agentSessionId,
+              agentTargetId: item.agentTargetId?.trim() || null,
               provider: item.provider
             })
           }

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.tsx
@@ -29,7 +29,8 @@ import {
   isInteractiveMessageCenterItem,
   selectMessageCenterAttentionDeckItems,
   type WorkspaceAgentMessageCenterItem,
-  type WorkspaceAgentMessageCenterModel
+  type WorkspaceAgentMessageCenterModel,
+  type WorkspaceAgentMessageCenterOpenChatInput
 } from "./workspaceAgentMessageCenterModel";
 import { WorkspaceAgentMessageCenterAttentionDeck } from "./WorkspaceAgentMessageCenterAttentionDeck";
 import { MessageCenterViewMenu } from "./WorkspaceAgentMessageCenterViewControls";
@@ -90,7 +91,7 @@ export interface WorkspaceAgentMessageCenterPanelProps {
     action: string;
     provider: string;
   }) => void;
-  onOpenChat: (input: { agentSessionId: string; provider: string }) => void;
+  onOpenChat: (input: WorkspaceAgentMessageCenterOpenChatInput) => void;
   promptStatus?: (
     item: WorkspaceAgentMessageCenterItem
   ) => "idle" | "responding" | "unknown" | "failed";
@@ -708,7 +709,7 @@ const MessageCenterRenderedCard = memo(function MessageCenterRenderedCard({
   item: WorkspaceAgentMessageCenterItem;
   lazySummary: boolean;
   onLinkAction?: (action: WorkspaceLinkAction) => void;
-  onOpenChat: (input: { agentSessionId: string; provider: string }) => void;
+  onOpenChat: (input: WorkspaceAgentMessageCenterOpenChatInput) => void;
   onSubmitPrompt: (
     item: WorkspaceAgentMessageCenterItem,
     input: WorkspaceAgentMessageCenterPromptInput

--- a/packages/agent/gui/agent-message-center/index.ts
+++ b/packages/agent/gui/agent-message-center/index.ts
@@ -108,7 +108,8 @@ export type {
   WorkspaceAgentMessageCenterIdentity,
   WorkspaceAgentMessageCenterInteractionTarget,
   WorkspaceAgentMessageCenterItem,
-  WorkspaceAgentMessageCenterModel
+  WorkspaceAgentMessageCenterModel,
+  WorkspaceAgentMessageCenterOpenChatInput
 } from "./workspaceAgentMessageCenterModel";
 export type {
   MessageCenterAgentUserStack,

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts
@@ -67,6 +67,12 @@ export interface WorkspaceAgentMessageCenterItem {
   sortTimeUnixMs: number;
 }
 
+export interface WorkspaceAgentMessageCenterOpenChatInput {
+  agentSessionId: string;
+  agentTargetId: string | null;
+  provider: string;
+}
+
 export interface WorkspaceAgentMessageCenterInteractionTarget {
   agentSessionId: string;
   requestId: string;

--- a/packages/agent/gui/workbench/contribution.test.ts
+++ b/packages/agent/gui/workbench/contribution.test.ts
@@ -265,6 +265,7 @@ describe("agent GUI workbench contribution copy", () => {
       layoutConstraints: testLaunchLayout.layoutConstraints,
       payload: {
         agentSessionId: "session-claude-1",
+        agentTargetId: "local:claude-code",
         provider: "claude-code"
       },
       reason: "dock",
@@ -281,7 +282,9 @@ describe("agent GUI workbench contribution copy", () => {
     expect(launchResult).toMatchObject({
       activation: {
         payload: {
-          agentSessionId: "session-claude-1"
+          agentSessionId: "session-claude-1",
+          agentTargetId: "local:claude-code",
+          provider: "claude-code"
         },
         type: "agent-gui:open-session"
       },
@@ -289,6 +292,12 @@ describe("agent GUI workbench contribution copy", () => {
       title: "Agent"
     });
     expect(launchResult?.instanceId).toMatch(/^agent-gui:instance:/);
+    expect(
+      contribution.externalStateSource?.getSnapshotNodeState?.({
+        instanceId: launchResult?.instanceId ?? "",
+        typeId: agentGuiWorkbenchTypeId
+      } as never)
+    ).toBeNull();
   });
 
   it("opens forced replay launches as distinct in-workspace nodes", async () => {
@@ -322,7 +331,7 @@ describe("agent GUI workbench contribution copy", () => {
     expect(firstLaunch?.instanceId).not.toBe(secondLaunch?.instanceId);
   });
 
-  it("clears stale target state when opening a session without a target payload", () => {
+  it("does not precommit session state before open-session admission", () => {
     const contribution = createTestAgentGuiWorkbenchContribution({
       renderBody: () => null,
       workspaceId: "workspace-1"
@@ -355,10 +364,7 @@ describe("agent GUI workbench contribution copy", () => {
         instanceId: seededLaunch?.instanceId ?? "",
         typeId: agentGuiWorkbenchTypeId
       } as never)
-    ).toMatchObject({
-      agentTargetId: "local:claude-code",
-      lastActiveAgentSessionId: "session-codex-1"
-    });
+    ).toBeNull();
 
     const relaunch = contribution.onLaunchRequest?.({
       ...baseRequest,
@@ -379,11 +385,7 @@ describe("agent GUI workbench contribution copy", () => {
         instanceId: relaunch?.instanceId ?? "",
         typeId: agentGuiWorkbenchTypeId
       } as never)
-    ).toEqual({
-      conversationRailCollapsed: false,
-      conversationRailWidthPx: null,
-      lastActiveAgentSessionId: "session-codex-1"
-    });
+    ).toBeNull();
   });
 
   it("opens prefill launches in a fresh node without overwriting an active session", () => {
@@ -445,12 +447,7 @@ describe("agent GUI workbench contribution copy", () => {
         instanceId: sessionLaunch?.instanceId ?? "",
         typeId: agentGuiWorkbenchTypeId
       } as never)
-    ).toEqual({
-      agentTargetId: "local:codex",
-      conversationRailCollapsed: false,
-      conversationRailWidthPx: null,
-      lastActiveAgentSessionId: "session-codex-1"
-    });
+    ).toBeNull();
   });
 
   it("resolves unified empty dock launches lazily from current provider availability", () => {
@@ -891,9 +888,7 @@ describe("agent GUI workbench contribution copy", () => {
     } as never;
 
     await expect(
-      Promise.resolve(
-        contribution.nodes?.[0]?.getWindowCloseEffect?.(context)
-      )
+      Promise.resolve(contribution.nodes?.[0]?.getWindowCloseEffect?.(context))
     ).resolves.toEqual({
       nodeId: "agent-gui-node-1",
       title: "Agent",
@@ -906,9 +901,7 @@ describe("agent GUI workbench contribution copy", () => {
     });
 
     await expect(
-      Promise.resolve(
-        contribution.nodes?.[0]?.getWindowCloseEffect?.(context)
-      )
+      Promise.resolve(contribution.nodes?.[0]?.getWindowCloseEffect?.(context))
     ).resolves.toBeNull();
   });
 
@@ -1231,7 +1224,8 @@ describe("agent GUI workbench contribution copy", () => {
     );
     expect(newWindowLaunch?.activation).toEqual({
       payload: {
-        agentSessionId: "session-1"
+        agentSessionId: "session-1",
+        provider: "codex"
       },
       type: "agent-gui:open-session"
     });
@@ -1321,19 +1315,13 @@ describe("agent GUI workbench contribution copy", () => {
         instanceId: firstSessionLaunch?.instanceId ?? "",
         typeId: agentGuiWorkbenchTypeId
       } as never)
-    ).toMatchObject({
-      agentTargetId: "local:codex",
-      lastActiveAgentSessionId: "session-1"
-    });
+    ).toBeNull();
     expect(
       contribution.externalStateSource?.getSnapshotNodeState?.({
         instanceId: secondSessionLaunch?.instanceId ?? "",
         typeId: agentGuiWorkbenchTypeId
       } as never)
-    ).toMatchObject({
-      agentTargetId: "local:codex",
-      lastActiveAgentSessionId: "session-2"
-    });
+    ).toBeNull();
   });
 
   it("does not treat a drifted session-keyed window as the requested session", async () => {
@@ -1386,6 +1374,75 @@ describe("agent GUI workbench contribution copy", () => {
     expect(relaunch?.instanceId).not.toBe("agent-gui:codex:session:session-1");
     expect(relaunch?.instanceId).toMatch(/^agent-gui:instance:/);
     expect(relaunch?.preserveExistingNodeFrame).not.toBe(true);
+  });
+
+  it("releases a stale reservation when a forced instance commits the session", async () => {
+    let writeForcedState: ((state: AgentGuiWorkbenchState) => void) | null =
+      null;
+    const contribution = createTestAgentGuiWorkbenchContribution({
+      renderBody: (context, helpers) => {
+        if (context.node.id === "forced-session-node") {
+          writeForcedState = helpers.onStateChange;
+        }
+        return null;
+      },
+      workspaceId: "workspace-1"
+    });
+    const baseRequest = {
+      layoutConstraints: testLaunchLayout.layoutConstraints,
+      reason: "host" as const,
+      surfaceSize: testLaunchLayout.surfaceSize,
+      typeId: agentGuiWorkbenchTypeId,
+      workspaceId: "workspace-1"
+    };
+    const pendingLaunch = await contribution.onLaunchRequest?.({
+      ...baseRequest,
+      payload: { agentSessionId: "session-1", provider: "codex" }
+    });
+    const forcedLaunch = await contribution.onLaunchRequest?.({
+      ...baseRequest,
+      payload: {
+        agentSessionId: "session-1",
+        openInNewWindow: true,
+        provider: "codex"
+      }
+    });
+
+    contribution.nodes?.[0]?.renderBody?.({
+      activation: forcedLaunch?.activation ?? null,
+      externalNodeState: null,
+      externalWorkspaceState: null,
+      instanceId: forcedLaunch?.instanceId ?? "",
+      instanceKey: null,
+      node: {
+        data: { runtimeNodeState: null },
+        displayMode: "floating",
+        frame: { height: 560, width: 1040, x: 0, y: 0 },
+        id: "forced-session-node",
+        title: "Agent"
+      }
+    } as Parameters<
+      NonNullable<(typeof contribution.nodes)[number]["renderBody"]>
+    >[0]);
+    expect(writeForcedState).not.toBeNull();
+    (writeForcedState as unknown as (state: AgentGuiWorkbenchState) => void)({
+      conversationRailCollapsed: false,
+      conversationRailWidthPx: null,
+      lastActiveAgentSessionId: "session-1"
+    });
+    (writeForcedState as unknown as (state: AgentGuiWorkbenchState) => void)({
+      conversationRailCollapsed: false,
+      conversationRailWidthPx: null,
+      lastActiveAgentSessionId: "session-2"
+    });
+
+    const retryLaunch = await contribution.onLaunchRequest?.({
+      ...baseRequest,
+      payload: { agentSessionId: "session-1", provider: "codex" }
+    });
+
+    expect(retryLaunch?.instanceId).not.toBe(pendingLaunch?.instanceId);
+    expect(retryLaunch?.instanceId).not.toBe(forcedLaunch?.instanceId);
   });
 
   it("keeps compact new-window session launches on the cascade policy", async () => {

--- a/packages/agent/gui/workbench/contribution.ts
+++ b/packages/agent/gui/workbench/contribution.ts
@@ -125,6 +125,7 @@ export function createAgentGuiWorkbenchContribution(
   const nodeStateSource = createAgentGuiWorkbenchNodeStateSource({
     workspaceId: input.workspaceId
   });
+  const pendingSessionInstanceIds = new Map<string, string>();
   const railLayoutStore = createAgentGuiWorkbenchRailLayoutStore();
   const frame = input.frame ?? agentGuiWorkbenchDefaultNodeFrame;
   const copy = resolveAgentGuiWorkbenchContributionCopy(input.copy);
@@ -228,6 +229,12 @@ export function createAgentGuiWorkbenchContribution(
                   state: nextState,
                   typeId: agentGuiWorkbenchTypeId
                 });
+                const committedSessionId =
+                  nextState.lastActiveAgentSessionId?.trim();
+                if (committedSessionId) {
+                  releasePendingSessionInstanceReservations(context.instanceId);
+                  pendingSessionInstanceIds.delete(committedSessionId);
+                }
               },
               provider: agent?.provider ?? null
             }
@@ -454,32 +461,26 @@ export function createAgentGuiWorkbenchContribution(
       // Locate an already-open node currently showing this session (its launch
       // instanceId may differ from the session-keyed one, e.g. a conversation
       // started fresh as a draft) so we focus it instead of opening a duplicate.
-      const existingInstanceId =
+      const committedInstanceId =
         reusePolicy.kind === "current-session"
           ? nodeStateSource.findInstanceIdByAgentSessionId(
               reusePolicy.agentSessionId
             )
           : null;
+      const existingInstanceId =
+        committedInstanceId ??
+        (reusePolicy.kind === "current-session"
+          ? (pendingSessionInstanceIds.get(reusePolicy.agentSessionId) ?? null)
+          : null);
+      if (
+        reusePolicy.kind === "current-session" &&
+        committedInstanceId !== null
+      ) {
+        pendingSessionInstanceIds.delete(reusePolicy.agentSessionId);
+      }
       const instanceId = existingInstanceId ?? descriptorInstanceId;
       const title = copy.nodeTitle;
-      const launchAgentTargetId = providerTarget.agentTargetId;
-      if (targetAgentSessionId) {
-        const previousState = nodeStateSource.readNodeState({
-          instanceId,
-          typeId: agentGuiWorkbenchTypeId
-        });
-        nodeStateSource.writeNodeState({
-          instanceId,
-          state: {
-            ...normalizeAgentGuiWorkbenchState(previousState),
-            ...(targetAgentSessionId
-              ? { lastActiveAgentSessionId: targetAgentSessionId }
-              : {}),
-            agentTargetId: launchAgentTargetId ?? null
-          },
-          typeId: agentGuiWorkbenchTypeId
-        });
-      } else if (providerTarget.agentTargetId) {
+      if (!targetAgentSessionId && providerTarget.agentTargetId) {
         const previousState = nodeStateSource.readNodeState({
           instanceId,
           typeId: agentGuiWorkbenchTypeId
@@ -493,6 +494,12 @@ export function createAgentGuiWorkbenchContribution(
           },
           typeId: agentGuiWorkbenchTypeId
         });
+      }
+      if (
+        reusePolicy.kind === "current-session" &&
+        committedInstanceId === null
+      ) {
+        reservePendingSessionInstanceId(reusePolicy.agentSessionId, instanceId);
       }
       const defaultFrame = resolveAgentGuiWorkbenchDefaultLaunchFrame({
         frame,
@@ -521,6 +528,30 @@ export function createAgentGuiWorkbenchContribution(
       };
     }
   };
+
+  function reservePendingSessionInstanceId(
+    agentSessionId: string,
+    instanceId: string
+  ): void {
+    pendingSessionInstanceIds.delete(agentSessionId);
+    pendingSessionInstanceIds.set(agentSessionId, instanceId);
+    while (pendingSessionInstanceIds.size > 512) {
+      const oldestSessionId = pendingSessionInstanceIds.keys().next().value;
+      if (typeof oldestSessionId !== "string") break;
+      pendingSessionInstanceIds.delete(oldestSessionId);
+    }
+  }
+
+  function releasePendingSessionInstanceReservations(instanceId: string): void {
+    for (const [
+      agentSessionId,
+      pendingInstanceId
+    ] of pendingSessionInstanceIds) {
+      if (pendingInstanceId === instanceId) {
+        pendingSessionInstanceIds.delete(agentSessionId);
+      }
+    }
+  }
 }
 
 function resolveAgentGuiWorkbenchStateAgent(

--- a/packages/agent/gui/workbench/launch.test.ts
+++ b/packages/agent/gui/workbench/launch.test.ts
@@ -95,6 +95,14 @@ describe("agent gui workbench launch contract", () => {
         typeId: "agent-gui"
       })
     ).toMatchObject({
+      activation: {
+        payload: {
+          agentSessionId: "session-2",
+          agentTargetId: "local:codex",
+          provider: "codex"
+        },
+        type: "agent-gui:open-session"
+      },
       openInNewWindow: false,
       reusePolicy: {
         agentSessionId: "session-2",
@@ -103,6 +111,42 @@ describe("agent gui workbench launch contract", () => {
       targetAgentSessionId: "session-2"
     });
   });
+
+  it("preserves an explicit null target in the exact activation contract", () => {
+    const descriptor = createAgentGuiWorkbenchLaunchDescriptor(
+      createAgentGuiWorkbenchSessionLaunchRequest({
+        agentSessionId: "session-provider-default",
+        agentTargetId: null,
+        provider: "codex"
+      })
+    );
+
+    expect(descriptor.activation).toEqual({
+      payload: {
+        agentSessionId: "session-provider-default",
+        agentTargetId: null,
+        provider: "codex"
+      },
+      type: "agent-gui:open-session"
+    });
+  });
+
+  it.each([" ", 42])(
+    "rejects invalid target identity %j instead of degrading to session-only",
+    (agentTargetId) => {
+      expect(() =>
+        createAgentGuiWorkbenchLaunchDescriptor({
+          dockEntryId: agentGuiWorkbenchUnifiedDockEntryId(),
+          payload: {
+            agentSessionId: "session-invalid-target",
+            agentTargetId,
+            provider: "codex"
+          },
+          typeId: "agent-gui"
+        })
+      ).toThrow("agent_gui_workbench.launch_agent_target_invalid");
+    }
+  );
 
   it("can launch an existing session into a new internal window", () => {
     const descriptor = createAgentGuiWorkbenchLaunchDescriptor({
@@ -117,7 +161,8 @@ describe("agent gui workbench launch contract", () => {
 
     expect(descriptor.activation).toEqual({
       payload: {
-        agentSessionId: "session-2"
+        agentSessionId: "session-2",
+        provider: "codex"
       },
       type: "agent-gui:open-session"
     });
@@ -160,7 +205,8 @@ describe("agent gui workbench launch contract", () => {
         composerAppend: {
           draftPrompt: "Modify the managed issue",
           focusComposer: true
-        }
+        },
+        provider: "codex"
       },
       type: "agent-gui:open-session"
     });

--- a/packages/agent/gui/workbench/launch.ts
+++ b/packages/agent/gui/workbench/launch.ts
@@ -87,12 +87,14 @@ export function createAgentGuiWorkbenchSessionLaunchRequest(input: {
   provider: unknown;
 }) {
   const provider = normalizeAgentGuiWorkbenchProvider(input.provider);
+  const agentTargetId =
+    input.agentTargetId === null
+      ? null
+      : input.agentTargetId?.trim() || undefined;
   return {
     dockEntryId: agentGuiWorkbenchUnifiedDockEntryId(),
     payload: {
-      ...(input.agentTargetId?.trim()
-        ? { agentTargetId: input.agentTargetId.trim() }
-        : {}),
+      ...(agentTargetId !== undefined ? { agentTargetId } : {}),
       ...(input.agentSessionId ? { agentSessionId: input.agentSessionId } : {}),
       ...(input.composerAppend?.draftPrompt.trim()
         ? {
@@ -193,6 +195,12 @@ export function createAgentGuiWorkbenchLaunchDescriptor(
   }
 
   const targetAgentSessionId = agentSessionIdFromLaunchPayload(request.payload);
+  const agentTargetIdentity = openSessionAgentTargetIdentityFromLaunchPayload(
+    request.payload
+  );
+  if (agentTargetIdentity.kind === "invalid") {
+    throw new Error("agent_gui_workbench.launch_agent_target_invalid");
+  }
   const composerAppend = openSessionComposerAppendFromLaunchPayload(
     request.payload
   );
@@ -205,6 +213,12 @@ export function createAgentGuiWorkbenchLaunchDescriptor(
       ? {
           payload: {
             agentSessionId: targetAgentSessionId,
+            ...(agentTargetIdentity.kind === "explicit-null"
+              ? { agentTargetId: null }
+              : agentTargetIdentity.kind === "value"
+                ? { agentTargetId: agentTargetIdentity.agentTargetId }
+                : {}),
+            provider,
             ...(composerAppend ? { composerAppend } : {})
           },
           type: agentGuiWorkbenchOpenSessionActivationType
@@ -222,6 +236,31 @@ export function createAgentGuiWorkbenchLaunchDescriptor(
           : { kind: "dock-entry" },
     targetAgentSessionId
   };
+}
+
+type OpenSessionAgentTargetIdentity =
+  | { kind: "absent" }
+  | { kind: "explicit-null" }
+  | { agentTargetId: string; kind: "value" }
+  | { kind: "invalid" };
+
+function openSessionAgentTargetIdentityFromLaunchPayload(
+  payload: unknown
+): OpenSessionAgentTargetIdentity {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return { kind: "absent" };
+  }
+  const record = payload as Record<string, unknown>;
+  if (!Object.prototype.hasOwnProperty.call(record, "agentTargetId")) {
+    return { kind: "absent" };
+  }
+  const rawAgentTargetId = record.agentTargetId;
+  if (rawAgentTargetId === null) {
+    return { kind: "explicit-null" };
+  }
+  return typeof rawAgentTargetId === "string" && rawAgentTargetId.trim()
+    ? { agentTargetId: rawAgentTargetId.trim(), kind: "value" }
+    : { kind: "invalid" };
 }
 
 function openSessionComposerAppendFromLaunchPayload(

--- a/packages/agent/gui/workbench/types.ts
+++ b/packages/agent/gui/workbench/types.ts
@@ -14,7 +14,11 @@ export interface AgentGuiWorkbenchOpenSessionComposerAppend {
 
 export interface AgentGuiWorkbenchOpenSessionPayload {
   agentSessionId: string;
+  /** Canonical Agent identity for target-aware in-window routing. */
+  agentTargetId?: string | null;
   composerAppend?: AgentGuiWorkbenchOpenSessionComposerAppend;
+  /** Runtime metadata used to validate the canonical Agent target. */
+  provider?: AgentGuiWorkbenchProvider;
 }
 
 export interface AgentGuiWorkbenchPrefillPromptPayload {


### PR DESCRIPTION
## Summary

- carry the exact Session / Agent Target / Provider identity from Message Center
- close the embedded Message Center before routing
- reuse the existing AgentGUI launch coordinator and standalone launch handler
- activate the target Session in the current Agent window without calling the native window opener
- pass the same exact identity into the existing Workbench node launch for workspace-hosted Message Center actions

## Intended behavior

In Agent mode, clicking **Open session**:

1. closes Message Center
2. stays in the current Agent window
3. switches to the Session and Agent Target that own the message
4. never creates a new native window

## Scope

This PR intentionally does not change OS notification delivery, Electron main/preload IPC, native window creation, replacement-window fallback, show/focus policy, or daemon/session lifecycle semantics.

It reuses:

- the existing Message Center model and card components
- `requestWorkspaceAgentGuiLaunch`
- `handleStandaloneAgentGuiLaunch`
- the existing Workbench Session launch request

## Validation

- `pnpm check:changed -- --base upstream/main`: 15/15 lanes passed
- AgentGUI focused regression: 9/9 tests passed
- Desktop standalone launch regression: 5/5 tests passed
- AgentGUI typecheck: passed
- Desktop typecheck: passed
- pre-commit formatting, lint, renderer/UI/Electron boundary, and AgentGUI degradation checks: passed

The fork's default pre-push comparison uses an `origin/main` that is 152 commits behind upstream, so it additionally ran unrelated repository lanes; 90/91 passed and the only failure was an unrelated `services/tuttid` Go test. The scoped upstream-based validation above is fully green.

## Manual acceptance

- open Agent A in one workspace
- ensure Message Center contains a Session owned by Agent B
- click **Open session**
- verify Message Center closes
- verify the same native Agent window remains
- verify header, rail, and detail show Agent B and the exact target Session
- repeat once on macOS and once on Windows

Windows requires only the same interaction check: this PR contains no Windows-specific path, process, shell, filesystem, native window, or show/focus changes.

The PR remains Draft until real-data cross-Agent acceptance is recorded.

