### PR TITLE
fix(connector): keep API-key authorization command-inline and rank installed shortcuts

### DIFF
--- a/.changeset/connector-authorization-secret-recovery.md
+++ b/.changeset/connector-authorization-secret-recovery.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/desktop": patch
+---
+
+Stop replaying in-flight connector authorization from durable state, so API-key Connect cannot complete a control-plane session with an empty secret.

--- a/.changeset/connector-authorization-start-cause.md
+++ b/.changeset/connector-authorization-start-cause.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/desktop": patch
+---
+
+Keep the control-plane status and session outcome in API-key authorization start errors, so Connect failures are diagnosable instead of collapsing to a generic toast.

--- a/.changeset/connector-catalog-idle-status.md
+++ b/.changeset/connector-catalog-idle-status.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/connector-renderer": patch
+---
+
+Hide the idle Not installed status on Connector catalog cards so Authorization required stays the distinctive installed-connector mark.

--- a/.changeset/connector-catalog-toolbar-explicit-refresh.md
+++ b/.changeset/connector-catalog-toolbar-explicit-refresh.md
@@ -1,0 +1,6 @@
+---
+"@tutti-os/connector-renderer": patch
+---
+
+Keep the Connector catalog toolbar Refresh spinner for explicit user refresh
+commands, not daemon scheduled catalog sync.

--- a/.changeset/connector-composer-menu-install-rank.md
+++ b/.changeset/connector-composer-menu-install-rank.md
@@ -1,0 +1,6 @@
+---
+"@tutti-os/connector-renderer": patch
+---
+
+Rank composer Connector shortcuts by installed authorized state first, then by
+installation event, before applying the bounded quick-list limit.

--- a/docs/architecture/connector.md
+++ b/docs/architecture/connector.md
@@ -320,9 +320,12 @@ supplies a guest process adapter.
 
 ## Durable Operations And Recovery
 
-Remote refresh, install, update, uninstall, and recoverable authorization work
+Remote refresh, install, update, uninstall, disconnect, and runtime reconcile
 use at-least-once execution. Exactly-once execution is not assumed across
-SQLite, the filesystem, runtime activation, and process restarts.
+SQLite, the filesystem, runtime activation, and process restarts. Start
+authorization is not in that set: the user secret exists only in the
+`BeginAuthorization` command, so an accepted or running `start_authorization`
+row must not be executed from persisted state.
 
 An installation request carries an immutable operation identity and release
 identity plus an explicit account execution scope. Each stage is idempotent for at least:
@@ -374,8 +377,12 @@ constraint remains device-global per Connector.
 
 `accepted` and `running` rows have no age-based expiry. The SQLite repository
 protects them with one-active-operation constraints plus renewable,
-token-fenced leases, and daemon startup reschedules every recoverable row. The
-cleanup path is therefore intentionally unable to select an active operation.
+token-fenced leases. Daemon startup reschedules every recoverable row whose
+effect is durable. Start authorization is command-inline and is not scheduled
+on accept; bootstrap fails leftover accepted or running `start_authorization`
+rows so they cannot block a later user retry, and the continuous recovery
+scanner must not execute them. The cleanup path is therefore intentionally
+unable to select an active operation.
 
 Terminal operation results are retained for 24 hours after `updatedAt`, with
 the cutoff inclusive. This is the supported `GET operation` result window and
@@ -420,10 +427,14 @@ installed release evidence needed for safe repair or uninstall. A later
 preserves the projection. Runtime reconcile then performs interface readiness
 checks before any route is published.
 
-Authorization operations follow the same recovery rule. Authorization creation
-is serialized per account and Connector. A repeated `clientRequestId` resumes
-the same external session. A different request retains the compatibility
-conflict unless it explicitly sends `replacementPolicy=replace_active`. Replace
+Authorization creation is serialized per account and Connector. A repeated
+`clientRequestId` resumes the same external session. Accepted or running
+`start_authorization` is not recovered by replaying the operation: that would
+complete a native-secret control-plane session with an empty secret and fail
+the live command. Completed authorization receipts recover through
+`ReconcileAuthorizations`, not through the durable operation scanner. A
+different request retains the compatibility conflict unless it explicitly
+sends `replacementPolicy=replace_active`. Replace
 is Host-owned: it interrupts an in-progress initial Begin, moves an existing
 receipt through durable `canceling`, asks the provider to terminate the exact
 attempt, waits until that attempt can no longer publish credentials or events,
@@ -602,6 +613,16 @@ synchronizing -> materializing -> ready`; failure is terminal and disposes
   Connector mutation token
 - event refreshes are coalesced, daemon reconnect performs a full reload, and
   accepted commands are followed through the operation endpoint or events
+- the settings catalog toolbar Refresh control indicates an explicit
+  `refreshCatalog()` command only. The daemon also runs a scheduled catalog
+  refresh after bootstrap and about once a minute; that background sync may set
+  `catalogState=refreshing` while keeping the last-known-good catalog visible,
+  and must not spin or disable the toolbar control
+- catalog cards show a status field only after installation. Idle uninstalled
+  cards keep the Install action and omit Not installed, so Authorization
+  required remains the distinctive installed-but-disconnected mark. First-time
+  install and update still show their in-progress status because that is live
+  work, not an idle catalog tier
 - hosts gate connector-market transport through `canRequest`; Tutti binds it to
   account authentication, activates the module without network access while
   signed out, reloads after login, and keeps reconnect/resume paths silent
@@ -636,12 +657,16 @@ instead of spinning. The host
 executes `openConnectorMarketDialog(root, connectorKey)`, which waits for the
 authoritative market view, rejects invalid or unknown keys, and then advances
 the package-owned dialog state machine. Before applying the bounded quick-list
-limit, the shared menu stably groups connected connectors ahead of connectors
-that still require authorization or setup; each group preserves host catalog
-order. Its compact trigger previews the installed and authorized group without
-requiring those connectors to be selected in the current draft; draft selection
-continues to control only structured prompt content. Selecting “more” remains
-host navigation because settings/workbench location is product-owned.
+limit, the shared menu ranks already installed and authorized connectors
+(`connected` and installed-but-stopped `disabled`) ahead of connectors that
+still require authorization or setup. The secondary key is the installation
+event timestamp (`installedAtUnixMs`, newest first). Connectors without a
+timestamp keep their relative host catalog order after timestamped entries in
+the same group. Its compact trigger previews the authorized and running
+(`connected`) group without requiring those connectors to be selected in the
+current draft; draft selection continues to control only structured prompt
+content. Selecting “more” remains host navigation because settings/workbench
+location is product-owned.
 
 Connector access-policy editors reuse `ConnectorAccessSelectionPanel` from the
 same shared UI entrypoint. The controlled panel accepts only loading/error/ready

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -145,6 +145,7 @@ Connector catalog, installation, account authorization, and runtime convergence.
 - [A second authorize click starts another OAuth session](./connector-market.md#a-second-authorize-click-starts-another-oauth-session)
 - [OAuth finishes in the browser but does not return to the initiating desktop build](./connector-market.md#oauth-finishes-in-the-browser-but-does-not-return-to-the-initiating-desktop-build)
 - [Composer install stays spinning on an OAuth remote connector](./connector-market.md#composer-install-stays-spinning-on-an-oauth-remote-connector)
+- [API-key Connect toast fails while the token is still in the form](./connector-market.md#api-key-connect-toast-fails-while-the-token-is-still-in-the-form)
 
 ## [Toolchain, Browser, And Terminal](./toolchain-browser-terminal.md)
 

--- a/docs/conventions/troubleshooting/connector-market.md
+++ b/docs/conventions/troubleshooting/connector-market.md
@@ -67,3 +67,23 @@ Separate device installation from account authorization. Confirm the connector i
 **Rule**
 
 HTTP 428 and JSON-RPC `-33001`/`-33002` are authorization-required, not retryable install failure. Persist an expired account projection, replan `RuntimeDesired` enabled=false, and complete install once that inactive generation is Observed. Do not keep the install operation retrying 428, and do not require a connected route before installation may become a device fact.
+
+### API-key Connect toast fails while the token is still in the form
+
+**Symptoms**
+
+- Settings or composer Connect for an API-key connector such as Cloudflare shows `无法启动授权，请重试`
+- the token field still contains the submitted secret
+- tuttid logs `connector authorization could not be started` wrapping either `requires a valid secret` or a control-plane status
+- HTTP `POST .../authorization:start` returns 503, often with a request body that already includes `secret`
+
+**Check**
+
+Inspect the SQLite `start_authorization` row and tuttid logs together.
+
+- `attempt >= 2` plus a lease, and the wrapped cause is `connector authorization requires a valid secret`: the 500 ms durable-operation scanner replayed the command without the secret. `BeginAuthorization` keeps the secret only in the command and must not schedule `start_authorization`. Daemon bootstrap must fail leftover accepted or running `start_authorization` rows instead of replaying them.
+- `attempt = 1`, no lease, and no `connector market operation failed` line: the live command reached the control plane with the submitted secret. Read the wrapped cause on `connector authorization could not be started` in tuttid.log and in the HTTP 503 `message`. `Post https://api.tutti.sh/...: EOF` is a transport failure before Composio sees the token. Check Clash/mihomo service logs at the same timestamp: if `tuttid --> api.tutti.sh` matches the final MATCH/漏网之鱼 rule and dials timeout, the request never reached Cloudflare. Fake-ip `198.18.0.0/15` alone is not evidence the origin is down. `did not complete: status ...` is a provider/session rejection, not the empty-secret race.
+
+**Rule**
+
+Native-secret authorization is command-inline. Recovery may resume install, uninstall, refresh, disconnect, and runtime reconcile from persisted state. It must not replay `start_authorization`, because the user secret is not durable. Crash leftovers must fail so a later Connect is not blocked by `operation in progress`. Live control-plane failures must keep their status or session outcome in the command error; do not collapse them to an empty `could not be started` toast with no cause.

--- a/packages/connector/daemon/adapters/controlplane/authorization_client.go
+++ b/packages/connector/daemon/adapters/controlplane/authorization_client.go
@@ -171,8 +171,18 @@ func (client *AuthorizationClient) Begin(ctx context.Context, request market.Aut
 			return market.AuthorizationSession{}, err
 		}
 		client.notifyChanged()
-		if completed.Session.SessionID != response.Session.SessionID || strings.TrimSpace(completed.Session.ConnectorRevision) != connectorVersion || !authorizationSessionSucceeded(completed.Session.Status) {
-			return market.AuthorizationSession{}, errors.New("connector secret authorization did not complete")
+		if completed.Session.SessionID != response.Session.SessionID {
+			return market.AuthorizationSession{}, errors.New("connector secret authorization returned a different session")
+		}
+		if strings.TrimSpace(completed.Session.ConnectorRevision) != connectorVersion {
+			return market.AuthorizationSession{}, errors.New("connector secret authorization returned a mismatched connector revision")
+		}
+		if !authorizationSessionSucceeded(completed.Session.Status) {
+			status := strings.TrimSpace(completed.Session.Status)
+			if status == "" {
+				return market.AuthorizationSession{}, errors.New("connector secret authorization did not complete")
+			}
+			return market.AuthorizationSession{}, fmt.Errorf("connector secret authorization did not complete: status %s", status)
 		}
 		session.ConnectionID = strings.TrimSpace(completed.Session.ResultConnectionID)
 		if session.ConnectionID == "" {
@@ -323,7 +333,7 @@ func (client *AuthorizationClient) doJSONWithAuthorizer(ctx context.Context, met
 		return errors.New("connector authorization response exceeds limit")
 	}
 	if httpResponse.StatusCode < 200 || httpResponse.StatusCode >= 300 {
-		return fmt.Errorf("connector authorization request failed: status %d", httpResponse.StatusCode)
+		return connectorAuthorizationHTTPError(httpResponse.StatusCode, payload)
 	}
 	if output != nil {
 		if len(payload) == 0 || json.Unmarshal(payload, output) != nil {
@@ -344,6 +354,38 @@ type connectorAuthorizationSessionReply struct {
 			URL  string `json:"url"`
 		} `json:"nextAction"`
 	} `json:"session"`
+}
+
+const connectorAuthorizationErrorDetailLimit = 240
+
+func connectorAuthorizationHTTPError(status int, payload []byte) error {
+	detail := connectorAuthorizationErrorDetail(payload)
+	if detail == "" {
+		return fmt.Errorf("connector authorization request failed: status %d", status)
+	}
+	return fmt.Errorf("connector authorization request failed: status %d: %s", status, detail)
+}
+
+func connectorAuthorizationErrorDetail(payload []byte) string {
+	var parsed struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+		Error   string `json:"error"`
+	}
+	if json.Unmarshal(payload, &parsed) != nil {
+		return ""
+	}
+	detail := strings.TrimSpace(parsed.Message)
+	if detail == "" {
+		detail = strings.TrimSpace(parsed.Error)
+	}
+	if detail == "" {
+		detail = strings.TrimSpace(parsed.Code)
+	}
+	if len(detail) > connectorAuthorizationErrorDetailLimit {
+		return detail[:connectorAuthorizationErrorDetailLimit]
+	}
+	return detail
 }
 
 func authorizationSessionSucceeded(status string) bool {

--- a/packages/connector/daemon/adapters/controlplane/authorization_client_test.go
+++ b/packages/connector/daemon/adapters/controlplane/authorization_client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	market "github.com/tutti-os/tutti/packages/connector/daemon/core"
@@ -227,6 +228,73 @@ func TestAuthorizationClientSubmitsNativeSecretWithoutPersistingItInSession(t *t
 		if value != 0 {
 			t.Fatalf("secret[%d] was not cleared", i)
 		}
+	}
+}
+
+func TestAuthorizationClientReportsControlPlaneHTTPErrorDetail(t *testing.T) {
+	const token = "user-provided-token"
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/v1/connectors/cloudflare/authorization-sessions" {
+			http.NotFound(response, request)
+			return
+		}
+		response.WriteHeader(http.StatusBadGateway)
+		_, _ = response.Write([]byte(`{"code":"upstream_unavailable","message":"composio session create failed"}`))
+	}))
+	defer server.Close()
+	client, err := NewAuthorizationClient(AuthorizationClientConfig{
+		BaseURL: server.URL, APIPrefix: "/v1", HTTPClient: server.Client(),
+		AuthorizeAccountRequest: func(*http.Request, string) error { return nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.Begin(context.Background(), market.AuthorizationStartRequest{
+		OperationID: "operation-secret-1", ClientRequestID: "request-secret-1", Secret: []byte(token),
+		Scope:     market.OperationScope{AccountID: "account-1"},
+		Connector: market.Connector{Key: "cloudflare"},
+		Release:   market.Release{Version: "2.0.0", Manifest: market.Manifest{AuthorizationKind: "api_key"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "status 502") ||
+		!strings.Contains(err.Error(), "composio session create failed") {
+		t.Fatalf("error = %v", err)
+	}
+	if strings.Contains(err.Error(), token) {
+		t.Fatalf("error leaked secret: %v", err)
+	}
+}
+
+func TestAuthorizationClientReportsUnsuccessfulSecretCompletionStatus(t *testing.T) {
+	const token = "user-provided-token"
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/v1/connectors/cloudflare/authorization-sessions":
+			_, _ = response.Write([]byte(`{"session":{"sessionId":"auth-secret-1","connectorRevision":"2.0.0","nextAction":{"type":"submit_secret"}}}`))
+		case "/v1/connector-authorization-sessions/auth-secret-1/complete":
+			_, _ = response.Write([]byte(`{"session":{"sessionId":"auth-secret-1","connectorRevision":"2.0.0","status":"CONNECTOR_AUTHORIZATION_SESSION_STATUS_FAILED"}}`))
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	defer server.Close()
+	client, err := NewAuthorizationClient(AuthorizationClientConfig{
+		BaseURL: server.URL, APIPrefix: "/v1", HTTPClient: server.Client(),
+		AuthorizeAccountRequest: func(*http.Request, string) error { return nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.Begin(context.Background(), market.AuthorizationStartRequest{
+		OperationID: "operation-secret-1", ClientRequestID: "request-secret-1", Secret: []byte(token),
+		Scope:     market.OperationScope{AccountID: "account-1"},
+		Connector: market.Connector{Key: "cloudflare"},
+		Release:   market.Release{Version: "2.0.0", Manifest: market.Manifest{AuthorizationKind: "api_key"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "CONNECTOR_AUTHORIZATION_SESSION_STATUS_FAILED") {
+		t.Fatalf("error = %v", err)
+	}
+	if strings.Contains(err.Error(), token) {
+		t.Fatalf("error leaked secret: %v", err)
 	}
 }
 

--- a/packages/connector/daemon/application/host.go
+++ b/packages/connector/daemon/application/host.go
@@ -637,9 +637,9 @@ func (host *Host) recoverAndWait(ctx context.Context) error {
 	for {
 		pending := false
 		for _, candidate := range operations {
-			// Remote refresh and authorization operations may legitimately wait on
-			// the network. Recover them, but do not make local route restoration
-			// wait for their terminal state.
+			// Remote refresh may wait on the network. Start authorization is not
+			// replayed from durable state. Recover those rows, but do not make
+			// local route restoration wait for their terminal state.
 			if candidate.Kind != market.OperationKindInstall && candidate.Kind != market.OperationKindUninstall &&
 				candidate.Kind != market.OperationKindReconcileRuntime {
 				continue

--- a/packages/connector/daemon/application/operation_recovery.go
+++ b/packages/connector/daemon/application/operation_recovery.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"log/slog"
 	"time"
+
+	market "github.com/tutti-os/tutti/packages/connector/daemon/core"
 )
 
 const (
@@ -59,6 +61,9 @@ func (host *Host) scheduleRecoverableOperations(ctx context.Context) error {
 	var scheduleErr error
 	now := time.Now().UTC()
 	for _, operation := range operations {
+		if !market.OperationEffectIsDurable(operation.Kind) {
+			continue
+		}
 		if delay := operationRetryDelay(int(operation.Attempt)); delay > 0 &&
 			!operation.UpdatedAt.IsZero() && now.Sub(operation.UpdatedAt) < delay {
 			continue

--- a/packages/connector/daemon/application/operation_recovery_test.go
+++ b/packages/connector/daemon/application/operation_recovery_test.go
@@ -43,6 +43,46 @@ func TestOperationRecoveryReschedulesDurableRunningWorkAfterWakeLoss(t *testing.
 	}
 }
 
+func TestOperationRecoverySkipsStartAuthorizationBecauseTheSecretIsNotDurable(t *testing.T) {
+	ctx := context.Background()
+	store, err := marketdata.Open(ctx, filepath.Join(t.TempDir(), "tuttid.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	install := market.Operation{
+		OperationID: "install-1", ClientRequestID: "request-install", ConnectorKey: "github",
+		Kind: market.OperationKindInstall, State: market.OperationStateRunning, Stage: market.OperationStageInstalling,
+		CreatedAt: time.Unix(1, 0).UTC(), UpdatedAt: time.Unix(2, 0).UTC(),
+	}
+	authorization := market.Operation{
+		OperationID: "authorization-1", ClientRequestID: "request-authorization", ConnectorKey: "cloudflare",
+		Kind: market.OperationKindStartAuthorization, State: market.OperationStateRunning, Stage: market.OperationStageAuthorizing,
+		CreatedAt: time.Unix(1, 0).UTC(), UpdatedAt: time.Unix(2, 0).UTC(),
+	}
+	if err := store.Transaction(ctx, func(tx market.Transaction) error {
+		if err := tx.SaveOperation(install); err != nil {
+			return err
+		}
+		return tx.SaveOperation(authorization)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	executor := &recordingOperationExecutor{}
+	scheduler := NewOperationScheduler(ctx)
+	if err := scheduler.Bind(executor); err != nil {
+		t.Fatal(err)
+	}
+	host := &Host{repository: store, scheduler: scheduler}
+	if err := host.scheduleRecoverableOperations(ctx); err != nil {
+		t.Fatal(err)
+	}
+	scheduler.Wait()
+	if calls := executor.operationIDs(); len(calls) != 1 || calls[0] != install.OperationID {
+		t.Fatalf("recovered operations = %#v", calls)
+	}
+}
+
 func TestOperationRecoveryDelaysRecentHighAttemptWork(t *testing.T) {
 	ctx := context.Background()
 	store, err := marketdata.Open(ctx, filepath.Join(t.TempDir(), "tuttid.db"))

--- a/packages/connector/daemon/core/application.go
+++ b/packages/connector/daemon/core/application.go
@@ -1192,7 +1192,12 @@ func (application *Application) executeOperation(ctx context.Context, operationI
 	case OperationKindDisconnectAuthorization:
 		executeErr = application.executeDisconnectAuthorization(executionContext, operation)
 	case OperationKindStartAuthorization:
-		_, executeErr = application.beginAuthorizationSession(executionContext, operation, nil, "")
+		executeErr = NewDomainError(
+			ErrorCodeAuthorizationFailed,
+			"connector authorization cannot be recovered without the original command",
+			false,
+			nil,
+		)
 	default:
 		executeErr = invalidRequest(fmt.Sprintf("operation kind %q is not executable", operation.Kind))
 	}
@@ -1254,6 +1259,12 @@ func (application *Application) Recover(ctx context.Context) error {
 		return err
 	}
 	for _, operation := range operations {
+		if !OperationEffectIsDurable(operation.Kind) {
+			if err := application.failOperation(ctx, operation.OperationID, ErrorCodeAuthorizationFailed); err != nil {
+				return err
+			}
+			continue
+		}
 		if operationTouchesImplementationHost(operation.Kind) && operation.HostGeneration.BootEpoch != application.config.BootEpoch {
 			operation, err = application.adoptRuntimeOperation(ctx, operation.OperationID)
 			if err != nil {
@@ -1290,6 +1301,15 @@ func operationTouchesImplementationHost(kind OperationKind) bool {
 	default:
 		return false
 	}
+}
+
+// OperationEffectIsDurable reports whether recovery may execute an accepted or
+// running operation from persisted state alone. Start authorization keeps the
+// user secret only in the BeginAuthorization command, so replaying it would
+// complete a native-secret session with an empty secret and fail the live
+// command.
+func OperationEffectIsDurable(kind OperationKind) bool {
+	return kind != OperationKindStartAuthorization
 }
 
 func (application *Application) adoptRuntimeOperation(ctx context.Context, operationID string) (Operation, error) {
@@ -1410,7 +1430,7 @@ func (application *Application) acceptConnectorOperation(
 	if err != nil {
 		return MutationResult{}, err
 	}
-	if kind != OperationKindStartAuthorization &&
+	if OperationEffectIsDurable(kind) &&
 		(result.Operation.State == OperationStateAccepted || result.Operation.State == OperationStateRunning) {
 		if err := application.config.Scheduler.Schedule(ctx, result.Operation.OperationID); err != nil {
 			return MutationResult{}, NewDomainError(ErrorCodeUnavailable, "connector operation could not be scheduled", true, err)

--- a/packages/connector/daemon/core/application_test.go
+++ b/packages/connector/daemon/core/application_test.go
@@ -1706,6 +1706,50 @@ func TestApplicationRecoveryAdoptsInstallAndUninstallIntoCurrentBootEpoch(t *tes
 	}
 }
 
+func TestApplicationRecoveryFailsStartAuthorizationInsteadOfReplayingIt(t *testing.T) {
+	github := testConnector("github")
+	cloudflare := testConnector("cloudflare")
+	cloudflare.Authorization = Authorization{State: AuthorizationStatePending}
+	repository := newMemoryRepository(github, cloudflare)
+	scheduler := &memoryScheduler{}
+	application := newTestApplication(t, repository, scheduler, &memoryInstallRuntime{}, CatalogSnapshot{})
+	accepted, err := application.Install(context.Background(), ConnectorMutation{
+		Mutation: Mutation{ClientRequestID: "request-install", ExpectedRevision: 0}, ConnectorKey: github.Key,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	authorization := Operation{
+		OperationID: "recover-authorization", ClientRequestID: "request-authorization", ConnectorKey: cloudflare.Key,
+		Kind: OperationKindStartAuthorization, State: OperationStateRunning, Stage: OperationStageAuthorizing,
+		CreatedAt: time.Unix(1, 0).UTC(), UpdatedAt: time.Unix(2, 0).UTC(),
+	}
+	repository.operations[authorization.OperationID] = authorization
+
+	if err := application.Recover(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	failed := repository.operations[authorization.OperationID]
+	if failed.State != OperationStateFailed || failed.FailureCode != string(ErrorCodeAuthorizationFailed) {
+		t.Fatalf("start_authorization after recovery = %#v", failed)
+	}
+	if connector := repository.connectors[cloudflare.Key]; connector.Authorization.State != AuthorizationStateFailed ||
+		connector.Authorization.FailureCode != string(ErrorCodeAuthorizationFailed) {
+		t.Fatalf("authorization projection after recovery = %#v", connector.Authorization)
+	}
+	if len(scheduler.operationIDs) != 2 { // Install acceptance plus durable install recovery.
+		t.Fatalf("scheduled operations = %#v", scheduler.operationIDs)
+	}
+	for _, operationID := range scheduler.operationIDs {
+		if operationID == authorization.OperationID {
+			t.Fatalf("start_authorization was scheduled: %#v", scheduler.operationIDs)
+		}
+		if operationID != accepted.Operation.OperationID {
+			t.Fatalf("unexpected scheduled operation %s: %#v", operationID, scheduler.operationIDs)
+		}
+	}
+}
+
 func TestApplicationWritesChangedEventsInsideRepositoryTransactions(t *testing.T) {
 	repository := newMemoryRepository(testConnector("github"))
 	application := newTestApplication(t, repository, &memoryScheduler{}, &memoryInstallRuntime{}, CatalogSnapshot{})

--- a/packages/connector/renderer/src/application/services/connectorMarketService.interface.ts
+++ b/packages/connector/renderer/src/application/services/connectorMarketService.interface.ts
@@ -22,6 +22,12 @@ export interface ConnectorMarketSectionState extends ConnectorMarketCategory {
 export interface ConnectorMarketStoreState {
   loadState: ConnectorMarketLoadState;
   catalogState: ConnectorCatalogState;
+  /**
+   * Renderer-local: an explicit `refreshCatalog()` command is in flight.
+   * Daemon scheduled refresh may set `catalogState` to `refreshing` without
+   * this flag; the toolbar must not spin for that background sync.
+   */
+  pendingExplicitCatalogRefresh: boolean;
   catalogOperation: ConnectorOperation | null;
   catalogSections: ConnectorMarketSectionState[];
   connectorsByKey: Record<string, Connector>;

--- a/packages/connector/renderer/src/application/services/connectorMarketService.test.ts
+++ b/packages/connector/renderer/src/application/services/connectorMarketService.test.ts
@@ -571,6 +571,63 @@ test("coalesces concurrent catalog refreshes", async () => {
   service.dispose();
 });
 
+test("does not treat a daemon scheduled catalog refresh as an explicit toolbar refresh", async () => {
+  const service = new ConnectorMarketService({
+    backend: backendWith({
+      getSnapshot: async () => ({
+        catalogState: "refreshing",
+        connectors: [connector("github", 1)],
+        operations: [
+          {
+            operationId: "operation-scheduled-refresh",
+            clientRequestId: "daemon-refresh-1",
+            kind: "refresh_catalog",
+            state: "running",
+            stage: "refreshing",
+            attempt: 1,
+            createdAt: "2026-08-03T00:00:00Z",
+            updatedAt: "2026-08-03T00:00:01Z"
+          }
+        ],
+        revision: 1
+      }),
+      listCategories: async () => []
+    })
+  });
+
+  await service.ensureLoaded();
+
+  assert.equal(service.dataStore.catalogState, "refreshing");
+  assert.equal(service.dataStore.pendingExplicitCatalogRefresh, false);
+  service.dispose();
+});
+
+test("clears an explicit catalog refresh when the accepted operation is already terminal", async () => {
+  const service = new ConnectorMarketService({
+    backend: backendWith({
+      refreshCatalog: async () => ({
+        operation: {
+          operationId: "operation-refresh-done",
+          clientRequestId: "request-refresh-done",
+          kind: "refresh_catalog",
+          state: "completed",
+          stage: "completed",
+          attempt: 1,
+          createdAt: "2026-08-03T00:00:00Z",
+          updatedAt: "2026-08-03T00:00:01Z"
+        },
+        revision: 2
+      })
+    })
+  });
+
+  await service.refreshCatalog();
+
+  assert.equal(service.dataStore.pendingExplicitCatalogRefresh, false);
+  assert.equal(service.dataStore.catalogOperation?.state, "completed");
+  service.dispose();
+});
+
 test("rejects overlapping mutations for one connector", async () => {
   const install =
     deferred<Awaited<ReturnType<ConnectorMarketBackend["installConnector"]>>>();
@@ -1095,6 +1152,7 @@ test("reconciles refresh completion from the local snapshot without reloading re
   assert.equal(categoryCalls, 0);
   assert.equal(snapshotCalls, 2);
   assert.equal(service.dataStore.catalogOperation?.state, "completed");
+  assert.equal(service.dataStore.pendingExplicitCatalogRefresh, false);
   assert.equal(service.dataStore.revision, 2);
   service.dispose();
 });

--- a/packages/connector/renderer/src/application/services/connectorMarketService.ts
+++ b/packages/connector/renderer/src/application/services/connectorMarketService.ts
@@ -247,6 +247,7 @@ export class ConnectorMarketService implements IConnectorMarketService {
       return this.refreshInFlight;
     }
     const generation = this.dataGeneration;
+    this.dataStore.pendingExplicitCatalogRefresh = true;
     this.dataStore.catalogState = "refreshing";
     const promise = this.dependencies.backend
       .refreshCatalog({
@@ -256,11 +257,15 @@ export class ConnectorMarketService implements IConnectorMarketService {
       .then((result) => {
         if (this.isCurrent(generation)) {
           applyConnectorMutationResult(this.dataStore, result);
-          this.trackOperation(result.operation);
+          const tracked = this.trackOperation(result.operation);
+          if (!tracked) {
+            this.dataStore.pendingExplicitCatalogRefresh = false;
+          }
         }
       })
       .catch((error) => {
         if (this.isCurrent(generation)) {
+          this.dataStore.pendingExplicitCatalogRefresh = false;
           this.dataStore.catalogState = "failed";
           this.recordError(error);
         }
@@ -1185,6 +1190,9 @@ export class ConnectorMarketService implements IConnectorMarketService {
         operation;
     } else if (operation.kind === "refresh_catalog") {
       this.dataStore.catalogOperation = operation;
+      if (operation.state === "completed" || operation.state === "failed") {
+        this.dataStore.pendingExplicitCatalogRefresh = false;
+      }
     }
     const notification =
       this.dataStore.pendingUninstallNotificationsByOperationId[

--- a/packages/connector/renderer/src/application/services/connectorMarketState.ts
+++ b/packages/connector/renderer/src/application/services/connectorMarketState.ts
@@ -13,6 +13,7 @@ export function createConnectorMarketStoreState(): ConnectorMarketStoreState {
   return {
     loadState: "idle",
     catalogState: "stale",
+    pendingExplicitCatalogRefresh: false,
     catalogOperation: null,
     catalogSections: [],
     connectorsByKey: {},
@@ -36,6 +37,7 @@ export function clearConnectorMarketStoreState(
   const initial = createConnectorMarketStoreState();
   state.loadState = initial.loadState;
   state.catalogState = initial.catalogState;
+  state.pendingExplicitCatalogRefresh = initial.pendingExplicitCatalogRefresh;
   state.catalogOperation = initial.catalogOperation;
   state.catalogSections = initial.catalogSections;
   state.connectorsByKey = initial.connectorsByKey;

--- a/packages/connector/renderer/src/application/services/view/connectorMarketViewBuilder.test.ts
+++ b/packages/connector/renderer/src/application/services/view/connectorMarketViewBuilder.test.ts
@@ -70,6 +70,17 @@ test("keeps a failed catalog section visible without failing the whole view", ()
   assert.equal(view.catalogError, null);
 });
 
+test("spins the catalog toolbar only for an explicit refresh command", () => {
+  const market = createConnectorMarketStoreState();
+  market.loadState = "ready";
+  market.catalogState = "refreshing";
+
+  assert.equal(buildConnectorMarketView(market, uiState).refreshing, false);
+
+  market.pendingExplicitCatalogRefresh = true;
+  assert.equal(buildConnectorMarketView(market, uiState).refreshing, true);
+});
+
 test("projects server-owned category names into the renderer view", () => {
   const market = createConnectorMarketStoreState();
   market.loadState = "ready";

--- a/packages/connector/renderer/src/application/services/view/connectorMarketViewBuilder.ts
+++ b/packages/connector/renderer/src/application/services/view/connectorMarketViewBuilder.ts
@@ -85,7 +85,7 @@ export function buildConnectorMarketView(
         ? market.authorizationViewsByConnectorKey[uiState.dialog.connectorKey]
         : undefined
     ),
-    refreshing: market.catalogState === "refreshing",
+    refreshing: market.pendingExplicitCatalogRefresh,
     sections: sections.filter(
       (section) =>
         section.connectorKeys.length > 0 ||

--- a/packages/connector/renderer/src/ui/catalog/ConnectorCard.tsx
+++ b/packages/connector/renderer/src/ui/catalog/ConnectorCard.tsx
@@ -31,7 +31,8 @@ export function ConnectorCard({ connectorKey }: { connectorKey: string }) {
   }
 
   const actionLabel = resolveActionLabel(card, i18n.t);
-  const status = resolveStatus(card.status, i18n.t);
+  const showStatus = card.status !== "not_installed";
+  const status = showStatus ? resolveStatus(card.status, i18n.t) : null;
   const handleAction = () => {
     if (card.action === "disconnect") {
       if (disconnecting) {
@@ -116,19 +117,27 @@ export function ConnectorCard({ connectorKey }: { connectorKey: string }) {
           </DropdownMenu>
         ) : null}
       </div>
-      <div className="flex items-center justify-between gap-3">
-        <div className="flex min-w-0 items-center gap-2 text-[12px] text-[var(--text-secondary)]">
-          <StatusDot
-            pulse={["installing", "updating"].includes(card.status)}
-            size="xs"
-            tone={status.tone}
-          />
-          <span className="truncate">
-            {card.operationStage && card.operationStage !== "completed"
-              ? operationStageLabel(card.operationStage, i18n.t)
-              : status.label}
-          </span>
-        </div>
+      <div
+        className={
+          showStatus
+            ? "flex items-center justify-between gap-3"
+            : "flex items-center justify-end gap-3"
+        }
+      >
+        {status ? (
+          <div className="flex min-w-0 items-center gap-2 text-[12px] text-[var(--text-secondary)]">
+            <StatusDot
+              pulse={["installing", "updating"].includes(card.status)}
+              size="xs"
+              tone={status.tone}
+            />
+            <span className="truncate">
+              {card.operationStage && card.operationStage !== "completed"
+                ? operationStageLabel(card.operationStage, i18n.t)
+                : status.label}
+            </span>
+          </div>
+        ) : null}
         <Button
           disabled={card.action === "busy" || disconnecting}
           size="sm"

--- a/packages/connector/renderer/src/ui/composer/ConnectorComposerMenu.spec.tsx
+++ b/packages/connector/renderer/src/ui/composer/ConnectorComposerMenu.spec.tsx
@@ -471,12 +471,12 @@ describe("ConnectorComposerMenu", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("shows four recently installed connectors and fills the remaining quick slots from discovery", async () => {
+  it("fills the quick menu with installed authorized connectors before discovery", async () => {
     const connectedConnectors = Array.from({ length: 10 }, (_, index) =>
       connector(`connected-${index}`, "connected", false, index + 1)
     );
     const discoveryConnectors = Array.from({ length: 6 }, (_, index) =>
-      connector(`setup-${index}`, "setup_required")
+      connector(`setup-${index}`, "setup_required", false, 1_000 + index)
     );
     render(
       <ConnectorComposerMenu
@@ -499,14 +499,27 @@ describe("ConnectorComposerMenu", () => {
     });
 
     expect(
-      await screen.findByTestId("connector-market-composer-item-setup-0")
-    ).toBeInTheDocument();
+      (await screen.findAllByTestId(/^connector-market-composer-item-/)).map(
+        (item) => item.dataset.testid
+      )
+    ).toEqual([
+      "connector-market-composer-item-stopped",
+      "connector-market-composer-item-connected-9",
+      "connector-market-composer-item-connected-8",
+      "connector-market-composer-item-connected-7",
+      "connector-market-composer-item-connected-6",
+      "connector-market-composer-item-connected-5",
+      "connector-market-composer-item-connected-4",
+      "connector-market-composer-item-connected-3",
+      "connector-market-composer-item-connected-2",
+      "connector-market-composer-item-connected-1"
+    ]);
     expect(
       screen.getByTestId("connector-market-composer-status-stopped")
     ).not.toBeChecked();
     expect(
-      screen.getAllByTestId(/^connector-market-composer-item-/)
-    ).toHaveLength(10);
+      screen.queryByTestId("connector-market-composer-item-setup-0")
+    ).not.toBeInTheDocument();
   });
 
   it("keeps an installed connector in place when its runtime is stopped", async () => {

--- a/packages/connector/renderer/src/ui/composer/ConnectorComposerMenu.tsx
+++ b/packages/connector/renderer/src/ui/composer/ConnectorComposerMenu.tsx
@@ -16,7 +16,6 @@ import {
 import { cn } from "@tutti-os/ui-system/utils";
 
 const QUICK_CONNECTOR_LIMIT = 10;
-const INSTALLED_CONNECTOR_PREVIEW_LIMIT = 4;
 const CONNECTOR_PREVIEW_LIMIT = 3;
 
 export type ConnectorComposerItemStatus =
@@ -93,18 +92,7 @@ export function ConnectorComposerMenu({
     ReadonlySet<string>
   >(new Set());
   const normalizedItems = normalizeConnectorItems(items);
-  const installedItems = normalizedItems.filter(isInstalledConnectorItem);
-  const discoveryItems = normalizedItems.filter(
-    (item) => !isInstalledConnectorItem(item)
-  );
-  const quickItems = [
-    ...installedItems.slice(0, INSTALLED_CONNECTOR_PREVIEW_LIMIT),
-    ...discoveryItems.slice(
-      0,
-      QUICK_CONNECTOR_LIMIT -
-        Math.min(installedItems.length, INSTALLED_CONNECTOR_PREVIEW_LIMIT)
-    )
-  ];
+  const quickItems = normalizedItems.slice(0, QUICK_CONNECTOR_LIMIT);
   const connectedItems = normalizedItems.filter(
     (item) => item.status === "connected"
   );
@@ -424,8 +412,7 @@ export function ConnectorComposerMenu({
 export function normalizeConnectorItems(
   items: readonly ConnectorComposerItem[]
 ): ConnectorComposerItem[] {
-  const installedItems: ConnectorComposerItem[] = [];
-  const remainingItems: ConnectorComposerItem[] = [];
+  const uniqueItems: ConnectorComposerItem[] = [];
   const seenConnectorKeys = new Set<string>();
   for (const item of items) {
     const connectorKey = item.connectorKey.trim();
@@ -433,18 +420,24 @@ export function normalizeConnectorItems(
       continue;
     }
     seenConnectorKeys.add(connectorKey);
-    const normalizedItem = { ...item, connectorKey };
-    if (isInstalledConnectorItem(normalizedItem)) {
-      installedItems.push(normalizedItem);
-    } else {
-      remainingItems.push(normalizedItem);
-    }
+    uniqueItems.push({ ...item, connectorKey });
   }
-  installedItems.sort(compareInstalledConnectorItems);
-  return [...installedItems, ...remainingItems];
+  return uniqueItems.sort(compareConnectorComposerItems);
 }
 
-function compareInstalledConnectorItems(
+function compareConnectorComposerItems(
+  left: ConnectorComposerItem,
+  right: ConnectorComposerItem
+): number {
+  const leftInstalled = isInstalledConnectorItem(left);
+  const rightInstalled = isInstalledConnectorItem(right);
+  if (leftInstalled !== rightInstalled) {
+    return leftInstalled ? -1 : 1;
+  }
+  return compareInstallationEvent(left, right);
+}
+
+function compareInstallationEvent(
   left: ConnectorComposerItem,
   right: ConnectorComposerItem
 ): number {

--- a/packages/connector/renderer/src/ui/composer/connectorComposerMenuModel.test.ts
+++ b/packages/connector/renderer/src/ui/composer/connectorComposerMenuModel.test.ts
@@ -6,20 +6,22 @@ import {
   type ConnectorComposerItem
 } from "./ConnectorComposerMenu.tsx";
 
-test("orders installed connectors by installation time and preserves catalog order for legacy entries", () => {
+test("orders installed authorized connectors first, then by installation event", () => {
   const items: ConnectorComposerItem[] = [
     item(" github "),
+    item("cloudflare", "authorization_required", false, 900),
     item("figma", "connected", false, 200),
     item("notion", "connected", true, 300),
     item("legacy", "disabled"),
     item("github"),
+    item("hubspot", "authorization_required", false, 400),
     item("lark"),
     item("   ")
   ];
 
   assert.deepEqual(
     normalizeConnectorItems(items).map((entry) => entry.connectorKey),
-    ["notion", "figma", "legacy", "github", "lark"]
+    ["notion", "figma", "legacy", "cloudflare", "hubspot", "github", "lark"]
   );
 });
 

--- a/services/tuttid/api/daemon_connector_market.go
+++ b/services/tuttid/api/daemon_connector_market.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 
 	market "github.com/tutti-os/tutti/packages/connector/daemon/core"
 	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
@@ -304,7 +305,9 @@ func (api DaemonAPI) StartConnectorMarketAuthorization(
 	defer clear(secret)
 	result, err := api.ConnectorMarketService.BeginAuthorization(ctx, mutation, secret)
 	if err != nil {
+		slog.Warn("connector authorization could not be started", "connectorKey", request.ConnectorKey, "error", err)
 		payload, status := connectorMarketError(err)
+		payload.Message = err.Error()
 		switch status {
 		case 400:
 			return tuttigenerated.StartConnectorMarketAuthorization400JSONResponse{ConnectorMarketInvalidRequestErrorJSONResponse: invalidConnectorMarketResponse(payload)}, nil

--- a/services/tuttid/api/daemon_connector_market_test.go
+++ b/services/tuttid/api/daemon_connector_market_test.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -213,6 +215,45 @@ func TestDaemonAPIForwardsReplaceActiveAuthorizationPolicy(t *testing.T) {
 	if received.AccountID != "account-1" || received.ClientRequestID != "authorization-b" ||
 		received.ReplacementPolicy != market.AuthorizationReplacementPolicyReplaceActive {
 		t.Fatalf("authorization mutation = %#v", received)
+	}
+}
+
+func TestDaemonAPIStartAuthorizationSurfacesControlPlaneCause(t *testing.T) {
+	const token = "cf-token"
+	service := stubConnectorMarketService{beginFn: func(
+		_ context.Context,
+		mutation market.ConnectorMutation,
+		secret []byte,
+	) (market.AuthorizationResult, error) {
+		if mutation.ConnectorKey != "cloudflare" || string(secret) != token {
+			t.Fatalf("mutation=%#v secret=%q", mutation, secret)
+		}
+		return market.AuthorizationResult{}, market.NewDomainError(
+			market.ErrorCodeAuthorizationFailed,
+			"connector authorization could not be started",
+			true,
+			errors.New("connector authorization request failed: status 502: composio session create failed"),
+		)
+	}}
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, NewRoutes(DaemonAPI{
+		ConnectorMarketService: service,
+		ConnectorMarketScope:   func() market.OperationScope { return market.OperationScope{AccountID: "account-1"} },
+	}))
+
+	recorder := performGeneratedRouteRequest(t, mux, http.MethodPost,
+		"/v1/connector-market/connectors/cloudflare/authorization:start", map[string]any{
+			"clientRequestId": "authorization-cloudflare", "expectedRevision": 1,
+			"replacementPolicy": "replace_active", "secret": token,
+		})
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d; body: %s", recorder.Code, http.StatusServiceUnavailable, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "composio session create failed") {
+		t.Fatalf("body = %s", recorder.Body.String())
+	}
+	if strings.Contains(recorder.Body.String(), token) {
+		t.Fatalf("response leaked secret: %s", recorder.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Keep `start_authorization` command-inline so recovery cannot replay API-key/Composio secret start without the original command, and fail leftover accepted/running operations instead of executing them.
- Surface the control-plane cause on live StartAuthorization 503s (daemon HTTP payload + richer authorization-client errors) so retries are diagnosable.
- Rank composer connector shortcuts as installed+authorized first, then by install time, and apply the 10-item cap after ranking.
- Spin the catalog toolbar only for explicit refresh, and hide idle Not-installed status so it does not weaken Need authorization.

## Test plan
- [ ] Restart the desktop/daemon, then authorize a Composio API-key connector (e.g. Cloudflare). The start request should keep the submitted secret; leftover recovered `start_authorization` ops should fail closed instead of replaying with a nil secret.
- [ ] If StartAuthorization still returns 503, the daemon response/log should include the inner control-plane cause rather than only the outer “could not be started” message.
- [ ] Composer connector menu: installed and authorized connectors appear first, newest install first within that group; the 10-item cap is applied after ranking.
- [ ] Settings → Connectors: a daemon scheduled catalog refresh does not spin the toolbar; clicking Refresh does.
- [ ] Catalog cards: uninstalled connectors omit the idle Not-installed status; installed cards still show Need authorization / connected / update / unavailable.


Made with [Cursor](https://cursor.com)