### PR TITLE
fix(ci): pin Microsoft Store CLI to v0.4.1

### DIFF
--- a/.github/workflows/desktop-store-submit.yml
+++ b/.github/workflows/desktop-store-submit.yml
@@ -333,6 +333,8 @@ jobs:
       - name: Setup Microsoft Store Developer CLI
         if: ${{ inputs.submit }}
         uses: microsoft/microsoft-store-apppublisher@v1.1
+        with:
+          version: v0.4.1
 
       - name: Authenticate Partner Center
         if: ${{ inputs.submit }}


### PR DESCRIPTION
Pin the Microsoft Store Developer CLI to v0.4.1.

The previous workflow used latest and pulled v0.4.0, which has the known Azure Blob upload progress callback crash (microsoft/msstore-cli#154).

Validation: YAML parse and git diff --check pass.