### PR TITLE
fix(desktop): preserve conversation rail when opening tools (release/0818)

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
@@ -572,7 +572,7 @@ export function StandaloneAgentWindow({
   const isConversationRailCollapsed = conversationRailPresentation.isCollapsed;
   const minimumAgentGuiViewportWidthPx =
     resolveStandaloneAgentGUIViewportMinimumWidthPx({
-      conversationRailCollapsed: isConversationRailCollapsed,
+      conversationRailCollapsed: nodeState.conversationRailCollapsed === true,
       conversationRailWidthPx: nodeState.conversationRailWidthPx
     });
   const host = useMemo(


### PR DESCRIPTION
## 回合来源

Backport of #2545 to `release/0818`.

- 原始修复提交：`9ae973fa105bd6249b596d8a5e0f151260d8221e`
- 回合提交：`5c6bc43d4`

## 变更范围

仅恢复打开工具时使用会话自身折叠状态判断的逻辑，避免 Agent 模式打开时自动收起会话栏；保留 #2504 的其他 WebView 尺寸同步修复。

## 验证

- `git diff --check` 通过
- `StandaloneAgentWindow.tsx` Oxlint 通过
- 主 PR #2545 的 TypeScript、Windows Desktop CI 全部通过

未发现需要更新的持久化文档影响。