### PR TITLE
fix(agent-extension): bump hermes pinnedVersion to 1.0.9

### DIFF
--- a/apps/desktop/src/main/generated/defaults.ts
+++ b/apps/desktop/src/main/generated/defaults.ts
@@ -87,7 +87,7 @@ export const generatedDefaults = {
       },
       {
         key: "hermes",
-        pinnedVersion: "1.0.8",
+        pinnedVersion: "1.0.9",
         releaseIndexUrl:
           "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/hermes/versions.json",
         signingKeyId: "tutti-hermes-release-v1",

--- a/config/tutti.defaults.json
+++ b/config/tutti.defaults.json
@@ -77,7 +77,7 @@
       },
       {
         "key": "hermes",
-        "pinnedVersion": "1.0.8",
+        "pinnedVersion": "1.0.9",
         "releaseIndexUrl": "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/hermes/versions.json",
         "signingKeyId": "tutti-hermes-release-v1",
         "signingPublicKey": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAIeel8ddNiN3b4qOq0KucF3BRxfi3zourM0BVyGuP8eY=\n-----END PUBLIC KEY-----\n",

--- a/services/tuttid/types/defaults_generated.go
+++ b/services/tuttid/types/defaults_generated.go
@@ -81,7 +81,7 @@ var generatedDefaults = generatedDefaultsSpec{
 			},
 			{
 				Key:                      "hermes",
-				PinnedVersion:            "1.0.8",
+				PinnedVersion:            "1.0.9",
 				ReleaseIndexURL:          "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/hermes/versions.json",
 				FallbackReleaseIndexURLs: []string{},
 				SigningKeyID:             "tutti-hermes-release-v1",

--- a/services/tuttid/types/defaults_test.go
+++ b/services/tuttid/types/defaults_test.go
@@ -92,7 +92,7 @@ func TestResolveAgentExtensionSourcesUsesGeneratedActivationDefaults(t *testing.
 	}
 	wantPinnedVersions := map[string]string{
 		"gemini": "2.0.3", "codebuddy": "2.0.3", "copilot": "2.0.3", "kilo": "2.0.3",
-		"qwen": "2.0.3", "hermes": "1.0.8", "kimi-code": "1.0.11", "grok": "0.1.2",
+		"qwen": "2.0.3", "hermes": "1.0.9", "kimi-code": "1.0.11", "grok": "0.1.2",
 	}
 	for key, wantVersion := range wantPinnedVersions {
 		if got := agentExtensionSourceByKey(t, sources, key).PinnedVersion; got != wantVersion {


### PR DESCRIPTION
## Summary

将 hermes 扩展的 `pinnedVersion` 从 `1.0.8` 升到 `1.0.9`，配合 hermes-agent 0.19.0 运行时发布。

背景：hermes 扩展 1.0.9 安装的 hermes-agent 0.19.0 已在 openai-codex 模型目录中收录 gpt-5.6 系列（0.18.2 未收录）。当前客户端仍固定 1.0.8，因此切换 gpt-5.6-luna/terra 时 `set_model` 误判到 openrouter 并报 `No LLM provider configured`。升级 pin 后客户端才能收敛到新版运行时。

改动：
- `config/tutti.defaults.json`：hermes `pinnedVersion` `1.0.8` → `1.0.9`（真源）
- 重新生成 `services/tuttid/types/defaults_generated.go`、`apps/desktop/src/main/generated/defaults.ts`
- 更新 `services/tuttid/types/defaults_test.go` 中 hermes pin 断言

## Verification

- `node tools/scripts/generate-defaults.mjs --check` 通过（defaults 生成一致性）
- `go test ./services/tuttid/types/...` 通过
- `pnpm check:changed`：61 lane 通过（仅 `TestAppRunnerRetriesFreshPortAfterBindFailure` 在完整并发跑时偶发 flaky，单独重跑 PASS，与本次改动无关）

## Checklist

- [x] I kept the change focused on one concern.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.