### PR TITLE
feat(agent): report Codex app-server resource counts

### DIFF
--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -22,7 +22,9 @@ const (
 	appServerMethodAccountRead         = "account/read"
 	appServerMethodRateLimitsRead      = "account/rateLimits/read"
 	appServerMethodModelList           = "model/list"
+	appServerMethodPluginList          = "plugin/list"
 	appServerMethodSkillsExtraRootsSet = "skills/extraRoots/set"
+	appServerMethodSkillsList          = "skills/list"
 	// Experimental: collaboration mode presets (plan/pair/execute). Absence of
 	// the method on older binaries downgrades planMode capability gracefully.
 	appServerMethodCollaborationModeList = "collaborationMode/list"
@@ -125,6 +127,10 @@ type CodexAppServerAdapterOptions struct {
 	// session start or resume finishes. It is best-effort observability only
 	// and must not influence provider startup or command correctness.
 	StartupObserver CodexAppServerStartupObserver
+	// StartupResourceObserver receives a best-effort snapshot of the resources
+	// exposed by the app-server. The snapshot is collected asynchronously and
+	// must not influence provider startup or command correctness.
+	StartupResourceObserver CodexAppServerResourceObserver
 }
 
 // CodexAppServerSpanObservation is one allowlisted startup span boundary
@@ -152,8 +158,7 @@ type CodexAppServerSpanObserver func(CodexAppServerSpanObservation)
 
 // CodexAppServerStartupObservation is one bounded summary of a Codex
 // app-server session start or resume. Counts describe resources bound to the
-// Tutti session and completed allowlisted Codex spans; Codex-native plugin and
-// skill counts are intentionally absent until Codex emits those counts.
+// Tutti session and completed allowlisted Codex spans.
 type CodexAppServerStartupObservation struct {
 	Provider           string
 	RoomID             string
@@ -168,6 +173,29 @@ type CodexAppServerStartupObservation struct {
 // CodexAppServerStartupObserver consumes one completed startup summary.
 // Implementations must be best-effort and must not affect provider behavior.
 type CodexAppServerStartupObserver func(CodexAppServerStartupObservation)
+
+// CodexAppServerResourceObservation is a bounded snapshot of the resources
+// visible to one app-server startup attempt. MCPServerCount is the number of
+// bindings supplied by the Tutti session. PluginCount and SkillCount are
+// Codex-native counts; -1 means that the corresponding list request did not
+// produce a trustworthy response.
+type CodexAppServerResourceObservation struct {
+	Provider           string
+	RoomID             string
+	AgentSessionID     string
+	StartedAt          string
+	Outcome            string
+	DurationMS         int64
+	MCPServerCount     int
+	PluginCount        int
+	SkillCount         int
+	PluginQueryOutcome string
+	SkillQueryOutcome  string
+}
+
+// CodexAppServerResourceObserver consumes one best-effort resource snapshot.
+// Implementations must be best-effort and must not affect provider behavior.
+type CodexAppServerResourceObserver func(CodexAppServerResourceObservation)
 
 // defaultCodexAppServerCancelGraceWindow is how long Cancel waits for codex to
 // honor turn/interrupt gracefully before force-closing the app-server process.
@@ -204,6 +232,7 @@ type CodexAppServerAdapter struct {
 	config                     appServerAdapterConfig
 	startupSpanObserver        CodexAppServerSpanObserver
 	startupObserver            CodexAppServerStartupObserver
+	startupResourceObserver    CodexAppServerResourceObserver
 	preparer                   ProviderLaunchPreparer
 	commandResolver            ProviderCommandResolver
 	mu                         sync.Mutex
@@ -477,6 +506,7 @@ func NewCodexAppServerAdapterWithHostMetadataAndOptions(
 	adapter.config.commandNetworkAccess = options.CommandNetworkAccess
 	adapter.startupSpanObserver = options.StartupSpanObserver
 	adapter.startupObserver = options.StartupObserver
+	adapter.startupResourceObserver = options.StartupResourceObserver
 	return adapter
 }
 
@@ -525,6 +555,7 @@ func NewTuttiAgentAppServerAdapterWithHostMetadataAndOptions(
 	adapter.config.commandNetworkAccess = options.CommandNetworkAccess
 	adapter.startupSpanObserver = options.StartupSpanObserver
 	adapter.startupObserver = options.StartupObserver
+	adapter.startupResourceObserver = options.StartupResourceObserver
 	return adapter
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_client.go
+++ b/packages/agent/daemon/runtime/codex_appserver_client.go
@@ -464,40 +464,6 @@ func (c *codexAppServerClient) SkillsExtraRootsSet(
 	return caller.rawResult, nil
 }
 
-func (c *codexAppServerClient) PluginList(
-	ctx context.Context,
-	timeout time.Duration,
-	params map[string]any,
-) (json.RawMessage, error) {
-	typedParams, err := codexProtoParams[codexproto.PluginListParams](params)
-	if err != nil {
-		return nil, err
-	}
-	client, caller := c.typed(timeout, nil, true)
-	_, err = client.PluginList(ctx, typedParams)
-	if err != nil {
-		return nil, err
-	}
-	return caller.rawResult, nil
-}
-
-func (c *codexAppServerClient) SkillsList(
-	ctx context.Context,
-	timeout time.Duration,
-	params map[string]any,
-) (json.RawMessage, error) {
-	typedParams, err := codexProtoParams[codexproto.SkillsListParams](params)
-	if err != nil {
-		return nil, err
-	}
-	client, caller := c.typed(timeout, nil, true)
-	_, err = client.SkillsList(ctx, typedParams)
-	if err != nil {
-		return nil, err
-	}
-	return caller.rawResult, nil
-}
-
 func (c *codexAppServerClient) ThreadStart(
 	ctx context.Context,
 	timeout time.Duration,

--- a/packages/agent/daemon/runtime/codex_appserver_client.go
+++ b/packages/agent/daemon/runtime/codex_appserver_client.go
@@ -464,6 +464,40 @@ func (c *codexAppServerClient) SkillsExtraRootsSet(
 	return caller.rawResult, nil
 }
 
+func (c *codexAppServerClient) PluginList(
+	ctx context.Context,
+	timeout time.Duration,
+	params map[string]any,
+) (json.RawMessage, error) {
+	typedParams, err := codexProtoParams[codexproto.PluginListParams](params)
+	if err != nil {
+		return nil, err
+	}
+	client, caller := c.typed(timeout, nil, true)
+	_, err = client.PluginList(ctx, typedParams)
+	if err != nil {
+		return nil, err
+	}
+	return caller.rawResult, nil
+}
+
+func (c *codexAppServerClient) SkillsList(
+	ctx context.Context,
+	timeout time.Duration,
+	params map[string]any,
+) (json.RawMessage, error) {
+	typedParams, err := codexProtoParams[codexproto.SkillsListParams](params)
+	if err != nil {
+		return nil, err
+	}
+	client, caller := c.typed(timeout, nil, true)
+	_, err = client.SkillsList(ctx, typedParams)
+	if err != nil {
+		return nil, err
+	}
+	return caller.rawResult, nil
+}
+
 func (c *codexAppServerClient) ThreadStart(
 	ctx context.Context,
 	timeout time.Duration,

--- a/packages/agent/daemon/runtime/codex_appserver_resource_client.go
+++ b/packages/agent/daemon/runtime/codex_appserver_resource_client.go
@@ -1,0 +1,43 @@
+package agentruntime
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/tutti-os/tutti/packages/agent/daemon/runtime/codexproto"
+)
+
+func (c *codexAppServerClient) PluginList(
+	ctx context.Context,
+	timeout time.Duration,
+	params map[string]any,
+) (json.RawMessage, error) {
+	typedParams, err := codexProtoParams[codexproto.PluginListParams](params)
+	if err != nil {
+		return nil, err
+	}
+	client, caller := c.typed(timeout, nil, true)
+	_, err = client.PluginList(ctx, typedParams)
+	if err != nil {
+		return nil, err
+	}
+	return caller.rawResult, nil
+}
+
+func (c *codexAppServerClient) SkillsList(
+	ctx context.Context,
+	timeout time.Duration,
+	params map[string]any,
+) (json.RawMessage, error) {
+	typedParams, err := codexProtoParams[codexproto.SkillsListParams](params)
+	if err != nil {
+		return nil, err
+	}
+	client, caller := c.typed(timeout, nil, true)
+	_, err = client.SkillsList(ctx, typedParams)
+	if err != nil {
+		return nil, err
+	}
+	return caller.rawResult, nil
+}

--- a/packages/agent/daemon/runtime/codex_appserver_resources.go
+++ b/packages/agent/daemon/runtime/codex_appserver_resources.go
@@ -1,0 +1,240 @@
+package agentruntime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+)
+
+const codexAppServerResourceQueryTimeout = 5 * time.Second
+const codexAppServerResourceProbeDelay = 100 * time.Millisecond
+
+// observeStartupResourcesAsync deliberately starts before thread/start or
+// thread/resume. The short scheduling delay lets the startup call acquire the
+// app-server client's serialized RPC lock first; a blocked startup call then
+// causes these bounded probes to time out without delaying provider startup.
+func (a *CodexAppServerAdapter) observeStartupResourcesAsync(
+	session Session,
+	client *codexAppServerClient,
+	trace *codexAppServerStartupTrace,
+) {
+	if a == nil || a.startupResourceObserver == nil || client == nil || trace == nil {
+		return
+	}
+	observer := a.startupResourceObserver
+	startedAt := trace.startedAt.UTC().Format(time.RFC3339Nano)
+	go func() {
+		timer := time.NewTimer(codexAppServerResourceProbeDelay)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+		case <-client.Done():
+		}
+		observation := collectCodexAppServerResourceObservation(
+			context.Background(),
+			session,
+			client,
+			startedAt,
+		)
+		trace.Log("startup.resource_snapshot", map[string]any{
+			"outcome":              observation.Outcome,
+			"duration_ms":          observation.DurationMS,
+			"mcp_server_count":     observation.MCPServerCount,
+			"plugin_count":         observation.PluginCount,
+			"skill_count":          observation.SkillCount,
+			"plugin_query_outcome": observation.PluginQueryOutcome,
+			"skill_query_outcome":  observation.SkillQueryOutcome,
+		})
+		notifyCodexAppServerResourceObserver(observer, observation)
+	}()
+}
+
+func collectCodexAppServerResourceObservation(
+	parent context.Context,
+	session Session,
+	client *codexAppServerClient,
+	startedAt string,
+) CodexAppServerResourceObservation {
+	started := time.Now()
+	observation := CodexAppServerResourceObservation{
+		Provider:           strings.TrimSpace(session.Provider),
+		RoomID:             strings.TrimSpace(session.RoomID),
+		AgentSessionID:     strings.TrimSpace(session.AgentSessionID),
+		StartedAt:          strings.TrimSpace(startedAt),
+		Outcome:            "failed",
+		MCPServerCount:     len(session.MCPServers),
+		PluginCount:        -1,
+		SkillCount:         -1,
+		PluginQueryOutcome: "not_started",
+		SkillQueryOutcome:  "not_started",
+	}
+	if client == nil {
+		observation.DurationMS = time.Since(started).Milliseconds()
+		return observation
+	}
+	ctx, cancel := context.WithTimeout(parent, codexAppServerResourceQueryTimeout)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	var pluginRaw, skillRaw json.RawMessage
+	var pluginErr, skillErr error
+	params := map[string]any{}
+	if cwd := strings.TrimSpace(session.CWD); cwd != "" {
+		params["cwds"] = []string{cwd}
+	}
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		pluginRaw, pluginErr = client.PluginList(ctx, codexAppServerResourceQueryTimeout, params)
+	}()
+	go func() {
+		defer wg.Done()
+		skillRaw, skillErr = client.SkillsList(ctx, codexAppServerResourceQueryTimeout, params)
+	}()
+	wg.Wait()
+
+	if pluginErr == nil {
+		if count, ok := countCodexAppServerPlugins(pluginRaw); ok {
+			observation.PluginCount = count
+			observation.PluginQueryOutcome = "succeeded"
+		} else {
+			observation.PluginQueryOutcome = "decode_failed"
+		}
+	} else {
+		observation.PluginQueryOutcome = codexAppServerResourceQueryOutcome(ctx, pluginErr)
+	}
+	if skillErr == nil {
+		if count, ok := countCodexAppServerSkills(skillRaw); ok {
+			observation.SkillCount = count
+			observation.SkillQueryOutcome = "succeeded"
+		} else {
+			observation.SkillQueryOutcome = "decode_failed"
+		}
+	} else {
+		observation.SkillQueryOutcome = codexAppServerResourceQueryOutcome(ctx, skillErr)
+	}
+	if observation.PluginQueryOutcome == "succeeded" && observation.SkillQueryOutcome == "succeeded" {
+		observation.Outcome = "succeeded"
+	} else if observation.PluginQueryOutcome == "succeeded" || observation.SkillQueryOutcome == "succeeded" {
+		observation.Outcome = "partial"
+	}
+	observation.DurationMS = time.Since(started).Milliseconds()
+	return observation
+}
+
+func codexAppServerResourceQueryOutcome(ctx context.Context, err error) string {
+	if err == nil {
+		return "succeeded"
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return "timeout"
+	}
+	return "failed"
+}
+
+func countCodexAppServerPlugins(raw json.RawMessage) (int, bool) {
+	var envelope map[string]json.RawMessage
+	if len(raw) == 0 || json.Unmarshal(raw, &envelope) != nil {
+		return 0, false
+	}
+	marketplacesRaw, ok := envelope["marketplaces"]
+	var marketplaces []json.RawMessage
+	if !ok || json.Unmarshal(marketplacesRaw, &marketplaces) != nil || marketplaces == nil {
+		return 0, false
+	}
+	var response struct {
+		Marketplaces []struct {
+			Name    string `json:"name"`
+			Plugins []struct {
+				ID        string `json:"id"`
+				Name      string `json:"name"`
+				Installed bool   `json:"installed"`
+				Enabled   bool   `json:"enabled"`
+			} `json:"plugins"`
+		} `json:"marketplaces"`
+	}
+	if json.Unmarshal(raw, &response) != nil {
+		return 0, false
+	}
+	seen := make(map[string]struct{})
+	for _, marketplace := range response.Marketplaces {
+		for _, plugin := range marketplace.Plugins {
+			if !plugin.Installed || !plugin.Enabled {
+				continue
+			}
+			key := strings.TrimSpace(plugin.ID)
+			if key == "" {
+				key = strings.TrimSpace(marketplace.Name) + "\x00" + strings.TrimSpace(plugin.Name)
+			}
+			if key != "\x00" {
+				seen[key] = struct{}{}
+			}
+		}
+	}
+	return len(seen), true
+}
+
+func countCodexAppServerSkills(raw json.RawMessage) (int, bool) {
+	var envelope map[string]json.RawMessage
+	if len(raw) == 0 || json.Unmarshal(raw, &envelope) != nil {
+		return 0, false
+	}
+	dataRaw, ok := envelope["data"]
+	var data []json.RawMessage
+	if !ok || json.Unmarshal(dataRaw, &data) != nil || data == nil {
+		return 0, false
+	}
+	var response struct {
+		Data []struct {
+			Skills []struct {
+				Name    string `json:"name"`
+				Path    string `json:"path"`
+				Enabled *bool  `json:"enabled"`
+			} `json:"skills"`
+		} `json:"data"`
+	}
+	if json.Unmarshal(raw, &response) != nil {
+		return 0, false
+	}
+	seen := make(map[string]struct{})
+	for _, group := range response.Data {
+		for _, skill := range group.Skills {
+			if skill.Enabled != nil && !*skill.Enabled {
+				continue
+			}
+			name := strings.TrimSpace(skill.Name)
+			path := strings.TrimSpace(skill.Path)
+			key := path
+			if key == "" {
+				key = name
+			}
+			if key != "" {
+				seen[key] = struct{}{}
+			}
+		}
+	}
+	return len(seen), true
+}
+
+func notifyCodexAppServerResourceObserver(
+	observer CodexAppServerResourceObserver,
+	observation CodexAppServerResourceObservation,
+) {
+	if observer == nil {
+		return
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			slog.Warn("agent session Codex app-server resource observer panicked",
+				"provider", observation.Provider,
+				"agent_session_id", observation.AgentSessionID,
+				"panic", recovered,
+			)
+		}
+	}()
+	observer(observation)
+}

--- a/packages/agent/daemon/runtime/codex_appserver_resources_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_resources_test.go
@@ -1,0 +1,83 @@
+package agentruntime
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestCountCodexAppServerPluginsCountsInstalledEnabledUniquePlugins(t *testing.T) {
+	count, ok := countCodexAppServerPlugins(json.RawMessage(`{
+		"marketplaces": [
+			{"name":"local","plugins":[
+				{"id":"one","name":"one","installed":true,"enabled":true},
+				{"id":"one","name":"one","installed":true,"enabled":true},
+				{"id":"two","name":"two","installed":true,"enabled":false},
+				{"id":"three","name":"three","installed":false,"enabled":true}
+			]}
+		]
+	}`))
+	if !ok || count != 1 {
+		t.Fatalf("plugin count = %d, parsed = %t, want 1/true", count, ok)
+	}
+}
+
+func TestCountCodexAppServerSkillsCountsEnabledUniqueSkills(t *testing.T) {
+	count, ok := countCodexAppServerSkills(json.RawMessage(`{
+		"data": [
+			{"skills":[
+				{"name":"one","path":"/one/SKILL.md","enabled":true},
+				{"name":"one","path":"/one/SKILL.md","enabled":true},
+				{"name":"two","path":"/two/SKILL.md","enabled":false},
+				{"name":"three","path":"/three/SKILL.md"}
+			]}
+		]
+	}`))
+	if !ok || count != 2 {
+		t.Fatalf("skill count = %d, parsed = %t, want 2/true", count, ok)
+	}
+}
+
+func TestCountCodexAppServerResourcesRejectsMalformedResponses(t *testing.T) {
+	if count, ok := countCodexAppServerPlugins(json.RawMessage(`not-json`)); ok || count != 0 {
+		t.Fatalf("plugin malformed response = %d/%t, want 0/false", count, ok)
+	}
+	if count, ok := countCodexAppServerSkills(json.RawMessage(`{"data":`)); ok || count != 0 {
+		t.Fatalf("skill malformed response = %d/%t, want 0/false", count, ok)
+	}
+}
+
+func TestCodexAppServerStartCollectsResourceSnapshotWithoutBlockingStartup(t *testing.T) {
+	transport := newScriptedAppServerTransport()
+	observations := make(chan CodexAppServerResourceObservation, 1)
+	adapter := NewCodexAppServerAdapterWithHostMetadataAndOptions(
+		transport,
+		LegacyHostMetadata(),
+		CodexAppServerAdapterOptions{
+			StartupResourceObserver: func(observation CodexAppServerResourceObservation) {
+				observations <- observation
+			},
+		},
+	)
+	session := testAppServerSession()
+	session.MCPServers = []MCPServerBinding{{Name: "mcp-one"}, {Name: "mcp-two"}}
+
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	select {
+	case observation := <-observations:
+		t.Fatalf("Start waited for resource probe: %#v", observation)
+	default:
+	}
+
+	select {
+	case observation := <-observations:
+		if observation.Outcome != "succeeded" || observation.MCPServerCount != 2 || observation.PluginCount != 1 || observation.SkillCount != 1 {
+			t.Fatalf("resource observation = %#v, want successful 2/1/1 snapshot", observation)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for resource snapshot")
+	}
+}

--- a/packages/agent/daemon/runtime/codex_appserver_scripted_session_rpc_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_scripted_session_rpc_test.go
@@ -294,6 +294,33 @@ func (s *fakeCodexAppServer) handleSessionRPC(message scriptedAppServerMessage) 
 				"thread": map[string]any{"id": "codex-thread-1"},
 			})
 		}
+	case appServerMethodPluginList:
+		s.sendJSON(map[string]any{
+			"id": message.ID,
+			"result": map[string]any{
+				"marketplaces": []any{map[string]any{
+					"name": "local",
+					"plugins": []any{
+						map[string]any{"id": "plugin-one", "name": "one", "installed": true, "enabled": true},
+						map[string]any{"id": "plugin-two", "name": "two", "installed": true, "enabled": false},
+					},
+				}},
+			},
+		})
+	case appServerMethodSkillsList:
+		s.sendJSON(map[string]any{
+			"id": message.ID,
+			"result": map[string]any{
+				"data": []any{map[string]any{
+					"cwd":    "/workspace/room-1",
+					"errors": []any{},
+					"skills": []any{
+						map[string]any{"name": "skill-one", "path": "/skills/one/SKILL.md", "enabled": true},
+						map[string]any{"name": "skill-two", "path": "/skills/two/SKILL.md", "enabled": false},
+					},
+				}},
+			},
+		})
 	case appServerMethodThreadFork:
 		if s.forkRPCError {
 			s.sendJSON(map[string]any{

--- a/packages/agent/daemon/runtime/codex_appserver_session.go
+++ b/packages/agent/daemon/runtime/codex_appserver_session.go
@@ -101,6 +101,7 @@ func (a *CodexAppServerAdapter) Start(ctx context.Context, session Session) (eve
 
 	threadParams := appServerThreadStartParams(session, a.sessionCWD(session))
 	trace.Log("thread.start.params", codexAppServerTraceThreadStartParams(session, threadParams, false))
+	a.observeStartupResourcesAsync(session, client, trace)
 	callbackSession := session
 	threadResult, err := trace.TypedCall(acpStartCallTimeout, appServerMethodThreadStart, func() (json.RawMessage, error) {
 		return client.ThreadStart(ctx, acpStartCallTimeout, threadParams,
@@ -318,6 +319,7 @@ func (a *CodexAppServerAdapter) Resume(ctx context.Context, session Session) (er
 	params := appServerThreadStartParams(session, a.sessionCWD(session))
 	params["threadId"] = strings.TrimSpace(session.ProviderSessionID)
 	trace.Log("thread.start.params", codexAppServerTraceThreadStartParams(session, params, true))
+	a.observeStartupResourcesAsync(session, client, trace)
 	// codex replays thread/tokenUsage/updated during thread/resume so the GUI
 	// can show context fill before a new turn runs. The resumed session is not
 	// stored yet, so applyTokenUsage cannot reach it; capture the replayed


### PR DESCRIPTION
## Summary
- Report MCP, Codex-native plugin, and skill counts for each app-server startup attempt.
- Emit bounded query status without blocking thread/start.
- Add the dependent TSH/DataFinder telemetry wiring in the TSH PR.

## Tests
- pnpm check:changed -- --push-ready

## Notes
- Remote DataFinder event registration and field association are handled in the dependent TSH PR.
- TSH must consume the published Tutti runtime package before its CI build can compile the new observer.