### PR TITLE
fix(release): bound AWS CLI bootstrap

### DIFF
--- a/.github/workflows/desktop-release-promote.yml
+++ b/.github/workflows/desktop-release-promote.yml
@@ -333,9 +333,8 @@ jobs:
           node apps/desktop/scripts/validate-release-summary.mjs release-assets/release-summary.json
 
       - name: Install AWS CLI
+        timeout-minutes: 5
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends unzip
           if ! command -v aws >/dev/null 2>&1; then
             case "$(uname -m)" in
               x86_64) awscli_arch="x86_64" ;;
@@ -345,9 +344,16 @@ jobs:
                 exit 1
                 ;;
             esac
-            curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${awscli_arch}.zip" -o /tmp/awscliv2.zip
-            unzip -q /tmp/awscliv2.zip -d /tmp
-            sudo /tmp/aws/install --update
+            awscli_dir="$(mktemp -d "${RUNNER_TEMP}/aws-cli.XXXXXX")"
+            curl --fail --silent --show-error --location \
+              --retry 3 \
+              --retry-all-errors \
+              --connect-timeout 10 \
+              --max-time 180 \
+              "https://awscli.amazonaws.com/awscli-exe-linux-${awscli_arch}.zip" \
+              --output "${awscli_dir}/awscliv2.zip"
+            python3 -m zipfile -e "${awscli_dir}/awscliv2.zip" "${awscli_dir}"
+            sudo "${awscli_dir}/aws/install" --update
           fi
           aws --version
 

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -707,9 +707,8 @@ jobs:
           echo "release_id=$(jq -r .id staged-release.json)" >> "$GITHUB_OUTPUT"
 
       - name: Install AWS CLI
+        timeout-minutes: 5
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends unzip
           if ! command -v aws >/dev/null 2>&1; then
             case "$(uname -m)" in
               x86_64) awscli_arch="x86_64" ;;
@@ -719,9 +718,16 @@ jobs:
                 exit 1
                 ;;
             esac
-            curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${awscli_arch}.zip" -o /tmp/awscliv2.zip
-            unzip -q /tmp/awscliv2.zip -d /tmp
-            sudo /tmp/aws/install --update
+            awscli_dir="$(mktemp -d "${RUNNER_TEMP}/aws-cli.XXXXXX")"
+            curl --fail --silent --show-error --location \
+              --retry 3 \
+              --retry-all-errors \
+              --connect-timeout 10 \
+              --max-time 180 \
+              "https://awscli.amazonaws.com/awscli-exe-linux-${awscli_arch}.zip" \
+              --output "${awscli_dir}/awscliv2.zip"
+            python3 -m zipfile -e "${awscli_dir}/awscliv2.zip" "${awscli_dir}"
+            sudo "${awscli_dir}/aws/install" --update
           fi
           aws --version
 

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -555,6 +555,12 @@ Recommended setup:
 - keep the S3 bucket and prefix configured so the workflow can upload mirrored assets
 - apply a 30-day lifecycle expiration to objects under `<prefix>/candidates/`; never apply that rule to formal `<tag>/` paths
 
+Release and promotion jobs bootstrap AWS CLI without refreshing Ubuntu package
+indexes. The bootstrap uses the runner's Python runtime to extract the official
+AWS CLI archive, retries transient download failures, and has a five-minute
+step deadline. Keep this path independent of APT mirrors so a mirror outage
+cannot consume the release job's full runtime limit after packages have built.
+
 If `TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL` is omitted, the workflow falls back to:
 
 ```text

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -75,6 +75,7 @@ Electron startup, daemon supervision, macOS packaging, updates, and performance 
 - [Packaged Tutti starts but external shells cannot find `tutti`](./desktop-release.md#packaged-tutti-starts-but-external-shells-cannot-find-tutti)
 - [Desktop stable release alias disappears or is not first on Releases](./desktop-release.md#desktop-stable-release-alias-disappears-or-is-not-first-on-releases)
 - [Desktop release notes exceed GitHub's body limit](./desktop-release.md#desktop-release-notes-exceed-githubs-body-limit)
+- [Desktop release stalls after all packages finish building](./desktop-release.md#desktop-release-stalls-after-all-packages-finish-building)
 - [Desktop dev GUI exits before opening](./desktop-release.md#desktop-dev-gui-exits-before-opening)
 - [Running a development tuttid breaks the production Agent session](./desktop-release.md#running-a-development-tuttid-breaks-the-production-agent-session)
 - [macOS updates fail from a mounted DMG](./desktop-release.md#macos-updates-fail-from-a-mounted-dmg)

--- a/docs/conventions/troubleshooting/desktop-release.md
+++ b/docs/conventions/troubleshooting/desktop-release.md
@@ -142,6 +142,38 @@
   [resolve-previous-release-tag.mjs](../../../apps/desktop/scripts/resolve-previous-release-tag.mjs)
   [githubReleaseBody.mjs](../../../apps/desktop/scripts/lib/githubReleaseBody.mjs)
 
+### Desktop release stalls after all packages finish building
+
+- Symptom:
+  Every macOS and Windows build succeeds and the GitHub draft assets are
+  staged, but `Stage Release Draft` remains in `Install AWS CLI` until GitHub
+  cancels the job near its six-hour runtime limit. The last output comes from
+  `apt-get update` and contains repeated `Ign` lines for Ubuntu package indexes.
+- Quick checks:
+  Inspect the start of `Install AWS CLI`. If the shell still runs
+  `sudo apt-get update`, the Actions run used a workflow revision from before
+  the bounded bootstrap fix. Confirm no later `curl` or `aws --version` line
+  appears; that distinguishes an APT mirror stall from an AWS CLI download or
+  credential failure.
+- Root cause:
+  The old bootstrap refreshed Ubuntu package indexes before checking for AWS
+  CLI. A transient runner mirror failure could therefore block an otherwise
+  complete release, and the step had no deadline below GitHub's job limit.
+- Fix:
+  Start a new release run from a revision that skips APT, extracts the official
+  AWS CLI archive with `python3 -m zipfile`, retries bounded downloads, and
+  limits the complete install step to five minutes. Re-running the original
+  Actions run is insufficient because GitHub reuses that run's old workflow
+  revision.
+- Validation:
+  Run `node --test tools/scripts/desktop-release-config.test.mjs`. Confirm both
+  release workflows reject `apt-get`, require the download retry/connect/total
+  time limits, use Python extraction, and set the step deadline.
+- References:
+  [.github/workflows/desktop-release.yml](../../../.github/workflows/desktop-release.yml)
+  [.github/workflows/desktop-release-promote.yml](../../../.github/workflows/desktop-release-promote.yml)
+  [desktop-release-config.test.mjs](../../../tools/scripts/desktop-release-config.test.mjs)
+
 ### Desktop dev GUI exits before opening
 
 - Symptom:

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -197,6 +197,35 @@ test("desktop release workflow uses the published desktop package name", async (
   }
 });
 
+test("desktop release AWS CLI bootstrap avoids apt mirrors and bounds downloads", async () => {
+  const workflows = [
+    ["release", await readFile(workflowPath, "utf8")],
+    ["promotion", await readFile(promoteWorkflowPath, "utf8")]
+  ];
+
+  for (const [name, workflow] of workflows) {
+    const installStep = workflow.match(
+      /      - name: Install AWS CLI\n[\s\S]*?(?=\n      - name:)/
+    )?.[0];
+    assert.ok(installStep, `${name} workflow must install AWS CLI`);
+    assert.doesNotMatch(
+      installStep,
+      /sudo apt-get (?:update|install)/,
+      `${name} workflow must not depend on an apt mirror to install AWS CLI`
+    );
+    assert.match(
+      installStep,
+      /- name: Install AWS CLI\n\s+timeout-minutes: 5/,
+      `${name} workflow must bound the complete AWS CLI bootstrap step`
+    );
+    assert.match(installStep, /--retry 3/);
+    assert.match(installStep, /--retry-all-errors/);
+    assert.match(installStep, /--connect-timeout 10/);
+    assert.match(installStep, /--max-time 180/);
+    assert.match(installStep, /python3 -m zipfile -e/);
+  }
+});
+
 test("desktop release submits only stable builds to an isolated Store workflow", async () => {
   const workflow = await readFile(workflowPath, "utf8");
   const storeWorkflow = await readFile(storeWorkflowPath, "utf8");


### PR DESCRIPTION
## Summary

- remove the release workflows' dependency on Ubuntu APT mirrors when bootstrapping AWS CLI
- retry and bound the official AWS CLI archive download, with a five-minute step deadline
- add workflow regression coverage and durable release troubleshooting guidance

## Root cause

[Desktop Release run 32300428729](https://github.com/tutti-os/tutti/actions/runs/32300428729) completed every macOS and Windows package build, then stalled in `Install AWS CLI`. The unconditional `apt-get update` stopped making progress while fetching Ubuntu package indexes and had no deadline below the GitHub job limit, so the stage job was canceled after roughly six hours.

## Validation

- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready`
- desktop release config tests: 54 passed

## Windows impact

Windows artifacts are unchanged. This only hardens the Ubuntu-hosted release staging and promotion jobs that mirror already-built macOS and Windows assets.
