### PR TITLE
fix(desktop): backport Windows light title bar fix to release/0818

### DIFF
--- a/apps/desktop/src/main/bootstrap.ts
+++ b/apps/desktop/src/main/bootstrap.ts
@@ -45,6 +45,7 @@ import {
 } from "./developerLogsDesktop.ts";
 import {
   applyDesktopThemeSource,
+  getDesktopThemeState,
   syncDesktopWindowBackgroundColors
 } from "./desktopTheme";
 import { registerIpcHandlers } from "./ipc/register";
@@ -68,7 +69,10 @@ import { registerWorkspaceFileIconProtocol } from "./host/workspaceFileIconProto
 import { applyDesktopElectronPlatformCompatibility } from "./electronPlatformCompatibility.ts";
 import { createAppUpdateService } from "./update/appUpdateService.ts";
 import { createTuttidDesktopUpdateAdmissionBackend } from "./update/desktopUpdateAdmissionBackend.ts";
-import { getWorkspaceWindowKind } from "./windows/workspaceWindow.ts";
+import {
+  getWorkspaceWindowKind,
+  syncWorkspaceWindowTitleBarOverlayColors
+} from "./windows/workspaceWindow.ts";
 import {
   resolveDesktopDistribution,
   resolveDesktopManualDownloadUrl
@@ -76,6 +80,11 @@ import {
 
 function envFlagEnabled(value: string | undefined): boolean {
   return /^(1|true|yes|on)$/iu.test(value?.trim() ?? "");
+}
+
+function syncDesktopWindowThemeColors(): void {
+  syncDesktopWindowBackgroundColors();
+  syncWorkspaceWindowTitleBarOverlayColors(getDesktopThemeState().appearance);
 }
 
 function applyElectronDiagnosticSwitches(): void {
@@ -372,7 +381,7 @@ export async function bootstrapDesktopApp(): Promise<void> {
   const theme = applyDesktopThemeSource(
     desktopAppServices.preferences.getThemeSource()
   );
-  syncDesktopWindowBackgroundColors();
+  syncDesktopWindowThemeColors();
 
   void import("electron").then(({ nativeTheme }) => {
     nativeTheme.on("updated", () => {
@@ -380,7 +389,7 @@ export async function bootstrapDesktopApp(): Promise<void> {
         return;
       }
 
-      syncDesktopWindowBackgroundColors();
+      syncDesktopWindowThemeColors();
     });
   });
 
@@ -442,7 +451,7 @@ export async function bootstrapDesktopApp(): Promise<void> {
     logger,
     preferences: desktopAppServices.preferences,
     updateService: desktopAppServices.updateService,
-    syncWindowBackgroundColors: syncDesktopWindowBackgroundColors
+    syncWindowBackgroundColors: syncDesktopWindowThemeColors
   });
   const agentPowerSaveBlocker = connectAgentPowerSaveBlocker({
     eventStreamClient: createDesktopHostPreferencesEventStreamClient(

--- a/apps/desktop/src/main/windows/workspaceWindow.ts
+++ b/apps/desktop/src/main/windows/workspaceWindow.ts
@@ -38,7 +38,10 @@ import {
   resolveStandaloneAgentWindowWorkArea
 } from "./standaloneAgentWindowBounds.ts";
 import { WorkspaceWindowRegistry } from "./workspaceWindowRegistry.ts";
-import { resolveWorkspaceWindowChromeOptions } from "./workspaceWindowChrome.ts";
+import {
+  resolveWorkspaceWindowChromeOptions,
+  resolveWorkspaceWindowTitleBarOverlay
+} from "./workspaceWindowChrome.ts";
 import { supportsWorkspaceWindowCloseGuard } from "./workspaceWindowCloseGuard.ts";
 
 export const workspaceAppBrowserPartitionPrefix = "persist:tutti-app:";
@@ -137,7 +140,8 @@ export function createWorkspaceWindow(
       : defaultAgentWindowBounds;
   const windowChromeOptions = resolveWorkspaceWindowChromeOptions(
     process.platform,
-    windowKind
+    windowKind,
+    options.theme.appearance
   );
   const workspaceWindow = new BrowserWindow({
     backgroundColor: resolveDesktopWindowBackgroundColor(),
@@ -380,6 +384,24 @@ export function getWorkspaceWindowWorkspaceID(
   workspaceWindow: BrowserWindow
 ): string | null {
   return workspaceWindows.getWorkspaceID(workspaceWindow);
+}
+
+export function syncWorkspaceWindowTitleBarOverlayColors(
+  appearance: DesktopThemeState["appearance"]
+): void {
+  if (process.platform !== "win32") {
+    return;
+  }
+
+  const titleBarOverlay = resolveWorkspaceWindowTitleBarOverlay(appearance);
+  for (const workspaceWindow of BrowserWindow.getAllWindows()) {
+    if (
+      !workspaceWindow.isDestroyed() &&
+      workspaceWindows.getKind(workspaceWindow) !== null
+    ) {
+      workspaceWindow.setTitleBarOverlay(titleBarOverlay);
+    }
+  }
 }
 
 export function findWorkspaceWindow(

--- a/apps/desktop/src/main/windows/workspaceWindowChrome.test.ts
+++ b/apps/desktop/src/main/windows/workspaceWindowChrome.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  resolveWorkspaceWindowChromeOptions,
+  resolveWorkspaceWindowTitleBarOverlay
+} from "./workspaceWindowChrome.ts";
+
+test("Windows title-bar symbols follow the active light and dark appearance", () => {
+  assert.deepEqual(resolveWorkspaceWindowTitleBarOverlay("light"), {
+    color: "rgba(0, 0, 0, 0)",
+    height: 52,
+    symbolColor: "rgba(17, 24, 39, 0.88)"
+  });
+  assert.deepEqual(resolveWorkspaceWindowTitleBarOverlay("dark"), {
+    color: "rgba(0, 0, 0, 0)",
+    height: 52,
+    symbolColor: "rgba(255, 255, 255, 0.92)"
+  });
+});
+
+test("Windows workspace chrome uses the requested appearance", () => {
+  assert.deepEqual(
+    resolveWorkspaceWindowChromeOptions("win32", "workspace", "light")
+      .titleBarOverlay,
+    resolveWorkspaceWindowTitleBarOverlay("light")
+  );
+  assert.deepEqual(
+    resolveWorkspaceWindowChromeOptions("win32", "agent", "dark")
+      .titleBarOverlay,
+    resolveWorkspaceWindowTitleBarOverlay("dark")
+  );
+});

--- a/apps/desktop/src/main/windows/workspaceWindowChrome.ts
+++ b/apps/desktop/src/main/windows/workspaceWindowChrome.ts
@@ -1,4 +1,5 @@
 import type { BrowserWindowConstructorOptions } from "electron";
+import type { DesktopThemeAppearance } from "../../shared/theme/index.ts";
 
 export type WorkspaceWindowChromeOptions = Pick<
   BrowserWindowConstructorOptions,
@@ -9,15 +10,25 @@ export type WorkspaceWindowChromeOptions = Pick<
   | "titleBarStyle"
 >;
 
-const windowsTitleBarOverlay = {
-  color: "rgba(0, 0, 0, 0)",
-  height: 52,
-  symbolColor: "rgba(255, 255, 255, 0.92)"
-} as const;
+const windowsTitleBarSymbolColors: Record<DesktopThemeAppearance, string> = {
+  dark: "rgba(255, 255, 255, 0.92)",
+  light: "rgba(17, 24, 39, 0.88)"
+};
+
+export function resolveWorkspaceWindowTitleBarOverlay(
+  appearance: DesktopThemeAppearance
+) {
+  return {
+    color: "rgba(0, 0, 0, 0)",
+    height: 52,
+    symbolColor: windowsTitleBarSymbolColors[appearance]
+  } as const;
+}
 
 export function resolveWorkspaceWindowChromeOptions(
   platform: NodeJS.Platform,
-  windowKind: "agent" | "workspace"
+  windowKind: "agent" | "workspace",
+  appearance: DesktopThemeAppearance
 ): WorkspaceWindowChromeOptions {
   if (platform === "win32") {
     return {
@@ -26,7 +37,7 @@ export function resolveWorkspaceWindowChromeOptions(
       // The native caption buttons remain system-managed, but are overlaid on
       // that header so Windows does not render a second title-bar row.
       autoHideMenuBar: true,
-      titleBarOverlay: windowsTitleBarOverlay,
+      titleBarOverlay: resolveWorkspaceWindowTitleBarOverlay(appearance),
       titleBarStyle: "hidden"
     };
   }


### PR DESCRIPTION
## Summary

Backport #2532 to `release/0818`.

- synchronize Windows native caption glyph colors with light/dark appearance
- refresh existing workspace and Agent windows when app or system theme changes
- include focused title-bar overlay tests

## Validation

- cleanly applied onto latest `origin/release/0818`
- focused `workspaceWindowChrome.test.ts`: 2/2 passed
- main PR #2532 passed all required CI, including Windows x64 packaging

No `patch_release` workflow should be triggered as part of this backport.