### PR TITLE
fix(ci): set Microsoft Store upload timeout

### DIFF
--- a/.github/workflows/desktop-store-submit.yml
+++ b/.github/workflows/desktop-store-submit.yml
@@ -368,17 +368,7 @@ jobs:
           $msixPath = '${{ steps.submission.outputs.path }}'
           $packageSize = (Get-Item -LiteralPath $msixPath).Length
           "Microsoft Store upload package size: $packageSize bytes"
-          $publishArgs = @('-v', 'publish', $msixPath, '-id', $env:TUTTI_MICROSOFT_STORE_PRODUCT_ID)
-          $publishOutput = & msstore @publishArgs 2>&1
-          $publishExitCode = $LASTEXITCODE
-          $publishOutput | ForEach-Object {
-            $line = [string]$_
-            $line = [regex]::Replace($line, '(?i)https?://[^\s`"<>]+', '<redacted-url>')
-            $line
-          }
-          if ($publishExitCode -ne 0) {
-            throw "msstore publish failed with exit code $publishExitCode"
-          }
+          msstore publish $msixPath -id "$env:TUTTI_MICROSOFT_STORE_PRODUCT_ID" -ut 600
 
       - name: Record submission summary
         shell: pwsh

--- a/.github/workflows/desktop-store-submit.yml
+++ b/.github/workflows/desktop-store-submit.yml
@@ -366,7 +366,19 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           $msixPath = '${{ steps.submission.outputs.path }}'
-          msstore publish $msixPath -id "$env:TUTTI_MICROSOFT_STORE_PRODUCT_ID"
+          $packageSize = (Get-Item -LiteralPath $msixPath).Length
+          "Microsoft Store upload package size: $packageSize bytes"
+          $publishArgs = @($msixPath, '-id', $env:TUTTI_MICROSOFT_STORE_PRODUCT_ID, '-v')
+          $publishOutput = & msstore @publishArgs 2>&1
+          $publishExitCode = $LASTEXITCODE
+          $publishOutput | ForEach-Object {
+            $line = [string]$_
+            $line = [regex]::Replace($line, '(?i)https?://[^\s`"<>]+', '<redacted-url>')
+            $line
+          }
+          if ($publishExitCode -ne 0) {
+            throw "msstore publish failed with exit code $publishExitCode"
+          }
 
       - name: Record submission summary
         shell: pwsh

--- a/.github/workflows/desktop-store-submit.yml
+++ b/.github/workflows/desktop-store-submit.yml
@@ -368,7 +368,7 @@ jobs:
           $msixPath = '${{ steps.submission.outputs.path }}'
           $packageSize = (Get-Item -LiteralPath $msixPath).Length
           "Microsoft Store upload package size: $packageSize bytes"
-          $publishArgs = @($msixPath, '-id', $env:TUTTI_MICROSOFT_STORE_PRODUCT_ID, '-v')
+          $publishArgs = @('-v', 'publish', $msixPath, '-id', $env:TUTTI_MICROSOFT_STORE_PRODUCT_ID)
           $publishOutput = & msstore @publishArgs 2>&1
           $publishExitCode = $LASTEXITCODE
           $publishOutput | ForEach-Object {


### PR DESCRIPTION
## Root cause
The Microsoft Store CLI defaulted the upload timeout to 0 seconds when `-ut` was omitted, causing Azure Blob uploads to fail with `TaskCanceledException` before completion.

## Fix
Pass `-ut 600` explicitly to `msstore publish`.

Validated by [successful Store submission run 32463092290](https://github.com/tutti-os/tutti/actions/runs/32463092290).