### PR TITLE
fix(agent-gui): refresh connectors on click and preview selected drafts

### DIFF
--- a/packages/agent/activity-core/src/engine/composerOptions.reducer.ts
+++ b/packages/agent/activity-core/src/engine/composerOptions.reducer.ts
@@ -267,14 +267,10 @@ function mergeSectionOptions(
   if (section === "connectors") {
     return cloneAgentActivityComposerOptions({
       ...existing,
-      capabilityCatalog: [
-        ...(existing.capabilityCatalog ?? []).filter(
-          (capability) => capability.kind !== "connector"
-        ),
-        ...(incoming.capabilityCatalog ?? []).filter(
-          (capability) => capability.kind === "connector"
-        )
-      ],
+      capabilityCatalog: mergeConnectorCatalog(
+        existing.capabilityCatalog,
+        incoming.capabilityCatalog
+      ),
       loadedAtUnixMs: incoming.loadedAtUnixMs
     });
   }
@@ -283,10 +279,43 @@ function mergeSectionOptions(
     capabilities: incoming.capabilities ?? existing.capabilities,
     commands: incoming.commands,
     skills: incoming.skills,
-    capabilityCatalog: incoming.capabilityCatalog,
+    capabilityCatalog: mergeNonConnectorCatalog(
+      existing.capabilityCatalog,
+      incoming.capabilityCatalog
+    ),
     slashCommandPolicy: existing.slashCommandPolicy,
     loadedAtUnixMs: incoming.loadedAtUnixMs
   });
+}
+
+function mergeConnectorCatalog(
+  existing: AgentActivityComposerOptions["capabilityCatalog"],
+  incoming: AgentActivityComposerOptions["capabilityCatalog"]
+): NonNullable<AgentActivityComposerOptions["capabilityCatalog"]> {
+  return [
+    ...(existing ?? []).filter((capability) => capability.kind !== "connector"),
+    ...(incoming ?? []).filter((capability) => capability.kind === "connector")
+  ];
+}
+
+function mergeNonConnectorCatalog(
+  existing: AgentActivityComposerOptions["capabilityCatalog"],
+  incoming: AgentActivityComposerOptions["capabilityCatalog"]
+): AgentActivityComposerOptions["capabilityCatalog"] {
+  const incomingCatalog = incoming ?? [];
+  const incomingConnectors = incomingCatalog.filter(
+    (capability) => capability.kind === "connector"
+  );
+  const incomingOther = incomingCatalog.filter(
+    (capability) => capability.kind !== "connector"
+  );
+  if (incomingConnectors.length > 0) {
+    return [...incomingOther, ...incomingConnectors];
+  }
+  return [
+    ...incomingOther,
+    ...(existing ?? []).filter((capability) => capability.kind === "connector")
+  ];
 }
 
 function invalidate(

--- a/packages/agent/activity-core/src/engine/composerOptions.semantic.test.ts
+++ b/packages/agent/activity-core/src/engine/composerOptions.semantic.test.ts
@@ -188,6 +188,64 @@ test("connector section replaces only connector capabilities", async () => {
   assert.equal(merged.models[0]?.value, "capability-model");
 });
 
+test("capabilities without connectors keep a previously loaded connector catalog", async () => {
+  const harness = createHarness();
+  const connectors = harness.engine.loadComposerOptions({
+    ...loadInput(),
+    section: "connectors"
+  });
+  harness.succeed(
+    harness.commands[0]!.commandId,
+    composerOptions("connector-model", {
+      capabilityCatalog: [
+        {
+          id: "connector:google-forms",
+          invocation: "textTrigger",
+          kind: "connector",
+          label: "Google Forms",
+          name: "google-forms",
+          status: "available"
+        }
+      ]
+    })
+  );
+  await connectors;
+
+  const capabilities = harness.engine.loadComposerOptions({
+    ...loadInput(),
+    section: "capabilities"
+  });
+  harness.succeed(
+    harness.commands[1]!.commandId,
+    composerOptions("capability-model", {
+      capabilityCatalog: [
+        {
+          id: "skill:review",
+          invocation: "promptItem",
+          kind: "skill",
+          label: "Review",
+          name: "review",
+          status: "available"
+        }
+      ],
+      skills: [
+        {
+          name: "search",
+          sourceKind: "project",
+          trigger: "/search"
+        }
+      ]
+    })
+  );
+  const merged = await capabilities;
+
+  assert.deepEqual(
+    merged.capabilityCatalog?.map((capability) => capability.id),
+    ["skill:review", "connector:google-forms"]
+  );
+  assert.equal(merged.skills[0]?.name, "search");
+});
+
 test("semantic composer load joins an identical request and reuses its ready cache", async () => {
   const harness = createHarness();
   const first = harness.engine.loadComposerOptions(loadInput());

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerModelReasoningDropdown.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerModelReasoningDropdown.tsx
@@ -89,6 +89,7 @@ export function AgentModelReasoningDropdown({
    */
   modelHistoryTargetId?: string | null;
   onRetryComposerOptions?: (options?: {
+    force?: boolean;
     section?: "core" | "capabilities" | "connectors";
     waitForFreshModelCatalog?: boolean;
   }) => void;

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
@@ -426,6 +426,7 @@ export interface AgentComposerProps {
   }) => void;
   /** Retries or explicitly refreshes the target-scoped composer options. */
   onRetryComposerOptions?: (options?: {
+    force?: boolean;
     section?: "core" | "capabilities" | "connectors";
     waitForFreshModelCatalog?: boolean;
   }) => void;

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerPrimaryCapabilityControl.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerPrimaryCapabilityControl.spec.tsx
@@ -85,6 +85,7 @@ describe("ComposerPrimaryCapabilityControl", () => {
       { button: 0, ctrlKey: false, pointerType: "mouse" }
     );
     expect(onRetryComposerOptions).toHaveBeenCalledWith({
+      force: true,
       section: "connectors"
     });
     expect(
@@ -184,6 +185,7 @@ describe("ComposerPrimaryCapabilityControl", () => {
 
     await act(async () => completeInstall());
     expect(onRetryComposerOptions).toHaveBeenCalledWith({
+      force: true,
       section: "connectors"
     });
   });
@@ -231,5 +233,30 @@ describe("ComposerPrimaryCapabilityControl", () => {
     });
     expect(onCapabilitySettingsRequest).not.toHaveBeenCalled();
     expect(onConnectorSelected).not.toHaveBeenCalled();
+  });
+
+  it("previews a read-only draft selection on the composer trigger", () => {
+    renderControl({
+      availableSkills: [
+        {
+          connectorKey: "google-forms",
+          kind: "connector",
+          name: "Google Forms",
+          sourceKind: "connector",
+          status: "setupRequired",
+          trigger: "/google-forms"
+        }
+      ],
+      connectorsReadOnly: true,
+      connectorsVisible: true,
+      selectedConnectorKeys: ["google-forms"]
+    });
+
+    expect(
+      screen.getByTestId("connector-market-composer-preview-google-forms")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Connectors" })
+    ).not.toHaveTextContent("Connectors");
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerPrimaryCapabilityControl.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerPrimaryCapabilityControl.tsx
@@ -71,7 +71,7 @@ export function ComposerPrimaryCapabilityControl({
         disabled={disabled}
         items={projectConnectorComposerItems(
           availableSkills ?? [],
-          connectorsReadOnly ? [] : selectedConnectorKeys
+          selectedConnectorKeys
         )}
         labels={{
           authorize: labels.addContentConnectorAuthorize,
@@ -93,12 +93,15 @@ export function ComposerPrimaryCapabilityControl({
                   connectorKey,
                   action: "install"
                 });
-                onRetryComposerOptions?.({ section: "connectors" });
+                onRetryComposerOptions?.({
+                  force: true,
+                  section: "connectors"
+                });
               }
         }
         onOpenChange={(open) => {
           if (open) {
-            onRetryComposerOptions?.({ section: "connectors" });
+            onRetryComposerOptions?.({ force: true, section: "connectors" });
           }
         }}
         onOpenConnector={

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.ts
@@ -522,6 +522,7 @@ export function useAgentGUIComposerSettingsActions(
   // user double-clicks the retry control instead of superseding it.
   const retryComposerOptions = useStableControllerEventCallback(
     (options?: {
+      force?: boolean;
       section?: "core" | "capabilities" | "connectors";
       waitForFreshModelCatalog?: boolean;
     }) => {

--- a/packages/connector/renderer/src/ui/composer/ConnectorComposerMenu.spec.tsx
+++ b/packages/connector/renderer/src/ui/composer/ConnectorComposerMenu.spec.tsx
@@ -120,6 +120,31 @@ describe("ConnectorComposerMenu", () => {
     ).toHaveTextContent("+2");
   });
 
+  it("previews selected connectors on the trigger even when they are not authorized", () => {
+    render(
+      <ConnectorComposerMenu
+        items={[
+          connector("google-forms", "setup_required", true),
+          connector("github", "connected")
+        ]}
+        disabled={false}
+        labels={labels}
+        onOpenConnector={vi.fn()}
+        onOpenMarket={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByTestId("connector-market-composer-preview-google-forms")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("connector-market-composer-preview-github")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Connectors" })
+    ).not.toHaveTextContent("Connectors");
+  });
+
   it("shows runtime state versus setup actions and opens the catalog footer", async () => {
     const onOpenConnector = vi.fn();
     const onOpenMarket = vi.fn();

--- a/packages/connector/renderer/src/ui/composer/ConnectorComposerMenu.tsx
+++ b/packages/connector/renderer/src/ui/composer/ConnectorComposerMenu.tsx
@@ -96,8 +96,13 @@ export function ConnectorComposerMenu({
   const connectedItems = normalizedItems.filter(
     (item) => item.status === "connected"
   );
-  const previewItems = connectedItems.slice(0, CONNECTOR_PREVIEW_LIMIT);
-  const additionalConnectorCount = connectedItems.length - previewItems.length;
+  const selectedItems = normalizedItems.filter(
+    (item) => item.selected === true
+  );
+  const previewSource =
+    selectedItems.length > 0 ? selectedItems : connectedItems;
+  const previewItems = previewSource.slice(0, CONNECTOR_PREVIEW_LIMIT);
+  const additionalConnectorCount = previewSource.length - previewItems.length;
   const closeAndRun = (action: () => void): void => {
     setOpen(false);
     onOpenChange?.(false);


### PR DESCRIPTION
## Summary

Shared Agent composer kept showing the word Connectors after the catalog loaded, and opening the menu did not refetch. Opening Agent GUI already loads `core`/`capabilities`; the Connectors control must force a `connectors` section reload and keep a read-only draft selection on the trigger.

## Verification

- `pnpm --dir packages/agent/activity-core test`
- `pnpm --dir packages/connector/renderer exec vitest run src/ui/composer/ConnectorComposerMenu.spec.tsx --run`
- `pnpm --dir packages/agent/gui exec vitest run agent-gui/agentGuiNode/composer/ComposerPrimaryCapabilityControl.spec.tsx --run`
- Push-ready `check:changed` on this branch

## Fallback Three Questions

- Source: a settled `connectors` section cache, plus a later `capabilities` merge that replaced `capabilityCatalog`.
- Why can it not be fixed at that source: hosts may omit connectors from `capabilities` on purpose (catalog loads only when the menu opens). Activity Core still has to merge that section without wiping a previously loaded catalog, and the menu has to send `force: true` for an explicit click refresh.
- Removal condition: delete the capabilities-catalog merge once `capabilities` is guaranteed never to carry connector rows and hosts always invalidate `connectors` on menu open.

## Checklist

- [ ] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.


Made with [Cursor](https://cursor.com)