### PR TITLE
feat(agent): expose active Codex app-server spans

### DIFF
--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -117,7 +117,7 @@ type CodexAppServerAdapterOptions struct {
 	// approval policy, and approval reviewer remain owned by the selected
 	// permission mode. Network proxy configuration remains a separate concern.
 	CommandNetworkAccess bool
-	// StartupSpanObserver receives completed Codex app-server startup spans.
+	// StartupSpanObserver receives Codex app-server startup span boundaries.
 	// It is best-effort observability only and must not influence provider
 	// startup or command correctness.
 	StartupSpanObserver CodexAppServerSpanObserver
@@ -127,16 +127,18 @@ type CodexAppServerAdapterOptions struct {
 	StartupObserver CodexAppServerStartupObserver
 }
 
-// CodexAppServerSpanObservation is one completed, allowlisted startup span
-// emitted by the Codex app-server. It intentionally contains only bounded
-// timing and session-scope facts; raw prompts, commands, paths, and payloads
-// are not part of this contract.
+// CodexAppServerSpanObservation is one allowlisted startup span boundary
+// emitted by the Codex app-server. A new observation is emitted when the span
+// starts and a close observation uses the same SpanInstanceID. It intentionally
+// contains only bounded timing and session-scope facts; raw prompts, commands,
+// paths, and payloads are not part of this contract.
 type CodexAppServerSpanObservation struct {
 	Provider       string
 	RoomID         string
 	AgentSessionID string
 	SpanName       string
 	SpanPhase      string
+	SpanInstanceID string
 	SpanTarget     string
 	CodexTimestamp string
 	DurationMS     int64
@@ -144,7 +146,7 @@ type CodexAppServerSpanObservation struct {
 	SpanIdle       string
 }
 
-// CodexAppServerSpanObserver consumes completed startup span observations.
+// CodexAppServerSpanObserver consumes startup span boundary observations.
 // Implementations must be best-effort and must not affect provider behavior.
 type CodexAppServerSpanObserver func(CodexAppServerSpanObservation)
 

--- a/packages/agent/daemon/runtime/codex_appserver_startup_trace.go
+++ b/packages/agent/daemon/runtime/codex_appserver_startup_trace.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -48,8 +49,15 @@ type codexAppServerStartupTrace struct {
 	startupObserver    CodexAppServerStartupObserver
 	stderrMu           sync.Mutex
 	stderrLine         []byte
-	spanStartedAt      map[string][]time.Time
+	openSpans          map[string][]codexAppServerOpenSpan
+	spanSequence       atomic.Uint64
 	completedSpanCount atomic.Int64
+}
+
+type codexAppServerOpenSpan struct {
+	instanceID string
+	startedAt  time.Time
+	timestamp  bool
 }
 
 func newCodexAppServerStartupTrace(
@@ -64,7 +72,7 @@ func newCodexAppServerStartupTrace(
 		path:            codexAppServerStartupTracePath(),
 		spanObserver:    spanObserver,
 		startupObserver: startupObserver,
-		spanStartedAt:   make(map[string][]time.Time),
+		openSpans:       make(map[string][]codexAppServerOpenSpan),
 	}
 	trace.Log("start.begin", map[string]any{
 		"permission_mode_id": session.PermissionModeID,
@@ -78,10 +86,10 @@ func newCodexAppServerStartupTrace(
 func newCodexAppServerTurnTrace(session Session, turnID string, metadata map[string]any) *codexAppServerStartupTrace {
 	settings := session.SettingsValue()
 	trace := &codexAppServerStartupTrace{
-		startedAt:     time.Now(),
-		session:       session,
-		path:          codexAppServerStartupTracePath(),
-		spanStartedAt: make(map[string][]time.Time),
+		startedAt: time.Now(),
+		session:   session,
+		path:      codexAppServerStartupTracePath(),
+		openSpans: make(map[string][]codexAppServerOpenSpan),
 	}
 	fields := map[string]any{
 		"turn_id":            strings.TrimSpace(turnID),
@@ -273,6 +281,7 @@ func (t *codexAppServerStartupTrace) logCodexAppServerSpan(line []byte) *CodexAp
 		"span_phase": phase,
 	}
 	var observation *CodexAppServerSpanObservation
+	spanInstanceID := ""
 	if record.Target != "" {
 		fields["span_target"] = record.Target
 	}
@@ -280,16 +289,34 @@ func (t *codexAppServerStartupTrace) logCodexAppServerSpan(line []byte) *CodexAp
 		fields["codex_timestamp"] = record.Timestamp
 	}
 	if phase == "new" {
-		if timestampOK {
-			t.spanStartedAt[spanName] = append(t.spanStartedAt[spanName], startedAt)
+		spanInstanceID = t.newSpanInstanceID()
+		t.openSpans[spanName] = append(t.openSpans[spanName], codexAppServerOpenSpan{
+			instanceID: spanInstanceID,
+			startedAt:  startedAt,
+			timestamp:  timestampOK,
+		})
+		fields["span_instance_id"] = spanInstanceID
+		if t.spanObserver != nil {
+			observation = &CodexAppServerSpanObservation{
+				Provider:       strings.TrimSpace(t.session.Provider),
+				RoomID:         strings.TrimSpace(t.session.RoomID),
+				AgentSessionID: strings.TrimSpace(t.session.AgentSessionID),
+				SpanName:       spanName,
+				SpanPhase:      phase,
+				SpanInstanceID: spanInstanceID,
+				SpanTarget:     strings.TrimSpace(record.Target),
+				CodexTimestamp: strings.TrimSpace(record.Timestamp),
+			}
 		}
-	} else if starts := t.spanStartedAt[spanName]; len(starts) > 0 {
+	} else if openSpans := t.openSpans[spanName]; len(openSpans) > 0 {
 		t.completedSpanCount.Add(1)
-		start := starts[len(starts)-1]
-		t.spanStartedAt[spanName] = starts[:len(starts)-1]
+		openSpan := openSpans[len(openSpans)-1]
+		t.openSpans[spanName] = openSpans[:len(openSpans)-1]
+		spanInstanceID = openSpan.instanceID
+		fields["span_instance_id"] = spanInstanceID
 		durationMS := int64(0)
-		if timestampOK {
-			durationMS = startedAt.Sub(start).Milliseconds()
+		if timestampOK && openSpan.timestamp {
+			durationMS = startedAt.Sub(openSpan.startedAt).Milliseconds()
 			fields["duration_ms"] = durationMS
 		}
 		if busy := codexJSONLogString(record.Fields["time.busy"]); busy != "" {
@@ -298,13 +325,14 @@ func (t *codexAppServerStartupTrace) logCodexAppServerSpan(line []byte) *CodexAp
 		if idle := codexJSONLogString(record.Fields["time.idle"]); idle != "" {
 			fields["span_idle"] = idle
 		}
-		if timestampOK && t.spanObserver != nil {
+		if t.spanObserver != nil {
 			observation = &CodexAppServerSpanObservation{
 				Provider:       strings.TrimSpace(t.session.Provider),
 				RoomID:         strings.TrimSpace(t.session.RoomID),
 				AgentSessionID: strings.TrimSpace(t.session.AgentSessionID),
 				SpanName:       spanName,
 				SpanPhase:      phase,
+				SpanInstanceID: spanInstanceID,
 				SpanTarget:     strings.TrimSpace(record.Target),
 				CodexTimestamp: strings.TrimSpace(record.Timestamp),
 				DurationMS:     durationMS,
@@ -315,6 +343,10 @@ func (t *codexAppServerStartupTrace) logCodexAppServerSpan(line []byte) *CodexAp
 	}
 	t.Log("app_server.span", fields)
 	return observation
+}
+
+func (t *codexAppServerStartupTrace) newSpanInstanceID() string {
+	return fmt.Sprintf("startup-%d-%d", t.startedAt.UnixNano(), t.spanSequence.Add(1))
 }
 
 func (t *codexAppServerStartupTrace) notifySpanObserver(observation CodexAppServerSpanObservation) {

--- a/packages/agent/daemon/runtime/codex_appserver_startup_trace_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_startup_trace_test.go
@@ -18,7 +18,7 @@ func TestCodexAppServerStartupTraceRecordsStructuredSpanClose(t *testing.T) {
 		spanObserver: func(observation CodexAppServerSpanObservation) {
 			observations = append(observations, observation)
 		},
-		spanStartedAt: make(map[string][]time.Time),
+		openSpans: make(map[string][]codexAppServerOpenSpan),
 	}
 	firstChunk := []byte(`{"timestamp":"2026-08-20T02:00:00.000Z","level":"INFO","target":"codex_core","fields":{"message":"new"},"span":{"name":"session_init"}`)
 	secondChunk := []byte(`}
@@ -68,18 +68,83 @@ func TestCodexAppServerStartupTraceRecordsStructuredSpanClose(t *testing.T) {
 	if closeRecord["span_busy"] != "120ms" || closeRecord["span_idle"] != "5ms" {
 		t.Fatalf("span timing = %#v, want busy/idle values", closeRecord)
 	}
+	if len(observations) != 2 {
+		t.Fatalf("span observations = %d, want new and close", len(observations))
+	}
+	newObservation := observations[0]
+	closeObservation := observations[1]
+	if newObservation.Provider != ProviderCodex || newObservation.RoomID != "room-1" || newObservation.AgentSessionID != "session-1" {
+		t.Fatalf("new observation scope = %#v, want Codex room/session scope", newObservation)
+	}
+	if newObservation.SpanName != "session_init" || newObservation.SpanPhase != "new" || newObservation.DurationMS != 0 {
+		t.Fatalf("new observation span = %#v, want session_init new at 0ms", newObservation)
+	}
+	if newObservation.SpanInstanceID == "" || newObservation.SpanInstanceID != closeObservation.SpanInstanceID {
+		t.Fatalf("span instance IDs = %q and %q, want the same non-empty ID", newObservation.SpanInstanceID, closeObservation.SpanInstanceID)
+	}
+	if closeObservation.SpanName != "session_init" || closeObservation.SpanPhase != "close" || closeObservation.DurationMS != 125 {
+		t.Fatalf("close observation span = %#v, want session_init close at 125ms", closeObservation)
+	}
+	if closeObservation.SpanBusy != "120ms" || closeObservation.SpanIdle != "5ms" {
+		t.Fatalf("close observation timing = %#v, want busy/idle values", closeObservation)
+	}
+}
+
+func TestCodexAppServerStartupTraceReportsOpenSpanBeforeClose(t *testing.T) {
+	var observations []CodexAppServerSpanObservation
+	trace := &codexAppServerStartupTrace{
+		startedAt: time.Now(),
+		session:   Session{Provider: ProviderCodex, RoomID: "room-1", AgentSessionID: "session-1"},
+		path:      filepath.Join(t.TempDir(), "trace.jsonl"),
+		spanObserver: func(observation CodexAppServerSpanObservation) {
+			observations = append(observations, observation)
+		},
+		openSpans: make(map[string][]codexAppServerOpenSpan),
+	}
+
+	trace.LogStderr([]byte(`{"timestamp":"2026-08-20T02:00:00.000Z","target":"codex_core","fields":{"message":"new"},"span":{"name":"app_server.thread_start.send_response"}}
+`))
+
 	if len(observations) != 1 {
-		t.Fatalf("span observations = %d, want one completed span", len(observations))
+		t.Fatalf("span observations = %d, want one open span", len(observations))
 	}
-	observation := observations[0]
-	if observation.Provider != ProviderCodex || observation.RoomID != "room-1" || observation.AgentSessionID != "session-1" {
-		t.Fatalf("observation scope = %#v, want Codex room/session scope", observation)
+	if observations[0].SpanPhase != "new" || observations[0].SpanName != "app_server.thread_start.send_response" {
+		t.Fatalf("open observation = %#v, want send_response new", observations[0])
 	}
-	if observation.SpanName != "session_init" || observation.SpanPhase != "close" || observation.DurationMS != 125 {
-		t.Fatalf("observation span = %#v, want session_init close at 125ms", observation)
+	if observations[0].SpanInstanceID == "" {
+		t.Fatal("open observation has empty span instance ID")
 	}
-	if observation.SpanBusy != "120ms" || observation.SpanIdle != "5ms" {
-		t.Fatalf("observation timing = %#v, want busy/idle values", observation)
+}
+
+func TestCodexAppServerStartupTraceAssociatesNestedSameNameSpans(t *testing.T) {
+	var observations []CodexAppServerSpanObservation
+	trace := &codexAppServerStartupTrace{
+		startedAt: time.Now(),
+		session:   Session{Provider: ProviderCodex, RoomID: "room-1", AgentSessionID: "session-1"},
+		path:      filepath.Join(t.TempDir(), "trace.jsonl"),
+		spanObserver: func(observation CodexAppServerSpanObservation) {
+			observations = append(observations, observation)
+		},
+		openSpans: make(map[string][]codexAppServerOpenSpan),
+	}
+
+	trace.LogStderr([]byte(`{"timestamp":"2026-08-20T02:00:00.000Z","fields":{"message":"new"},"span":{"name":"session_init"}}
+{"timestamp":"2026-08-20T02:00:00.001Z","fields":{"message":"new"},"span":{"name":"session_init"}}
+{"timestamp":"2026-08-20T02:00:00.003Z","fields":{"message":"close"},"span":{"name":"session_init"}}
+{"timestamp":"2026-08-20T02:00:00.005Z","fields":{"message":"close"},"span":{"name":"session_init"}}
+`))
+
+	if len(observations) != 4 {
+		t.Fatalf("span observations = %d, want two new and two close", len(observations))
+	}
+	if observations[0].SpanInstanceID == observations[1].SpanInstanceID {
+		t.Fatal("nested spans have the same instance ID")
+	}
+	if observations[2].SpanInstanceID != observations[1].SpanInstanceID || observations[3].SpanInstanceID != observations[0].SpanInstanceID {
+		t.Fatalf("close instance IDs = %q, %q; want LIFO association", observations[2].SpanInstanceID, observations[3].SpanInstanceID)
+	}
+	if observations[2].DurationMS != 2 || observations[3].DurationMS != 5 {
+		t.Fatalf("close durations = %d, %d; want 2ms and 5ms", observations[2].DurationMS, observations[3].DurationMS)
 	}
 }
 
@@ -100,7 +165,7 @@ func TestCodexAppServerStartupTraceReportsBoundedSummary(t *testing.T) {
 		startupObserver: func(observation CodexAppServerStartupObservation) {
 			observations = append(observations, observation)
 		},
-		spanStartedAt: make(map[string][]time.Time),
+		openSpans: make(map[string][]codexAppServerOpenSpan),
 	}
 
 	trace.LogStderr([]byte(`{"timestamp":"2026-08-20T02:00:00.000Z","fields":{"message":"new"},"span":{"name":"session_init"}}
@@ -134,7 +199,7 @@ func TestCodexAppServerStartupTraceStartupObserverPanicDoesNotEscape(t *testing.
 		startupObserver: func(CodexAppServerStartupObservation) {
 			panic("analytics observer failure")
 		},
-		spanStartedAt: make(map[string][]time.Time),
+		openSpans: make(map[string][]codexAppServerOpenSpan),
 	}
 
 	trace.Finish(nil)
@@ -148,7 +213,7 @@ func TestCodexAppServerStartupTraceObserverPanicDoesNotEscape(t *testing.T) {
 		spanObserver: func(CodexAppServerSpanObservation) {
 			panic("analytics observer failure")
 		},
-		spanStartedAt: make(map[string][]time.Time),
+		openSpans: make(map[string][]codexAppServerOpenSpan),
 	}
 
 	trace.LogStderr([]byte(`{"timestamp":"2026-08-20T02:00:00.000Z","fields":{"message":"new"},"span":{"name":"session_init"}}


### PR DESCRIPTION
## Summary
- emit allowlisted Codex app-server span observations at both `new` and `close`
- carry a bounded `SpanInstanceID` across nested/repeated span boundaries
- preserve completed-span timing while exposing spans that remain open at timeout

## Tests
- `go test -race ./packages/agent/daemon/runtime`
- pre-push `pnpm check:changed -- --push-ready` (8 lanes passed)

## Notes
- best-effort observability only; provider execution and lifecycle semantics are unchanged
- TSH/DataFinder consumer upgrade follows after this Tutti change is released