### PR TITLE
fix(agent): classify provider runtime failures

### DIFF
--- a/packages/agent/daemon/runtime/visible_error.go
+++ b/packages/agent/daemon/runtime/visible_error.go
@@ -287,6 +287,12 @@ func visibleFailureCode(detail string) string {
 	case strings.Contains(normalized, "session/set_config_option") &&
 		strings.Contains(normalized, "timed out"):
 		return "provider_config_timeout"
+	case strings.Contains(normalized, "stream disconnected before completion") &&
+		strings.Contains(normalized, "modelcode") && strings.Contains(normalized, "不存在"):
+		return "provider_model_not_found"
+	case strings.Contains(normalized, "configured-routes/") &&
+		strings.Contains(normalized, "404 page not found"):
+		return "configured_route_not_found"
 	case strings.Contains(normalized, "stream disconnected before completion") ||
 		strings.Contains(normalized, "stream closed before response.completed"):
 		return "provider_stream_disconnected"
@@ -351,7 +357,7 @@ func structuredRuntimeTransportFailureCode(normalized string) string {
 		end++
 	}
 	code := remainder[:end]
-	if strings.HasPrefix(code, "egress_") || strings.HasPrefix(code, "provider_process_exit_") {
+	if strings.HasPrefix(code, "egress_") || strings.HasPrefix(code, "provider_process_") {
 		return code
 	}
 	return ""
@@ -521,6 +527,10 @@ func visibleFailureContent(provider string, phase string, code string) string {
 			return fmt.Sprintf("%s could not apply session settings before startup timed out. Try again in a moment.", name)
 		case "provider_stream_disconnected":
 			return fmt.Sprintf("%s could not start because the response was interrupted. Try again in a moment.", name)
+		case "provider_model_not_found":
+			return fmt.Sprintf("%s could not start because the selected model was not found. Check the model setting and try again.", name)
+		case "configured_route_not_found":
+			return fmt.Sprintf("%s could not start because its runtime route was not available. Try again in a moment.", name)
 		case "session_interrupted":
 			return fmt.Sprintf("%s stopped unexpectedly before it finished starting. Try again.", name)
 		case "request_timed_out":
@@ -558,6 +568,10 @@ func visibleFailureContent(provider string, phase string, code string) string {
 		return fmt.Sprintf("%s could not apply session settings before the request timed out. Try again in a moment.", name)
 	case "provider_stream_disconnected":
 		return fmt.Sprintf("%s response was interrupted before it completed. Try again in a moment.", name)
+	case "provider_model_not_found":
+		return fmt.Sprintf("%s could not use the selected model because it was not found. Check the model setting and try again.", name)
+	case "configured_route_not_found":
+		return fmt.Sprintf("%s could not reach its runtime route. Try again in a moment.", name)
 	case "provider_empty_response":
 		return fmt.Sprintf("%s returned no response. Check the provider settings or try again.", name)
 	case "session_interrupted":

--- a/packages/agent/daemon/runtime/visible_error_test.go
+++ b/packages/agent/daemon/runtime/visible_error_test.go
@@ -95,6 +95,27 @@ func TestVisibleFailureCodeClassifiesStreamDisconnected(t *testing.T) {
 	}
 }
 
+func TestVisibleFailureCodeClassifiesProviderModelNotFound(t *testing.T) {
+	detail := `stream disconnected before completion: modelCode：不存在[2026082021072905b55e622c4a42ba]`
+	if got := visibleFailureCode(detail); got != "provider_model_not_found" {
+		t.Fatalf("visibleFailureCode() = %q, want provider_model_not_found", got)
+	}
+}
+
+func TestVisibleFailureCodeClassifiesConfiguredRouteNotFound(t *testing.T) {
+	detail := `unexpected status 404 Not Found: 404 page not found, url: http://127.0.0.1:7794/_tsh/configured-routes/route-1/v1/responses`
+	if got := visibleFailureCode(detail); got != "configured_route_not_found" {
+		t.Fatalf("visibleFailureCode() = %q, want configured_route_not_found", got)
+	}
+}
+
+func TestVisibleFailureCodeClassifiesClosedProviderStream(t *testing.T) {
+	detail := `provider process stream is closed; error_code=provider_process_stream_closed; stream_phase=send; cause=io: read/write on closed pipe`
+	if got := visibleFailureCode(detail); got != "provider_process_stream_closed" {
+		t.Fatalf("visibleFailureCode() = %q, want provider_process_stream_closed", got)
+	}
+}
+
 func TestVisibleFailureCodeClassifiesProviderEmptyResponse(t *testing.T) {
 	detail := "provider_empty_response: ACP agent ended the turn without assistant output or tool activity"
 	if got := visibleFailureCode(detail); got != "provider_empty_response" {


### PR DESCRIPTION
## Summary
- Classify provider model-code-not-found stream failures as `provider_model_not_found`.
- Classify configured route `404 page not found` failures as `configured_route_not_found`.
- Preserve structured `provider_process_*` transport failure codes, including closed provider streams.
- Keep the existing retry behavior unchanged.

## Tests
- `go test ./packages/agent/daemon/runtime`
- `go test ./services/tuttid/service/workspace -run '^TestAppRunnerRetriesFreshPortAfterBindFailure$' -count=1 -v` on `origin/main` baseline

## Notes
- The full changed-check in the main worktree was blocked by an unrelated uncommitted `go.work.sum`; the failing workspace test passes on the `origin/main` baseline.
