### PR TITLE
fix(agent-gui): rewrite target setup description in user language

### DIFF
--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
@@ -53,7 +53,7 @@ export const enAgentGui = {
   providerGatePendingRefresh: "Checking…",
   targetSetupTitle: "Set up {{provider}}",
   targetSetupDescription:
-    "Use a compatible local runtime, or let Tutti install and verify the pinned runtime.",
+    "Already have {{provider}} installed? Tutti can use it — or set it up for you.",
   targetSetupAuthRequired:
     "Runtime is installed and responds over ACP, but authentication is required.",
   targetSetupReady:

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
@@ -53,7 +53,7 @@ export const zhCNAgentGui = {
   providerGatePendingRefresh: "正在检测…",
   targetSetupTitle: "设置 {{provider}}",
   targetSetupDescription:
-    "优先使用兼容的本地运行时，也可由 Tutti 安装并验证固定版本",
+    "已经安装了 {{provider}}？Tutti 可以直接使用，也可以为你安装",
   targetSetupAuthRequired: "运行时已安装并通过 ACP 检测，但仍需完成登录",
   targetSetupReady: "已检测到运行时，可重新检测或重新登录",
   targetSetupOpen: "打开设置",


### PR DESCRIPTION
## Summary

Rewrites the provider target-setup dialog description from engineering vocabulary into user language. The old copy exposed internal concepts ("compatible local runtime", "pinned runtime", "install and verify") that users neither know nor need; the new copy answers the user's actual question — "can Tutti use what I already have?" — in words already in their vocabulary.

| Locale | Before | After |
|---|---|---|
| en | Use a compatible local runtime, or let Tutti install and verify the pinned runtime. | Already have {{provider}} installed? Tutti can use it — or set it up for you. |
| zh-CN | 优先使用兼容的本地运行时，也可由 Tutti 安装并验证固定版本 | 已经安装了 {{provider}}？Tutti 可以直接使用，也可以为你安装 |

The version pin is not user-visible, so the copy intentionally drops it; "verify" is an internal guarantee and likewise omitted. `{{provider}}` keeps the copy generic for Claude Code / Codex / other providers, matching `targetSetupTitle`.

## Testing

- String-only change to `targetSetupDescription` in `en.agentGui.ts` / `zh-CN.agentGui.ts`; keys untouched, so `schema.ts` typing is unaffected. Pre-commit (oxfmt/oxlint + boundary checks) passed.
- Pre-push Go test failures in `services/tuttid/service/agentstatus` were verified to also fail on a clean `origin/main` checkout on this machine (host-environment leakage: tests pick up the real `/opt/homebrew/bin/claude` and live auth state) — pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)