### PR TITLE
test(agent-gui): cover input history acceptance criteria

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2489,7 +2489,14 @@ An existing-Session composer derives input history from that Session's
 canonical user-message projection and its turnless Goal-control audit entries;
 it does not persist a second history store. These sources are merged by their
 timeline timestamps so Goal commands participate in the same Up/Down sequence
-as ordinary prompts.
+as ordinary prompts. The retention boundary is the canonical Session
+projection currently loaded by the Engine: older entries are admitted only
+through the existing authoritative older-page read, and AgentGUI does not
+create an independent count-based or time-based history cache. Input history
+therefore survives an application restart only when the canonical Session
+messages survive and are loaded again; the UI-local cursor and unsent Composer
+draft do not survive restart. Home and new-Session composers have no input
+history.
 The host capability remains explicit so unsupported hosts can fail closed, but
 Tutti Desktop always supplies `sessionInputHistoryEnabled: true`; historical
 `lab.agentInputHistory` preference values do not hide or disable the feature.

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextKeyboard.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextKeyboard.spec.ts
@@ -21,21 +21,24 @@ describe("handleAgentRichTextKeyDownCapture input history", () => {
     expect(event.stopPropagation).toHaveBeenCalledOnce();
   });
 
-  it("leaves arrows in the middle of multiline input alone", () => {
-    const onHistoryNavigation = vi.fn(() => true);
-    const event = keyboardEvent("ArrowDown");
+  it.each(["ArrowUp", "ArrowDown"])(
+    "leaves %s in the middle of multiline input alone",
+    (key) => {
+      const onHistoryNavigation = vi.fn(() => true);
+      const event = keyboardEvent(key);
 
-    handleAgentRichTextKeyDownCapture(
-      event as unknown as ReactKeyboardEvent<HTMLDivElement>,
-      keyboardInput({
-        editor: editorAt({ from: 2, to: 2, documentSize: 5 }),
-        onHistoryNavigation
-      })
-    );
+      handleAgentRichTextKeyDownCapture(
+        event as unknown as ReactKeyboardEvent<HTMLDivElement>,
+        keyboardInput({
+          editor: editorAt({ from: 2, to: 2, documentSize: 5 }),
+          onHistoryNavigation
+        })
+      );
 
-    expect(onHistoryNavigation).not.toHaveBeenCalled();
-    expect(event.preventDefault).not.toHaveBeenCalled();
-  });
+      expect(onHistoryNavigation).not.toHaveBeenCalled();
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    }
+  );
 
   it("gives an open palette priority over input history", () => {
     const onHistoryNavigation = vi.fn(() => true);
@@ -54,6 +57,27 @@ describe("handleAgentRichTextKeyDownCapture input history", () => {
     expect(onHistoryNavigation).not.toHaveBeenCalled();
     expect(event.preventDefault).toHaveBeenCalledOnce();
   });
+
+  it.each(["ArrowUp", "ArrowDown"])(
+    "does not enter input history on %s while IME composition is active",
+    (key) => {
+      const onHistoryNavigation = vi.fn(() => true);
+      const event = keyboardEvent(key);
+      event.nativeEvent.isComposing = true;
+
+      handleAgentRichTextKeyDownCapture(
+        event as unknown as ReactKeyboardEvent<HTMLDivElement>,
+        keyboardInput({
+          editor: editorAt({ from: 1, to: 1, documentSize: 5 }),
+          onHistoryNavigation
+        })
+      );
+
+      expect(onHistoryNavigation).not.toHaveBeenCalled();
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(event.stopPropagation).not.toHaveBeenCalled();
+    }
+  );
 });
 
 function keyboardInput(input: {

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerInputHistory.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerInputHistory.spec.tsx
@@ -158,6 +158,104 @@ describe("useComposerInputHistory", () => {
       "session:session-1"
     );
   });
+
+  it("keeps an edited recalled draft and exits history navigation", () => {
+    const onDraftContentChange = vi.fn();
+    const entries = historyEntries("sent prompt");
+    const editedDraft = buildAgentComposerDraft({ prompt: "edited prompt" });
+    const draftByScopeKeyRef = {
+      current: { "session:session-1": emptyAgentComposerDraft() }
+    };
+    const { result, rerender } = renderHook(
+      ({ currentDraft }) => {
+        draftByScopeKeyRef.current["session:session-1"] = currentDraft;
+        return useComposerInputHistory({
+          agentSessionId: "session-1",
+          currentDraft,
+          draftByScopeKeyRef,
+          draftScopeKey: "session:session-1",
+          entries,
+          hasOlderPage: false,
+          isLoadingOlderPage: false,
+          onDraftContentChange,
+          runtime: null,
+          workspaceId: "workspace-1"
+        });
+      },
+      { initialProps: { currentDraft: emptyAgentComposerDraft() } }
+    );
+
+    act(() => {
+      expect(result.current.onHistoryNavigation("older")).toBe(true);
+    });
+    rerender({ currentDraft: editedDraft });
+
+    act(() => {
+      expect(result.current.onHistoryNavigation("older")).toBe(false);
+    });
+    expect(draftByScopeKeyRef.current["session:session-1"]).toBe(editedDraft);
+    expect(onDraftContentChange).toHaveBeenCalledOnce();
+    expect(onDraftContentChange).toHaveBeenCalledWith(
+      entries[0]!.draft,
+      "session:session-1"
+    );
+  });
+
+  it("isolates recalled text and navigation cursor between Session scopes", () => {
+    const onDraftContentChange = vi.fn();
+    const sessionOneEntries = historyEntries("session one old", "session one");
+    const sessionTwoEntries = historyEntries("session two old", "session two");
+    const draftByScopeKeyRef: {
+      current: Record<string, ReturnType<typeof emptyAgentComposerDraft>>;
+    } = {
+      current: {
+        "session:session-1": emptyAgentComposerDraft(),
+        "session:session-2": emptyAgentComposerDraft()
+      }
+    };
+    const { result, rerender } = renderHook(
+      ({ agentSessionId, draftScopeKey, entries }) =>
+        useComposerInputHistory({
+          agentSessionId,
+          currentDraft: draftByScopeKeyRef.current[draftScopeKey]!,
+          draftByScopeKeyRef,
+          draftScopeKey,
+          entries,
+          hasOlderPage: false,
+          isLoadingOlderPage: false,
+          onDraftContentChange,
+          runtime: null,
+          workspaceId: "workspace-1"
+        }),
+      {
+        initialProps: {
+          agentSessionId: "session-1",
+          draftScopeKey: "session:session-1",
+          entries: sessionOneEntries
+        }
+      }
+    );
+
+    act(() => {
+      expect(result.current.onHistoryNavigation("older")).toBe(true);
+    });
+    rerender({
+      agentSessionId: "session-2",
+      draftScopeKey: "session:session-2",
+      entries: sessionTwoEntries
+    });
+
+    expect(draftByScopeKeyRef.current["session:session-2"]).toEqual(
+      emptyAgentComposerDraft()
+    );
+    act(() => {
+      expect(result.current.onHistoryNavigation("older")).toBe(true);
+    });
+    expect(onDraftContentChange).toHaveBeenLastCalledWith(
+      sessionTwoEntries[1]!.draft,
+      "session:session-2"
+    );
+  });
 });
 
 function historyEntries(

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerSlashActions.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerSlashActions.spec.tsx
@@ -1,0 +1,120 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  agentComposerDraftPrompt,
+  buildAgentComposerDraft,
+  emptyAgentComposerDraft
+} from "../model/agentComposerDraft";
+import type { AgentComposerProps } from "./AgentComposer.types";
+import { useComposerSlashActions } from "./useComposerSlashActions";
+
+describe("useComposerSlashActions input history resend", () => {
+  it("submits the edited draft after a historical prompt was recalled", () => {
+    const onSubmit = vi.fn();
+    const draftPromptRef = { current: "old prompt" };
+    const originalDraft = buildAgentComposerDraft({ prompt: "old prompt" });
+    const editedDraft = buildAgentComposerDraft({
+      prompt: "edited prompt"
+    });
+    const commonInput = createInput({
+      draftPromptRef,
+      onSubmit
+    });
+    const { result, rerender } = renderHook(
+      ({ draftContent }) =>
+        useComposerSlashActions({
+          ...commonInput,
+          draftContent
+        }),
+      { initialProps: { draftContent: originalDraft } }
+    );
+
+    act(() => {
+      draftPromptRef.current = "edited prompt";
+      rerender({ draftContent: editedDraft });
+      result.current.submitCurrentPrompt();
+    });
+
+    expect(onSubmit).toHaveBeenCalledOnce();
+    const [content, displayPrompt, options] = onSubmit.mock.calls[0]!;
+    expect(content).toEqual([{ type: "text", text: "edited prompt" }]);
+    expect(displayPrompt).toBeUndefined();
+    const submittedDraft = options?.submittedDraft;
+    if (!submittedDraft) {
+      throw new Error("submit payload did not include the submitted draft");
+    }
+    expect(agentComposerDraftPrompt(submittedDraft)).toBe("edited prompt");
+  });
+});
+
+function createInput(input: {
+  draftPromptRef: { current: string };
+  onSubmit: AgentComposerProps["onSubmit"];
+}) {
+  return {
+    workspaceId: "workspace-1",
+    provider: "codex",
+    draftContent: emptyAgentComposerDraft(),
+    disabled: false,
+    submitDisabled: false,
+    canQueueWhileBusy: false,
+    isSendingTurn: false,
+    isSubmittingPrompt: false,
+    showStopButton: false,
+    promptImagesSupported: true,
+    availableSkills: [],
+    composerSettings: {
+      sessionSettings: null,
+      draftSettings: {
+        model: null,
+        reasoningEffort: null,
+        speed: null,
+        planMode: false
+      },
+      supportsModel: false,
+      supportsReasoningEffort: false,
+      supportsSpeed: false,
+      supportsPlanMode: false,
+      isSettingsLoading: false,
+      modelUnavailable: false,
+      reasoningUnavailable: false,
+      speedUnavailable: false,
+      slashCommandPolicy: null
+    } as AgentComposerProps["composerSettings"],
+    tuttiModeSupported: false,
+    capabilityControlsReadOnly: false,
+    onDraftContentChange: vi.fn(),
+    onSettingsChange: vi.fn(),
+    onSubmit: input.onSubmit,
+    onSubmitEmpty: vi.fn(),
+    onSubmitGuidance: vi.fn(),
+    onCapabilitySettingsRequest: vi.fn(),
+    onTuttiModeActivate: vi.fn(),
+    onSlashStatusOpen: vi.fn(),
+    onSlashStatusClose: vi.fn(),
+    onPromptImagesUnsupported: vi.fn(),
+    onRequestGitBranches: vi.fn(),
+    selectedProjectPath: "",
+    slashStatusAgentSessionId: null,
+    isSlashStatusPanelOpen: false,
+    slashCommandPolicy: null,
+    skillQueryMatch: null,
+    promptBeforeSelection: "",
+    resolvedSlashCommands: [],
+    slashPaletteEntries: [],
+    activeHighlight: 0,
+    showSlashPalette: false,
+    showCommandMenuPanel: false,
+    isSelectedProjectMissing: false,
+    editorHandleRef: { current: null },
+    draftPromptRef: input.draftPromptRef,
+    draftImagesRef: { current: [] },
+    draftFilesRef: { current: [] },
+    draftLargeTextsRef: { current: [] },
+    setPaletteDraftPrompt: vi.fn(),
+    setIsPaletteOpen: vi.fn(),
+    setIsReviewPickerOpen: vi.fn(),
+    setIsSlashStatusPanelOpen: vi.fn(),
+    setHighlightedIndex: vi.fn()
+  } as Parameters<typeof useComposerSlashActions>[0];
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerInputHistory.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerInputHistory.spec.ts
@@ -162,6 +162,29 @@ describe("agent composer input history", () => {
     expect(agentComposerDraftPrompt(history[0]!.draft)).toBe("resendable");
   });
 
+  it("rebuilds history from canonical messages for a reloaded conversation", () => {
+    const messages = [
+      { id: "first", body: "first prompt", occurredAtUnixMs: 100 },
+      { id: "second", body: "second prompt", occurredAtUnixMs: 200 }
+    ];
+    const beforeRestart = projectAgentComposerInputHistory(
+      conversationWithUserMessages(messages)
+    );
+    const afterRestart = projectAgentComposerInputHistory(
+      conversationWithUserMessages(messages)
+    );
+
+    expect(
+      afterRestart.map((entry) => agentComposerDraftPrompt(entry.draft))
+    ).toEqual(
+      beforeRestart.map((entry) => agentComposerDraftPrompt(entry.draft))
+    );
+    expect(afterRestart.map((entry) => entry.id)).toEqual([
+      "turn-1:first",
+      "turn-1:second"
+    ]);
+  });
+
   it("restores a file-only structured input with a resendable mention", () => {
     const displayPrompt = createAgentComposerFileMentionMarkdown({
       id: "original-file",

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerInputHistory.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerInputHistory.spec.ts
@@ -149,6 +149,19 @@ describe("agent composer input history", () => {
     expect(agentComposerDraftImages(history[0]!.draft)).toHaveLength(1);
   });
 
+  it("filters empty user messages out of input history", () => {
+    const history = projectAgentComposerInputHistory(
+      conversationWithUserMessages([
+        { id: "empty", body: "   ", sourceTimelineItems: [] },
+        { id: "text", body: "resendable" }
+      ])
+    );
+
+    expect(history).toHaveLength(1);
+    expect(history[0]!.id).toBe("turn-1:text");
+    expect(agentComposerDraftPrompt(history[0]!.draft)).toBe("resendable");
+  });
+
   it("restores a file-only structured input with a resendable mention", () => {
     const displayPrompt = createAgentComposerFileMentionMarkdown({
       id: "original-file",


### PR DESCRIPTION
## Summary

Closes #2320.

This PR adds focused regression coverage for shell-style AgentGUI composer input history navigation:

- Up/Down navigation, multiline caret behavior, palette priority, and IME composition
- Session-scoped history isolation and older-page loading
- Editing a recalled prompt and submitting the edited payload
- Rebuilding input history from canonical Session messages after reload
- Empty and structured attachment input handling
- Documentation of history retention and application-restart behavior

The production input-history flow already exists in the base branch; this change locks the Issue #2320 acceptance criteria with regression tests and documents the existing ownership and persistence boundary.

## Verification

- `corepack pnpm@10.11.0 --filter @tutti-os/agent-gui test` — 332 test files, 2998 tests passed
- `corepack pnpm@10.11.0 --filter @tutti-os/agent-gui typecheck` — passed
- `node tools/scripts/run-check-changed.mjs --base HEAD^ --push-ready` — 11/11 lanes passed
- `git diff --check` — passed
- Electron + `tuttid` development startup — verified separately; Codex provider reached `ready`

## Checklist

- [x] No Agent lifecycle semantics were changed; no Host conformance scenario is required.
- [x] The change is focused on one concern.
- [x] Documentation was updated for the retention and restart behavior.
- [x] README/CONTRIBUTING language variants were not applicable.
- [x] The lowest meaningful local checks were run.
- [x] Commits are signed off with DCO.
