### PR TITLE
fix(connector-renderer): render access-selection icons without circular avatars

### DIFF
--- a/packages/connector/renderer/src/ui/access/ConnectorAccessSelectionPanel.spec.tsx
+++ b/packages/connector/renderer/src/ui/access/ConnectorAccessSelectionPanel.spec.tsx
@@ -99,6 +99,17 @@ describe("ConnectorAccessSelectionPanel", () => {
     expect(screen.getByRole("checkbox", { name: "Notion" })).toBeChecked();
   });
 
+  it("renders connector icons without a circular avatar surface", () => {
+    const { container } = render(
+      <ConnectorAccessSelectionPanel {...createProps()} />
+    );
+
+    const githubIcon = container.querySelector('img[src="/github.png"]');
+    expect(githubIcon).toHaveClass("object-contain");
+    expect(githubIcon).not.toHaveClass("rounded-full");
+    expect(container.querySelector('[data-slot="avatar"]')).toBeNull();
+  });
+
   it("emits the complete controlled selection without imposing host ordering", () => {
     const onSelectionChange = vi.fn();
     const props = createProps({ onSelectionChange });

--- a/packages/connector/renderer/src/ui/access/ConnectorAccessSelectionPanel.tsx
+++ b/packages/connector/renderer/src/ui/access/ConnectorAccessSelectionPanel.tsx
@@ -1,7 +1,6 @@
-import type { JSX } from "react";
+import { useState, type JSX } from "react";
 import {
   ArrowLeftIcon,
-  Avatar,
   Button,
   Checkbox,
   Spinner,
@@ -45,6 +44,38 @@ export interface ConnectorAccessSelectionPanelProps {
   onSubmit(): void;
   selectedConnectorKeys: readonly string[];
   state: ConnectorAccessSelectionState;
+}
+
+function ConnectorAccessIcon({
+  iconUrl,
+  name
+}: {
+  iconUrl?: string;
+  name: string;
+}): JSX.Element {
+  const normalizedIconUrl = iconUrl?.trim() ?? "";
+  const [failedIconUrl, setFailedIconUrl] = useState<string | null>(null);
+
+  if (normalizedIconUrl && failedIconUrl !== normalizedIconUrl) {
+    return (
+      <img
+        alt=""
+        aria-hidden="true"
+        className="size-5 shrink-0 object-contain"
+        src={normalizedIconUrl}
+        onError={() => setFailedIconUrl(normalizedIconUrl)}
+      />
+    );
+  }
+
+  return (
+    <span
+      aria-hidden="true"
+      className="flex size-5 shrink-0 items-center justify-center text-[11px] font-medium text-[var(--text-secondary)]"
+    >
+      {name.trim().charAt(0).toLocaleUpperCase() || "?"}
+    </span>
+  );
 }
 
 /**
@@ -141,12 +172,9 @@ export function ConnectorAccessSelectionPanel({
                   )}
                   key={item.connectorKey}
                 >
-                  <Avatar
-                    aria-hidden="true"
-                    className="text-[10px]"
-                    label={item.name}
-                    size={28}
-                    src={item.iconUrl}
+                  <ConnectorAccessIcon
+                    iconUrl={item.iconUrl}
+                    name={item.name}
                   />
                   <span className="min-w-0 flex-1">
                     <span className="block truncate text-[13px] font-medium text-[var(--text-primary)]">


### PR DESCRIPTION
## Summary

- Shared-Agent connector access selection rendered brand icons inside `Avatar`, which always uses a circular surface and background. That disk showed behind Google Docs/Sheets/Notion marks.
- Render the connector icon (or a letter fallback) directly with `object-contain`, matching the composer connector icon treatment.

## Verification

- `pnpm check:changed` (10 lanes, including `@tutti-os/connector-renderer` typecheck/test and connector/UI/i18n boundaries)
- Visual: TSH Desktop linked to this checkout; share-connector list no longer shows circular icon backgrounds

## Checklist

- [x] I kept the change focused on one concern.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.


Made with [Cursor](https://cursor.com)