### PR TITLE
fix(agent-gui): preserve forked rail membership

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1766,6 +1766,16 @@ do not alter cursors, `hasMore`, or server totals. Unchanged summaries preserve
 structural sharing so unrelated engine updates do not rebuild the whole Rail
 snapshot.
 
+A locally initiated Session creation projects its exact target identity as
+pending-creation reconciliation evidence until the canonical Session arrives.
+This covers both new-conversation activation and Session fork, and the marker
+is independent from any optimistic or runtime-overlay render source. When that
+identity becomes canonical, the Rail controller refreshes the exact persisted
+`railSectionKey` even if the new Session is currently selected. The selected
+historical-Session fast path remains valid only when no pending-creation
+evidence exists. An active or running overlay must never mask a missing
+authoritative section membership that would disappear after the Turn settles.
+
 Scroll, section collapse, visible limits, and search query belong to mounted view scope. Non-search state is isolated by `workspaceId + agentTargetId/all`; search creates a temporary navigation scope. `activeConversationId` expresses selection only. Scrolling requires an explicit reveal intent.
 
 On the Home composer, a single-Agent Rail filter follows the effective composer

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -46,7 +46,9 @@ Use the focused runtime index or open one area directly:
   the durable transcript, Claude failures before provider Turn identity that
   leave AgentGUI thinking, and Claude Fork operations that fail because an
   empty query never creates a durable provider child. It also covers a Claude
-  Query that keeps returning connection errors after the machine network recovers.
+  Query that keeps returning connection errors after the machine network
+  recovers, and forked conversations that disappear from the Rail after their
+  active/running overlay settles.
   Also covers inactive Claude Resume timing out the queue send and leaving later
   prompts stuck as 排队中 behind `uncertainDelivery`, and Standard ACP process
   cleanup failures that stop a send before provider dispatch while preserving

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -3588,6 +3588,42 @@ inline data URL instead`. Claude or standard ACP may instead receive no
   [workspaceAgentActivityReconcileBridge.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts)
   [workspaceAgentActivityService.test.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts)
 
+### Forked conversation disappears from the Rail after completion
+
+- Symptom:
+  A newly forked conversation is visible and selected while its first Turn is
+  running, but disappears from the Rail as soon as that Turn settles. Opening
+  the exact Session still works, and a later full Rail reload may restore it.
+- Quick checks:
+  Correlate `session/forkThroughTurnRequested`, the canonical child
+  `session/upserted`, and the bounded `listSessionSectionPage` request. If the
+  child becomes canonical while selected but no exact request is made for its
+  inherited `railSectionKey`, inspect pending-creation membership rather than
+  the fork persistence path. Also verify that the child was initially visible
+  only through the active or running overlay.
+- Root cause:
+  Fork selected the child immediately, while membership reconciliation skipped
+  every newly observed active Session to avoid refreshing for historical detail
+  hydration. The fork child therefore never entered its bounded authoritative
+  section page. Its active/running overlay temporarily hid that omission and
+  settlement exposed it by removing the overlay row.
+- Fix:
+  Project in-flight fork targets and pending activations as pending-creation
+  reconciliation evidence. Keep that semantic marker separate from render
+  provenance. When the same identity becomes canonical, refresh its exact
+  persisted Rail section even when selected; continue skipping ordinary
+  selected historical hydration when no pending-creation evidence exists.
+- Validation:
+  Drive a real `AgentSessionEngine` and
+  `AgentGUIConversationRailQueryController` through a held fork command,
+  select the target before canonical upsert, then verify the controller requests
+  the inherited section and publishes the child in authoritative membership.
+  Retain the existing selected historical-Session no-refresh coverage.
+- References:
+  [agentGuiConversationRailMembershipRecords.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRailMembershipRecords.ts)
+  [agentGuiConversationRailMembershipRefresh.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRailMembershipRefresh.ts)
+  [AgentGUIConversationRailQueryController.spec.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts)
+
 ### Shared Agent composer stays disabled after the target connects
 
 - Symptom:

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
@@ -258,6 +258,118 @@ describe("AgentGUIConversationRailQueryController", () => {
     engine.dispose();
   });
 
+  it("refreshes a selected fork creation into its authoritative rail page", async () => {
+    const source = normalizeAgentActivitySession({
+      ...createTestSession("source-session", "conversations"),
+      lifecycleCapabilities: { fork: true, forkThroughTurn: true }
+    });
+    const child = normalizeAgentActivitySession({
+      ...source,
+      agentSessionId: "fork-child",
+      forkedFrom: {
+        forkedAtUnixMs: 2,
+        operationId: "fork-operation",
+        sourceAgentSessionId: source.agentSessionId,
+        sourceTurnId: "source-turn",
+        targetTurnId: "fork-target-turn"
+      },
+      title: "Fork child",
+      updatedAtUnixMs: 2
+    });
+    let resolveForkCommand: (value: unknown) => void = () => {};
+    const engine = createTestAgentSessionEngine("test-workspace", {
+      execute: async (command) => {
+        if (command.type === "session/forkThroughTurn") {
+          return new Promise((resolve) => {
+            resolveForkCommand = resolve;
+          });
+        }
+        return { ok: true };
+      }
+    });
+    let activeConversationId: string | null = null;
+    const listSessionSectionPage = vi.fn(async (input) => ({
+      hasMore: false,
+      kind: "conversations" as const,
+      sectionKey: input.sectionKey,
+      sessions: [child, source],
+      totalCount: 2
+    }));
+    const controller = new AgentGUIConversationRailQueryController({
+      engine,
+      getActiveConversationId: () => activeConversationId,
+      runtime: {
+        listSessionSectionPage,
+        listSessionSections: async (input) => ({
+          sections: [
+            {
+              hasMore: false,
+              kind: "conversations",
+              sectionKey: "conversations",
+              sessions: [source],
+              totalCount: 1
+            }
+          ],
+          workspaceId: input.workspaceId
+        })
+      },
+      workspaceId: "test-workspace"
+    });
+    controller.configure({
+      conversationFilter: { kind: "all" },
+      userProjects: []
+    });
+    const detach = controller.attach();
+    await vi.waitFor(() =>
+      expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(false)
+    );
+
+    engine.dispatch({
+      live: true,
+      turn: {
+        agentSessionId: source.agentSessionId,
+        completedCommand: null,
+        error: null,
+        fileChanges: null,
+        origin: "user_prompt",
+        outcome: "completed",
+        phase: "settled",
+        providerForkBindingAvailable: true,
+        settledAtUnixMs: 2,
+        startedAtUnixMs: 1,
+        turnId: "source-turn",
+        updatedAtUnixMs: 2
+      },
+      type: "turn/upserted"
+    });
+    engine.dispatch({
+      requestId: "fork-request",
+      sourceAgentSessionId: source.agentSessionId,
+      targetAgentSessionId: child.agentSessionId,
+      turnId: "source-turn",
+      type: "session/forkThroughTurnRequested",
+      workspaceId: "test-workspace"
+    });
+    activeConversationId = child.agentSessionId;
+    engine.dispatch({ session: child, type: "session/upserted" });
+
+    await vi.waitFor(() =>
+      expect(listSessionSectionPage).toHaveBeenCalledWith(
+        expect.objectContaining({ sectionKey: "conversations" })
+      )
+    );
+    await vi.waitFor(() =>
+      expect(
+        controller.getSnapshot().runtimeRailMemberships?.[0]?.sessionIds
+      ).toEqual([child.agentSessionId, source.agentSessionId])
+    );
+
+    resolveForkCommand({});
+    await Promise.resolve();
+    detach();
+    engine.dispose();
+  });
+
   it("does not start a targeted page refresh while the rail scope is pending", async () => {
     const engine = createTestAgentSessionEngine();
     const session = normalizeAgentActivitySession({

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.spec.ts
@@ -256,11 +256,11 @@ describe("planRuntimeRailMembershipRefresh", () => {
     });
   });
 
-  it("ignores pending activation add and removal", () => {
+  it("ignores pending creation add and removal", () => {
     const recent = conversation("recent");
     const pending = {
       ...conversation("pending"),
-      projectionSource: "pending_activation" as const
+      pendingCreation: true
     };
 
     expect(
@@ -292,11 +292,11 @@ describe("planRuntimeRailMembershipRefresh", () => {
     ).toEqual({ kind: "none" });
   });
 
-  it("refreshes and preserves display membership when pending activation becomes canonical", () => {
+  it("refreshes and preserves display membership when pending creation becomes canonical", () => {
     const recent = conversation("recent");
     const pending = {
       ...conversation("new-session"),
-      projectionSource: "pending_activation" as const
+      pendingCreation: true
     };
 
     expect(

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRailMembershipRecords.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRailMembershipRecords.ts
@@ -1,6 +1,7 @@
 import {
   isPendingActivationViable,
   selectPendingActivations,
+  selectSessionMutations,
   selectWorkspaceAgentConsumerSessions,
   type AgentSessionEngineState
 } from "@tutti-os/agent-activity-core";
@@ -11,6 +12,9 @@ export function projectConversationRailMembershipRecords(
   const sessions = selectWorkspaceAgentConsumerSessions(state);
   const canonicalIds = new Set(
     sessions.map((item) => item.session.agentSessionId)
+  );
+  const sessionsById = new Map(
+    sessions.map((item) => [item.session.agentSessionId, item.session] as const)
   );
   return [
     ...sessions.map((item) => ({
@@ -30,10 +34,39 @@ export function projectConversationRailMembershipRecords(
       .map((record) => ({
         agentTargetId: record.agentTargetId,
         id: record.agentSessionId,
+        pendingCreation: true,
         pinnedAtUnixMs: null,
         projectionSource: "pending_activation" as const,
         railSectionKey: record.railSectionKey?.trim() || null,
         title: record.title ?? ""
-      }))
+      })),
+    ...selectSessionMutations(state).flatMap((record) => {
+      const targetAgentSessionId =
+        record.kind === "forkThroughTurn"
+          ? record.targetAgentSessionId.trim()
+          : "";
+      if (
+        record.kind !== "forkThroughTurn" ||
+        record.status !== "inFlight" ||
+        !targetAgentSessionId ||
+        canonicalIds.has(targetAgentSessionId)
+      ) {
+        return [];
+      }
+      const source = sessionsById.get(record.agentSessionIds[0]);
+      if (!source || source.workspaceId !== record.workspaceId) {
+        return [];
+      }
+      return [
+        {
+          agentTargetId: source.agentTargetId,
+          id: targetAgentSessionId,
+          pendingCreation: true,
+          pinnedAtUnixMs: null,
+          railSectionKey: source.railSectionKey?.trim() || null,
+          title: source.title
+        }
+      ];
+    })
   ];
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRailMembershipRefresh.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRailMembershipRefresh.ts
@@ -3,6 +3,7 @@ import type { ConversationRailSectionMembership } from "../controller/agentConve
 export interface ConversationRailMembershipRecord {
   agentTargetId?: string | null;
   id: string;
+  pendingCreation?: boolean;
   pinnedAtUnixMs?: number | null;
   projectionSource?: "pending_activation" | "runtime_overlay";
   railSectionKey?: string | null;
@@ -32,8 +33,7 @@ export function planRuntimeRailMembershipRefresh(input: {
   const previousPendingIds = new Set(
     input.previous
       .filter(
-        (record) =>
-          record.projectionSource === "pending_activation" && visible(record)
+        (record) => record.pendingCreation === true && visible(record)
       )
       .map((record) => record.id)
   );
@@ -41,7 +41,10 @@ export function planRuntimeRailMembershipRefresh(input: {
     new Map(
       records
         .filter(
-          (record) => record.projectionSource === undefined && visible(record)
+          (record) =>
+            record.pendingCreation !== true &&
+            record.projectionSource === undefined &&
+            visible(record)
         )
         .map((record) => [record.id, record] as const)
     );


### PR DESCRIPTION
## Summary

Forked conversations could disappear from the Agent Rail after their active/running overlay settled. The canonical child was selected immediately, so the existing historical-session fast path skipped the authoritative section refresh; once the overlay disappeared, the persisted Rail page still did not contain the child.

This change projects in-flight fork targets and new-session activations as explicit pending-creation reconciliation evidence. When that identity becomes canonical, the Rail controller refreshes the exact inherited `railSectionKey`, including `conversations`, while preserving the no-refresh behavior for ordinary selected historical-session hydration.

It also adds controller-level regression coverage and documents the lifecycle symptom, cause, and diagnostic path.

## Verification

- `pnpm check:changed` — passed 11 lanes.
- Reproduced a real fork from the `conversations` Rail in the desktop app. The child committed, appeared immediately in the `对话` list, and remained visible after selection switched and the active overlay settled.

## Checklist

- [x] N/A — this changes AgentGUI Rail reconciliation, not host-owned session/turn/goal/runtime-operation lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] N/A — no README/CONTRIBUTING language source changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
