### PR TITLE
fix(agent-gui): render selected text as a reference chip

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -421,7 +421,9 @@ blocks are UI-local draft state and materialize as Markdown blockquote text at
 the existing submit boundary, so the Side transport remains text-only. When a
 typed question accompanies those quotes, Side keeps the blockquotes in provider
 content but projects only the typed question as the visible user message; a
-quote-only submission keeps the existing blockquote display fallback. Focus
+legacy quote-only submission keeps the existing blockquote display fallback;
+only a future explicit selected-text content kind can make that ambiguous shape
+safe to render as a chip. Focus
 ownership follows the currently visible Side pane: an unmounted or
 source-mismatched Side cannot keep the main composer inactive, and pane cleanup
 must release its focus scope.
@@ -1935,7 +1937,16 @@ packaged with AgentGUI and performs no runtime network fetch.
 Attachment-only fallback labels such as `[Image]` may provide title or summary
 text, but they are not an additional transcript text block when the canonical
 structured content already renders the same image. Explicit display prompts
-remain transcript content and continue to replace expanded rich prompt text.
+remain transcript content and continue to replace expanded rich prompt text,
+except when the structured content carries the composer’s selected-text
+reference blocks. In that case the conversation projection preserves ordinary
+structured text and images, groups selected-text blocks into one leading typed
+compact reference part, and uses `displayPrompt` only as a compatibility
+fallback; the renderer owns the chip presentation. The selected reference is
+presentation-only, so copy/edit actions remain attached to the ordinary typed
+prompt part. This keeps the durable prompt and editing source unchanged while
+preventing a display-only flattened prompt from discarding the reference
+boundary.
 
 Structured user-prompt transcript images keep resource acquisition and browser
 image decoding as separate presentation states. A URL or hydrated data source

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
@@ -332,6 +332,8 @@ export const enAgentGui = {
   pastedTextAttachmentFailed: "Pasted text couldn't be saved",
   pastedTextRestoreToComposer: "Show in text field",
   copyMessage: "Copy message",
+  selectedTextFragment: "1 selected text fragment",
+  selectedTextFragments: "{{count}} selected text fragments",
   forkThroughTurn: "Fork through this turn",
   forkThroughTurnPending: "Forking through this turn",
   continuedFromTask: "Continued from task",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
@@ -369,6 +369,8 @@ export const zhCNAgentGui = {
   pastedTextAttachmentFailed: "无法保存粘贴的文本",
   pastedTextRestoreToComposer: "在文本框中显示",
   copyMessage: "复制消息",
+  selectedTextFragment: "1 个已选文本片段",
+  selectedTextFragments: "{{count}} 个已选文本片段",
   forkThroughTurn: "从此轮进行会话 Fork",
   forkThroughTurnPending: "正在进行会话 Fork",
   continuedFromTask: "接续自任务",

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.selectedText.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.selectedText.spec.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { AgentMessageBlock } from "./AgentMessageBlock";
+
+afterEach(cleanup);
+
+describe("AgentMessageBlock selected text", () => {
+  it("renders a selected-text message as a compact reference chip", () => {
+    render(
+      <AgentMessageBlock
+        workspaceRoot="/workspace"
+        basePath="/workspace"
+        row={{
+          kind: "message",
+          id: "row-user",
+          turnId: "turn-1",
+          speaker: "user",
+          rawFirstTextBlock: null,
+          messages: [
+            {
+              kind: "message-content",
+              id: "message-user:selected-text",
+              turnId: "turn-1",
+              body: "",
+              presentationKind: "content",
+              contentKind: "selected-text",
+              selectedText: {
+                count: 1,
+                texts: ["Selected source text"]
+              },
+              occurredAtUnixMs: 1
+            }
+          ],
+          thinking: [],
+          occurredAtUnixMs: 1
+        }}
+        thinkingLabel="Thinking"
+      />
+    );
+
+    const chip = screen.getByTestId("agent-selected-text-chip");
+    expect(chip.getAttribute("data-selected-text-count")).toBe("1");
+    expect(chip).toHaveTextContent("1 selected text fragment");
+    expect(screen.queryByText("Selected source text")).toBeNull();
+  });
+
+  it("does not expose the selected-text chip as an editable message target", () => {
+    render(
+      <AgentMessageBlock
+        workspaceRoot="/workspace"
+        basePath="/workspace"
+        row={{
+          kind: "message",
+          id: "row-user",
+          turnId: "turn-1",
+          speaker: "user",
+          rawFirstTextBlock: "> Selected source text",
+          messages: [
+            {
+              kind: "message-content",
+              id: "message-user:selected-text",
+              turnId: "turn-1",
+              body: "",
+              presentationKind: "content",
+              contentKind: "selected-text",
+              selectedText: {
+                count: 1,
+                texts: ["Selected source text"]
+              },
+              occurredAtUnixMs: 1
+            }
+          ],
+          thinking: [],
+          occurredAtUnixMs: 1
+        }}
+        editRetry={{
+          pending: false,
+          labels: {
+            edit: "Edit message",
+            cancel: "Cancel",
+            submit: "Save and retry"
+          },
+          onSubmit: async () => true
+        }}
+        thinkingLabel="Thinking"
+      />
+    );
+
+    expect(screen.queryByRole("button", { name: "Edit message" })).toBeNull();
+  });
+});

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.selectedText.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.selectedText.spec.tsx
@@ -42,7 +42,9 @@ describe("AgentMessageBlock selected text", () => {
 
     const chip = screen.getByTestId("agent-selected-text-chip");
     expect(chip.getAttribute("data-selected-text-count")).toBe("1");
-    expect(chip).toHaveTextContent("1 selected text fragment");
+    expect(chip).toHaveTextContent("1 selected file snippet");
+    expect(chip).toHaveClass("rounded-[10px]");
+    expect(chip).toHaveClass("bg-[var(--background-fronted)]");
     expect(screen.queryByText("Selected source text")).toBeNull();
   });
 

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
@@ -39,6 +39,7 @@ import { RawTimelineJsonDisclosure } from "./RawTimelineJsonDisclosure";
 import { useElapsedSeconds } from "./useElapsedSeconds";
 import styles from "../../../agent-gui/agentGuiNode/AgentGUIConversation.styles";
 import { AgentUserImageGrid } from "./AgentMessageImages";
+import { AgentSelectedTextChip } from "./AgentSelectedTextChip";
 import {
   AgentUserMessageEditor,
   type AgentUserMessageEditRetryControl
@@ -237,7 +238,11 @@ export function AgentMessageBlock({
         ? recoverVisibleErrorFromMessage(message, provider)
         : null;
     const renderedContent =
-      isUser && message.contentKind === "image-grid" ? (
+      isUser &&
+      message.contentKind === "selected-text" &&
+      message.selectedText ? (
+        <AgentSelectedTextChip selectedText={message.selectedText} />
+      ) : isUser && message.contentKind === "image-grid" ? (
         <AgentUserImageGrid message={message} />
       ) : isUser &&
         message.contentKind === "tutti-checkpoint-wake" &&

--- a/packages/agent/gui/shared/agentConversation/components/AgentSelectedTextChip.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentSelectedTextChip.tsx
@@ -22,7 +22,6 @@ export function AgentSelectedTextChip({
     <div
       data-testid="agent-selected-text-chip"
       data-selected-text-count={count}
-      aria-label={label}
       className="group inline-flex max-w-full items-center rounded-[10px] border border-[var(--line-1)] bg-[var(--background-fronted)] text-sm font-medium text-[var(--text-primary)]"
     >
       <span className="inline-flex min-w-0 items-center gap-2 rounded-[9px] py-2 pl-3 pr-2">

--- a/packages/agent/gui/shared/agentConversation/components/AgentSelectedTextChip.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentSelectedTextChip.tsx
@@ -1,6 +1,5 @@
 import { MessageSquareText } from "lucide-react";
 import type { JSX } from "react";
-import { Badge } from "@tutti-os/ui-system";
 import { useTranslation } from "../../../i18n/index";
 import type { AgentSelectedTextVM } from "../contracts/agentMessageRowVM";
 
@@ -14,26 +13,27 @@ export function AgentSelectedTextChip({
   const count = selectedText.count;
   const label =
     count === 1
-      ? t("agentHost.agentGui.selectedTextFragment")
-      : t("agentHost.agentGui.selectedTextFragments", {
+      ? t("agentHost.agentGui.selectionReferenceCountOne")
+      : t("agentHost.agentGui.selectionReferenceCountMany", {
           count: String(count)
         });
 
   return (
-    <Badge
-      variant="outline"
+    <div
       data-testid="agent-selected-text-chip"
       data-selected-text-count={count}
       aria-label={label}
-      className="max-w-full rounded-full border-[var(--line-2)] bg-transparent px-3 py-1.5 text-[13px] font-normal leading-5 text-[var(--text-primary)]"
+      className="group inline-flex max-w-full items-center rounded-[10px] border border-[var(--line-1)] bg-[var(--background-fronted)] text-sm font-medium text-[var(--text-primary)]"
     >
-      <MessageSquareText
-        size={16}
-        strokeWidth={1.8}
-        aria-hidden="true"
-        className="shrink-0 text-[var(--text-secondary)]"
-      />
-      <span className="truncate">{label}</span>
-    </Badge>
+      <span className="inline-flex min-w-0 items-center gap-2 rounded-[9px] py-2 pl-3 pr-2">
+        <MessageSquareText
+          aria-hidden="true"
+          className="shrink-0 text-[var(--text-secondary)]"
+          size={16}
+          strokeWidth={2}
+        />
+        <span className="truncate">{label}</span>
+      </span>
+    </div>
   );
 }

--- a/packages/agent/gui/shared/agentConversation/components/AgentSelectedTextChip.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentSelectedTextChip.tsx
@@ -1,0 +1,39 @@
+import { MessageSquareText } from "lucide-react";
+import type { JSX } from "react";
+import { Badge } from "@tutti-os/ui-system";
+import { useTranslation } from "../../../i18n/index";
+import type { AgentSelectedTextVM } from "../contracts/agentMessageRowVM";
+
+export function AgentSelectedTextChip({
+  selectedText
+}: {
+  selectedText: AgentSelectedTextVM;
+}): JSX.Element {
+  "use memo";
+  const { t } = useTranslation();
+  const count = selectedText.count;
+  const label =
+    count === 1
+      ? t("agentHost.agentGui.selectedTextFragment")
+      : t("agentHost.agentGui.selectedTextFragments", {
+          count: String(count)
+        });
+
+  return (
+    <Badge
+      variant="outline"
+      data-testid="agent-selected-text-chip"
+      data-selected-text-count={count}
+      aria-label={label}
+      className="max-w-full rounded-full border-[var(--line-2)] bg-transparent px-3 py-1.5 text-[13px] font-normal leading-5 text-[var(--text-primary)]"
+    >
+      <MessageSquareText
+        size={16}
+        strokeWidth={1.8}
+        aria-hidden="true"
+        className="shrink-0 text-[var(--text-secondary)]"
+      />
+      <span className="truncate">{label}</span>
+    </Badge>
+  );
+}

--- a/packages/agent/gui/shared/agentConversation/components/agentTranscriptModel.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/components/agentTranscriptModel.spec.ts
@@ -6,6 +6,7 @@ import {
   buildAgentParticipantTurnProjection,
   buildAgentTranscriptTurnGroups,
   findTurnDividerRowIndexes,
+  summarizeUserMessageRow,
   transcriptRowKey
 } from "./agentTranscriptModel";
 
@@ -79,6 +80,40 @@ describe("findTurnDividerRowIndexes", () => {
         row("turn-2")
       ])
     ]).toEqual([2]);
+  });
+});
+
+describe("summarizeUserMessageRow", () => {
+  it("keeps a quote-only selected-text row addressable by the transcript locator", () => {
+    const selectedOnlyRow: AgentTranscriptRowVM = {
+      kind: "message",
+      id: "row:user:selection-only",
+      turnId: "turn-selection-only",
+      speaker: "user",
+      messages: [
+        {
+          kind: "message-content",
+          id: "message:user:selection-only",
+          turnId: "turn-selection-only",
+          body: "",
+          presentationKind: "content",
+          contentKind: "selected-text",
+          selectedText: {
+            count: 1,
+            texts: ["Selected source text"]
+          },
+          occurredAtUnixMs: 1
+        }
+      ],
+      thinking: [],
+      occurredAtUnixMs: 1
+    };
+
+    expect(
+      summarizeUserMessageRow(
+        selectedOnlyRow as Extract<AgentTranscriptRowVM, { kind: "message" }>
+      )
+    ).toBe("Selected source text");
   });
 });
 

--- a/packages/agent/gui/shared/agentConversation/components/agentTranscriptModel.ts
+++ b/packages/agent/gui/shared/agentConversation/components/agentTranscriptModel.ts
@@ -211,7 +211,14 @@ export function summarizeUserMessageRow(
   row: Extract<AgentConversationVM["rows"][number], { kind: "message" }>
 ): string {
   return normalizeLocatorSummary(
-    row.messages.map((message) => message.copyText ?? message.body).join(" ")
+    row.messages
+      .map((message) => {
+        if (message.contentKind === "selected-text") {
+          return message.selectedText?.texts.join(" ") ?? "";
+        }
+        return message.copyText ?? message.body;
+      })
+      .join(" ")
   );
 }
 

--- a/packages/agent/gui/shared/agentConversation/components/useAgentUserMessageEditRetry.ts
+++ b/packages/agent/gui/shared/agentConversation/components/useAgentUserMessageEditRetry.ts
@@ -22,9 +22,7 @@ export function useAgentUserMessageEditRetry(input: {
       ? (input.row.messages.find(
           (message) =>
             message.contentKind === "text" || message.contentKind === undefined
-        )?.id ??
-        input.row.messages.at(-1)?.id ??
-        null)
+        )?.id ?? null)
       : null;
   const canEdit =
     input.isUser &&

--- a/packages/agent/gui/shared/agentConversation/contracts/agentMessageRowVM.ts
+++ b/packages/agent/gui/shared/agentConversation/contracts/agentMessageRowVM.ts
@@ -5,6 +5,15 @@ import type { AgentTranscriptPresentationKind } from "./agentTranscriptPresentat
 import type { AgentCollaborationVM } from "./agentCollaborationVM";
 import type { AgentToolGroupRowVM } from "./agentToolGroupRowVM";
 
+export type AgentMessageContentKind =
+  | "text"
+  | "image-grid"
+  | "plan"
+  | "collaboration"
+  | "tutti-checkpoint-wake"
+  | "tutti-plan-issue-link"
+  | "selected-text";
+
 export interface AgentMessageContentVM {
   kind: "message-content";
   id: string;
@@ -13,13 +22,7 @@ export interface AgentMessageContentVM {
   presentationKind: AgentTranscriptPresentationKind;
   copyText?: string | null;
   statusKind?: ToolCallStatusKind | null;
-  contentKind?:
-    | "text"
-    | "image-grid"
-    | "plan"
-    | "collaboration"
-    | "tutti-checkpoint-wake"
-    | "tutti-plan-issue-link";
+  contentKind?: AgentMessageContentKind;
   isTurnFinalText?: true;
   /** Typed payload for `contentKind: "collaboration"` rows. */
   collaboration?: AgentCollaborationVM | null;
@@ -35,6 +38,8 @@ export interface AgentMessageContentVM {
    * Mode plan (messageId "plan-issue:<issueID>").
    */
   planIssueLink?: AgentTuttiPlanIssueLinkVM | null;
+  /** Typed payload for `contentKind: "selected-text"` rows. */
+  selectedText?: AgentSelectedTextVM | null;
   images?: AgentMessageImageVM[];
   occurredAtUnixMs: number | null;
   visibleError?: {
@@ -57,6 +62,11 @@ export interface AgentMessageContentVM {
     retryable: boolean | null;
   } | null;
   sourceTimelineItems?: WorkspaceAgentActivityTimelineItem[];
+}
+
+export interface AgentSelectedTextVM {
+  count: number;
+  texts: readonly string[];
 }
 
 export interface AgentTuttiModeCheckpointWakeVM {

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
@@ -2138,6 +2138,198 @@ describe("projectAgentConversationVM", () => {
     );
   });
 
+  it("projects selected prompt text as a reference part instead of flattening it into the bubble", () => {
+    const conversation = projectAgentConversationVM(
+      detailViewModel({
+        turns: [
+          {
+            id: "turn-1",
+            userMessage: null,
+            userMessages: [
+              {
+                id: "user-1",
+                body: "这里说了什么\n> 对 tutti-lab/tutti 的影响是：它需要把 Go 依赖从旧的 tsh-server module 更新到新的 tutti-server module。",
+                sourceTimelineItems: [
+                  {
+                    id: 1,
+                    agentSessionId: "session-1",
+                    eventId: "event-1",
+                    actorType: "user",
+                    actorId: "user",
+                    itemType: "message",
+                    role: "user",
+                    payload: {
+                      displayPrompt:
+                        "这里说了什么\n> 对 tutti-lab/tutti 的影响是：它需要把 Go 依赖从旧的 tsh-server module 更新到新的 tutti-server module。",
+                      content: [
+                        { type: "text", text: "这里说了什么" },
+                        {
+                          type: "text",
+                          text: "> 对 tutti-lab/tutti 的影响是：它需要把 Go 依赖从旧的 tsh-server module 更新到新的 tutti-server module。"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            agentMessages: [],
+            toolCalls: [],
+            toolCallCount: 0,
+            hasFailedToolCall: false,
+            agentItems: []
+          }
+        ],
+        showProcessingIndicator: false
+      })
+    );
+
+    const userRow = conversation.rows.find(
+      (
+        row
+      ): row is Extract<
+        (typeof conversation.rows)[number],
+        { kind: "message" }
+      > => row.kind === "message" && row.speaker === "user"
+    );
+
+    expect(userRow?.messages.map((message) => message.contentKind)).toEqual([
+      "selected-text",
+      "text"
+    ]);
+    expect(userRow?.messages[0]).toMatchObject({
+      body: "",
+      selectedText: {
+        count: 1,
+        texts: [
+          "对 tutti-lab/tutti 的影响是：它需要把 Go 依赖从旧的 tsh-server module 更新到新的 tutti-server module。"
+        ]
+      }
+    });
+    expect(userRow?.messages[1]?.body).toBe("这里说了什么");
+  });
+
+  it("projects every legacy quote after a typed prompt into one reference part", () => {
+    const conversation = projectUserPromptForTest({
+      body: "Ask about both excerpts\n> first excerpt\n> second excerpt",
+      displayPrompt:
+        "Ask about both excerpts\n> first excerpt\n> second excerpt",
+      content: [
+        { type: "text", text: "Ask about both excerpts" },
+        { type: "text", text: "> first excerpt" },
+        { type: "text", text: "> second excerpt" }
+      ]
+    });
+
+    const userRow = conversation.rows.find(
+      (
+        row
+      ): row is Extract<
+        (typeof conversation.rows)[number],
+        { kind: "message" }
+      > => row.kind === "message" && row.speaker === "user"
+    );
+
+    expect(userRow?.messages.map((message) => message.contentKind)).toEqual([
+      "selected-text",
+      "text"
+    ]);
+    expect(userRow?.messages[0]?.selectedText).toEqual({
+      count: 2,
+      texts: ["first excerpt", "second excerpt"]
+    });
+    expect(userRow?.messages[1]?.body).toBe("Ask about both excerpts");
+  });
+
+  it("keeps ambiguous quote-only legacy content as ordinary Markdown", () => {
+    const conversation = projectUserPromptForTest({
+      body: "> first authored line\n> second authored line",
+      displayPrompt: "> first authored line\n> second authored line",
+      content: [
+        { type: "text", text: "> first authored line" },
+        { type: "text", text: "> second authored line" }
+      ]
+    });
+
+    const userRow = conversation.rows.find(
+      (
+        row
+      ): row is Extract<
+        (typeof conversation.rows)[number],
+        { kind: "message" }
+      > => row.kind === "message" && row.speaker === "user"
+    );
+
+    expect(userRow?.messages.map((message) => message.contentKind)).toEqual([
+      "text"
+    ]);
+    expect(userRow?.messages[0]?.body).toBe(
+      "> first authored line\n> second authored line"
+    );
+  });
+
+  it("preserves an explicit selected-text kind already present in persisted content", () => {
+    const conversation = projectAgentConversationVM(
+      detailViewModel({
+        turns: [
+          {
+            id: "turn-1",
+            userMessage: null,
+            userMessages: [
+              {
+                id: "user-1",
+                body: "Ask about the selection",
+                sourceTimelineItems: [
+                  {
+                    id: 1,
+                    agentSessionId: "session-1",
+                    eventId: "event-1",
+                    actorType: "user",
+                    actorId: "user",
+                    itemType: "message",
+                    role: "user",
+                    payload: {
+                      displayPrompt: "Ask about the selection",
+                      content: [
+                        { type: "text", text: "Ask about the selection" },
+                        {
+                          type: "text",
+                          kind: "selected-text",
+                          text: "Selected source text"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            agentMessages: [],
+            toolCalls: [],
+            toolCallCount: 0,
+            hasFailedToolCall: false,
+            agentItems: []
+          }
+        ],
+        showProcessingIndicator: false
+      })
+    );
+
+    const userRow = conversation.rows.find(
+      (
+        row
+      ): row is Extract<
+        (typeof conversation.rows)[number],
+        { kind: "message" }
+      > => row.kind === "message" && row.speaker === "user"
+    );
+
+    expect(userRow?.messages[0]?.selectedText).toEqual({
+      count: 1,
+      texts: ["Selected source text"]
+    });
+    expect(userRow?.messages[1]?.body).toBe("Ask about the selection");
+  });
+
   it("prefers materialized content text over legacy composer-file displayPrompt", () => {
     const conversation = projectAgentConversationVM(
       detailViewModel({
@@ -2537,6 +2729,52 @@ function detailViewModel(
     showProcessingIndicator: true,
     ...overrides
   };
+}
+
+function projectUserPromptForTest(input: {
+  body: string;
+  displayPrompt: string;
+  content: readonly unknown[];
+}): ReturnType<typeof projectAgentConversationVM> {
+  const baseTurn = detailViewModel().turns[0]!;
+  return projectAgentConversationVM(
+    detailViewModel({
+      turns: [
+        {
+          ...baseTurn,
+          id: "turn-user-prompt",
+          userMessage: null,
+          userMessages: [
+            {
+              id: "user-prompt",
+              body: input.body,
+              sourceTimelineItems: [
+                {
+                  id: 1,
+                  agentSessionId: "session-1",
+                  eventId: "event-1",
+                  actorType: "user",
+                  actorId: "user",
+                  itemType: "message",
+                  role: "user",
+                  payload: {
+                    displayPrompt: input.displayPrompt,
+                    content: input.content
+                  }
+                }
+              ]
+            }
+          ],
+          agentMessages: [],
+          toolCalls: [],
+          toolCallCount: 0,
+          hasFailedToolCall: false,
+          agentItems: []
+        }
+      ],
+      showProcessingIndicator: false
+    })
+  );
 }
 
 function compactNoticeMessage(

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationUserProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationUserProjection.ts
@@ -66,11 +66,12 @@ function firstRawUserPromptTextBlock(
       continue;
     }
     for (const raw of content) {
-      const block =
-        raw && typeof raw === "object" && !Array.isArray(raw)
-          ? (raw as Record<string, unknown>)
-          : null;
-      if (block?.type === "text" && typeof block.text === "string") {
+      const block = promptContentRecord(raw);
+      if (
+        block?.type === "text" &&
+        typeof block.text === "string" &&
+        block.kind !== "selected-text"
+      ) {
         return block.text;
       }
     }
@@ -97,6 +98,31 @@ function projectUserMessageContentParts(
     return [textPart(message, turnId)];
   }
   const parts: AgentMessageContentVM[] = [];
+  const selectedTextBlocks = blocks.filter(
+    (block): block is UserPromptTextBlock =>
+      block.type === "text" && block.kind === "selected-text"
+  );
+  if (selectedTextBlocks.length > 0) {
+    // Reference context is a presentation-only part. The ordinary text part
+    // remains the sole editable/copyable user message, matching the composer
+    // question bubble while keeping the selected boundary visible.
+    parts.push({
+      kind: "message-content",
+      id: `${message.id}:selected-text`,
+      turnId,
+      body: "",
+      presentationKind: "content",
+      contentKind: "selected-text",
+      selectedText: {
+        count: selectedTextBlocks.length,
+        texts: selectedTextBlocks.map((block) =>
+          stripSelectedTextPrefix(block.text)
+        )
+      },
+      occurredAtUnixMs: message.occurredAtUnixMs ?? null,
+      sourceTimelineItems: message.sourceTimelineItems
+    });
+  }
   const imageBlocks = blocks.filter(
     (block): block is UserPromptImageBlock => block.type === "image"
   );
@@ -124,7 +150,13 @@ function projectUserMessageContentParts(
     });
   }
   blocks.forEach((block, index) => {
-    if (block.type === "image" || block.text.trim() === "") return;
+    if (
+      block.type === "image" ||
+      block.text.trim() === "" ||
+      block.kind === "selected-text"
+    ) {
+      return;
+    }
     parts.push({
       kind: "message-content",
       id: `${message.id}:text:${index}`,
@@ -160,6 +192,7 @@ type UserPromptContentBlock = UserPromptTextBlock | UserPromptImageBlock;
 interface UserPromptTextBlock {
   type: "text";
   text: string;
+  kind?: string;
 }
 
 interface UserPromptImageBlock {
@@ -192,6 +225,10 @@ function userPromptContentBlocks(
         : ""
     ) ?? []
   );
+  const selectedTextBlockIndexes = selectedTextContentBlockIndexes(
+    content,
+    displayPrompt
+  );
   const visibleDisplayPrompt = isSyntheticImageOnlyDisplayPrompt(
     displayPrompt,
     content
@@ -217,38 +254,115 @@ function userPromptContentBlocks(
     });
   const effectiveDisplayPrompt = preferMaterializedContentText
     ? ""
-    : visibleDisplayPrompt;
-  const blocks = content.flatMap((raw): UserPromptContentBlock[] => {
-    const block =
-      raw && typeof raw === "object" && !Array.isArray(raw)
-        ? (raw as Record<string, unknown>)
-        : null;
-    if (!block) return [];
-    if (block.type === "text" && typeof block.text === "string") {
-      return effectiveDisplayPrompt
-        ? []
-        : [{ type: "text", text: linkifyPastedTextReferences(block.text) }];
-    }
-    if (block.type !== "image") return [];
-    const mimeType =
-      typeof block.mimeType === "string" ? block.mimeType.trim() : "";
-    return [
-      {
-        type: "image",
-        workspaceId: item?.workspaceId ?? fallbackWorkspaceId ?? null,
-        agentSessionId: item?.agentSessionId ?? message.id,
-        attachmentId: optionalString(block.attachmentId),
-        mimeType,
-        name: optionalString(block.name),
-        data: optionalString(block.data),
-        url: optionalString(block.url),
-        path: optionalString(block.path)
+    : selectedTextBlockIndexes.size > 0
+      ? ""
+      : visibleDisplayPrompt;
+  const blocks = content.flatMap(
+    (raw, contentIndex): UserPromptContentBlock[] => {
+      const block = promptContentRecord(raw);
+      if (!block) return [];
+      if (block.type === "text" && typeof block.text === "string") {
+        const kind = selectedTextBlockIndexes.has(contentIndex)
+          ? "selected-text"
+          : typeof block.kind === "string"
+            ? block.kind
+            : undefined;
+        return effectiveDisplayPrompt
+          ? []
+          : [
+              {
+                type: "text",
+                text: linkifyPastedTextReferences(block.text),
+                ...(kind ? { kind } : {})
+              }
+            ];
       }
-    ];
-  });
+      if (block.type !== "image") return [];
+      const mimeType =
+        typeof block.mimeType === "string" ? block.mimeType.trim() : "";
+      return [
+        {
+          type: "image",
+          workspaceId: item?.workspaceId ?? fallbackWorkspaceId ?? null,
+          agentSessionId: item?.agentSessionId ?? message.id,
+          attachmentId: optionalString(block.attachmentId),
+          mimeType,
+          name: optionalString(block.name),
+          data: optionalString(block.data),
+          url: optionalString(block.url),
+          path: optionalString(block.path)
+        }
+      ];
+    }
+  );
   return effectiveDisplayPrompt
     ? [{ type: "text", text: effectiveDisplayPrompt }, ...blocks]
     : blocks;
+}
+
+function selectedTextContentBlockIndexes(
+  content: readonly unknown[],
+  displayPrompt: string
+): ReadonlySet<number> {
+  const result = new Set<number>();
+  const textIndexes: number[] = [];
+  for (const [index, raw] of content.entries()) {
+    const block = promptContentRecord(raw);
+    if (block?.type === "text" && typeof block.text === "string") {
+      textIndexes.push(index);
+    }
+  }
+  const firstNonQuoteTextOrdinal = textIndexes.findIndex((contentIndex) => {
+    const block = promptContentRecord(content[contentIndex]);
+    return (
+      typeof block?.text === "string" &&
+      block.text.trim() !== "" &&
+      !isSelectedTextBlockquote(block.text)
+    );
+  });
+  const normalizedDisplayPrompt = displayPrompt.replace(/\r\n?/gu, "\n");
+  for (const [textOrdinal, contentIndex] of textIndexes.entries()) {
+    const block = promptContentRecord(content[contentIndex]);
+    const text = typeof block?.text === "string" ? block.text : "";
+    if (block?.kind === "selected-text") {
+      result.add(contentIndex);
+      continue;
+    }
+    if (
+      firstNonQuoteTextOrdinal < 0 ||
+      textOrdinal <= firstNonQuoteTextOrdinal ||
+      !isSelectedTextBlockquote(text) ||
+      !normalizedDisplayPrompt.includes(text.replace(/\r\n?/gu, "\n").trim())
+    ) {
+      continue;
+    }
+    // The composer currently puts a non-quote typed prompt first and each
+    // selected transcript quote after it. Ambiguous quote-only legacy payloads
+    // stay ordinary Markdown; only an explicit kind can identify those.
+    result.add(contentIndex);
+  }
+  return result;
+}
+
+function isSelectedTextBlockquote(text: string): boolean {
+  const lines = text.trim().split(/\r?\n/u);
+  return (
+    lines.length > 0 && lines.every((line) => /^>\s?/u.test(line.trimStart()))
+  );
+}
+
+function stripSelectedTextPrefix(text: string): string {
+  return text
+    .split(/\r?\n/u)
+    .map((line) => line.replace(/^\s*>\s?/u, ""))
+    .join("\n")
+    .trim();
+}
+
+function promptContentRecord(raw: unknown): Record<string, unknown> | null {
+  return raw && typeof raw === "object" && !Array.isArray(raw)
+    ? (raw as Record<string, unknown>)
+    : null;
 }
 
 function isSyntheticImageOnlyDisplayPrompt(


### PR DESCRIPTION
## Summary

- Preserve the typed prompt and legacy selected-text quote boundary in the conversation projection.
- Render selected references as a localized compact chip, while keeping ordinary prompt text as the editable/copyable bubble.
- Keep ambiguous quote-only legacy Markdown unchanged and support an explicit selected-text kind when already present in persisted content.
- Cover projection, renderer, edit-target, locator-summary, i18n, and architecture documentation behavior.

## Validation

- Focused Vitest: 4 files, 107 tests passed.
- Oxfmt check passed on changed TypeScript files.
- Oxlint passed on changed TypeScript files.
- git diff --check passed.
- Desktop replay E2E was attempted but the sparse checkout does not contain tools/scripts/run-agent-session-replay.mjs.
- Full package suite and package typecheck are environment-blocked in this sparse checkout by duplicate React and older linked workspace package APIs; no failure points to the changed files.

## Risk

No API, SQLite, daemon, or Side protocol changes. Legacy quote-only payloads remain ordinary Markdown because the text-only wire shape cannot distinguish them from authored blockquotes; an authoritative chip for that case needs a future protocol/adapter change.