### PR TITLE
fix(agent-gui): show shared caller error codes

### DIFF
--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.visibleError.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.visibleError.spec.tsx
@@ -358,6 +358,7 @@ describe("AgentVisibleErrorMessage", () => {
     expect(
       getByText("Codex needs authentication or configuration")
     ).toBeTruthy();
+    expect(getByText("auth_required")).toBeTruthy();
     expect(
       getByText("Contact the person who shared this Agent, then try again.")
     ).toBeTruthy();
@@ -404,6 +405,28 @@ describe("AgentVisibleErrorMessage", () => {
     expect(queryByText("Recharge credits to continue")).toBeNull();
     expect(queryByText("Recharge credits")).toBeNull();
     expect(onLinkAction).not.toHaveBeenCalled();
+  });
+
+  it("shows the stable shared-caller code when provider detail is absent or unknown", () => {
+    const { getByText, queryByText } = renderBlock(
+      buildRow({
+        code: "future_owner_failure",
+        phase: "provider_start",
+        provider: "codex",
+        detail: null,
+        detailAvailable: false,
+        retryable: null
+      }),
+      "codex",
+      undefined,
+      undefined,
+      "shared_caller"
+    );
+
+    expect(getByText("future_owner_failure")).toBeTruthy();
+    expect(queryByText("invocation-1")).toBeNull();
+    expect(queryByText("correlation-1")).toBeNull();
+    expect(queryByText("owner-device-1")).toBeNull();
   });
 
   it("preserves neutral transient copy while suppressing local setup actions", () => {

--- a/packages/agent/gui/shared/agentConversation/components/AgentVisibleErrorMessage.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentVisibleErrorMessage.tsx
@@ -109,6 +109,11 @@ export function AgentVisibleErrorMessage({
           <div className="font-medium text-[var(--text-primary)]">
             {headline}
           </div>
+          {scope === "shared_caller" && error?.code ? (
+            <code className="mt-1 block break-all font-mono text-[10px] leading-4 text-[var(--text-secondary)]">
+              {error.code}
+            </code>
+          ) : null}
           {hint ? (
             <div className="mt-1 text-[11px] text-[var(--text-secondary)]">
               {hint}


### PR DESCRIPTION
## Summary
- show the stable error code in the existing shared-caller AgentGUI error card
- keep local setup actions, retry CTAs, and invocation/correlation/owner identifiers hidden
- cover known and forward-compatible unknown error codes

## Tests
- `pnpm --dir packages/agent/gui test -- shared/agentConversation/components/AgentMessageBlock.visibleError.spec.tsx`
- `pnpm --dir packages/agent/gui typecheck`
- AgentGUI degradation and staged UI boundary checks

## Notes
- Downstream TSH desktop PR: https://github.com/tutti-lab/tsh/pull/2884
- Companion server PR: https://github.com/tutti-lab/tsh-server/pull/862
- Presentation-only change; it does not alter Agent lifecycle ownership or runtime data flow.
- Windows impact: none; the change is platform-neutral React presentation.
- A follow-up Tutti release and full TSH dependency-cohort upgrade are required before the label ships in TSH Desktop.
