### PR TITLE
fix(desktop): backport native config actions and OS titlebar visibility

### DIFF
--- a/apps/desktop/src/main/windows/workspaceWindow.ts
+++ b/apps/desktop/src/main/windows/workspaceWindow.ts
@@ -40,7 +40,7 @@ import {
 import { WorkspaceWindowRegistry } from "./workspaceWindowRegistry.ts";
 import {
   resolveWorkspaceWindowChromeOptions,
-  resolveWorkspaceWindowTitleBarOverlay
+  syncWorkspaceWindowTitleBarOverlayTargets
 } from "./workspaceWindowChrome.ts";
 import { supportsWorkspaceWindowCloseGuard } from "./workspaceWindowCloseGuard.ts";
 
@@ -393,15 +393,15 @@ export function syncWorkspaceWindowTitleBarOverlayColors(
     return;
   }
 
-  const titleBarOverlay = resolveWorkspaceWindowTitleBarOverlay(appearance);
-  for (const workspaceWindow of BrowserWindow.getAllWindows()) {
-    if (
-      !workspaceWindow.isDestroyed() &&
-      workspaceWindows.getKind(workspaceWindow) !== null
-    ) {
-      workspaceWindow.setTitleBarOverlay(titleBarOverlay);
-    }
-  }
+  syncWorkspaceWindowTitleBarOverlayTargets({
+    appearance,
+    getWindowKind: (workspaceWindow) =>
+      workspaceWindows.getKind(workspaceWindow),
+    isDestroyed: (workspaceWindow) => workspaceWindow.isDestroyed(),
+    setTitleBarOverlay: (workspaceWindow, titleBarOverlay) =>
+      workspaceWindow.setTitleBarOverlay(titleBarOverlay),
+    targets: BrowserWindow.getAllWindows()
+  });
 }
 
 export function findWorkspaceWindow(

--- a/apps/desktop/src/main/windows/workspaceWindowChrome.test.ts
+++ b/apps/desktop/src/main/windows/workspaceWindowChrome.test.ts
@@ -2,31 +2,74 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   resolveWorkspaceWindowChromeOptions,
-  resolveWorkspaceWindowTitleBarOverlay
+  resolveWorkspaceWindowTitleBarOverlay,
+  syncWorkspaceWindowTitleBarOverlayTargets
 } from "./workspaceWindowChrome.ts";
 
-test("Windows title-bar symbols follow the active light and dark appearance", () => {
-  assert.deepEqual(resolveWorkspaceWindowTitleBarOverlay("light"), {
+test("Windows Agent title-bar symbols follow the active appearance", () => {
+  assert.deepEqual(resolveWorkspaceWindowTitleBarOverlay("light", "agent"), {
     color: "rgba(0, 0, 0, 0)",
     height: 52,
     symbolColor: "rgba(17, 24, 39, 0.88)"
   });
-  assert.deepEqual(resolveWorkspaceWindowTitleBarOverlay("dark"), {
+  assert.deepEqual(resolveWorkspaceWindowTitleBarOverlay("dark", "agent"), {
     color: "rgba(0, 0, 0, 0)",
     height: 52,
     symbolColor: "rgba(255, 255, 255, 0.92)"
   });
 });
 
-test("Windows workspace chrome uses the requested appearance", () => {
+test("Windows OS workspace title-bar symbols stay visible over its dark chrome", () => {
+  for (const appearance of ["light", "dark"] as const) {
+    assert.deepEqual(
+      resolveWorkspaceWindowTitleBarOverlay(appearance, "workspace"),
+      {
+        color: "rgba(0, 0, 0, 0)",
+        height: 52,
+        symbolColor: "rgba(255, 255, 255, 0.92)"
+      }
+    );
+  }
+});
+
+test("Windows workspace chrome uses the matching window surface", () => {
   assert.deepEqual(
     resolveWorkspaceWindowChromeOptions("win32", "workspace", "light")
       .titleBarOverlay,
-    resolveWorkspaceWindowTitleBarOverlay("light")
+    resolveWorkspaceWindowTitleBarOverlay("light", "workspace")
   );
   assert.deepEqual(
     resolveWorkspaceWindowChromeOptions("win32", "agent", "dark")
       .titleBarOverlay,
-    resolveWorkspaceWindowTitleBarOverlay("dark")
+    resolveWorkspaceWindowTitleBarOverlay("dark", "agent")
   );
+});
+
+test("runtime title-bar sync applies each registered window surface independently", () => {
+  type Target = {
+    destroyed?: boolean;
+    kind: "agent" | "workspace" | null;
+    name: string;
+  };
+  const targets: Target[] = [
+    { kind: "agent", name: "agent" },
+    { kind: "workspace", name: "workspace" },
+    { destroyed: true, kind: "workspace", name: "destroyed" },
+    { kind: null, name: "unregistered" }
+  ];
+  const applied: Array<{ name: string; symbolColor: string }> = [];
+
+  syncWorkspaceWindowTitleBarOverlayTargets({
+    appearance: "light",
+    getWindowKind: (target) => target.kind,
+    isDestroyed: (target) => target.destroyed === true,
+    setTitleBarOverlay: (target, overlay) =>
+      applied.push({ name: target.name, symbolColor: overlay.symbolColor }),
+    targets
+  });
+
+  assert.deepEqual(applied, [
+    { name: "agent", symbolColor: "rgba(17, 24, 39, 0.88)" },
+    { name: "workspace", symbolColor: "rgba(255, 255, 255, 0.92)" }
+  ]);
 });

--- a/apps/desktop/src/main/windows/workspaceWindowChrome.ts
+++ b/apps/desktop/src/main/windows/workspaceWindowChrome.ts
@@ -14,15 +14,47 @@ const windowsTitleBarSymbolColors: Record<DesktopThemeAppearance, string> = {
   dark: "rgba(255, 255, 255, 0.92)",
   light: "rgba(17, 24, 39, 0.88)"
 };
+const workspaceTitleBarSymbolColor = "rgba(255, 255, 255, 0.92)";
 
 export function resolveWorkspaceWindowTitleBarOverlay(
-  appearance: DesktopThemeAppearance
+  appearance: DesktopThemeAppearance,
+  windowKind: "agent" | "workspace"
 ) {
   return {
     color: "rgba(0, 0, 0, 0)",
     height: 52,
-    symbolColor: windowsTitleBarSymbolColors[appearance]
+    // The OS workspace chrome deliberately keeps its controls white over the
+    // wallpaper-backed dark header, independently of the global theme. Agent
+    // windows use a theme-backed panel and can follow the active appearance.
+    symbolColor:
+      windowKind === "workspace"
+        ? workspaceTitleBarSymbolColor
+        : windowsTitleBarSymbolColors[appearance]
   } as const;
+}
+
+export function syncWorkspaceWindowTitleBarOverlayTargets<T>(input: {
+  appearance: DesktopThemeAppearance;
+  getWindowKind: (target: T) => "agent" | "workspace" | null;
+  isDestroyed: (target: T) => boolean;
+  setTitleBarOverlay: (
+    target: T,
+    overlay: ReturnType<typeof resolveWorkspaceWindowTitleBarOverlay>
+  ) => void;
+  targets: readonly T[];
+}): void {
+  for (const target of input.targets) {
+    if (input.isDestroyed(target)) {
+      continue;
+    }
+    const windowKind = input.getWindowKind(target);
+    if (windowKind !== null) {
+      input.setTitleBarOverlay(
+        target,
+        resolveWorkspaceWindowTitleBarOverlay(input.appearance, windowKind)
+      );
+    }
+  }
 }
 
 export function resolveWorkspaceWindowChromeOptions(
@@ -37,7 +69,10 @@ export function resolveWorkspaceWindowChromeOptions(
       // The native caption buttons remain system-managed, but are overlaid on
       // that header so Windows does not render a second title-bar row.
       autoHideMenuBar: true,
-      titleBarOverlay: resolveWorkspaceWindowTitleBarOverlay(appearance),
+      titleBarOverlay: resolveWorkspaceWindowTitleBarOverlay(
+        appearance,
+        windowKind
+      ),
       titleBarStyle: "hidden"
     };
   }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentConfigSystemActions.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentConfigSystemActions.test.ts
@@ -32,7 +32,15 @@ test("Agent config system actions stay hidden in OS mode", () => {
 test("Agent config log export uses the ui-system native submenu", () => {
   assert.match(source, /<DropdownMenuSub>/);
   assert.match(source, /<DropdownMenuSubTrigger[\s\S]*exportLogs/);
-  assert.match(source, /<DropdownMenuSubContent className="w-64">/);
+  assert.match(
+    source,
+    /<DropdownMenuSubContent[\s\S]*zIndex: "calc\(var\(--z-panel-popover\) \+ 1\)"/
+  );
+  assert.match(
+    source,
+    /className="nodrag w-64 \[-webkit-app-region:no-drag\]"/
+  );
+  assert.match(source, /sideOffset=\{4\}/);
   assert.equal(source.match(/<DropdownMenuItem/g)?.length, 5);
   assert.equal(source.match(/onSelect=/g)?.length, 5);
   assert.doesNotMatch(source, /onClick=/);

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentConfigSystemActions.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentConfigSystemActions.tsx
@@ -47,7 +47,11 @@ export function DesktopAgentConfigSystemActions(): React.JSX.Element {
           <DownloadIcon aria-hidden="true" className="size-4" />
           <span>{t("workspace.settings.developer.exportLogs")}</span>
         </DropdownMenuSubTrigger>
-        <DropdownMenuSubContent className="w-64">
+        <DropdownMenuSubContent
+          className="nodrag w-64 [-webkit-app-region:no-drag]"
+          sideOffset={4}
+          style={{ zIndex: "calc(var(--z-panel-popover) + 1)" }}
+        >
           <DropdownMenuItem
             disabled={settingsState.developerLogs.exporting}
             onSelect={() =>

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.spec.tsx
@@ -77,6 +77,10 @@ describe("AgentGUIConfigMenu", () => {
     );
 
     openConfigMenu();
+    expect(screen.getByTestId("agent-gui-config-menu")).toHaveClass(
+      "nodrag",
+      "[-webkit-app-region:no-drag]"
+    );
     const exportTrigger = screen.getByRole("menuitem", {
       name: "Export logs"
     });

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.tsx
@@ -124,7 +124,7 @@ export function AgentGUIConfigMenu({
       <DropdownMenuContent
         side="right"
         align="end"
-        className="w-[300px] max-w-[calc(100vw-32px)] p-1 text-xs"
+        className="nodrag w-[300px] max-w-[calc(100vw-32px)] p-1 text-xs [-webkit-app-region:no-drag]"
         data-testid="agent-gui-config-menu"
         style={{ zIndex: "var(--z-panel-popover)" }}
       >


### PR DESCRIPTION
## 变更
- 修复 Agent 配置菜单及导出日志原生 submenu 的 Electron no-drag 点击区域、层级与间距
- OS 模式 Windows 原生最小化/最大化/关闭按钮固定使用适配深色顶部栏的白色符号
- 主题切换时按窗口类型分别同步 title-bar overlay，跳过销毁或未注册窗口

## 验证
- AgentGUI 定向测试：16/16
- Desktop submenu/titlebar 定向测试：6/6
- @tutti-os/agent-gui typecheck
- @tutti-os/desktop typecheck
- 独立 review：no findings

Backport of #2561 to release/0818.
