### PR TITLE
fix(desktop): backport managed daemon startup recovery to release/0818

### DIFF
--- a/apps/desktop/src/main/daemon/daemonRestartController.test.ts
+++ b/apps/desktop/src/main/daemon/daemonRestartController.test.ts
@@ -32,10 +32,11 @@ test("restarts the daemon once after an unexpected exit", async () => {
     config
   });
 
-  await controller.notifyExited();
+  const recovered = await controller.notifyExited();
 
   assert.equal(restartCount, 1);
   assert.deepEqual(delays, [500]);
+  assert.equal(recovered, true);
 });
 
 test("does not restart when stop was requested", async () => {
@@ -51,9 +52,10 @@ test("does not restart when stop was requested", async () => {
     config
   });
 
-  await controller.notifyExited();
+  const recovered = await controller.notifyExited();
 
   assert.equal(restartCount, 0);
+  assert.equal(recovered, false);
 });
 
 test("uses exponential backoff and gives up after max attempts", async () => {
@@ -85,11 +87,12 @@ test("uses exponential backoff and gives up after max attempts", async () => {
     }
   });
 
-  await controller.notifyExited();
+  const recovered = await controller.notifyExited();
 
   assert.equal(restartCount, 4);
   assert.deepEqual(delays, [500, 1_000, 2_000, 4_000]);
   assert.ok(errors.some((message) => message.includes("giving up")));
+  assert.equal(recovered, false);
 });
 
 test("resets backoff after the daemon stays healthy", async () => {

--- a/apps/desktop/src/main/daemon/daemonRestartController.ts
+++ b/apps/desktop/src/main/daemon/daemonRestartController.ts
@@ -21,7 +21,7 @@ export interface DaemonRestartControllerDeps {
 }
 
 export interface DaemonRestartController {
-  notifyExited(): Promise<void>;
+  notifyExited(): Promise<boolean>;
   notifyStarted(): void;
 }
 
@@ -39,13 +39,13 @@ export function createDaemonRestartController(
 
   let attempts = 0;
   let lastHealthyAt: number | null = null;
-  let inFlight: Promise<void> | null = null;
+  let inFlight: Promise<boolean> | null = null;
 
   function backoffDelayMs(attempt: number): number {
     return Math.min(config.baseDelayMs * 2 ** attempt, config.maxDelayMs);
   }
 
-  async function runRestartLoop(): Promise<void> {
+  async function runRestartLoop(): Promise<boolean> {
     // A sustained-healthy period before this death earns a fresh retry budget.
     // Evaluate once per cycle — doing it inside the loop would re-fire on every
     // failing retry (lastHealthyAt stays old) and never reach maxAttempts.
@@ -61,7 +61,7 @@ export function createDaemonRestartController(
         deps.logger.error("managed tuttid restart giving up", {
           attempts
         });
-        return;
+        return false;
       }
 
       const waitMs = backoffDelayMs(attempts);
@@ -69,14 +69,17 @@ export function createDaemonRestartController(
       await deps.delay(waitMs);
 
       if (deps.isStopRequested()) {
-        return;
+        return false;
       }
 
       try {
         await deps.restart();
+        if (deps.isStopRequested()) {
+          return false;
+        }
         lastHealthyAt = deps.now();
         deps.logger.info("managed tuttid restarted", { attempts });
-        return;
+        return true;
       } catch (error: unknown) {
         deps.logger.error("managed tuttid restart failed", {
           attempts,
@@ -84,12 +87,13 @@ export function createDaemonRestartController(
         });
       }
     }
+    return false;
   }
 
   return {
     notifyExited() {
       if (deps.isStopRequested()) {
-        return Promise.resolve();
+        return Promise.resolve(false);
       }
 
       if (inFlight) {

--- a/apps/desktop/src/main/daemon/tuttidManager.test.ts
+++ b/apps/desktop/src/main/daemon/tuttidManager.test.ts
@@ -4,6 +4,7 @@ import {
   chmod,
   mkdir,
   mkdtemp,
+  readFile,
   rm,
   stat,
   utimes,
@@ -19,6 +20,7 @@ import type { DesktopDaemonEndpoint } from "../transport/paths.ts";
 import {
   createTuttidManager,
   isLikelyTuttidProcess,
+  isRetryableManagedTuttidStartupError,
   managedTuttidStartupError,
   resolveBrowserMcpDaemonEnv,
   resolveComputerMcpDaemonEnv,
@@ -28,6 +30,7 @@ import {
   resolveManagedPosixShellDaemonEnv,
   resolveManagedUVDaemonEnv,
   resolveMutagenDaemonEnv,
+  shouldScheduleManagedTuttidRestart,
 } from "./tuttidManager.ts";
 
 test("resolveManagedUVDaemonEnv points the daemon at packaged archives", async () => {
@@ -98,15 +101,147 @@ test("rejects startup when the managed tuttid binary cannot be spawned", async (
       throw new Error("health must not run when spawn fails");
     },
   } as unknown as TuttidClient;
+  let manager: ReturnType<typeof createTuttidManager> | undefined;
 
   try {
     process.env.TUTTID_BIN = join(runtimeDirectory, "missing-tuttid");
-    const manager = createTuttidManager(endpoint, tuttidClient);
+    manager = createTuttidManager(endpoint, tuttidClient);
 
     await assert.rejects(manager.start(), { code: "managed_process_error" });
     assert.equal(endpoint.boundAddr, null);
     await manager.stop();
   } finally {
+    await manager?.stop().catch(() => undefined);
+    restoreEnv(previousEnv);
+    await rm(runtimeDirectory, { force: true, recursive: true });
+  }
+});
+
+test("stop wins while a managed tuttid start is still preparing", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("the executable fixture uses a POSIX shebang");
+    return;
+  }
+
+  const previousEnv = { ...process.env };
+  const runtimeDirectory = await mkdtemp(
+    join(tmpdir(), "tutti-tuttid-stop-start-"),
+  );
+  const fixturePath = join(runtimeDirectory, "tuttid-fixture.mjs");
+  const spawnedPath = join(runtimeDirectory, "spawned.txt");
+  const endpoint: DesktopDaemonEndpoint = {
+    accessToken: "test-token",
+    boundAddr: null,
+    listenerInfoPath: join(runtimeDirectory, "listener.json"),
+    pidPath: join(runtimeDirectory, "tuttid.pid"),
+    requestedAddr: "127.0.0.1:0",
+  };
+  const tuttidClient = {
+    async getHealth() {
+      throw new Error("a canceled start must not reach health polling");
+    },
+  } as unknown as TuttidClient;
+  let manager: ReturnType<typeof createTuttidManager> | undefined;
+
+  try {
+    await writeFile(
+      fixturePath,
+      `#!/usr/bin/env node
+import { writeFile } from "node:fs/promises";
+await writeFile(process.env.TUTTI_TEST_SPAWNED_PATH, "spawned");
+setInterval(() => {}, 1_000);
+`,
+    );
+    await chmod(fixturePath, 0o755);
+    process.env.TUTTID_BIN = fixturePath;
+    process.env.TUTTI_TEST_SPAWNED_PATH = spawnedPath;
+
+    manager = createTuttidManager(endpoint, tuttidClient);
+    const start = manager.start();
+    await manager.stop();
+    await start;
+    await assert.rejects(readFile(spawnedPath, "utf8"), { code: "ENOENT" });
+    assert.equal(endpoint.boundAddr, null);
+  } finally {
+    await manager?.stop().catch(() => undefined);
+    restoreEnv(previousEnv);
+    await rm(runtimeDirectory, { force: true, recursive: true });
+  }
+});
+
+test("keeps the original startup alive while recovering a transient SQLite failure", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("the executable fixture uses a POSIX shebang");
+    return;
+  }
+
+  const previousEnv = { ...process.env };
+  const runtimeDirectory = await mkdtemp(join(tmpdir(), "tutti-tuttid-retry-"));
+  const fixturePath = join(runtimeDirectory, "tuttid-fixture.mjs");
+  const attemptsPath = join(runtimeDirectory, "attempts.txt");
+  const fixturePIDPath = join(runtimeDirectory, "fixture.pid");
+  const endpoint: DesktopDaemonEndpoint = {
+    accessToken: "test-token",
+    boundAddr: null,
+    listenerInfoPath: join(runtimeDirectory, "listener.json"),
+    pidPath: join(runtimeDirectory, "tuttid.pid"),
+    requestedAddr: "127.0.0.1:0",
+  };
+  const tuttidClient = {
+    async getHealth() {
+      assert.equal(endpoint.boundAddr, "127.0.0.1:4545");
+      return {};
+    },
+  } as unknown as TuttidClient;
+  let manager: ReturnType<typeof createTuttidManager> | undefined;
+
+  try {
+    await writeFile(
+      fixturePath,
+      `#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+const attemptsPath = process.env.TUTTI_TEST_START_ATTEMPTS_PATH;
+const fixturePIDPath = process.env.TUTTI_TEST_FIXTURE_PID_PATH;
+const listenerInfoPath = process.env.TUTTID_LISTENER_INFO_PATH;
+const previous = Number(await readFile(attemptsPath, "utf8").catch(() => "0"));
+const attempt = previous + 1;
+await writeFile(attemptsPath, String(attempt));
+if (attempt === 1) {
+  console.error("enable sqlite wal mode: disk I/O error (1546)");
+  process.exit(1);
+}
+await mkdir(dirname(listenerInfoPath), { recursive: true });
+await writeFile(fixturePIDPath, String(process.pid));
+await writeFile(listenerInfoPath, JSON.stringify({ addr: "127.0.0.1:4545" }));
+setInterval(() => {}, 1_000);
+`,
+    );
+    await chmod(fixturePath, 0o755);
+    process.env.TUTTID_BIN = fixturePath;
+    process.env.TUTTID_LISTENER_INFO_PATH = endpoint.listenerInfoPath;
+    process.env.TUTTI_TEST_FIXTURE_PID_PATH = fixturePIDPath;
+    process.env.TUTTI_TEST_START_ATTEMPTS_PATH = attemptsPath;
+
+    manager = createTuttidManager(endpoint, tuttidClient);
+    await manager.start();
+
+    assert.equal(await readFile(attemptsPath, "utf8"), "2");
+    assert.equal(endpoint.boundAddr, "127.0.0.1:4545");
+
+    const recoveredPID = Number(await readFile(fixturePIDPath, "utf8"));
+    process.kill(recoveredPID, "SIGTERM");
+    await waitForTestProcessExit(recoveredPID);
+    await manager.start();
+    await new Promise((resolve) => setTimeout(resolve, 750));
+    assert.equal(
+      await readFile(attemptsPath, "utf8"),
+      "3",
+      "background recovery and an explicit start must share one spawn attempt",
+    );
+    await manager.stop();
+  } finally {
+    await manager?.stop().catch(() => undefined);
     restoreEnv(previousEnv);
     await rm(runtimeDirectory, { force: true, recursive: true });
   }
@@ -136,6 +271,34 @@ test("classifies startup errors without daemon diagnostics", () => {
     (failure as NodeJS.ErrnoException).code,
     "managed_process_error",
   );
+});
+
+test("retries only the transient SQLite truncate startup failure", () => {
+  const transient = managedTuttidStartupError(
+    new Error("tuttid exited before it published its listener info."),
+    "enable sqlite wal mode: disk I/O error (1546)",
+  );
+  const named = managedTuttidStartupError(
+    new Error("tuttid exited before it published its listener info."),
+    "SQLITE_IOERR_TRUNCATE",
+  );
+  const permanent = managedTuttidStartupError(
+    new Error("tuttid exited before it published its listener info."),
+    "permission denied",
+  );
+
+  assert.equal(isRetryableManagedTuttidStartupError(transient), true);
+  assert.equal(isRetryableManagedTuttidStartupError(named), true);
+  assert.equal(isRetryableManagedTuttidStartupError(permanent), false);
+  assert.equal(isRetryableManagedTuttidStartupError(new Error("1546")), false);
+});
+
+test("only a previously healthy daemon exit schedules background recovery", () => {
+  assert.equal(shouldScheduleManagedTuttidRestart("healthy", false), true);
+  assert.equal(shouldScheduleManagedTuttidRestart("starting", false), false);
+  assert.equal(shouldScheduleManagedTuttidRestart("recovering", false), false);
+  assert.equal(shouldScheduleManagedTuttidRestart("stopping", false), false);
+  assert.equal(shouldScheduleManagedTuttidRestart("healthy", true), false);
 });
 
 test("resolveLaunchSpec prefers the development tuttid binary when present", async (t) => {
@@ -742,4 +905,17 @@ async function developmentBinaryIsFresh(binaryPath: string): Promise<boolean> {
   } catch {
     return true;
   }
+}
+
+async function waitForTestProcessExit(pid: number): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    } catch {
+      return;
+    }
+  }
+  throw new Error(`timed out waiting for fixture process ${pid} to exit`);
 }

--- a/apps/desktop/src/main/daemon/tuttidManager.ts
+++ b/apps/desktop/src/main/daemon/tuttidManager.ts
@@ -68,6 +68,13 @@ interface ResolveLaunchSpecOptions {
   repoRoot?: string;
 }
 
+export type ManagedTuttidPhase =
+  | "stopped"
+  | "starting"
+  | "healthy"
+  | "recovering"
+  | "stopping";
+
 export function createTuttidManager(
   endpoint: DesktopDaemonEndpoint,
   tuttidClient: TuttidClient,
@@ -87,6 +94,9 @@ export function createTuttidManager(
 class ManagedTuttid implements TuttidManager {
   private process: ChildProcess | null = null;
   private stopRequested = false;
+  private phase: ManagedTuttidPhase = "stopped";
+  private startInFlight: Promise<void> | null = null;
+  private attemptInFlight: Promise<void> | null = null;
   private readonly endpoint: DesktopDaemonEndpoint;
   private readonly tuttidClient: TuttidClient;
   private readonly restartController: DaemonRestartController;
@@ -106,7 +116,7 @@ class ManagedTuttid implements TuttidManager {
     this.desktopUpdateAdmission = desktopUpdateAdmission;
     this.workspaceAppCliPath = workspaceAppCliPath;
     this.restartController = createDaemonRestartController({
-      restart: () => this.start(),
+      restart: () => this.startAttempt("recovering"),
       isStopRequested: () => this.stopRequested,
       delay: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
       now: () => Date.now(),
@@ -123,9 +133,66 @@ class ManagedTuttid implements TuttidManager {
   }
 
   async start(): Promise<void> {
+    if (this.phase === "healthy" && this.isProcessAlive()) {
+      return Promise.resolve();
+    }
+    if (this.startInFlight) {
+      return this.startInFlight;
+    }
+
+    this.stopRequested = false;
+    const start = this.startWithRecovery().finally(() => {
+      if (this.startInFlight === start) {
+        this.startInFlight = null;
+      }
+    });
+    this.startInFlight = start;
+    return start;
+  }
+
+  private async startWithRecovery(): Promise<void> {
+    try {
+      await this.startAttempt("starting");
+      return;
+    } catch (initialError) {
+      if (this.stopRequested) {
+        this.phase = "stopped";
+        return;
+      }
+      if (!isRetryableManagedTuttidStartupError(initialError)) {
+        this.phase = "stopped";
+        throw initialError;
+      }
+      this.phase = "recovering";
+      if (await this.restartController.notifyExited()) {
+        return;
+      }
+      this.phase = "stopped";
+      throw initialError;
+    }
+  }
+
+  private async startAttempt(phase: "starting" | "recovering"): Promise<void> {
+    if (this.attemptInFlight) {
+      return this.attemptInFlight;
+    }
+
+    const attempt = this.runStartAttempt(phase).finally(() => {
+      if (this.attemptInFlight === attempt) {
+        this.attemptInFlight = null;
+      }
+    });
+    this.attemptInFlight = attempt;
+    return attempt;
+  }
+
+  private async runStartAttempt(
+    phase: "starting" | "recovering",
+  ): Promise<void> {
     if (this.process) {
       return;
     }
+    this.phase = phase;
 
     this.endpoint.boundAddr = null;
     await stopStaleTuttid(this.endpoint.pidPath);
@@ -144,6 +211,10 @@ class ManagedTuttid implements TuttidManager {
       logOutput,
       userShellEnv,
     });
+    if (this.stopRequested) {
+      this.phase = "stopped";
+      return;
+    }
     logger.info("starting managed tuttid", {
       command: launchSpec.command,
       args: launchSpec.args,
@@ -164,7 +235,6 @@ class ManagedTuttid implements TuttidManager {
     const spawned = waitForChildSpawn(child);
 
     this.process = child;
-    this.stopRequested = false;
     let startupDiagnostic = "";
 
     if (forwardStdout) {
@@ -193,7 +263,9 @@ class ManagedTuttid implements TuttidManager {
 
     child.on("exit", (code, signal) => {
       const pid = child.pid ?? null;
-      this.process = null;
+      if (this.process === child) {
+        this.process = null;
+      }
 
       if (!this.stopRequested) {
         getDesktopLogger().error("managed tuttid exited unexpectedly", {
@@ -202,7 +274,16 @@ class ManagedTuttid implements TuttidManager {
           signal,
           error_code: desktopErrorCodes.managedProcessExited,
         });
-        void this.restartController.notifyExited();
+        if (
+          shouldScheduleManagedTuttidRestart(this.phase, this.stopRequested)
+        ) {
+          this.phase = "recovering";
+          void this.restartController.notifyExited().then((recovered) => {
+            if (!recovered && !this.stopRequested) {
+              this.phase = "stopped";
+            }
+          });
+        }
       }
     });
 
@@ -221,12 +302,15 @@ class ManagedTuttid implements TuttidManager {
       throw managedTuttidStartupError(error, startupDiagnostic);
     }
 
+    this.phase = "healthy";
     this.restartController.notifyStarted();
   }
 
   async stop(): Promise<void> {
     this.stopRequested = true;
+    this.phase = "stopping";
     await this.terminateProcess();
+    this.phase = "stopped";
   }
 
   private async terminateProcess(): Promise<void> {
@@ -300,6 +384,28 @@ export function managedTuttidStartupError(
   (failure as NodeJS.ErrnoException).code =
     desktopErrorCodes.managedProcessError;
   return failure;
+}
+
+export function isRetryableManagedTuttidStartupError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  const cause = error.cause;
+  if (!cause || typeof cause !== "object" || !("message" in cause)) {
+    return false;
+  }
+  const diagnostic = String(cause.message).toLowerCase();
+  return (
+    diagnostic.includes("disk i/o error (1546)") ||
+    diagnostic.includes("sqlite_ioerr_truncate")
+  );
+}
+
+export function shouldScheduleManagedTuttidRestart(
+  phase: ManagedTuttidPhase,
+  stopRequested: boolean,
+): boolean {
+  return !stopRequested && phase === "healthy";
 }
 
 function resolveEndpointEnv(

--- a/docs/conventions/troubleshooting/desktop-release.md
+++ b/docs/conventions/troubleshooting/desktop-release.md
@@ -325,29 +325,49 @@
 
 - Symptom:
   The desktop logs `Timed out waiting for tuttid listener info: daemon runtime
-information is not available yet`, but `ps` or `lsof` still shows an older
-  `tuttid` process holding the development database or a loopback listener.
+information is not available yet`, or the first restart reports a daemon
+  startup failure while a second restart succeeds. `ps`, `lsof`, or Task Manager
+  may still show an older `tuttid` process holding the database or a loopback
+  listener.
 - Quick checks:
   Inspect `~/.tutti-dev/run/tuttid.pid`, run `lsof` on
   `~/.tutti-dev/tuttid.db`, and check whether the daemon process
   has parent PID `1`. That combination means the Electron parent no longer owns
-  the process even though the daemon survived.
+  the process even though the daemon survived. On Windows, align
+  `desktop parent process disappeared`, `http server shutdown error`,
+  `process did not exit after kill`, `stopping stale tuttid process`, and
+  `disk I/O error (1546)` across `tuttid.log` and `tutti-desktop.log`. A later
+  `managed tuttid restarted` after `failed to start managed tuttid` identifies
+  two competing startup owners rather than a second user action fixing data.
 - Root cause:
   In development, launching through `go run` can create a wrapper process and a
   compiled daemon child. Killing only the direct child can leave the compiled
   daemon alive. If the desktop also removes the listener info file before the
   next launch, the orphan can keep local state busy while the new managed daemon
-  never publishes runtime info within the startup timeout.
+  never publishes runtime info within the startup timeout. The same symptom can
+  occur in packaged builds when HTTP shutdown returns before active handlers and
+  live Agent transports finish closing. A stale-daemon handoff can transiently
+  fail SQLite WAL initialization with `SQLITE_IOERR_TRUNCATE`. Initial startup
+  must own recovery until the daemon first becomes healthy; runtime supervision
+  must not independently recover the same child exit while bootstrap propagates
+  the original failure.
 - Fix:
   Prefer a prebuilt `apps/desktop/build/tuttid/tuttid` binary in development
   when present, kill managed daemon process groups during desktop shutdown,
   write and clear `tuttid.pid`, and inject `TUTTI_DESKTOP_PARENT_PID` so
-  `tuttid` can self-shutdown when its desktop parent disappears.
+  `tuttid` can self-shutdown when its desktop parent disappears. Keep one
+  startup recovery owner until health succeeds, wait for HTTP shutdown before
+  closing daemon wiring, and retry only the bounded transient
+  `SQLITE_IOERR_TRUNCATE` WAL handoff error. Do not delete WAL/SHM files or retry
+  arbitrary SQLite failures.
 - Validation:
   Repeatedly quit and restart the desktop, then confirm there is at most one
   `tuttid` process and that `~/.tutti-dev/run/tuttid.pid`
-  matches it. Also run the desktop daemon-manager tests and
-  `cd services/tuttid && go test .`.
+  matches it. Fault-inject the first WAL initialization attempt and verify the
+  original desktop bootstrap continues after one recovery loop. Hold an HTTP
+  request open during cancellation and verify daemon `Run` does not return until
+  the request drains. Also run the desktop daemon-manager tests and
+  `cd services/tuttid && go test ./...`.
 - References:
   [tuttidManager.ts](../../../apps/desktop/src/main/daemon/tuttidManager.ts)
   [main.go](../../../services/tuttid/main.go)

--- a/packages/agent/daemon/runtime/controller_live_sessions.go
+++ b/packages/agent/daemon/runtime/controller_live_sessions.go
@@ -372,7 +372,22 @@ func (c *Controller) CloseAllLiveSessions(ctx context.Context) CloseAllLiveSessi
 			continue
 		}
 		result.Scanned++
-		releaseLifecycleLock := c.acquireLifecycleLock(cand.session.RoomID, cand.session.AgentSessionID)
+		releaseLifecycleLock, lockErr := c.acquireLifecycleLockContext(ctx, cand.session.RoomID, cand.session.AgentSessionID)
+		if lockErr != nil {
+			result.Failed++
+			failedProviders[provider] = true
+			slog.Warn("agent live session shutdown lock failed",
+				"event", "agent_session.shutdown_close.lock_failed",
+				"room_id", cand.session.RoomID,
+				"agent_session_id", cand.session.AgentSessionID,
+				"provider", cand.session.Provider,
+				"error", lockErr.Error(),
+			)
+			if ctx.Err() != nil {
+				break
+			}
+			continue
+		}
 		err := cand.adapter.Close(ctx, cand.session)
 		releaseLifecycleLock()
 		if err != nil {

--- a/packages/agent/daemon/runtime/controller_live_sessions_test.go
+++ b/packages/agent/daemon/runtime/controller_live_sessions_test.go
@@ -419,6 +419,26 @@ func TestControllerCloseAllLiveSessionsBoundsFailedCloseBudgetPerAdapter(t *test
 	}
 }
 
+func TestControllerCloseAllLiveSessionsHonorsCancellationWhileWaitingForLifecycleLock(t *testing.T) {
+	t.Parallel()
+
+	adapter := newReleasableAdapter()
+	controller := NewController([]Adapter{adapter}, nil)
+	started := startReleasableSession(t, controller, "locked-session")
+	releaseLock := controller.acquireLifecycleLock(started.Session.RoomID, started.Session.AgentSessionID)
+	defer releaseLock()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result := controller.CloseAllLiveSessions(ctx)
+	if result.Scanned != 1 || result.Failed != 1 || result.Closed != 0 {
+		t.Fatalf("close-all result = %#v, want canceled lock acquisition failure", result)
+	}
+	if calls := adapter.closeCallCount(started.Session.AgentSessionID); calls != 0 {
+		t.Fatalf("close calls = %d, want no adapter close after cancellation", calls)
+	}
+}
+
 func TestControllerDetachedCleanupGivesEveryAdapterOneBoundedAttempt(t *testing.T) {
 	t.Parallel()
 

--- a/services/tuttid/app/app.go
+++ b/services/tuttid/app/app.go
@@ -51,20 +51,24 @@ func (a *App) Run(ctx context.Context) error {
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
 	defer signal.Stop(sigCh)
 
+	serveDone := make(chan error, 1)
 	go func() {
-		select {
-		case <-ctx.Done():
-			a.shutdown(context.Background(), "context-cancelled", nil)
-		case sig := <-sigCh:
-			a.shutdown(context.Background(), "signal", sig)
+		if a.Listener != nil {
+			serveDone <- a.Server.Serve(a.Listener)
+			return
 		}
+		serveDone <- a.Server.ListenAndServe()
 	}()
 
 	var err error
-	if a.Listener != nil {
-		err = a.Server.Serve(a.Listener)
-	} else {
-		err = a.Server.ListenAndServe()
+	select {
+	case err = <-serveDone:
+	case <-ctx.Done():
+		a.shutdown(context.Background(), "context-cancelled", nil)
+		err = <-serveDone
+	case sig := <-sigCh:
+		a.shutdown(context.Background(), "signal", sig)
+		err = <-serveDone
 	}
 
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -72,7 +76,6 @@ func (a *App) Run(ctx context.Context) error {
 		return err
 	}
 
-	logger.Info("tuttid main exiting", "event", "tutti.main.exit")
 	return nil
 }
 

--- a/services/tuttid/app/app_test.go
+++ b/services/tuttid/app/app_test.go
@@ -1,0 +1,77 @@
+package app
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRunWaitsForActiveRequestShutdownBeforeReturning(t *testing.T) {
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	var releaseRequestOnce sync.Once
+	release := func() { releaseRequestOnce.Do(func() { close(releaseRequest) }) }
+	shutdownStarted := make(chan struct{})
+	server := &http.Server{Handler: http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		close(requestStarted)
+		<-releaseRequest
+	})}
+	server.RegisterOnShutdown(func() { close(shutdownStarted) })
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() {
+		cancel()
+		release()
+		_ = listener.Close()
+	})
+	app := New(server, listener, "")
+	app.ShutdownTimeout = 5 * time.Second
+	app.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	runDone := make(chan error, 1)
+	go func() { runDone <- app.Run(ctx) }()
+
+	responseDone := make(chan error, 1)
+	go func() {
+		response, requestErr := http.Get("http://" + listener.Addr().String())
+		if response != nil {
+			_ = response.Body.Close()
+		}
+		responseDone <- requestErr
+	}()
+	waitForTestChannel(t, requestStarted, "request to start")
+	cancel()
+	waitForTestChannel(t, shutdownStarted, "server shutdown to start")
+
+	select {
+	case err := <-runDone:
+		t.Fatalf("Run returned before the active request drained: %v", err)
+	default:
+	}
+	release()
+	if err := waitForTestChannel(t, responseDone, "request to finish"); err != nil {
+		t.Fatal(err)
+	}
+	if err := waitForTestChannel(t, runDone, "Run to return"); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+}
+
+func waitForTestChannel[T any](t *testing.T, channel <-chan T, description string) T {
+	t.Helper()
+	select {
+	case value := <-channel:
+		return value
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", description)
+		var zero T
+		return zero
+	}
+}

--- a/services/tuttid/data/workspace/sqlite_store.go
+++ b/services/tuttid/data/workspace/sqlite_store.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -22,6 +23,10 @@ import (
 const defaultSQLiteBusyTimeoutMillisec = 5000
 const defaultSQLiteReaderConnections = 4
 
+const sqliteIOErrTruncate = 1546
+
+var sqliteWALRetryDelays = []time.Duration{100 * time.Millisecond, 300 * time.Millisecond}
+
 type SQLiteStore struct {
 	dbPath                 string
 	writeDB                *sql.DB
@@ -33,6 +38,14 @@ type SQLiteStore struct {
 
 type sqliteOnlineBackuper interface {
 	NewBackup(string) (*sqlitedriver.Backup, error)
+}
+
+type sqlitePragmaExecutor interface {
+	Exec(string, ...any) (sql.Result, error)
+}
+
+type sqliteErrorCoder interface {
+	Code() int
 }
 
 func OpenSQLiteStore(dbPath string) (*SQLiteStore, error) {
@@ -54,12 +67,37 @@ func OpenSQLiteStore(dbPath string) (*SQLiteStore, error) {
 	store := &SQLiteStore{dbPath: dbPath, writeDB: db}
 	store.agentWriter = newAgentStore(db)
 
-	if _, err := db.Exec("PRAGMA journal_mode = WAL"); err != nil {
+	if err := enableSQLiteWAL(db, time.Sleep); err != nil {
 		_ = store.Close()
 		return nil, fmt.Errorf("enable sqlite wal mode: %w", err)
 	}
 
 	return store, nil
+}
+
+func enableSQLiteWAL(executor sqlitePragmaExecutor, sleep func(time.Duration)) error {
+	for attempt := 0; ; attempt++ {
+		if _, err := executor.Exec("PRAGMA journal_mode = WAL"); err != nil {
+			if attempt >= len(sqliteWALRetryDelays) || !isSQLiteIOErrTruncate(err) {
+				return err
+			}
+			delay := sqliteWALRetryDelays[attempt]
+			slog.Warn("retrying sqlite wal mode after transient truncate error",
+				"event", "workspace.sqlite.wal_retry",
+				"attempt", attempt+1,
+				"retry_in_ms", delay.Milliseconds(),
+				"sqlite_error_code", sqliteIOErrTruncate,
+				"error", err)
+			sleep(delay)
+			continue
+		}
+		return nil
+	}
+}
+
+func isSQLiteIOErrTruncate(err error) bool {
+	var coded sqliteErrorCoder
+	return errors.As(err, &coded) && coded.Code() == sqliteIOErrTruncate
 }
 
 func DefaultDBPath() string {

--- a/services/tuttid/data/workspace/sqlite_store_test.go
+++ b/services/tuttid/data/workspace/sqlite_store_test.go
@@ -19,6 +19,77 @@ import (
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 )
 
+type sqlitePragmaExecutorStub struct {
+	errors []error
+	calls  int
+}
+
+func (s *sqlitePragmaExecutorStub) Exec(string, ...any) (sql.Result, error) {
+	index := s.calls
+	s.calls++
+	if index < len(s.errors) {
+		return nil, s.errors[index]
+	}
+	return nil, nil
+}
+
+type sqliteCodedTestError struct {
+	code int
+}
+
+func (e sqliteCodedTestError) Error() string { return fmt.Sprintf("sqlite error %d", e.code) }
+func (e sqliteCodedTestError) Code() int     { return e.code }
+
+func TestEnableSQLiteWALRetriesTransientTruncateErrors(t *testing.T) {
+	executor := &sqlitePragmaExecutorStub{errors: []error{
+		sqliteCodedTestError{code: sqliteIOErrTruncate},
+		sqliteCodedTestError{code: sqliteIOErrTruncate},
+	}}
+	var delays []time.Duration
+
+	if err := enableSQLiteWAL(executor, func(delay time.Duration) { delays = append(delays, delay) }); err != nil {
+		t.Fatalf("enableSQLiteWAL() error = %v", err)
+	}
+	if executor.calls != 3 {
+		t.Fatalf("Exec calls = %d, want 3", executor.calls)
+	}
+	if !slices.Equal(delays, sqliteWALRetryDelays) {
+		t.Fatalf("retry delays = %v, want %v", delays, sqliteWALRetryDelays)
+	}
+}
+
+func TestEnableSQLiteWALDoesNotRetryOtherErrors(t *testing.T) {
+	executor := &sqlitePragmaExecutorStub{errors: []error{sqliteCodedTestError{code: 5}}}
+
+	err := enableSQLiteWAL(executor, func(time.Duration) { t.Fatal("unexpected retry") })
+	if err == nil {
+		t.Fatal("enableSQLiteWAL() error = nil, want failure")
+	}
+	if executor.calls != 1 {
+		t.Fatalf("Exec calls = %d, want 1", executor.calls)
+	}
+}
+
+func TestEnableSQLiteWALStopsAfterTransientRetryBudget(t *testing.T) {
+	executor := &sqlitePragmaExecutorStub{errors: []error{
+		sqliteCodedTestError{code: sqliteIOErrTruncate},
+		sqliteCodedTestError{code: sqliteIOErrTruncate},
+		sqliteCodedTestError{code: sqliteIOErrTruncate},
+	}}
+	var delays []time.Duration
+
+	err := enableSQLiteWAL(executor, func(delay time.Duration) { delays = append(delays, delay) })
+	if err == nil {
+		t.Fatal("enableSQLiteWAL() error = nil, want failure")
+	}
+	if executor.calls != 3 {
+		t.Fatalf("Exec calls = %d, want 3", executor.calls)
+	}
+	if !slices.Equal(delays, sqliteWALRetryDelays) {
+		t.Fatalf("retry delays = %v, want %v", delays, sqliteWALRetryDelays)
+	}
+}
+
 func TestSQLiteDSNPathUsesFileURLFormOnWindows(t *testing.T) {
 	got := sqliteDSNPath(`C:\Users\Tutti User\state\tuttid.db`, "windows")
 	if got != "/C:/Users/Tutti User/state/tuttid.db" {

--- a/services/tuttid/main.go
+++ b/services/tuttid/main.go
@@ -60,12 +60,13 @@ func run(args []string, stdout io.Writer, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "build tuttid server: %v\n", err)
 		return 1
 	}
-	defer func() {
-		_ = wiring.Close()
-	}()
-
-	if err := tuttiapp.New(srv, listener, loggerSetup.LogFilePath).Run(ctx); err != nil {
-		fmt.Fprintf(stderr, "tuttid exited: %v\n", err)
+	runErr := tuttiapp.New(srv, listener, loggerSetup.LogFilePath).Run(ctx)
+	if closeErr := wiring.Close(); closeErr != nil {
+		slog.Warn("tuttid wiring close failed", "event", "tutti.wiring.close_failed", "error", closeErr)
+	}
+	slog.Info("tuttid main exiting", "event", "tutti.main.exit")
+	if runErr != nil {
+		fmt.Fprintf(stderr, "tuttid exited: %v\n", runErr)
 		return 1
 	}
 	return 0


### PR DESCRIPTION
Backport of #2527 to `release/0818`.

## Changes
- serialize managed daemon startup and make stop win over in-flight startup
- retry the targeted SQLite busy-snapshot extended error
- make daemon HTTP shutdown deterministic before closing wiring
- allow live-session lifecycle lock waits to be cancelled

## Validation
- `pnpm check:changed -- --base origin/release/0818 --push-ready` (17/17 passed)
- `pnpm smoke:desktop-transport` (passed; shutdown completed before main exit)
- original PR #2527 CI passed, including Windows daemon/agent adapters and Windows x64 packaging

(cherry picked from commit e98bd44ff37c139cebb34d88eff95bef4b5be4d0)