### PR TITLE
fix(agent): extend Codex thread start timeout

### DIFF
--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -1536,6 +1536,8 @@ inline data URL instead`. Claude or standard ACP may instead receive no
   `thread/resume` response. Distinguish this from a completely silent provider:
   without an authoritative lifecycle notification, process termination, or
   transport error, the call must still time out rather than manufacture success.
+  The Codex adapter allows 90 seconds for `thread/start`; `thread/resume` and
+  the `turn/start` acknowledgement retain their 30-second budgets.
 - Root cause:
   App-server notifications and the response for their triggering RPC have no
   safe application-order guarantee. Waiting only on the response leaves the

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_session_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_session_test.go
@@ -10,6 +10,18 @@ import (
 	"time"
 )
 
+func TestCodexAppServerStartupTimeoutsStayScoped(t *testing.T) {
+	if got, want := codexAppServerThreadStartTimeout, 90*time.Second; got != want {
+		t.Fatalf("thread/start timeout = %s, want %s", got, want)
+	}
+	if got, want := acpStartCallTimeout, 30*time.Second; got != want {
+		t.Fatalf("generic ACP timeout = %s, want %s", got, want)
+	}
+	if got, want := defaultCodexAppServerTurnStartAckTimeout, 30*time.Second; got != want {
+		t.Fatalf("turn/start ACK timeout = %s, want %s", got, want)
+	}
+}
+
 func TestCodexAppServerAdapterStartCreatesThread(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/codex_appserver_session.go
+++ b/packages/agent/daemon/runtime/codex_appserver_session.go
@@ -12,6 +12,10 @@ import (
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
 )
 
+// Codex may synchronously finish resource and thread initialization before
+// replying to thread/start; keep this budget separate from generic ACP calls.
+const codexAppServerThreadStartTimeout = 90 * time.Second
+
 func (a *CodexAppServerAdapter) Start(ctx context.Context, session Session) (events []activityshared.Event, err error) {
 	unlockLifecycle := a.lockSessionLifecycle(session.AgentSessionID)
 	defer unlockLifecycle()
@@ -103,8 +107,8 @@ func (a *CodexAppServerAdapter) Start(ctx context.Context, session Session) (eve
 	trace.Log("thread.start.params", codexAppServerTraceThreadStartParams(session, threadParams, false))
 	a.observeStartupResourcesAsync(session, client, trace)
 	callbackSession := session
-	threadResult, err := trace.TypedCall(acpStartCallTimeout, appServerMethodThreadStart, func() (json.RawMessage, error) {
-		return client.ThreadStart(ctx, acpStartCallTimeout, threadParams,
+	threadResult, err := trace.TypedCall(codexAppServerThreadStartTimeout, appServerMethodThreadStart, func() (json.RawMessage, error) {
+		return client.ThreadStart(ctx, codexAppServerThreadStartTimeout, threadParams,
 			func(ctx context.Context, message acpMessage) error {
 				trace.LogMessage(message.Method, len(message.ID) > 0, len(message.Params))
 				_, err := a.handleAppServerMessage(ctx, client, callbackSession, "", message, nil, nil, nil)


### PR DESCRIPTION
## Summary
- Increase Tutti Codex app-server `thread/start` timeout from 30s to 90s.
- Keep generic ACP, `thread/resume`, and `turn/start` acknowledgement budgets unchanged.
- Add scoped timeout regression coverage and troubleshooting documentation.

## Tests
- `go test ./packages/agent/daemon/runtime -count=1`
- `go test -race ./packages/agent/daemon/runtime -run TestCodexAppServer\(AdapterStartCreatesThread|StartupTimeoutsStayScoped\)$ -count=1`
- `git diff --check`

## Notes
- Local changed-aware pre-push was attempted. The remaining failure is in unrelated existing `services/tuttid` tests: `TestOpenCodeSlashCommandPolicyComesFromProviderDescriptor` and `TestAppRunnerRetriesFreshPortAfterBindFailure`.