### PR TITLE
fix(agent): route child live events by session scope

### DIFF
--- a/docs/conventions/troubleshooting/agent-approvals-subagents.md
+++ b/docs/conventions/troubleshooting/agent-approvals-subagents.md
@@ -162,13 +162,21 @@ session-level child summaries.
 - Check: correlate app-server `threadId` with the root
   `provider_session_id` and the child session's provider thread handle.
 - Cause: notifications sharing one connection were normalized against the root
-  session instead of their registered child thread.
+  session instead of their registered child thread. The live publication
+  boundary can also receive root and child Activity Events in one callback; if
+  that mixed batch is projected under the root scope, the business-event bridge
+  rejects every child delta and emits a reconcile request for every delta.
 - Fix: unknown foreign threads never mutate the root. A registered child thread
   emits events owned by its child session/turn and carries immutable root and
-  parent relations. AgentGUI keeps child rows out of the root transcript and
-  attaches them under `parentToolCallId`.
+  parent relations. The Controller groups live projections by canonical
+  `AgentSessionID` before publication, and AgentGUI keeps child rows out of the
+  root transcript and attaches them under `parentToolCallId`. The business-event
+  bridge coalesces concurrent/recent reconcile requests per workspace/session
+  while retaining bounded retries.
 - Validate: inject root, known-child, and unknown-thread notifications in one
-  run; assert three distinct routing outcomes.
+  run; assert three distinct routing outcomes. Then replay one root plus at
+  least three children with high-frequency deltas and assert each scope matches
+  its payload and one reconcile request is emitted per throttle window.
 
 ### Codex subagents ran but AgentGUI shows no child lanes
 

--- a/packages/agent/daemon/runtime/controller_activity_publish.go
+++ b/packages/agent/daemon/runtime/controller_activity_publish.go
@@ -1,0 +1,39 @@
+package agentruntime
+
+import (
+	"log/slog"
+	"strings"
+
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+)
+
+func (c *Controller) publish(session Session, events []activityshared.Event) {
+	if len(events) == 0 {
+		return
+	}
+	projectedBatches := projectActivityEventsByOwner(session, events)
+	projected := make([]StreamEvent, 0)
+	for _, batch := range projectedBatches {
+		projected = append(projected, batch.events...)
+	}
+	slog.Debug(
+		"agent session publish events",
+		"event", "agent_session.publish",
+		"room_id", session.RoomID,
+		"agent_session_id", session.AgentSessionID,
+		"provider", session.Provider,
+		"provider_session_id", session.ProviderSessionID,
+		"activity_event_count", len(events),
+		"projected_event_count", len(projected),
+		"projected_event_type_counts", streamEventTypeCounts(projected),
+	)
+	for _, batch := range projectedBatches {
+		// Runtime snapshots belong to the Controller's registered root session.
+		// Child sessions are provider-created projections and must not inherit
+		// root-only state while their event stream is being routed.
+		if batch.session.AgentSessionID == strings.TrimSpace(session.AgentSessionID) {
+			c.enrichStreamStateEventsWithSessionSnapshot(batch.session, batch.events)
+		}
+		c.publishStreamEvents(batch.session.RoomID, batch.session.AgentSessionID, batch.events)
+	}
+}

--- a/packages/agent/daemon/runtime/controller_session_registry.go
+++ b/packages/agent/daemon/runtime/controller_session_registry.go
@@ -519,26 +519,6 @@ func (c *Controller) publishConfigOptionsUpdates(
 	c.enqueueSessionSnapshotReport(context.Background(), session)
 }
 
-func (c *Controller) publish(session Session, events []activityshared.Event) {
-	if len(events) == 0 {
-		return
-	}
-	projected := ProjectActivityEventsToStreamEvents(session, events)
-	c.enrichStreamStateEventsWithSessionSnapshot(session, projected)
-	slog.Debug(
-		"agent session publish events",
-		"event", "agent_session.publish",
-		"room_id", session.RoomID,
-		"agent_session_id", session.AgentSessionID,
-		"provider", session.Provider,
-		"provider_session_id", session.ProviderSessionID,
-		"activity_event_count", len(events),
-		"projected_event_count", len(projected),
-		"projected_event_type_counts", streamEventTypeCounts(projected),
-	)
-	c.publishStreamEvents(session.RoomID, session.AgentSessionID, projected)
-}
-
 func streamEventTypeCounts(events []StreamEvent) []string {
 	if len(events) == 0 {
 		return nil

--- a/packages/agent/daemon/runtime/controller_stream_observer.go
+++ b/packages/agent/daemon/runtime/controller_stream_observer.go
@@ -4,7 +4,76 @@ import (
 	"context"
 	"log/slog"
 	"strings"
+
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
+
+type projectedActivityEventBatch struct {
+	session Session
+	events  []StreamEvent
+}
+
+type activityEventOwnerGroup struct {
+	agentSessionID    string
+	providerSessionID string
+	events            []activityshared.Event
+}
+
+// projectActivityEventsByOwner preserves the provider event's canonical
+// session owner through the live publication boundary. A root Controller turn
+// can receive root and child Activity Events in the same callback, but each
+// public stream must be scoped to the session that owns its payload.
+func projectActivityEventsByOwner(
+	session Session,
+	events []activityshared.Event,
+) []projectedActivityEventBatch {
+	if len(events) == 0 {
+		return nil
+	}
+	defaultAgentSessionID := strings.TrimSpace(session.AgentSessionID)
+	groups := make([]activityEventOwnerGroup, 0, 1)
+	groupIndexBySessionID := make(map[string]int, 1)
+	for _, event := range events {
+		agentSessionID := strings.TrimSpace(event.AgentSessionID)
+		if agentSessionID == "" {
+			agentSessionID = defaultAgentSessionID
+		}
+		if agentSessionID == "" {
+			continue
+		}
+		providerSessionID := strings.TrimSpace(event.ProviderSessionID)
+		groupKey := agentSessionID + "\x00" + providerSessionID
+		groupIndex, ok := groupIndexBySessionID[groupKey]
+		if !ok {
+			groupIndex = len(groups)
+			groupIndexBySessionID[groupKey] = groupIndex
+			groups = append(groups, activityEventOwnerGroup{
+				agentSessionID:    agentSessionID,
+				providerSessionID: providerSessionID,
+			})
+		}
+		event.AgentSessionID = agentSessionID
+		groups[groupIndex].events = append(groups[groupIndex].events, event)
+	}
+
+	projected := make([]projectedActivityEventBatch, 0, len(groups))
+	for _, group := range groups {
+		projectionSession := session
+		projectionSession.AgentSessionID = group.agentSessionID
+		if group.providerSessionID != "" {
+			projectionSession.ProviderSessionID = group.providerSessionID
+		}
+		streamEvents := ProjectActivityEventsToStreamEvents(projectionSession, group.events)
+		if len(streamEvents) == 0 {
+			continue
+		}
+		projected = append(projected, projectedActivityEventBatch{
+			session: projectionSession,
+			events:  streamEvents,
+		})
+	}
+	return projected
+}
 
 // SetStreamEventObserver binds the daemon-local business-event projection.
 // The observer is intentionally singular: one Controller has one ordered
@@ -58,6 +127,9 @@ func (c *Controller) publishStreamEvents(
 		if filter, ok := observer.(RuntimeStreamEventFilter); ok {
 			publishedEvents = filter.FilterRuntimeStreamEvents(roomID, agentSessionID, events)
 		}
+		// The filter only protects local EventHub subscribers. The observer sees
+		// the original batch so the business-event bridge can reject malformed
+		// identities and publish a bounded reconcile hint.
 		if err := observer.ObserveRuntimeStreamEvents(
 			context.Background(),
 			roomID,

--- a/packages/agent/daemon/runtime/controller_stream_observer_test.go
+++ b/packages/agent/daemon/runtime/controller_stream_observer_test.go
@@ -3,14 +3,24 @@ package agentruntime
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
+
+	"github.com/tutti-os/tutti/packages/agent/daemon/liveprotocol"
 )
 
 type recordingRuntimeStreamObserver struct {
-	called bool
-	events []StreamEvent
-	err    error
+	called       bool
+	events       []StreamEvent
+	observations []recordedRuntimeStreamObservation
+	err          error
+}
+
+type recordedRuntimeStreamObservation struct {
+	roomID         string
+	agentSessionID string
+	events         []StreamEvent
 }
 
 type recordingSideStreamCleanupObserver struct {
@@ -42,12 +52,17 @@ func (*filteringRuntimeStreamObserver) FilterRuntimeStreamEvents(
 
 func (o *recordingRuntimeStreamObserver) ObserveRuntimeStreamEvents(
 	_ context.Context,
-	_ string,
-	_ string,
+	roomID string,
+	agentSessionID string,
 	events []StreamEvent,
 ) error {
 	o.called = true
 	o.events = append(o.events, events...)
+	o.observations = append(o.observations, recordedRuntimeStreamObservation{
+		roomID:         roomID,
+		agentSessionID: agentSessionID,
+		events:         append([]StreamEvent(nil), events...),
+	})
 	return o.err
 }
 
@@ -146,5 +161,99 @@ func TestPublishStreamEventsUsesObserverFilterForLocalFanout(t *testing.T) {
 	}
 	if !observer.called || len(observer.events) != 2 {
 		t.Fatalf("observer events = %#v, want both events", observer.events)
+	}
+}
+
+func TestPublishRoutesHighFrequencyRootAndChildDeltasByEventOwner(t *testing.T) {
+	controller := NewController(nil, nil)
+	observer := &recordingRuntimeStreamObserver{}
+	controller.SetStreamEventObserver(observer)
+
+	root := Session{
+		RoomID:            "workspace-1",
+		AgentSessionID:    "root-session",
+		Provider:          ProviderCodex,
+		ProviderSessionID: "root-thread",
+	}
+	childSessions := []Session{
+		{RoomID: root.RoomID, AgentSessionID: "child-session-1", Provider: root.Provider, ProviderSessionID: "child-thread-1"},
+		{RoomID: root.RoomID, AgentSessionID: "child-session-2", Provider: root.Provider, ProviderSessionID: "child-thread-2"},
+		{RoomID: root.RoomID, AgentSessionID: "child-session-3", Provider: root.Provider, ProviderSessionID: "child-thread-3"},
+	}
+	events := newACPTurnNormalizer().AppendAssistantChunk(root, "root-turn", "root")
+	for _, child := range childSessions {
+		normalizer := newACPTurnNormalizer()
+		for index := 0; index < 32; index++ {
+			events = append(events, normalizer.AppendAssistantChunk(child, "child-turn", fmt.Sprintf("child output %d", index))...)
+		}
+	}
+
+	controller.publish(root, events)
+
+	if len(observer.observations) != 4 {
+		t.Fatalf("stream observations = %#v, want root plus three child scopes", observer.observations)
+	}
+	for index, observation := range observer.observations {
+		wantSessionID := root.AgentSessionID
+		wantCount := 1
+		if index > 0 {
+			wantSessionID = childSessions[index-1].AgentSessionID
+			wantCount = 32
+		}
+		if observation.roomID != root.RoomID || observation.agentSessionID != wantSessionID {
+			t.Fatalf("observation[%d] = %#v, want scope %s/%s", index, observation, root.RoomID, wantSessionID)
+		}
+		if len(observation.events) != wantCount {
+			t.Fatalf("observation[%d] event count = %d, want %d", index, len(observation.events), wantCount)
+		}
+		for _, streamEvent := range observation.events {
+			data, ok := streamEvent.Data.(liveprotocol.Event)
+			if !ok {
+				t.Fatalf("observation[%d] data type = %T, want liveprotocol.Event", index, streamEvent.Data)
+			}
+			if data.AgentSessionID != wantSessionID {
+				t.Fatalf("observation[%d] event scope = %q, want %q", index, data.AgentSessionID, wantSessionID)
+			}
+		}
+	}
+}
+
+func TestProjectActivityEventsByOwnerSeparatesProviderSessionChanges(t *testing.T) {
+	root := Session{
+		RoomID:            "workspace-1",
+		AgentSessionID:    "root-session",
+		Provider:          ProviderCodex,
+		ProviderSessionID: "root-thread",
+	}
+	child := Session{
+		RoomID:            root.RoomID,
+		AgentSessionID:    "child-session",
+		Provider:          root.Provider,
+		ProviderSessionID: "child-thread-a",
+	}
+	normalizer := newACPTurnNormalizer()
+	first := normalizer.AppendAssistantChunk(child, "child-turn", "first")
+	second := normalizer.AppendAssistantChunk(child, "child-turn", "second")
+	for index := range first {
+		first[index].ProviderSessionID = "child-thread-a"
+	}
+	for index := range second {
+		second[index].ProviderSessionID = "child-thread-b"
+	}
+
+	batches := projectActivityEventsByOwner(root, append(first, second...))
+	if len(batches) != 2 {
+		t.Fatalf("projected batches = %#v, want one batch per provider session", batches)
+	}
+	for index, providerSessionID := range []string{"child-thread-a", "child-thread-b"} {
+		if batches[index].session.AgentSessionID != child.AgentSessionID {
+			t.Fatalf("batch[%d] agent session = %q, want %q", index, batches[index].session.AgentSessionID, child.AgentSessionID)
+		}
+		if batches[index].session.ProviderSessionID != providerSessionID {
+			t.Fatalf("batch[%d] provider session = %q, want %q", index, batches[index].session.ProviderSessionID, providerSessionID)
+		}
+		if len(batches[index].events) != 1 {
+			t.Fatalf("batch[%d] events = %#v, want one event", index, batches[index].events)
+		}
 	}
 }

--- a/packages/agent/daemon/runtime/controller_turn_lifecycle_test.go
+++ b/packages/agent/daemon/runtime/controller_turn_lifecycle_test.go
@@ -111,6 +111,13 @@ func TestControllerSessionEventSinkCommitsChildTerminalBeforePublish(t *testing.
 		Status:         SessionStatusReady,
 	}
 	controller.store(session)
+	childSession := Session{
+		RoomID:         session.RoomID,
+		AgentSessionID: "child-session-1",
+		Provider:       session.Provider,
+		Status:         SessionStatusReady,
+	}
+	controller.store(childSession)
 	stream, unsubscribe, ok := controller.Subscribe(session.RoomID, session.AgentSessionID)
 	if !ok {
 		t.Fatal("Subscribe returned ok=false")
@@ -120,6 +127,16 @@ func TestControllerSessionEventSinkCommitsChildTerminalBeforePublish(t *testing.
 	case <-stream:
 	case <-time.After(2 * time.Second):
 		t.Fatal("initial session snapshot was not published")
+	}
+	childStream, childUnsubscribe, ok := controller.Subscribe(childSession.RoomID, childSession.AgentSessionID)
+	if !ok {
+		t.Fatal("child Subscribe returned ok=false")
+	}
+	defer childUnsubscribe()
+	select {
+	case <-childStream:
+	case <-time.After(2 * time.Second):
+		t.Fatal("initial child session snapshot was not published")
 	}
 
 	done := make(chan struct{})
@@ -143,7 +160,8 @@ func TestControllerSessionEventSinkCommitsChildTerminalBeforePublish(t *testing.
 	expectNoStreamEventType(t, stream, StreamEventStatePatch)
 
 	reporter.release <- nil
-	waitForPublishedSessionEvent(t, stream, EventTurnCompleted, "", "")
+	waitForPublishedSessionEvent(t, childStream, EventTurnCompleted, "", "")
+	expectNoStreamEventType(t, stream, StreamEventStatePatch)
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):

--- a/services/tuttid/agent_runtime_activity_event_bridge.go
+++ b/services/tuttid/agent_runtime_activity_event_bridge.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/tutti-os/tutti/packages/agent/daemon/liveprotocol"
@@ -16,11 +17,24 @@ import (
 // stream into the public business-event WebSocket. Durable canonical updates
 // continue to come from ActivityProjection after commit.
 type agentRuntimeActivityEventBridge struct {
-	publisher eventstreamservice.AgentActivityPublisher
+	publisher              eventstreamservice.AgentActivityPublisher
+	reconcileMu            sync.Mutex
+	reconcileLastByKey     map[string]time.Time
+	reconcileInFlightByKey map[string]struct{}
 }
 
+const (
+	// A malformed or cross-scoped live event is a hint to refresh canonical
+	// state, not a reason to enqueue one refresh per delta. Keep a short retry
+	// window so a persistent protocol error still gets periodic recovery while
+	// a burst is collapsed to one notification.
+	agentRuntimeReconcileThrottle  = 250 * time.Millisecond
+	agentRuntimeReconcileRetention = 5 * time.Minute
+	agentRuntimeReconcileStateCap  = 1024
+)
+
 //nolint:revive // RuntimeStreamEventFilter requires a bridge method; filtering is stateless.
-func (b agentRuntimeActivityEventBridge) FilterRuntimeStreamEvents(
+func (b *agentRuntimeActivityEventBridge) FilterRuntimeStreamEvents(
 	workspaceID string,
 	agentSessionID string,
 	events []agentruntime.StreamEvent,
@@ -44,12 +58,19 @@ func (b agentRuntimeActivityEventBridge) FilterRuntimeStreamEvents(
 	return filtered
 }
 
-func (b agentRuntimeActivityEventBridge) publishSessionReconcileRequired(
+func (b *agentRuntimeActivityEventBridge) publishSessionReconcileRequired(
 	ctx context.Context,
 	workspaceID string,
 	agentSessionID string,
 ) error {
-	return b.publisher.PublishAgentActivityUpdated(
+	workspaceID = strings.TrimSpace(workspaceID)
+	agentSessionID = strings.TrimSpace(agentSessionID)
+	key := workspaceID + "\x00" + agentSessionID
+	claimedAt := time.Now()
+	if !b.claimSessionReconcile(key, claimedAt) {
+		return nil
+	}
+	err := b.publisher.PublishAgentActivityUpdated(
 		ctx,
 		workspaceID,
 		agentSessionID,
@@ -58,9 +79,11 @@ func (b agentRuntimeActivityEventBridge) publishSessionReconcileRequired(
 			"lastEventUnixMs": time.Now().UnixMilli(),
 		},
 	)
+	b.finishSessionReconcile(key, claimedAt, err)
+	return err
 }
 
-func (b agentRuntimeActivityEventBridge) ObserveRuntimeStreamEvents(
+func (b *agentRuntimeActivityEventBridge) ObserveRuntimeStreamEvents(
 	ctx context.Context,
 	workspaceID string,
 	agentSessionID string,
@@ -113,6 +136,62 @@ func (b agentRuntimeActivityEventBridge) ObserveRuntimeStreamEvents(
 		}
 	}
 	return errors.Join(publishErrors...)
+}
+
+func (b *agentRuntimeActivityEventBridge) claimSessionReconcile(key string, now time.Time) bool {
+	if b == nil || key == "\x00" {
+		return false
+	}
+	b.reconcileMu.Lock()
+	defer b.reconcileMu.Unlock()
+	if b.reconcileLastByKey == nil {
+		b.reconcileLastByKey = make(map[string]time.Time)
+	}
+	if b.reconcileInFlightByKey == nil {
+		b.reconcileInFlightByKey = make(map[string]struct{})
+	}
+	for staleKey, last := range b.reconcileLastByKey {
+		if _, inFlight := b.reconcileInFlightByKey[staleKey]; !inFlight && now.Sub(last) >= agentRuntimeReconcileRetention {
+			delete(b.reconcileLastByKey, staleKey)
+		}
+	}
+	if _, inFlight := b.reconcileInFlightByKey[key]; inFlight {
+		return false
+	}
+	if last, ok := b.reconcileLastByKey[key]; ok && now.Sub(last) < agentRuntimeReconcileThrottle {
+		return false
+	}
+	if len(b.reconcileLastByKey) >= agentRuntimeReconcileStateCap {
+		var oldestKey string
+		var oldest time.Time
+		for candidateKey, last := range b.reconcileLastByKey {
+			if oldestKey == "" || last.Before(oldest) {
+				oldestKey = candidateKey
+				oldest = last
+			}
+		}
+		if oldestKey != "" {
+			delete(b.reconcileLastByKey, oldestKey)
+		}
+	}
+	b.reconcileInFlightByKey[key] = struct{}{}
+	return true
+}
+
+func (b *agentRuntimeActivityEventBridge) finishSessionReconcile(key string, claimedAt time.Time, _ error) {
+	if b == nil {
+		return
+	}
+	b.reconcileMu.Lock()
+	defer b.reconcileMu.Unlock()
+	delete(b.reconcileInFlightByKey, key)
+	if b.reconcileLastByKey == nil {
+		b.reconcileLastByKey = make(map[string]time.Time)
+	}
+	// Throttle failed attempts too. A broken publisher must not turn a
+	// persistent scope mismatch into one retry per incoming delta; the next
+	// event after the short window can still retry the recovery signal.
+	b.reconcileLastByKey[key] = claimedAt
 }
 
 func runtimeMessageDeltaMatchesScope(

--- a/services/tuttid/agent_runtime_activity_event_bridge_test.go
+++ b/services/tuttid/agent_runtime_activity_event_bridge_test.go
@@ -186,4 +186,22 @@ func TestAgentRuntimeActivityEventBridgeReconcilesMismatchedMessageDelta(t *test
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for session_reconcile_required")
 	}
+	for index := 0; index < 64; index++ {
+		if err := bridge.ObserveRuntimeStreamEvents(
+			context.Background(),
+			"workspace-1",
+			"session-1",
+			[]agentruntime.StreamEvent{{
+				EventType: agentruntime.StreamEventMessageDelta,
+				Data:      delta,
+			}},
+		); err == nil {
+			t.Fatal("ObserveRuntimeStreamEvents() error = nil for repeated mismatched delta")
+		}
+	}
+	select {
+	case extra := <-events.Events(session):
+		t.Fatalf("repeated mismatches published an extra event: %#v", extra)
+	case <-time.After(100 * time.Millisecond):
+	}
 }

--- a/services/tuttid/agent_runtime_side_event_bridge.go
+++ b/services/tuttid/agent_runtime_side_event_bridge.go
@@ -27,7 +27,7 @@ func configureAgentRuntimeEventObservers(
 	controller *agentruntime.Controller,
 	events *eventstreamservice.Service,
 ) {
-	controller.SetStreamEventObserver(agentRuntimeActivityEventBridge{
+	controller.SetStreamEventObserver(&agentRuntimeActivityEventBridge{
 		publisher: eventstreamservice.AgentActivityPublisher{Service: events},
 	})
 	controller.SetSideStreamEventObserver(&agentRuntimeSideEventBridge{


### PR DESCRIPTION
## 背景
长时间运行时，root 与 child 的高频 Activity Events 被按 root scope 投影并发布。业务事件桥接层因此把每个 child delta 视为 session identity mismatch，持续触发 reconcile，造成事件风暴、WebSocket 队列堆积，并最终表现为 Tutti/Renderer 卡死或 crash。

## 变更
- Controller 按 canonical `AgentSessionID + ProviderSessionID` 分组并在对应 session scope 发布 live events；root snapshot enrichment 仅作用于 root。
- 保留 observer 对原始 batch 的校验语义，同时明确 local EventHub 使用过滤后的事件。
- bridge 对 `session_reconcile_required` 增加 per workspace/session 的 single-flight、250ms throttle、5 分钟 retention 和 1024 条上限，并对失败尝试也限流。
- 补充 root/child 高频 delta、provider session 切换、child terminal durable barrier 和 bridge reconcile 回归测试及排障文档。

## 验证
- `go test -mod=readonly ./runtime -run 'TestPublishRoutesHighFrequencyRootAndChildDeltasByEventOwner|TestProjectActivityEventsByOwnerSeparatesProviderSessionChanges' -count=1 -v` ✅
- `go test ./runtime -run 'TestControllerSessionEventSink(CommitsChildTerminalBeforePublish|WithholdsChildTerminalWhenCommitFails)' -count=1 -v` ✅
- `go test . -run TestAgentRuntimeActivityEventBridge -count=1 -v`（`services/tuttid`）✅
- touched Go files 的 `golangci-lint --fast-only` ✅ 0 issues
- `pnpm check:changed -- --dry-run` ✅；正式 `pnpm check:changed` 在 Windows 环境运行约 5 分钟无输出后超时，未产生新的失败诊断。

## 限制与风险
- 完整 Go package 检查仍会命中现有 Windows/sidecar/Claude appserver 环境失败；`-race` 受当前 `CGO_ENABLED=0` 且无 C 编译器限制，未能执行。
- Renderer backpressure/orphan-process 变更保持在独立分支，不包含在本 PR。
- provider thread 发生变化时会拆分为多个 observer batch；reconcile 仍是有界、最终一致的提示机制。