### PR TITLE
fix(agent): normalize provider failures and rebind model plans

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -614,6 +614,12 @@ command, marker, token, or API key proves only `configured`. A provider-backed
 account probe or successful agent request proves `authenticated`. An explicit
 remote authentication failure proves `required` and outranks stale local
 credentials until credentials change or a later provider request succeeds.
+Conversation failures may update this provider-global state only for a
+provider-native runtime and only from the typed completed root-provider Turn:
+`auth_required` records required, while a completed outcome records success.
+Model Plan and Agent Extension failures are connection-scoped and never mutate
+the provider-global login state. Shared layers do not infer authentication from
+provider prose, HTTP 403, gateway timeouts, billing, quota, or model errors.
 `packages/agent/daemon/providerstatus` owns evidence reduction; `tuttid` owns
 the live outcome store, cache invalidation, and public status projection. Tutti
 Desktop management surfaces and AgentGUI consume that same status. They may
@@ -628,6 +634,11 @@ Desktop windows reconcile stale providers on focus/visibility activation and
 on the 15-minute poll. API-key configuration skips subscription OAuth checks.
 Explicit authentication rejection is authoritative; rate limits, server
 errors, and network failures leave the weaker `configured` state intact.
+Conversation error adapters preserve typed provider code, HTTP status,
+retryability, origin, and sanitized upstream detail. AgentGUI shows sanitized
+provider-origin detail directly; Tutti-owned transport and lifecycle failures
+continue to use localized product copy. Secrets are redacted before logging,
+persistence, or presentation.
 These checks validate current access but do not rotate refresh tokens; refresh
 ownership requires a separate serialized credential lifecycle that can gate on
 live provider processes.

--- a/docs/architecture/model-access-plans.md
+++ b/docs/architecture/model-access-plans.md
@@ -166,8 +166,11 @@ Rules:
 - Responses-gateway routes are in-memory runtime resources keyed by
   workspace/session.
   Create failure, deletion, legacy cleanup paths, and resume replacement revoke
-  the previous token. Resume resolves the immutable Model Plan revision from
-  the session runtime snapshot before registering the replacement route.
+  the previous token. Before each new ordinary Turn, a plan-bound Session
+  compares its snapshotted revision with the current revision of that exact
+  Plan. A change prepares a replacement runtime from the new immutable
+  revision, atomically swaps the durable snapshot, and only then admits the
+  Turn. Guidance and an already-running Turn keep their existing binding.
 - The Responses-to-Chat gateway is bound to `127.0.0.1:0` on its own listener
   and serves only authenticated `POST /v1/responses`. It is not mounted on the
   public tuttid HTTP router, so no daemon OpenAPI change is involved.

--- a/packages/agent/daemon/providerstatus/codex_remote_auth.go
+++ b/packages/agent/daemon/providerstatus/codex_remote_auth.go
@@ -1,31 +1,13 @@
 package providerstatus
 
-import "strings"
-
 // CodexRemoteAuthEvidence converts the provider-backed result of
 // account/rateLimits/read into the shared authentication evidence vocabulary.
-// Only explicit authentication rejection invalidates the weaker local session.
+// This compatibility helper deliberately does not parse failure prose. New
+// callers use account/read's structured AccountState instead.
 func CodexRemoteAuthEvidence(success bool, failure string) AuthEvidence {
 	if success {
 		return AuthEvidence{Kind: AuthEvidenceRemoteSuccess}
 	}
-	lower := strings.ToLower(strings.TrimSpace(failure))
-	switch {
-	case strings.Contains(lower, "session expired"),
-		strings.Contains(lower, "unauthorized"),
-		strings.Contains(lower, "401"),
-		strings.Contains(lower, "403"),
-		strings.Contains(lower, "access token expired"),
-		strings.Contains(lower, "refresh token"),
-		strings.Contains(lower, "token has been revoked"),
-		strings.Contains(lower, "token was revoked"),
-		strings.Contains(lower, "invalid bearer token"):
-		return AuthEvidence{Kind: AuthEvidenceRemoteAuthFailure, Reason: AuthReasonSessionExpired}
-	case strings.Contains(lower, "not logged in"),
-		strings.Contains(lower, "unauthenticated"),
-		strings.Contains(lower, "authentication required"):
-		return AuthEvidence{Kind: AuthEvidenceRemoteAuthFailure, Reason: AuthReasonAuthRequired}
-	default:
-		return AuthEvidence{Kind: AuthEvidenceProbeFailure, Reason: AuthReasonProbeFailed}
-	}
+	_ = failure
+	return AuthEvidence{Kind: AuthEvidenceProbeFailure, Reason: AuthReasonProbeFailed}
 }

--- a/packages/agent/daemon/providerstatus/codex_remote_auth_test.go
+++ b/packages/agent/daemon/providerstatus/codex_remote_auth_test.go
@@ -11,8 +11,8 @@ func TestCodexRemoteAuthEvidenceClassifiesProviderResult(t *testing.T) {
 		wantReason string
 	}{
 		{name: "accepted", success: true, wantKind: AuthEvidenceRemoteSuccess},
-		{name: "revoked", failure: "401 Unauthorized: refresh token was revoked", wantKind: AuthEvidenceRemoteAuthFailure, wantReason: AuthReasonSessionExpired},
-		{name: "signed out", failure: "authentication required", wantKind: AuthEvidenceRemoteAuthFailure, wantReason: AuthReasonAuthRequired},
+		{name: "revoked prose is not evidence", failure: "401 Unauthorized: refresh token was revoked", wantKind: AuthEvidenceProbeFailure, wantReason: AuthReasonProbeFailed},
+		{name: "signed out prose is not evidence", failure: "authentication required", wantKind: AuthEvidenceProbeFailure, wantReason: AuthReasonProbeFailed},
 		{name: "transient", failure: "connection reset", wantKind: AuthEvidenceProbeFailure, wantReason: AuthReasonProbeFailed},
 	}
 	for _, test := range tests {

--- a/packages/agent/daemon/providerstatus/remote_auth.go
+++ b/packages/agent/daemon/providerstatus/remote_auth.go
@@ -31,7 +31,7 @@ type RemoteAuthProbeResult struct {
 
 // ProbeRemoteAuth converts a descriptor-owned HTTP bearer request into the
 // shared authentication evidence vocabulary. Only explicit provider rejection
-// (401/403) revokes local configuration; rate limits, server failures and
+// (401) revokes local configuration; forbidden, rate limits, server failures and
 // transport errors remain probe failures so local credentials stay launchable.
 func ProbeRemoteAuth(
 	ctx context.Context,
@@ -88,7 +88,7 @@ func ProbeRemoteAuth(
 		result.Body = body
 		result.Evidence = AuthEvidence{Kind: AuthEvidenceRemoteSuccess}
 		return result
-	case response.StatusCode == http.StatusUnauthorized || response.StatusCode == http.StatusForbidden:
+	case response.StatusCode == http.StatusUnauthorized:
 		result.Evidence = AuthEvidence{
 			Kind:   AuthEvidenceRemoteAuthFailure,
 			Reason: AuthReasonSessionExpired,

--- a/packages/agent/daemon/providerstatus/remote_auth_test.go
+++ b/packages/agent/daemon/providerstatus/remote_auth_test.go
@@ -18,7 +18,7 @@ func TestProbeRemoteAuthClassifiesProviderEvidence(t *testing.T) {
 	}{
 		{name: "accepted", statusCode: http.StatusOK, wantKind: AuthEvidenceRemoteSuccess},
 		{name: "unauthorized", statusCode: http.StatusUnauthorized, wantKind: AuthEvidenceRemoteAuthFailure, wantReason: AuthReasonSessionExpired},
-		{name: "forbidden", statusCode: http.StatusForbidden, wantKind: AuthEvidenceRemoteAuthFailure, wantReason: AuthReasonSessionExpired},
+		{name: "forbidden", statusCode: http.StatusForbidden, wantKind: AuthEvidenceProbeFailure, wantReason: AuthReasonProbeFailed},
 		{name: "rate limited", statusCode: http.StatusTooManyRequests, wantKind: AuthEvidenceProbeFailure, wantReason: AuthReasonProbeFailed},
 		{name: "server failure", statusCode: http.StatusBadGateway, wantKind: AuthEvidenceProbeFailure, wantReason: AuthReasonProbeFailed},
 	}

--- a/packages/agent/daemon/runtime/acp_client.go
+++ b/packages/agent/daemon/runtime/acp_client.go
@@ -91,11 +91,8 @@ func (e *acpCallError) AuthRequired() bool {
 	if e == nil {
 		return false
 	}
-	haystack := strings.ToLower(e.Err.Message + " " + string(e.Err.Data))
-	if structuredProviderFailureCode(haystack) != "" {
-		return false
-	}
-	return strings.Contains(haystack, "auth")
+	failure := failureFromACPCall(e)
+	return failure.AuthImpact == providerFailureAuthRequired
 }
 
 func newACPClientWithStderrMessageMapper(conn ProcessConnection, mapper acpStderrMessageMapper) *acpClient {
@@ -297,13 +294,15 @@ func (c *acpClient) callLocked(
 			return result, nil
 		case message := <-pending.response:
 			if message.Error != nil {
+				sanitizedMessage := sanitizeProviderFailureText(message.Error.Message)
+				sanitizedData := sanitizeProviderFailureText(string(message.Error.Data))
 				slog.Warn("agent session ACP request failed",
 					"event", "agent_session.acp.request.failed",
 					"method", method,
 					"id", id,
 					"error_code", message.Error.Code,
-					"error_message", message.Error.Message,
-					"error_data", truncateACPLogValue(string(message.Error.Data), 1200),
+					"error_message", sanitizedMessage,
+					"error_data", truncateACPLogValue(sanitizedData, 1200),
 				)
 				return nil, &acpCallError{Method: method, Err: *message.Error}
 			}

--- a/packages/agent/daemon/runtime/acp_update_events.go
+++ b/packages/agent/daemon/runtime/acp_update_events.go
@@ -337,9 +337,7 @@ func acpFailureMetadata(err error) map[string]any {
 	if err == nil {
 		return nil
 	}
-	payload := map[string]any{
-		"error": err.Error(),
-	}
+	payload := map[string]any{"error": sanitizeProviderFailureText(err.Error())}
 	var transportFailure RuntimeTransportFailure
 	if errors.As(err, &transportFailure) {
 		if code := boundedRuntimeTransportFailureCode(transportFailure.RuntimeTransportFailureCode()); code != "" {
@@ -357,16 +355,22 @@ func acpFailureMetadata(err error) map[string]any {
 	if !errors.As(err, &callErr) {
 		return payload
 	}
+	for key, value := range failureFromACPCall(callErr).metadata() {
+		payload[key] = value
+	}
 	payload["acpErrorCode"] = callErr.Err.Code
 	if message := strings.TrimSpace(callErr.Err.Message); message != "" {
-		payload["acpErrorMessage"] = message
+		payload["acpErrorMessage"] = sanitizeProviderFailureText(message)
 	}
 	data := acpErrorDataPayload(callErr.Err.Data)
-	if message := strings.TrimSpace(asString(data["message"])); message != "" {
-		payload["error"] = message
-		payload["errorMessage"] = message
+	if rawData := sanitizeProviderFailureText(string(callErr.Err.Data)); rawData != "" && rawData != "null" {
+		payload["acpErrorData"] = rawData
 	}
-	if codexErrorInfo := firstNonEmpty(asString(data["codex_error_info"]), asString(data["codexErrorInfo"])); codexErrorInfo != "" {
+	if message := strings.TrimSpace(asString(data["message"])); message != "" {
+		payload["error"] = sanitizeProviderFailureText(message)
+		payload["errorMessage"] = sanitizeProviderFailureText(message)
+	}
+	if codexErrorInfo := clonePayloadValue(firstPresentAny(data["codex_error_info"], data["codexErrorInfo"])); codexErrorInfo != nil {
 		payload["codexErrorInfo"] = codexErrorInfo
 	}
 	return payload

--- a/packages/agent/daemon/runtime/activity_projection.go
+++ b/packages/agent/daemon/runtime/activity_projection.go
@@ -8,6 +8,7 @@ import (
 	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 	"github.com/tutti-os/tutti/packages/agent/daemon/liveprotocol"
+	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
 	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
 )
 
@@ -215,14 +216,25 @@ func isPrecommitTerminalTextMessage(event activityshared.Event) bool {
 
 func eventSourceFromSession(session Session) canonical.EventSource {
 	return canonical.EventSource{
-		Provider:               strings.TrimSpace(session.Provider),
-		ProviderSessionID:      strings.TrimSpace(session.ProviderSessionID),
-		SessionCreatedAtUnixMS: session.CreatedAtUnixMS,
-		AgentID:                strings.TrimSpace(session.AgentSessionID),
-		AgentTargetID:          strings.TrimSpace(session.AgentTargetID),
-		CWD:                    strings.TrimSpace(session.CWD),
-		SessionOrigin:          agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+		Provider:                   strings.TrimSpace(session.Provider),
+		ProviderSessionID:          strings.TrimSpace(session.ProviderSessionID),
+		SessionCreatedAtUnixMS:     session.CreatedAtUnixMS,
+		AgentID:                    strings.TrimSpace(session.AgentSessionID),
+		AgentTargetID:              strings.TrimSpace(session.AgentTargetID),
+		CWD:                        strings.TrimSpace(session.CWD),
+		SessionOrigin:              agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+		ProviderGlobalAuthEligible: providerGlobalAuthEligible(session),
 	}
+}
+
+func providerGlobalAuthEligible(session Session) bool {
+	snapshot, _ := session.RuntimeContext["sessionRuntimeSnapshot"].(map[string]any)
+	configuration, _ := snapshot["modelConfiguration"].(map[string]any)
+	if strings.TrimSpace(asString(configuration["source"])) != "provider-native" {
+		return false
+	}
+	_, migrated := providerregistry.Find(session.Provider)
+	return migrated
 }
 
 func activityEventContext(session Session, eventID string, turnID string) (activityshared.EventContext, bool) {

--- a/packages/agent/daemon/runtime/activity_projection_test.go
+++ b/packages/agent/daemon/runtime/activity_projection_test.go
@@ -576,6 +576,32 @@ func TestEventSourceCarriesStableSessionIncarnation(t *testing.T) {
 	}
 }
 
+func TestProviderGlobalAuthEligibilityRequiresProviderNativeConfiguration(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		source   string
+		want     bool
+	}{
+		{name: "codex native", provider: "codex", source: "provider-native", want: true},
+		{name: "claude model plan", provider: "claude-code", source: "model-plan"},
+		{name: "cursor extension", provider: "cursor", source: "agent-extension"},
+		{name: "unknown provider", provider: "third-party", source: "provider-native"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			session := Session{Provider: test.provider, RuntimeContext: map[string]any{
+				"sessionRuntimeSnapshot": map[string]any{
+					"modelConfiguration": map[string]any{"source": test.source},
+				},
+			}}
+			if got := providerGlobalAuthEligible(session); got != test.want {
+				t.Fatalf("providerGlobalAuthEligible() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
 func TestSessionAuditProjectsSeparatelyFromTurnMessages(t *testing.T) {
 	t.Parallel()
 	session := reportTestSession()

--- a/packages/agent/daemon/runtime/claude_sdk_events.go
+++ b/packages/agent/daemon/runtime/claude_sdk_events.go
@@ -466,10 +466,9 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 			return events, true, nil
 		}
 		events := a.finishClaudeSDKTurnLifecycle(adapterSession, session, rootTurnID, claudeSDKTurnFinishFailed, "turn_failed")
-		events = append(events, claudeSDKRootProviderTurnCompletedEvent(session, rootTurnID, boundProviderTurnID, activityshared.TurnOutcomeFailed, map[string]any{
-			"adapter": claudeSDKSidecarAdapterName,
-			"error":   payloadString(event.Payload, "error"),
-		}))
+		failureMetadata := claudeProviderFailure(event.Payload).metadata()
+		failureMetadata["adapter"] = claudeSDKSidecarAdapterName
+		events = append(events, claudeSDKRootProviderTurnCompletedEvent(session, rootTurnID, boundProviderTurnID, activityshared.TurnOutcomeFailed, failureMetadata))
 		if len(goalEvents) > 0 {
 			events = append(events, goalEvents...)
 		} else {

--- a/packages/agent/daemon/runtime/claude_sdk_rejection.go
+++ b/packages/agent/daemon/runtime/claude_sdk_rejection.go
@@ -2,7 +2,6 @@ package agentruntime
 
 import (
 	"errors"
-	"strings"
 
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
@@ -29,21 +28,11 @@ func newClaudeSDKProviderRejectedError(
 	session Session,
 	payload map[string]any,
 ) error {
-	detail := strings.TrimSpace(payloadString(payload, "error"))
-	providerCode := strings.TrimSpace(payloadString(payload, "code"))
-	if detail == "" {
-		detail = providerCode
-	}
-	if detail == "" {
-		detail = "Claude provider rejected the Turn before acceptance"
-	}
-	code := visibleFailureCode(strings.Join([]string{providerCode, detail}, " "))
-	if providerCode == "authentication_failed" || payloadInt64(payload, "apiErrorStatus") == 401 {
-		code = "auth_required"
-	}
+	failure := claudeProviderFailure(payload)
+	detail := sanitizeProviderFailureText(failure.Message)
 	return &claudeSDKProviderRejectedError{providerError: &AppError{
-		Code:         code,
-		Message:      visibleFailureContent(session.Provider, "turn", code),
+		Code:         failure.Code,
+		Message:      visibleFailureContent(session.Provider, "turn", failure.Code),
 		DebugMessage: detail,
 		Cause:        errors.New(detail),
 	}}
@@ -69,11 +58,17 @@ func ensureClaudeSDKPreAcceptanceFailureEvent(
 		}
 	}
 	if !hasTurnFailed {
-		metadata := map[string]any{
+		metadata := claudeProviderFailure(payload).metadata()
+		metadata["stopReason"] = "failed_before_provider_acceptance"
+		for key, value := range map[string]any{
 			"stopReason":     "failed_before_provider_acceptance",
 			"code":           payloadString(payload, "code"),
 			"error":          payloadString(payload, "error"),
 			"apiErrorStatus": payloadInt64(payload, "apiErrorStatus"),
+		} {
+			if _, exists := metadata[key]; !exists {
+				metadata[key] = value
+			}
 		}
 		if rejected {
 			metadata["dispatchDisposition"] = string(DispatchDispositionRejected)

--- a/packages/agent/daemon/runtime/codex_appserver_event_info.go
+++ b/packages/agent/daemon/runtime/codex_appserver_event_info.go
@@ -181,15 +181,11 @@ func appServerTurnTerminalEvents(
 			"stopReason": "failed",
 		}
 		if turnError := payloadObject(turn["error"]); len(turnError) > 0 {
-			if message := asStringRaw(turnError["message"]); message != "" {
-				metadata["error"] = message
-				metadata["errorMessage"] = message
+			for key, value := range failureFromCodexTurnError(turnError).metadata() {
+				metadata[key] = value
 			}
 			if codexErrorInfo := turnError["codexErrorInfo"]; codexErrorInfo != nil {
 				metadata["codexErrorInfo"] = clonePayloadValue(codexErrorInfo)
-			}
-			if details := asStringRaw(turnError["additionalDetails"]); details != "" {
-				metadata["additionalDetails"] = details
 			}
 		}
 		terminal := appServerRootProviderTurnCompletedEvent(session, turnID, providerTurnID, activityshared.TurnOutcomeFailed, metadata)

--- a/packages/agent/daemon/runtime/provider_failure.go
+++ b/packages/agent/daemon/runtime/provider_failure.go
@@ -1,0 +1,255 @@
+package agentruntime
+
+import (
+	"encoding/json"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	providerFailureOriginProvider  = "provider"
+	providerFailureOriginTransport = "transport"
+	providerFailureAuthNone        = "none"
+	providerFailureAuthRequired    = "required"
+)
+
+// ProviderFailure is the normalized boundary between provider protocols and
+// canonical activity. Provider adapters own classification; shared layers must
+// not infer authentication state from provider prose.
+type ProviderFailure struct {
+	Code              string
+	ProviderCode      string
+	HTTPStatus        *int
+	Message           string
+	AdditionalDetails string
+	Retryable         *bool
+	Origin            string
+	AuthImpact        string
+	AuthReason        string
+}
+
+func (failure ProviderFailure) metadata() map[string]any {
+	message := sanitizeProviderFailureText(failure.Message)
+	details := sanitizeProviderFailureText(failure.AdditionalDetails)
+	payload := map[string]any{
+		"code":       firstNonEmptyString(strings.TrimSpace(failure.Code), "provider_error"),
+		"origin":     firstNonEmptyString(strings.TrimSpace(failure.Origin), providerFailureOriginProvider),
+		"authImpact": firstNonEmptyString(strings.TrimSpace(failure.AuthImpact), providerFailureAuthNone),
+	}
+	if message != "" {
+		payload["error"] = message
+		payload["errorMessage"] = message
+	}
+	if details != "" && details != message {
+		payload["additionalDetails"] = details
+	}
+	if code := strings.TrimSpace(failure.ProviderCode); code != "" {
+		payload["providerCode"] = code
+	}
+	if failure.HTTPStatus != nil {
+		payload["httpStatus"] = *failure.HTTPStatus
+	}
+	if failure.Retryable != nil {
+		payload["retryable"] = *failure.Retryable
+	}
+	if failure.AuthImpact == providerFailureAuthRequired {
+		payload["authReason"] = firstNonEmptyString(strings.TrimSpace(failure.AuthReason), "auth_required")
+	}
+	return payload
+}
+
+func claudeProviderFailure(payload map[string]any) ProviderFailure {
+	providerCode := strings.TrimSpace(payloadString(payload, "code"))
+	message := strings.TrimSpace(payloadString(payload, "error"))
+	statusValue := payloadInt64(payload, "apiErrorStatus")
+	var status *int
+	if statusValue > 0 {
+		value := int(statusValue)
+		status = &value
+	}
+	failure := ProviderFailure{
+		Code:         "provider_error",
+		ProviderCode: providerCode,
+		HTTPStatus:   status,
+		Message:      firstNonEmptyString(message, providerCode, "Claude provider rejected the Turn before acceptance"),
+		Origin:       providerFailureOriginProvider,
+		AuthImpact:   providerFailureAuthNone,
+	}
+	switch providerCode {
+	case "authentication_failed":
+		failure.Code, failure.AuthImpact, failure.AuthReason = "auth_required", providerFailureAuthRequired, "authentication_failed"
+	case "oauth_org_not_allowed":
+		failure.Code = "account_not_allowed"
+	case "billing_error":
+		failure.Code = "billing_error"
+	case "rate_limit":
+		failure.Code = FailureCodeQuotaOrRateLimit
+	case "overloaded", "server_error":
+		failure.Code = "provider_unavailable"
+	case "invalid_request":
+		failure.Code = "invalid_request"
+	case "model_not_found":
+		failure.Code = "model_not_available"
+	case "max_output_tokens":
+		failure.Code = "max_output_tokens"
+	case "unknown":
+		if status == nil {
+			failure.Code = "network_error"
+			failure.Origin = providerFailureOriginTransport
+		}
+	}
+	if status != nil {
+		switch *status {
+		case 401:
+			if providerCode == "" || providerCode == "unknown" || providerCode == "authentication_failed" {
+				failure.Code, failure.AuthImpact, failure.AuthReason = "auth_required", providerFailureAuthRequired, "http_401"
+			}
+		case 408, 522, 524:
+			failure.Code = "request_timed_out"
+		default:
+			if *status >= 500 && failure.Code == "provider_error" {
+				failure.Code = "provider_unavailable"
+			}
+		}
+	}
+	return failure
+}
+
+func failureFromACPCall(err *acpCallError) ProviderFailure {
+	failure := ProviderFailure{
+		Code:       "provider_error",
+		Message:    err.Err.Message,
+		Origin:     providerFailureOriginProvider,
+		AuthImpact: providerFailureAuthNone,
+	}
+	data := acpErrorDataPayload(err.Err.Data)
+	if message := strings.TrimSpace(asString(data["message"])); message != "" {
+		failure.Message = message
+	}
+	if details := firstNonEmpty(asString(data["additional_details"]), asString(data["additionalDetails"])); details != "" {
+		failure.AdditionalDetails = details
+	}
+	info := firstPresentAny(data["codex_error_info"], data["codexErrorInfo"])
+	providerCode, httpStatus := codexFailureIdentity(info)
+	if providerCode != "" {
+		failure.ProviderCode = providerCode
+		failure.HTTPStatus = httpStatus
+		failure.Code, failure.AuthImpact, failure.AuthReason = codexFailureClassification(providerCode, httpStatus)
+	}
+	if retryable, ok := firstPresentAny(data["will_retry"], data["willRetry"]).(bool); ok {
+		failure.Retryable = &retryable
+	}
+	failure.Message = firstNonEmptyString(failure.Message, failure.AdditionalDetails, failure.ProviderCode, "Provider request failed")
+	return failure
+}
+
+func failureFromCodexTurnError(turnError map[string]any) ProviderFailure {
+	providerCode, httpStatus := codexFailureIdentity(turnError["codexErrorInfo"])
+	code, authImpact, authReason := codexFailureClassification(providerCode, httpStatus)
+	message := asStringRaw(turnError["message"])
+	details := asStringRaw(turnError["additionalDetails"])
+	failure := ProviderFailure{
+		Code:              code,
+		ProviderCode:      providerCode,
+		HTTPStatus:        httpStatus,
+		Message:           firstNonEmptyString(message, details, providerCode, "Codex provider request failed"),
+		AdditionalDetails: details,
+		Origin:            providerFailureOriginProvider,
+		AuthImpact:        authImpact,
+		AuthReason:        authReason,
+	}
+	if retryable, ok := turnError["willRetry"].(bool); ok {
+		failure.Retryable = &retryable
+	}
+	return failure
+}
+
+func codexFailureIdentity(value any) (string, *int) {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed), nil
+	case map[string]any:
+		code := firstNonEmpty(asString(typed["type"]), asString(typed["code"]), asString(typed["kind"]))
+		if code == "" && len(typed) == 1 {
+			for key, nested := range typed {
+				code = key
+				if object, ok := nested.(map[string]any); ok {
+					typed = object
+				}
+			}
+		}
+		var status *int
+		for _, candidate := range []any{typed["httpStatusCode"], typed["http_status_code"]} {
+			if parsed, ok := providerFailureInt(candidate); ok {
+				status = &parsed
+				break
+			}
+		}
+		return strings.TrimSpace(code), status
+	default:
+		return "", nil
+	}
+}
+
+func codexFailureClassification(providerCode string, httpStatus *int) (string, string, string) {
+	normalized := strings.ToLower(strings.NewReplacer("_", "", "-", "").Replace(strings.TrimSpace(providerCode)))
+	switch normalized {
+	case "unauthorized":
+		return "auth_required", providerFailureAuthRequired, "unauthorized"
+	case "usagelimitexceeded", "sessionbudgetexceeded":
+		return FailureCodeQuotaOrRateLimit, providerFailureAuthNone, ""
+	case "serveroverloaded", "internalservererror":
+		return "provider_unavailable", providerFailureAuthNone, ""
+	case "badrequest", "contextwindowexceeded":
+		return "invalid_request", providerFailureAuthNone, ""
+	}
+	if httpStatus != nil {
+		switch {
+		case *httpStatus == 408 || *httpStatus == 522 || *httpStatus == 524:
+			return "request_timed_out", providerFailureAuthNone, ""
+		case *httpStatus == 429:
+			return FailureCodeQuotaOrRateLimit, providerFailureAuthNone, ""
+		case *httpStatus >= 500:
+			return "provider_unavailable", providerFailureAuthNone, ""
+		}
+	}
+	switch normalized {
+	case "httpconnectionfailed", "responsestreamconnectionfailed", "responsestreamdisconnected", "responsetoomanyfailedattempts":
+		return "provider_stream_disconnected", providerFailureAuthNone, ""
+	default:
+		return "provider_error", providerFailureAuthNone, ""
+	}
+}
+
+func providerFailureInt(value any) (int, bool) {
+	switch typed := value.(type) {
+	case float64:
+		return int(typed), true
+	case int:
+		return typed, true
+	case json.Number:
+		parsed, err := strconv.Atoi(string(typed))
+		return parsed, err == nil
+	case string:
+		parsed, err := strconv.Atoi(strings.TrimSpace(typed))
+		return parsed, err == nil
+	default:
+		return 0, false
+	}
+}
+
+var providerFailureSecretPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)("(?:authorization|proxy-authorization|cookie|set-cookie|api[_-]?key|auth[_-]?token|access[_-]?token|refresh[_-]?token|secret|signature)"\s*:\s*")[^"]*`),
+	regexp.MustCompile(`(?i)(\b(?:cookie|set-cookie)\s*:\s*)[^\r\n]*`),
+	regexp.MustCompile(`(?i)((?:"?(?:authorization|proxy-authorization|api[_-]?key|auth[_-]?token|access[_-]?token|refresh[_-]?token|secret|signature)"?)\s*[:=]\s*"?(?:bearer\s+)?)[^"\s,;}]+`),
+	regexp.MustCompile(`(?i)([?&](?:api[_-]?key|key|token|signature)=)[^&\s]+`),
+}
+
+func sanitizeProviderFailureText(value string) string {
+	value = cleanVisibleErrorText(value)
+	for _, pattern := range providerFailureSecretPatterns {
+		value = pattern.ReplaceAllString(value, `${1}[REDACTED]`)
+	}
+	return limitVisibleErrorDetail(value)
+}

--- a/packages/agent/daemon/runtime/provider_failure_test.go
+++ b/packages/agent/daemon/runtime/provider_failure_test.go
@@ -1,0 +1,154 @@
+package agentruntime
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
+)
+
+func TestClaudePreAcceptanceFailureSanitizesReturnedError(t *testing.T) {
+	err := newClaudeSDKProviderRejectedError(Session{Provider: "claude-code"}, map[string]any{
+		"code": "authentication_failed", "apiErrorStatus": float64(401),
+		"error": "Authorization: Bearer must-not-escape",
+	})
+	var appErr *AppError
+	if !errors.As(err, &appErr) || appErr == nil {
+		t.Fatalf("error = %#v", err)
+	}
+	if containsAny(err.Error(), "must-not-escape") || containsAny(appErr.DebugMessage, "must-not-escape") {
+		t.Fatalf("unsanitized rejection error = %v debug=%q", err, appErr.DebugMessage)
+	}
+}
+
+func TestClaudeProviderFailureClassification(t *testing.T) {
+	tests := []struct {
+		name       string
+		code       string
+		status     int64
+		wantCode   string
+		wantImpact string
+	}{
+		{name: "auth", code: "authentication_failed", status: 401, wantCode: "auth_required", wantImpact: providerFailureAuthRequired},
+		{name: "org", code: "oauth_org_not_allowed", status: 403, wantCode: "account_not_allowed", wantImpact: providerFailureAuthNone},
+		{name: "specific org beats status", code: "oauth_org_not_allowed", status: 401, wantCode: "account_not_allowed", wantImpact: providerFailureAuthNone},
+		{name: "billing", code: "billing_error", status: 402, wantCode: "billing_error", wantImpact: providerFailureAuthNone},
+		{name: "rate", code: "rate_limit", status: 429, wantCode: FailureCodeQuotaOrRateLimit, wantImpact: providerFailureAuthNone},
+		{name: "overloaded", code: "overloaded", status: 503, wantCode: "provider_unavailable", wantImpact: providerFailureAuthNone},
+		{name: "timeout", code: "server_error", status: 524, wantCode: "request_timed_out", wantImpact: providerFailureAuthNone},
+		{name: "unknown forbidden", code: "unknown", status: 403, wantCode: "provider_error", wantImpact: providerFailureAuthNone},
+		{name: "transport", code: "unknown", wantCode: "network_error", wantImpact: providerFailureAuthNone},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			payload := map[string]any{"code": test.code, "error": "upstream detail"}
+			if test.status != 0 {
+				payload["apiErrorStatus"] = test.status
+			}
+			failure := claudeProviderFailure(payload)
+			if failure.Code != test.wantCode || failure.AuthImpact != test.wantImpact {
+				t.Fatalf("failure = %#v, want code=%q impact=%q", failure, test.wantCode, test.wantImpact)
+			}
+		})
+	}
+}
+
+func TestAppServerProviderFailureUsesCodexErrorInfo(t *testing.T) {
+	data := json.RawMessage(`{"message":"upstream rejected","additionalDetails":"details","codexErrorInfo":{"type":"unauthorized","httpStatusCode":401},"willRetry":false}`)
+	failure := failureFromACPCall(&acpCallError{Method: "turn/start", Err: acpError{Code: -32000, Message: "wrapper", Data: data}})
+	if failure.Code != "auth_required" || failure.ProviderCode != "unauthorized" || failure.HTTPStatus == nil || *failure.HTTPStatus != 401 || failure.AuthImpact != providerFailureAuthRequired {
+		t.Fatalf("failure = %#v", failure)
+	}
+}
+
+func TestCodexProviderFailureCoversProtocolVariants(t *testing.T) {
+	tests := []struct {
+		value    any
+		wantCode string
+		status   int
+	}{
+		{value: "unauthorized", wantCode: "auth_required"},
+		{value: "usageLimitExceeded", wantCode: FailureCodeQuotaOrRateLimit},
+		{value: "sessionBudgetExceeded", wantCode: FailureCodeQuotaOrRateLimit},
+		{value: "serverOverloaded", wantCode: "provider_unavailable"},
+		{value: "internalServerError", wantCode: "provider_unavailable"},
+		{value: "badRequest", wantCode: "invalid_request"},
+		{value: "contextWindowExceeded", wantCode: "invalid_request"},
+		{value: "cyberPolicy", wantCode: "provider_error"},
+		{value: map[string]any{"httpConnectionFailed": map[string]any{"httpStatusCode": float64(503)}}, wantCode: "provider_unavailable", status: 503},
+		{value: map[string]any{"responseStreamConnectionFailed": map[string]any{"httpStatusCode": float64(524)}}, wantCode: "request_timed_out", status: 524},
+		{value: map[string]any{"responseStreamDisconnected": map[string]any{"httpStatusCode": nil}}, wantCode: "provider_stream_disconnected"},
+		{value: map[string]any{"responseTooManyFailedAttempts": map[string]any{"httpStatusCode": float64(429)}}, wantCode: FailureCodeQuotaOrRateLimit, status: 429},
+		{value: map[string]any{"activeTurnNotSteerable": map[string]any{"turnKind": "review"}}, wantCode: "provider_error"},
+	}
+	for _, test := range tests {
+		providerCode, status := codexFailureIdentity(test.value)
+		code, authImpact, _ := codexFailureClassification(providerCode, status)
+		if code != test.wantCode {
+			t.Fatalf("codexErrorInfo=%#v providerCode=%q code=%q, want %q", test.value, providerCode, code, test.wantCode)
+		}
+		if code != "auth_required" && authImpact != providerFailureAuthNone {
+			t.Fatalf("codexErrorInfo=%#v authImpact=%q", test.value, authImpact)
+		}
+		if test.status == 0 && status != nil {
+			t.Fatalf("codexErrorInfo=%#v status=%v, want nil", test.value, status)
+		}
+		if test.status != 0 && (status == nil || *status != test.status) {
+			t.Fatalf("codexErrorInfo=%#v status=%v, want %d", test.value, status, test.status)
+		}
+	}
+}
+
+func TestStandardACPUnknownErrorNeverInfersAuthenticationFromText(t *testing.T) {
+	err := &acpCallError{Method: "session/prompt", Err: acpError{Code: -32000, Message: "auth token quota gateway error", Data: json.RawMessage(`{"message":"invalid api key"}`)}}
+	failure := failureFromACPCall(err)
+	if failure.Code != "provider_error" || failure.AuthImpact != providerFailureAuthNone || err.AuthRequired() {
+		t.Fatalf("failure = %#v AuthRequired=%v", failure, err.AuthRequired())
+	}
+}
+
+func TestStandardACPFailurePreservesSanitizedJSONRPCFacts(t *testing.T) {
+	err := &acpCallError{Method: "session/prompt", Err: acpError{
+		Code: -32042, Message: "relay rejected request",
+		Data: json.RawMessage(`{"message":"model unavailable","apiKey":"must-not-persist","requestId":"req-1"}`),
+	}}
+	metadata := acpFailureMetadata(err)
+	if metadata["code"] != "provider_error" || metadata["acpErrorCode"] != -32042 || metadata["acpErrorMessage"] != "relay rejected request" {
+		t.Fatalf("metadata = %#v", metadata)
+	}
+	rawData, _ := metadata["acpErrorData"].(string)
+	if !strings.Contains(rawData, `"requestId":"req-1"`) || strings.Contains(rawData, "must-not-persist") {
+		t.Fatalf("sanitized ACP data = %q", rawData)
+	}
+}
+
+func TestProviderFailureSanitizesSecretsBeforeMetadata(t *testing.T) {
+	metadata := (ProviderFailure{Code: "provider_error", Message: "Authorization: Bearer secret-token\nCookie: session=first-secret; refresh=second-secret\nupstream headers: Set-Cookie: inline-secret; HttpOnly\nANTHROPIC_AUTH_TOKEN=env-secret\n{\"apiKey\":\"json-secret\",\"Cookie\":\"json-cookie-secret; other=value\"} https://example.test/?token=query-secret", Origin: providerFailureOriginProvider}).metadata()
+	message, _ := metadata["error"].(string)
+	if message == "" || containsAny(message, "secret-token", "first-secret", "second-secret", "inline-secret", "env-secret", "json-secret", "json-cookie-secret", "query-secret") {
+		t.Fatalf("sanitized message = %q", message)
+	}
+}
+
+func TestEveryRegisteredRuntimeKindHasFailureMapper(t *testing.T) {
+	for _, descriptor := range providerregistry.Migrated() {
+		switch descriptor.Runtime.Kind {
+		case providerregistry.RuntimeKindClaudeSDK,
+			providerregistry.RuntimeKindCodexAppServer,
+			providerregistry.RuntimeKindStandardACP:
+		default:
+			t.Fatalf("provider %q has runtime kind %q without a failure mapper", descriptor.Identity.ID, descriptor.Runtime.Kind)
+		}
+	}
+}
+
+func containsAny(value string, candidates ...string) bool {
+	for _, candidate := range candidates {
+		if strings.Contains(value, candidate) {
+			return true
+		}
+	}
+	return false
+}

--- a/packages/agent/daemon/runtime/reporter_state.go
+++ b/packages/agent/daemon/runtime/reporter_state.go
@@ -192,7 +192,10 @@ func turnFailureDetails(event activityshared.Event) (string, string) {
 		return "", ""
 	}
 	message := activityshared.BestEffortErrorMessage(event.Payload)
-	code := activityshared.BestEffortErrorCode(event.Payload)
+	code := firstNonEmptyString(
+		payloadString(event.Payload.Metadata, "code"),
+		activityshared.BestEffortErrorCode(event.Payload),
+	)
 	if code == "" {
 		code = providerStopFailureCode(payloadString(event.Payload.Metadata, "stopReason"))
 	}
@@ -550,7 +553,7 @@ func statePatchLastError(event activityshared.Event) string {
 	if detail == "" {
 		return ""
 	}
-	code := visibleFailureCode(detail)
+	code := firstNonEmptyString(payloadString(event.Payload.Metadata, "code"), visibleFailureCode(detail))
 	switch code {
 	case FailureCodeInsufficientCredits,
 		FailureCodeModelNotAllowed,

--- a/packages/agent/daemon/runtime/standard_acp_setup.go
+++ b/packages/agent/daemon/runtime/standard_acp_setup.go
@@ -147,12 +147,27 @@ func RunStandardACPSetup(
 			}
 			return StandardACPSetupResult{Status: StandardACPSetupAuthRequired, AuthMethods: methods}, nil
 		}
+		// A caller-selected method is a scoped setup operation. Preserve its
+		// provider error while keeping the setup surface actionable; this does
+		// not classify the error as provider-global authentication evidence.
+		if methodID != "" && !errors.Is(err, ErrACPAuthMethodUnavailable) {
+			return StandardACPSetupResult{Status: StandardACPSetupAuthRequired, AuthMethods: methods}, err
+		}
 		// Some ACP agents advertise both a provider credential method and a
 		// terminal setup method. Before setup is completed, session/new may
 		// synchronously initialize the provider and exceed the probe timeout.
 		// Keep the install successful and expose the terminal setup action;
 		// explicit authenticate/setup attempts still return their real error.
 		if methodID == "" && standardACPSetupSessionNewTimedOut(err) && standardACPSetupHasInteractiveAuth(methods) {
+			return StandardACPSetupResult{Status: StandardACPSetupAuthRequired, AuthMethods: methods}, nil
+		}
+		// This compatibility check is deliberately exact and scoped to the setup
+		// probe. Some ACP agents use the generic -32000 JSON-RPC code with the
+		// literal value below after advertising authentication methods. Do not
+		// teach acpCallError.AuthRequired to infer from prose: ordinary Turns must
+		// keep generic JSON-RPC failures provider-scoped, and unrelated setup
+		// failures (for example overloaded relays) must remain visible.
+		if methodID == "" && standardACPSetupSessionNewAuthRejected(err) && len(methods) > 0 {
 			return StandardACPSetupResult{Status: StandardACPSetupAuthRequired, AuthMethods: methods}, nil
 		}
 		if IsAuthenticationRequired(err) || standardACPSetupNeedsConfiguration(err, methods) {
@@ -169,6 +184,13 @@ func RunStandardACPSetup(
 		return StandardACPSetupResult{}, fmt.Errorf("close ACP setup session: %w", err)
 	}
 	return StandardACPSetupResult{Status: StandardACPSetupReady, AuthMethods: methods, Account: account}, nil
+}
+
+func standardACPSetupSessionNewAuthRejected(err error) bool {
+	var callErr *acpCallError
+	return errors.As(err, &callErr) &&
+		callErr.Method == acpMethodNewSession &&
+		strings.EqualFold(strings.TrimSpace(callErr.Err.Message), "authentication required")
 }
 
 func standardACPSetupHasInteractiveAuth(methods []StandardACPAuthMethod) bool {

--- a/packages/agent/daemon/runtime/standard_acp_setup_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_setup_test.go
@@ -57,7 +57,7 @@ func TestRunStandardACPSetupRejectsUnadvertisedMethod(t *testing.T) {
 	}
 }
 
-func TestRunStandardACPSetupPreservesExplicitAuthenticationFailure(t *testing.T) {
+func TestRunStandardACPSetupPreservesExplicitAuthenticationFailureWithoutTextInference(t *testing.T) {
 	t.Parallel()
 
 	transport := newStandardACPTransport("Example Agent", "setup-session")
@@ -233,6 +233,22 @@ func TestRunStandardACPSetupReadyWhenTerminalMethodRemainsAdvertised(t *testing.
 	}
 	if got := transport.conn.authenticatedMethodID(); got != "" {
 		t.Fatalf("authenticated method id = %q, want no ACP authenticate call", got)
+	}
+}
+
+func TestStandardACPSetupSessionNewAuthCompatibilityIsExact(t *testing.T) {
+	authErr := &acpCallError{Method: acpMethodNewSession, Err: acpError{
+		Code: -32000, Message: "authentication required",
+	}}
+	if !standardACPSetupSessionNewAuthRejected(authErr) {
+		t.Fatal("exact setup authentication rejection was not recognized")
+	}
+
+	providerErr := &acpCallError{Method: acpMethodNewSession, Err: acpError{
+		Code: -32000, Message: "server overloaded; relay returned 524",
+	}}
+	if standardACPSetupSessionNewAuthRejected(providerErr) {
+		t.Fatal("unrelated provider failure must not become setup auth_required")
 	}
 }
 

--- a/packages/agent/daemon/runtime/visible_error.go
+++ b/packages/agent/daemon/runtime/visible_error.go
@@ -28,7 +28,10 @@ func IsAuthenticationRequired(err error) bool {
 		return false
 	}
 	var callErr *acpCallError
-	return (errors.As(err, &callErr) && callErr.AuthRequired()) || authFailurePattern.MatchString(err.Error())
+	if errors.As(err, &callErr) {
+		return callErr.AuthRequired()
+	}
+	return AppErrorCode(err) == "auth_required"
 }
 
 const (
@@ -86,9 +89,21 @@ func projectVisibleFailure(source canonical.EventSource, event activityshared.Ev
 		phase = "start"
 	}
 	detail := visibleFailureDetail(event)
-	code := visibleFailureCode(detail)
+	code := firstNonEmptyString(
+		payloadString(event.Payload.Metadata, "code"),
+		visibleFailureCode(detail),
+	)
+	// A Model Plan or Agent Extension can reject its own credential without
+	// proving that the provider-native account needs login. Keep the upstream
+	// detail, but do not emit the provider-login action code for that scope.
+	if code == "auth_required" && !source.ProviderGlobalAuthEligible {
+		code = "provider_error"
+	}
 	provider := firstNonEmptyString(string(event.Provider), source.Provider)
 	content := visibleFailureContent(provider, phase, code)
+	if payloadString(event.Payload.Metadata, "origin") == providerFailureOriginProvider && detail != "" {
+		content = detail
+	}
 	payload := map[string]any{
 		"kind":          visibleErrorKind,
 		"severity":      visibleErrorSeverity,
@@ -102,6 +117,17 @@ func projectVisibleFailure(source canonical.EventSource, event activityshared.Ev
 	}
 	if detail != "" {
 		payload["detail"] = detail
+	}
+	for _, key := range []string{"providerCode", "origin", "authImpact", "authReason", "additionalDetails"} {
+		if value := payloadString(event.Payload.Metadata, key); value != "" {
+			payload[key] = value
+		}
+	}
+	if status, ok := event.Payload.Metadata["httpStatus"]; ok {
+		payload["httpStatus"] = status
+	}
+	if retryable, ok := event.Payload.Metadata["retryable"].(bool); ok {
+		payload["retryable"] = retryable
 	}
 	return visibleFailureProjection{eventID: eventID, content: content, payload: payload}, true
 }
@@ -184,7 +210,11 @@ func shouldAppendVisibleFailure(events []activityshared.Event, event activitysha
 }
 
 func visibleFailureDetail(event activityshared.Event) string {
-	detail := activityshared.BestEffortErrorMessage(event.Payload)
+	detail := firstNonEmptyString(
+		payloadString(event.Payload.Metadata, "errorMessage"),
+		payloadString(event.Payload.Metadata, "error"),
+		activityshared.BestEffortErrorMessage(event.Payload),
+	)
 	if detail == "" {
 		detail = firstNonEmptyString(
 			payloadString(event.Payload.Metadata, "stopReason"),
@@ -192,7 +222,7 @@ func visibleFailureDetail(event activityshared.Event) string {
 			strings.TrimSpace(event.Payload.Status),
 		)
 	}
-	return limitVisibleErrorDetail(cleanVisibleErrorText(detail))
+	return sanitizeProviderFailureText(detail)
 }
 
 func cleanVisibleErrorText(value string) string {

--- a/packages/agent/daemon/runtime/visible_error_test.go
+++ b/packages/agent/daemon/runtime/visible_error_test.go
@@ -4,8 +4,33 @@ import (
 	"errors"
 	"testing"
 
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
 )
+
+func TestModelPlanAuthenticationFailureDoesNotOfferProviderLogin(t *testing.T) {
+	session := Session{Provider: "claude-code", AgentSessionID: "session-1", ProviderSessionID: "provider-1"}
+	event := newTurnActivityEvent(session, EventTurnFailed, "turn-1", SessionStatusFailed, "", "", map[string]any{
+		"code": "auth_required", "authImpact": "required", "origin": "provider",
+		"error": "relay rejected request: HTTP 401",
+	})
+	if event.Type != activityshared.EventTurnFailed {
+		t.Fatalf("event type = %q", event.Type)
+	}
+	projection, ok := projectVisibleFailure(canonical.EventSource{
+		Provider: "claude-code", ProviderGlobalAuthEligible: false,
+	}, event)
+	if !ok || projection.payload["code"] != "provider_error" || projection.content != "relay rejected request: HTTP 401" {
+		t.Fatalf("projection = %#v ok=%v", projection, ok)
+	}
+
+	nativeProjection, ok := projectVisibleFailure(canonical.EventSource{
+		Provider: "claude-code", ProviderGlobalAuthEligible: true,
+	}, event)
+	if !ok || nativeProjection.payload["code"] != "auth_required" {
+		t.Fatalf("provider-native projection = %#v ok=%v", nativeProjection, ok)
+	}
+}
 
 type testRuntimeTransportFailure struct {
 	code string
@@ -42,10 +67,10 @@ func TestVisibleFailureCodeClassifiesDeadlineExceededAsRequestTimedOut(t *testin
 	}
 }
 
-func TestIsAuthenticationRequiredClassifiesGeminiMissingAPIKey(t *testing.T) {
+func TestIsAuthenticationRequiredDoesNotInferFromProviderText(t *testing.T) {
 	err := errors.New("Gemini API key is missing or not configured")
-	if !IsAuthenticationRequired(err) {
-		t.Fatalf("IsAuthenticationRequired(%q) = false, want true", err)
+	if IsAuthenticationRequired(err) {
+		t.Fatalf("IsAuthenticationRequired(%q) = true, want false without typed evidence", err)
 	}
 }
 

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.visibleError.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.visibleError.spec.tsx
@@ -226,6 +226,41 @@ describe("AgentVisibleErrorMessage", () => {
     ).toBeTruthy();
   });
 
+  it("shows a sanitized provider error directly without rewriting it", () => {
+    const { getByText, queryByRole } = renderBlock(
+      buildRow({
+        code: "provider_unavailable",
+        phase: "turn",
+        provider: "claude-code",
+        origin: "provider",
+        detail: "relay returned HTTP 503: upstream overloaded",
+        detailAvailable: true,
+        retryable: true
+      })
+    );
+
+    expect(
+      getByText("relay returned HTTP 503: upstream overloaded")
+    ).toBeTruthy();
+    expect(queryByRole("button", { name: "Raw error" })).toBeNull();
+  });
+
+  it("does not offer provider login for a relay-scoped 401", () => {
+    const { getByText, queryByText } = renderBlock(
+      buildRow({
+        code: "provider_error",
+        phase: "turn",
+        provider: "claude-code",
+        origin: "provider",
+        detail: "relay rejected request: HTTP 401",
+        retryable: false
+      })
+    );
+
+    expect(getByText("relay rejected request: HTTP 401")).toBeTruthy();
+    expect(queryByText("Sign in")).toBeNull();
+  });
+
   it("shows accurate copy but NO wizard CTA for transient/server-side failures", () => {
     const { getByText, queryByText } = renderBlock(
       buildRow({

--- a/packages/agent/gui/shared/agentConversation/components/AgentVisibleErrorMessage.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentVisibleErrorMessage.tsx
@@ -74,7 +74,11 @@ export function AgentVisibleErrorMessage({
     insufficientCreditsOverride?.providers.includes(error.provider ?? "")
       ? insufficientCreditsOverride
       : undefined;
+  const rawDetail = error?.detail ?? "";
+  const providerHeadline =
+    error?.origin === "provider" && rawDetail.trim() ? rawDetail : null;
   const headline =
+    providerHeadline ||
     presentationOverride?.message ||
     (presentation?.messageKey
       ? translate(presentation.messageKey, { provider: providerLabel })
@@ -83,8 +87,10 @@ export function AgentVisibleErrorMessage({
   const actionKey = presentation?.actionKey ?? null;
   const externalAction = presentationOverride?.action ?? null;
   const hint = visibleErrorHint(message, scope);
-  const rawDetail = error?.detail ?? "";
-  const showRawDetail = error?.detailAvailable === true && rawDetail !== "";
+  const showRawDetail =
+    error?.origin !== "provider" &&
+    error?.detailAvailable === true &&
+    rawDetail !== "";
   // Account limits are status notices, not process crashes. Provider payloads
   // stay in the canonical model and diagnostics; raw upstream text is only
   // rendered through the explicit disclosure below.

--- a/packages/agent/gui/shared/agentConversation/contracts/agentMessageRowVM.ts
+++ b/packages/agent/gui/shared/agentConversation/contracts/agentMessageRowVM.ts
@@ -41,6 +41,7 @@ export interface AgentMessageContentVM {
     code: string | null;
     phase: string | null;
     provider: string | null;
+    origin?: string | null;
     detail: string | null;
     detailAvailable?: boolean;
     retryable: boolean | null;

--- a/packages/agent/gui/shared/agentEnv/agentErrorPresentation.ts
+++ b/packages/agent/gui/shared/agentEnv/agentErrorPresentation.ts
@@ -10,6 +10,8 @@ import type { AgentEnvPanelFocus } from "./agentEnvPanelActions";
  */
 export type AgentRunErrorCode =
   | "auth_required"
+  | "account_not_allowed"
+  | "billing_error"
   | "cli_not_found"
   | "cli_version_unsupported"
   | "network_error"
@@ -19,6 +21,10 @@ export type AgentRunErrorCode =
   | "provider_stream_disconnected"
   | "provider_empty_response"
   | "provider_concurrency_limit"
+  | "provider_unavailable"
+  | "invalid_request"
+  | "model_not_available"
+  | "max_output_tokens"
   | "insufficient_credits"
   | "model_not_allowed"
   | "plugin_unavailable"
@@ -122,6 +128,8 @@ const PRESENTATIONS: Record<AgentRunErrorCode, AgentErrorPresentation> = {
     focus: "auth",
     actionKey: "agentHost.agentGui.visibleErrorActionRelogin"
   },
+  account_not_allowed: { messageKey: null, ...NO_CTA },
+  billing_error: { messageKey: null, ...NO_CTA },
   cli_not_found: {
     messageKey: "agentHost.agentGui.visibleErrorCliNotFound",
     focus: "install",
@@ -165,6 +173,10 @@ const PRESENTATIONS: Record<AgentRunErrorCode, AgentErrorPresentation> = {
     messageKey: "agentHost.agentGui.visibleErrorConcurrencyLimit",
     ...NO_CTA
   },
+  provider_unavailable: { messageKey: null, ...NO_CTA },
+  invalid_request: { messageKey: null, ...NO_CTA },
+  model_not_available: { messageKey: null, ...NO_CTA },
+  max_output_tokens: { messageKey: null, ...NO_CTA },
   insufficient_credits: {
     messageKey: "agentHost.agentGui.visibleErrorInsufficientCreditsUnknown",
     ...NO_CTA

--- a/packages/agent/gui/shared/workspaceAgentSessionDetailViewModel.ts
+++ b/packages/agent/gui/shared/workspaceAgentSessionDetailViewModel.ts
@@ -21,6 +21,7 @@ export interface WorkspaceAgentSessionDetailMessage {
     code: string | null;
     phase: string | null;
     provider: string | null;
+    origin?: string | null;
     detail: string | null;
     detailAvailable?: boolean;
     retryable: boolean | null;

--- a/packages/agent/gui/shared/workspaceAgentTimelineProjectionHelpers.ts
+++ b/packages/agent/gui/shared/workspaceAgentTimelineProjectionHelpers.ts
@@ -147,10 +147,12 @@ export function visibleErrorFromPayload(
   payload: Record<string, unknown> | null
 ): WorkspaceAgentSessionDetailMessage["visibleError"] {
   if (stringRecordValue(payload, "kind") !== "agent_visible_error") return null;
+  const origin = stringRecordValue(payload, "origin");
   return {
     code: stringRecordValue(payload, "code"),
     phase: stringRecordValue(payload, "phase"),
     provider: stringRecordValue(payload, "provider"),
+    ...(origin ? { origin } : {}),
     detail: stringRecordValue(payload, "detail"),
     retryable: booleanRecordValue(payload, "retryable")
   };

--- a/packages/agent/host/conformance/conformance.go
+++ b/packages/agent/host/conformance/conformance.go
@@ -28,6 +28,7 @@ type SessionSeed struct {
 	ExternalResumeSupported *bool
 	Settings                agenthost.ComposerSettings
 	Pinned                  bool
+	RuntimeContext          map[string]any
 }
 
 type TurnSeed struct {

--- a/packages/agent/host/conformance/conformance_test.go
+++ b/packages/agent/host/conformance/conformance_test.go
@@ -52,6 +52,14 @@ func TestPublishedWorkspaceRuntimeDisconnectScenarioCatalogHasUniqueNames(t *tes
 	}
 }
 
+func TestPublishedRuntimeConfigurationRebindScenarioCatalogHasUniqueNames(t *testing.T) {
+	t.Parallel()
+	scenarios := RuntimeConfigurationRebindScenarios()
+	if len(scenarios) != 1 || scenarios[0].Name == "" {
+		t.Fatalf("runtime configuration rebind scenarios=%#v", scenarios)
+	}
+}
+
 func TestPublishedWorkspaceRuntimeAdmissionScenarioCatalogHasUniqueNames(t *testing.T) {
 	scenarios := WorkspaceRuntimeAdmissionScenarios()
 	seen := make(map[string]struct{}, len(scenarios))

--- a/packages/agent/host/conformance/runtime_configuration_rebind_scenarios.go
+++ b/packages/agent/host/conformance/runtime_configuration_rebind_scenarios.go
@@ -1,0 +1,65 @@
+package conformance
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+)
+
+type RuntimeConfigurationRebindDriver interface {
+	Reset(context.Context, Fixture) error
+	RebindAndSend(context.Context, agenthost.SessionRef, agenthost.ReprepareRuntimeSessionInput, agenthost.SendInput) (SendObservation, error)
+	CanonicalRuntimeContext(context.Context, agenthost.SessionRef) (map[string]any, error)
+}
+
+type RuntimeConfigurationRebindScenario struct {
+	Name string
+	run  func(context.Context, RuntimeConfigurationRebindDriver) error
+}
+
+func RuntimeConfigurationRebindScenarios() []RuntimeConfigurationRebindScenario {
+	return []RuntimeConfigurationRebindScenario{{
+		Name: "runtime replacement commits configuration before turn admission",
+		run:  runRuntimeReplacementCommitsConfigurationBeforeTurnAdmission,
+	}}
+}
+
+func RunRuntimeConfigurationRebind(ctx context.Context, driver RuntimeConfigurationRebindDriver, scenario RuntimeConfigurationRebindScenario) error {
+	if driver == nil || scenario.run == nil {
+		return fmt.Errorf("runtime configuration rebind conformance driver and scenario are required")
+	}
+	return scenario.run(ctx, driver)
+}
+
+func runRuntimeReplacementCommitsConfigurationBeforeTurnAdmission(ctx context.Context, driver RuntimeConfigurationRebindDriver) error {
+	expected := map[string]any{"connectionRevision": float64(1), "tuttiInitialTitleEstablished": false}
+	replacement := map[string]any{"connectionRevision": float64(2), "tuttiInitialTitleEstablished": false}
+	ref := agenthost.SessionRef{WorkspaceID: "workspace-rebind", AgentSessionID: "session-rebind"}
+	if err := driver.Reset(ctx, Fixture{Session: &SessionSeed{
+		WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
+		Provider: "codex", ProviderSessionID: "provider-rebind", Cwd: "/workspace",
+		RuntimeContext: expected,
+	}}); err != nil {
+		return err
+	}
+	result, err := driver.RebindAndSend(ctx, ref, agenthost.ReprepareRuntimeSessionInput{
+		WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
+		ExpectedRuntimeContext: expected, ReplacementRuntimeContext: replacement,
+	}, agenthost.SendInput{Content: []agenthost.PromptContentBlock{{Type: "text", Text: "continue"}}, ClientSubmitID: "submit-rebind"})
+	if err != nil {
+		return err
+	}
+	if result.TurnID == "" {
+		return fmt.Errorf("rebind did not admit a canonical turn")
+	}
+	got, err := driver.CanonicalRuntimeContext(ctx, ref)
+	if err != nil {
+		return err
+	}
+	if !reflect.DeepEqual(got, replacement) {
+		return fmt.Errorf("canonical runtime context = %#v, want %#v", got, replacement)
+	}
+	return nil
+}

--- a/packages/agent/host/errors.go
+++ b/packages/agent/host/errors.go
@@ -26,6 +26,7 @@ var (
 	ErrRuntimeCancelDeliveryUnconfirmed   = errors.New("agent runtime cancellation delivery is unconfirmed")
 	ErrRuntimeSessionActive               = errors.New("agent runtime session has an active turn")
 	ErrRuntimeSessionReprepareUnavailable = errors.New("agent runtime session reprepare is unavailable")
+	ErrRuntimeContextConflict             = errors.New("agent runtime context changed before rebind commit")
 	ErrRuntimeSessionPublishUnavailable   = errors.New("agent runtime session initialization publication is unavailable")
 	ErrRuntimeRailPlacementUnavailable    = errors.New("agent runtime rail placement resolution is unavailable")
 	ErrWorkspaceDisconnectUnavailable     = errors.New("agent workspace runtime disconnect is unavailable")

--- a/packages/agent/host/lifecycle_reprepare.go
+++ b/packages/agent/host/lifecycle_reprepare.go
@@ -3,6 +3,7 @@ package agenthost
 import (
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 	"time"
 )
@@ -57,6 +58,18 @@ func (h *Host) reprepareRuntimeSession(
 		strings.TrimSpace(canonicalSession.ProviderSessionID) == "" {
 		return ProviderRuntimeSession{}, ErrSessionNotFound
 	}
+	hasExpected := input.ExpectedRuntimeContext != nil
+	hasReplacement := input.ReplacementRuntimeContext != nil
+	if hasExpected != hasReplacement {
+		return ProviderRuntimeSession{}, ErrInvalidArgument
+	}
+	durableRuntimeContext := cloneMap(canonicalSession.InternalRuntimeContext)
+	if hasExpected {
+		if !reflect.DeepEqual(canonicalSession.InternalRuntimeContext, input.ExpectedRuntimeContext) {
+			return ProviderRuntimeSession{}, ErrRuntimeContextConflict
+		}
+		durableRuntimeContext = cloneMap(input.ReplacementRuntimeContext)
+	}
 	if strings.TrimSpace(canonicalSession.ActiveTurnID) != "" {
 		return ProviderRuntimeSession{}, ErrRuntimeSessionActive
 	}
@@ -83,7 +96,7 @@ func (h *Host) reprepareRuntimeSession(
 	settings := composerSettingsFromMap(canonicalSession.Settings)
 	preparationInput := resumePreparationInput(canonicalSession, settings)
 	preparationInput.RuntimeContext = overlayRuntimeContext(
-		canonicalSession.InternalRuntimeContext,
+		durableRuntimeContext,
 		input.RuntimeContextOverlay,
 	)
 	prepared, err := h.preparation.Prepare(ctx, preparationInput)
@@ -113,10 +126,10 @@ func (h *Host) reprepareRuntimeSession(
 		Env: append([]string(nil), prepared.Env...), MCPServers: cloneHostMCPServerBindings(prepared.MCPServers), Title: strings.TrimSpace(canonicalSession.Title),
 		Status: persistedRuntimeStatus(""), Settings: settings,
 		CreatedAtUnixMS: canonicalSession.CreatedAtUnixMS, UpdatedAtUnixMS: canonicalSession.UpdatedAtUnixMS,
-		Visible: boolPointer(canonicalSession.Metadata.Visible), RuntimeContext: cloneMap(canonicalSession.InternalRuntimeContext),
+		Visible: boolPointer(canonicalSession.Metadata.Visible), RuntimeContext: cloneMap(durableRuntimeContext),
 		ProviderLaunchRuntimeContext: cloneMap(firstMap(prepared.RuntimeContext, preparationInput.RuntimeContext)),
 		ProviderTargetRef:            cloneMap(prepared.ProviderTargetRef), Metadata: canonicalSession.Metadata,
-		InternalRuntimeContext: cloneMap(canonicalSession.InternalRuntimeContext),
+		InternalRuntimeContext: cloneMap(durableRuntimeContext),
 		GoalGenerationFences:   append([]RuntimeGoalGenerationFenceInput(nil), goalGenerationFences...),
 		RecreateIfMissing:      ResolveResumePolicy(canonicalSession).Mode == ResumeModeRecreate,
 	}
@@ -128,6 +141,24 @@ func (h *Host) reprepareRuntimeSession(
 	}
 	if err != nil {
 		return ProviderRuntimeSession{}, h.cleanupFailedReprepare(ctx, ref, canonicalSession.Provider, err)
+	}
+	if hasReplacement {
+		casStore, ok := h.store.(CanonicalRuntimeContextCASStore)
+		if !ok {
+			closeErr := h.runtime.Close(ctx, RuntimeCloseInput{WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID, PreserveCanonicalState: true})
+			return ProviderRuntimeSession{}, h.cleanupFailedReprepare(ctx, ref, canonicalSession.Provider, errors.Join(ErrRuntimeSessionReprepareUnavailable, closeErr))
+		}
+		_, updated, casErr := casStore.CompareAndSwapSessionRuntimeContext(
+			ctx, ref.WorkspaceID, ref.AgentSessionID,
+			input.ExpectedRuntimeContext, input.ReplacementRuntimeContext,
+		)
+		if casErr != nil || !updated {
+			closeErr := h.runtime.Close(ctx, RuntimeCloseInput{WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID, PreserveCanonicalState: true})
+			if casErr == nil {
+				casErr = ErrRuntimeContextConflict
+			}
+			return ProviderRuntimeSession{}, h.cleanupFailedReprepare(ctx, ref, canonicalSession.Provider, errors.Join(casErr, closeErr))
+		}
 	}
 	return result, nil
 }

--- a/packages/agent/host/lifecycle_resume_test.go
+++ b/packages/agent/host/lifecycle_resume_test.go
@@ -3,6 +3,7 @@ package agenthost
 import (
 	"context"
 	"errors"
+	"reflect"
 	"runtime"
 	"testing"
 	"time"
@@ -14,6 +15,25 @@ type liveResumeCanonicalStore struct {
 	CanonicalStore
 	session  storesqlite.Session
 	evidence storesqlite.ProviderSessionResumeEvidence
+}
+
+type runtimeContextCASStore struct {
+	liveResumeCanonicalStore
+	casCalls int
+}
+
+func (s *runtimeContextCASStore) CompareAndSwapSessionRuntimeContext(
+	_ context.Context,
+	_, _ string,
+	expected map[string]any,
+	replacement map[string]any,
+) (storesqlite.Session, bool, error) {
+	s.casCalls++
+	if !reflect.DeepEqual(s.session.InternalRuntimeContext, expected) {
+		return storesqlite.Session{}, false, nil
+	}
+	s.session.InternalRuntimeContext = cloneMap(replacement)
+	return s.session, true, nil
 }
 
 func (s liveResumeCanonicalStore) GetSession(context.Context, string, string) (storesqlite.Session, bool, error) {
@@ -311,6 +331,40 @@ func TestReprepareRuntimeSessionUsesRequestScopedPreparationContextAndPreservesI
 	}
 	if result.ID != "session-1" || result.ProviderSessionID != "provider-session-1" {
 		t.Fatalf("reprepared identity = %#v", result)
+	}
+}
+
+func TestReprepareRuntimeSessionCommitsReplacementContextBeforeReturning(t *testing.T) {
+	expected := map[string]any{"sessionRuntimeSnapshot": map[string]any{"revision": float64(1)}}
+	replacement := map[string]any{"sessionRuntimeSnapshot": map[string]any{"revision": float64(2)}}
+	store := &runtimeContextCASStore{liveResumeCanonicalStore: liveResumeCanonicalStore{
+		session: storesqlite.Session{
+			ID: "session-1", WorkspaceID: "workspace-1", Kind: storesqlite.SessionKindRoot,
+			Provider: "codex", ProviderSessionID: "provider-session-1", Cwd: "/workspace",
+			InternalRuntimeContext: cloneMap(expected),
+		},
+		evidence: storesqlite.ProviderSessionResumeEvidence{Established: true},
+	}}
+	runtime := &reprepareRuntime{session: ProviderRuntimeSession{
+		ID: "session-1", WorkspaceID: "workspace-1", Provider: "codex",
+		ProviderSessionID: "provider-session-1", Cwd: "/workspace",
+	}}
+	preparation := &trackingResumePreparation{prepared: PreparedRuntime{Cwd: "/workspace"}}
+	host := New(Config{CanonicalStore: store, Runtime: runtime, RuntimePreparation: preparation})
+
+	_, err := host.ReprepareRuntimeSession(t.Context(), ReprepareRuntimeSessionInput{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1",
+		ExpectedRuntimeContext: expected, ReplacementRuntimeContext: replacement,
+	})
+	if err != nil {
+		t.Fatalf("ReprepareRuntimeSession() error = %v", err)
+	}
+	if store.casCalls != 1 || !reflect.DeepEqual(store.session.InternalRuntimeContext, replacement) {
+		t.Fatalf("CAS calls=%d context=%#v", store.casCalls, store.session.InternalRuntimeContext)
+	}
+	if !reflect.DeepEqual(preparation.prepareInput.RuntimeContext, replacement) ||
+		!reflect.DeepEqual(runtime.reprepareInput.RuntimeContext, replacement) {
+		t.Fatalf("prepare=%#v runtime=%#v", preparation.prepareInput.RuntimeContext, runtime.reprepareInput.RuntimeContext)
 	}
 }
 

--- a/packages/agent/host/ports.go
+++ b/packages/agent/host/ports.go
@@ -16,6 +16,13 @@ type CanonicalSessionStore interface {
 	ListChildSessions(context.Context, string, string) ([]storesqlite.Session, error)
 }
 
+// CanonicalRuntimeContextCASStore is the narrow durable commit required by a
+// runtime configuration rebind. It remains optional so external read/custom
+// stores are not source-broken; rebind fails closed when it is unavailable.
+type CanonicalRuntimeContextCASStore interface {
+	CompareAndSwapSessionRuntimeContext(context.Context, string, string, map[string]any, map[string]any) (storesqlite.Session, bool, error)
+}
+
 // RuntimeSessionRailPlacementResolver is the optional create-time capability
 // that resolves a prepared runtime's final canonical rail placement before a
 // provider process starts. Keeping it separate preserves source compatibility

--- a/packages/agent/host/sqlite_workspace_store.go
+++ b/packages/agent/host/sqlite_workspace_store.go
@@ -43,6 +43,7 @@ type RuntimeSessionInitializationObserver interface {
 }
 
 var _ CanonicalStore = (*SQLiteWorkspaceStore)(nil)
+var _ CanonicalRuntimeContextCASStore = (*SQLiteWorkspaceStore)(nil)
 var _ TurnSubmissionStore = (*SQLiteWorkspaceStore)(nil)
 var _ EffectiveHistoryStore = (*SQLiteWorkspaceStore)(nil)
 var _ SessionManagementStore = (*SQLiteWorkspaceStore)(nil)

--- a/packages/agent/host/sqlite_workspace_store_runtime_context.go
+++ b/packages/agent/host/sqlite_workspace_store_runtime_context.go
@@ -1,0 +1,31 @@
+package agenthost
+
+import (
+	"context"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+func (s *SQLiteWorkspaceStore) CompareAndSwapSessionRuntimeContext(
+	ctx context.Context,
+	workspaceID string,
+	sessionID string,
+	expected map[string]any,
+	replacement map[string]any,
+) (storesqlite.Session, bool, error) {
+	store, err := s.store(workspaceID)
+	if err != nil {
+		return storesqlite.Session{}, false, err
+	}
+	session, changed, err := store.CompareAndSwapSessionRuntimeContext(
+		ctx,
+		workspaceID,
+		sessionID,
+		expected,
+		replacement,
+	)
+	if err == nil && changed {
+		NotifyCommitted(ctx, s.Observer, CanonicalDelta(session.CommitDelta))
+	}
+	return session, changed, err
+}

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -374,6 +374,12 @@ type ReprepareRuntimeSessionInput struct {
 	WorkspaceID           string
 	AgentSessionID        string
 	RuntimeContextOverlay map[string]any
+	// ExpectedRuntimeContext and ReplacementRuntimeContext are supplied
+	// together for a durable configuration rebind. Host prepares and launches
+	// from ReplacementRuntimeContext, then compare-and-swaps it into canonical
+	// state before admitting a Turn.
+	ExpectedRuntimeContext    map[string]any
+	ReplacementRuntimeContext map[string]any
 }
 
 // ReprepareRuntimeSessionAndSendInputInput atomically replaces an idle

--- a/packages/agent/store-sqlite/activity_update.go
+++ b/packages/agent/store-sqlite/activity_update.go
@@ -8,6 +8,84 @@ import (
 	"time"
 )
 
+// CompareAndSwapSessionRuntimeContext replaces provider-private runtime context
+// only when it still equals the caller's observed value. Runtime rebind uses
+// this fence so a prepared connection and its durable launch snapshot cannot
+// silently diverge.
+func (s *Store) CompareAndSwapSessionRuntimeContext(
+	ctx context.Context,
+	workspaceID string,
+	agentSessionID string,
+	expected map[string]any,
+	replacement map[string]any,
+) (Session, bool, error) {
+	if s == nil || s.db == nil {
+		return Session{}, false, errors.New("workspace database is not initialized")
+	}
+	workspaceID = strings.TrimSpace(workspaceID)
+	agentSessionID = strings.TrimSpace(agentSessionID)
+	if workspaceID == "" || agentSessionID == "" {
+		return Session{}, false, nil
+	}
+	expectedJSON, err := marshalJSONMap(expected)
+	if err != nil {
+		return Session{}, false, err
+	}
+	replacementJSON, err := marshalJSONMap(replacement)
+	if err != nil {
+		return Session{}, false, err
+	}
+	now := unixMs(time.Now().UTC())
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Session{}, false, err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	result, err := tx.ExecContext(ctx, `
+UPDATE workspace_agent_sessions
+SET internal_runtime_context_json = ?,
+    updated_at_unix_ms = CASE
+      WHEN ? > updated_at_unix_ms THEN ?
+      ELSE updated_at_unix_ms + 1
+    END
+WHERE workspace_id = ? AND agent_session_id = ? AND deleted_at_unix_ms = 0
+  AND internal_runtime_context_json = ?
+`, replacementJSON, now, now, workspaceID, agentSessionID, expectedJSON)
+	if err != nil {
+		return Session{}, false, fmt.Errorf("compare and swap workspace agent runtime context: %w", err)
+	}
+	updated, err := rowsWereAffected(result, "compare and swap workspace agent runtime context")
+	if err != nil {
+		return Session{}, false, err
+	}
+	if !updated {
+		if _, err := s.commitTransaction(ctx, tx, workspaceID, nil); err != nil {
+			return Session{}, false, err
+		}
+		committed = true
+		return Session{}, false, nil
+	}
+	delta, err := s.commitTransaction(ctx, tx, workspaceID, []TransactionMutation{
+		transactionMutation(workspaceID, agentSessionID, MutationEntitySession, agentSessionID, "upsert", now),
+	})
+	if err != nil {
+		return Session{}, false, err
+	}
+	committed = true
+	session, ok, err := s.GetSession(ctx, workspaceID, agentSessionID)
+	if err != nil {
+		return Session{}, false, err
+	}
+	session.CommitTransactionID = delta.TransactionID
+	session.CommitDelta = delta
+	return session, ok, nil
+}
+
 func (s *Store) UpdateSessionPinned(
 	ctx context.Context,
 	workspaceID string,

--- a/packages/agent/store-sqlite/canonical/activity_reports.go
+++ b/packages/agent/store-sqlite/canonical/activity_reports.go
@@ -260,7 +260,11 @@ type EventSource struct {
 	DeviceID               string `json:"deviceId,omitempty"`
 	CWD                    string `json:"cwd,omitempty"`
 	SessionOrigin          string `json:"sessionOrigin,omitempty"`
-	UserID                 string `json:"-"`
+	// ProviderGlobalAuthEligible is true only when the runtime uses the same
+	// provider-native credential scope as the provider-global status probe.
+	// Model Plan and Agent Extension runs deliberately leave it false.
+	ProviderGlobalAuthEligible bool   `json:"providerGlobalAuthEligible,omitempty"`
+	UserID                     string `json:"-"`
 }
 
 type flexibleUint64 uint64

--- a/packages/agent/store-sqlite/store_test.go
+++ b/packages/agent/store-sqlite/store_test.go
@@ -399,6 +399,20 @@ WHERE workspace_id = 'ws-1' AND agent_session_id = 'session-1'
 	if err != nil || !ok || sessionAfterBlankTitle.Title != "" {
 		t.Fatalf("GetSession() after blank title = %#v ok=%v error=%v", sessionAfterBlankTitle, ok, err)
 	}
+	expectedRuntimeContext := cloneJSONMap(sessionAfterBlankTitle.InternalRuntimeContext)
+	replacementRuntimeContext := cloneJSONMap(expectedRuntimeContext)
+	replacementRuntimeContext["sessionRuntimeSnapshot"] = map[string]any{"revision": float64(2)}
+	rebound, updated, err := store.CompareAndSwapSessionRuntimeContext(
+		ctx, "ws-1", "session-1", expectedRuntimeContext, replacementRuntimeContext,
+	)
+	if err != nil || !updated || rebound.InternalRuntimeContext["sessionRuntimeSnapshot"] == nil {
+		t.Fatalf("CompareAndSwapSessionRuntimeContext() = %#v updated=%v error=%v", rebound, updated, err)
+	}
+	if _, updated, err := store.CompareAndSwapSessionRuntimeContext(
+		ctx, "ws-1", "session-1", expectedRuntimeContext, map[string]any{"stale": true},
+	); err != nil || updated {
+		t.Fatalf("stale CompareAndSwapSessionRuntimeContext() updated=%v error=%v", updated, err)
+	}
 
 	removed, err := store.DeleteSession(ctx, "ws-1", "session-1")
 	if err != nil || !removed {

--- a/services/tuttid/agent_run_outcome_reporter.go
+++ b/services/tuttid/agent_run_outcome_reporter.go
@@ -28,7 +28,7 @@ func (r agentRunOutcomeReporter) Report(
 	input agentsessionstore.ReportActivityInput,
 ) error {
 	provider := strings.TrimSpace(input.Source.Provider)
-	if provider != "" && r.store != nil {
+	if provider != "" && input.Source.ProviderGlobalAuthEligible && r.store != nil {
 		switch reportRunOutcome(input) {
 		case runOutcomeAuthFailed:
 			r.store.RecordAuthFailure(provider)
@@ -65,54 +65,19 @@ const (
 
 func reportRunOutcome(input agentsessionstore.ReportActivityInput) runOutcome {
 	outcome := runOutcomeNone
-	consider := func(status string, payload map[string]any) {
+	for _, patch := range input.StatePatches {
+		root := patch.RootProviderTurn
+		if root == nil || root.Phase != agentsessionstore.RootProviderTurnPhaseCompleted {
+			continue
+		}
 		switch {
-		case messageLooksLikeAuthFailure(status, payload):
-			// An auth failure anywhere in the batch wins over a stray completion.
+		case strings.EqualFold(root.Outcome, "failed") && strings.EqualFold(root.ErrorCode, "auth_required"):
+			// A typed root-provider authentication failure wins over every other
+			// projection in the report batch.
 			outcome = runOutcomeAuthFailed
-		case outcome == runOutcomeNone && status == "completed":
+		case outcome == runOutcomeNone && strings.EqualFold(root.Outcome, "completed"):
 			outcome = runOutcomeSuccess
 		}
 	}
-	for _, message := range input.MessageUpdates {
-		consider(message.Status, message.Payload)
-	}
-	for _, item := range input.TimelineItems {
-		consider(item.Status, item.Payload)
-	}
 	return outcome
-}
-
-func messageLooksLikeAuthFailure(status string, payload map[string]any) bool {
-	if status != "failed" {
-		return false
-	}
-	if code, ok := payload["code"].(string); ok &&
-		strings.EqualFold(code, "auth_required") {
-		return true
-	}
-	var text strings.Builder
-	for _, key := range []string{"content", "text", "detail"} {
-		if value, ok := payload[key].(string); ok {
-			text.WriteString(" ")
-			text.WriteString(value)
-		}
-	}
-	lower := strings.ToLower(text.String())
-	for _, marker := range []string{
-		"authentication_failed",
-		"invalid authentication credentials",
-		"401 invalid authentication",
-		"unauthorized",
-		"not logged in",
-		"please run /login",
-		"invalid api key",
-		"could not load the default credentials",
-		"api key is missing or not configured",
-	} {
-		if strings.Contains(lower, marker) {
-			return true
-		}
-	}
-	return false
 }

--- a/services/tuttid/agent_run_outcome_reporter_test.go
+++ b/services/tuttid/agent_run_outcome_reporter_test.go
@@ -6,6 +6,7 @@ import (
 
 	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
+	agentstatusservice "github.com/tutti-os/tutti/services/tuttid/service/agentstatus"
 )
 
 type submitProvenanceCaptureReporter struct {
@@ -21,50 +22,12 @@ func (r *submitProvenanceCaptureReporter) ReportSubmitProvenance(_ context.Conte
 	return nil
 }
 
-func TestMessageLooksLikeAuthFailureMatchesRealClaude401(t *testing.T) {
-	// The exact shape seen in the field logs: a failed runtime text message.
-	payload := map[string]any{
-		"source":  "runtime",
-		"content": "Failed to authenticate. API Error: 401 Invalid authentication credentials",
-		"text":    "Failed to authenticate. API Error: 401 Invalid authentication credentials",
-	}
-	if !messageLooksLikeAuthFailure("failed", payload) {
-		t.Fatal("a failed Claude 401 message should be classified as an auth failure")
-	}
-}
-
-func TestMessageLooksLikeAuthFailureMatchesRealGeminiVertexADCFailure(t *testing.T) {
-	payload := map[string]any{
-		"text": "Could not load the default credentials. Browse to Google Cloud authentication documentation for more information",
-	}
-	if !messageLooksLikeAuthFailure("failed", payload) {
-		t.Fatal("a failed Gemini Vertex ADC message should be classified as an auth failure")
-	}
-}
-
-func TestMessageLooksLikeAuthFailureUsesStructuredCode(t *testing.T) {
-	if !messageLooksLikeAuthFailure("failed", map[string]any{"code": "auth_required"}) {
-		t.Fatal("an explicit auth_required code should classify as auth failure")
-	}
-}
-
-func TestMessageLooksLikeAuthFailureIgnoresNonFailedAndNonAuth(t *testing.T) {
-	if messageLooksLikeAuthFailure("completed", map[string]any{"text": "401 auth"}) {
-		t.Fatal("a non-failed message must not be an auth failure")
-	}
-	if messageLooksLikeAuthFailure("failed", map[string]any{"text": "rate limit exceeded"}) {
-		t.Fatal("a non-auth failure must not match")
-	}
-}
-
 func TestReportRunOutcomeAuthFailureWinsOverCompletion(t *testing.T) {
 	input := agentsessionstore.ReportActivityInput{
 		Source: canonical.EventSource{Provider: "claude-code"},
-		MessageUpdates: []agentsessionstore.WorkspaceAgentMessageUpdate{
-			{Status: "completed", Payload: map[string]any{"text": "hi"}},
-			{Status: "failed", Payload: map[string]any{
-				"text": "Failed to authenticate. API Error: 401 Invalid authentication credentials",
-			}},
+		StatePatches: []agentsessionstore.WorkspaceAgentStatePatch{
+			{RootProviderTurn: &canonical.WorkspaceAgentRootProviderTurnTransition{Phase: agentsessionstore.RootProviderTurnPhaseCompleted, Outcome: "completed"}},
+			{RootProviderTurn: &canonical.WorkspaceAgentRootProviderTurnTransition{Phase: agentsessionstore.RootProviderTurnPhaseCompleted, Outcome: "failed", ErrorCode: "auth_required"}},
 		},
 	}
 	if got := reportRunOutcome(input); got != runOutcomeAuthFailed {
@@ -75,12 +38,51 @@ func TestReportRunOutcomeAuthFailureWinsOverCompletion(t *testing.T) {
 func TestReportRunOutcomeSuccessClears(t *testing.T) {
 	input := agentsessionstore.ReportActivityInput{
 		Source: canonical.EventSource{Provider: "codex"},
-		MessageUpdates: []agentsessionstore.WorkspaceAgentMessageUpdate{
-			{Status: "completed", Payload: map[string]any{"text": "done"}},
+		StatePatches: []agentsessionstore.WorkspaceAgentStatePatch{
+			{RootProviderTurn: &canonical.WorkspaceAgentRootProviderTurnTransition{Phase: agentsessionstore.RootProviderTurnPhaseCompleted, Outcome: "completed"}},
 		},
 	}
 	if got := reportRunOutcome(input); got != runOutcomeSuccess {
 		t.Fatalf("reportRunOutcome = %v, want success", got)
+	}
+}
+
+func TestReportRunOutcomeIgnoresMessageTextAndToolCompletion(t *testing.T) {
+	input := agentsessionstore.ReportActivityInput{
+		MessageUpdates: []agentsessionstore.WorkspaceAgentMessageUpdate{{Status: "failed", Payload: map[string]any{"text": "401 unauthorized auth token"}}},
+		TimelineItems:  []agentsessionstore.WorkspaceAgentTimelineItem{{Status: "completed"}},
+	}
+	if got := reportRunOutcome(input); got != runOutcomeNone {
+		t.Fatalf("reportRunOutcome = %v, want none", got)
+	}
+}
+
+func TestAgentRunOutcomeReporterScopesProviderGlobalAuthentication(t *testing.T) {
+	store := agentstatusservice.NewRunOutcomeStore()
+	reporter := agentRunOutcomeReporter{
+		DurableActivityReporter: &submitProvenanceCaptureReporter{},
+		store:                   store,
+	}
+	failure := []agentsessionstore.WorkspaceAgentStatePatch{{
+		RootProviderTurn: &canonical.WorkspaceAgentRootProviderTurnTransition{
+			Phase: agentsessionstore.RootProviderTurnPhaseCompleted, Outcome: "failed", ErrorCode: "auth_required",
+		},
+	}}
+	if err := reporter.Report(context.Background(), agentsessionstore.ReportActivityInput{
+		Source: canonical.EventSource{Provider: "claude-code"}, StatePatches: failure,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, found := store.AuthEvidence("claude-code"); found {
+		t.Fatal("model-plan/extension scoped failure must not mutate provider-global authentication")
+	}
+	if err := reporter.Report(context.Background(), agentsessionstore.ReportActivityInput{
+		Source: canonical.EventSource{Provider: "claude-code", ProviderGlobalAuthEligible: true}, StatePatches: failure,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !store.AuthInvalidated("claude-code") {
+		t.Fatal("provider-native typed authentication failure must invalidate provider authentication")
 	}
 }
 

--- a/services/tuttid/service/agent/host_conformance_test.go
+++ b/services/tuttid/service/agent/host_conformance_test.go
@@ -67,6 +67,18 @@ func TestHostWorkspaceRuntimeDisconnectConformance(t *testing.T) {
 	}
 }
 
+func TestHostRuntimeConfigurationRebindConformance(t *testing.T) {
+	for _, scenario := range hostconformance.RuntimeConfigurationRebindScenarios() {
+		scenario := scenario
+		t.Run(scenario.Name, func(t *testing.T) {
+			driver := &legacyHostConformanceDriver{t: t, directHost: true}
+			if err := hostconformance.RunRuntimeConfigurationRebind(context.Background(), driver, scenario); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 func TestHostWorkspaceRuntimeAdmissionConformance(t *testing.T) {
 	for _, scenario := range hostconformance.WorkspaceRuntimeAdmissionScenarios() {
 		scenario := scenario
@@ -568,7 +580,11 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 		settings.BrowserUse == nil && settings.ComputerUse == nil && settings.ReasoningEffort == "" && settings.Speed == "" {
 		settings.PlanMode = true
 	}
-	runtimeContext := map[string]any{"tuttiInitialTitleEstablished": seed.InitialTitleEstablished}
+	runtimeContext := clonePayload(seed.RuntimeContext)
+	if runtimeContext == nil {
+		runtimeContext = map[string]any{}
+	}
+	runtimeContext["tuttiInitialTitleEstablished"] = seed.InitialTitleEstablished
 	if seed.ExternalResumeSupported != nil {
 		runtimeContext["externalImportResumeSupported"] = *seed.ExternalResumeSupported
 	}
@@ -649,7 +665,7 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 			ID: seed.AgentSessionID, WorkspaceID: seed.WorkspaceID, Provider: seed.Provider,
 			ProviderSessionID: seed.ProviderSessionID, Cwd: seed.Cwd, Status: "ready",
 			Settings: &settings, Title: seed.Title, InitialTitleEstablished: seed.InitialTitleEstablished,
-			Visible: true, PinnedAtUnixMS: boolUnixMS(seed.Pinned), CreatedAtUnixMS: 1, UpdatedAtUnixMS: 2,
+			Visible: true, RuntimeContext: clonePayload(runtimeContext), PinnedAtUnixMS: boolUnixMS(seed.Pinned), CreatedAtUnixMS: 1, UpdatedAtUnixMS: 2,
 		}
 	}
 	if fixture.Turn != nil {
@@ -712,6 +728,28 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 		}
 	}
 	return nil
+}
+
+func (d *legacyHostConformanceDriver) RebindAndSend(
+	ctx context.Context,
+	ref agenthost.SessionRef,
+	reprepare agenthost.ReprepareRuntimeSessionInput,
+	send agenthost.SendInput,
+) (hostconformance.SendObservation, error) {
+	result, err := d.service.ApplicationHost().ReprepareRuntimeSessionAndSendInput(ctx, agenthost.ReprepareRuntimeSessionAndSendInputInput{Reprepare: reprepare, Send: send})
+	if err != nil {
+		return hostconformance.SendObservation{}, err
+	}
+	d.recordSubmittedTurn(ref.WorkspaceID, ref.AgentSessionID, result.TurnID)
+	return hostconformance.SendObservation{TurnID: result.TurnID, Kind: result.Kind}, nil
+}
+
+func (d *legacyHostConformanceDriver) CanonicalRuntimeContext(ctx context.Context, ref agenthost.SessionRef) (map[string]any, error) {
+	result, err := d.service.ApplicationHost().GetSession(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	return clonePayload(result.Canonical.InternalRuntimeContext), nil
 }
 
 func (d *legacyHostConformanceDriver) ResetProviderlessTerminalExec(

--- a/services/tuttid/service/agent/host_test_adapters_test.go
+++ b/services/tuttid/service/agent/host_test_adapters_test.go
@@ -71,6 +71,25 @@ func (a serviceHostStore) GetSession(ctx context.Context, workspaceID, sessionID
 	return storesqlite.Session{}, false, nil
 }
 
+func (a serviceHostStore) CompareAndSwapSessionRuntimeContext(
+	ctx context.Context,
+	workspaceID string,
+	sessionID string,
+	expected map[string]any,
+	replacement map[string]any,
+) (storesqlite.Session, bool, error) {
+	updater, ok := a.service.SessionReader.(interface {
+		CompareAndSwapSessionRuntimeContext(context.Context, string, string, map[string]any, map[string]any) (PersistedSession, bool, error)
+	})
+	if !ok {
+		return storesqlite.Session{}, false, nil
+	}
+	persisted, updated, err := updater.CompareAndSwapSessionRuntimeContext(
+		ctx, workspaceID, sessionID, expected, replacement,
+	)
+	return activitySessionFromPersisted(persisted), updated, err
+}
+
 func (a serviceHostStore) ResolveRuntimeSessionRailPlacement(
 	ctx context.Context,
 	input agenthost.ResolveRuntimeSessionRailPlacementInput,

--- a/services/tuttid/service/agent/model_plan_binding_test.go
+++ b/services/tuttid/service/agent/model_plan_binding_test.go
@@ -3,9 +3,12 @@ package agent
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"strings"
 	"testing"
 
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 	modelbindingbiz "github.com/tutti-os/tutti/services/tuttid/biz/modelbinding"
 	modelplanbiz "github.com/tutti-os/tutti/services/tuttid/biz/modelplan"
 )
@@ -13,6 +16,124 @@ import (
 type staticBindingSource struct {
 	binding modelbindingbiz.Binding
 	err     error
+}
+
+type countingPlanSource struct {
+	staticPlanSource
+	calls int
+}
+
+func (s *countingPlanSource) GetModelPlan(ctx context.Context, workspaceID string, planID string) (modelplanbiz.Plan, error) {
+	s.calls++
+	return s.staticPlanSource.GetModelPlan(ctx, workspaceID, planID)
+}
+
+func TestDuplicateSubmitDoesNotRebindUpdatedModelPlan(t *testing.T) {
+	runtime := newFakeRuntime()
+	service := newTestService(runtime)
+	store := openAgentServiceSQLiteStore(t)
+	service.SubmitClaimStore = store
+	service.ConfigureModelPlanBinding(staticBindingSource{binding: modelbindingbiz.Binding{
+		WorkspaceID: "ws-1", AgentTargetID: agenttargetbiz.IDLocalOpenCode,
+		ModelPlanID: "mp-1", DefaultModel: "plan-default",
+	}}, staticPlanSource{plan: modelplanbiz.Plan{
+		ID: "mp-1", WorkspaceID: "ws-1", Revision: 7, Protocol: modelplanbiz.ProtocolOpenAI, Enabled: true,
+		BaseURL: "https://old.example/v1", APIKey: "old-secret", Models: []modelplanbiz.Model{{ID: "plan-default"}},
+	}})
+	if _, err := service.Create(context.Background(), "ws-1", CreateSessionInput{
+		AgentSessionID: "78787878-7878-4878-8878-787878787878", AgentTargetID: agenttargetbiz.IDLocalOpenCode,
+	}); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	input := SendInput{Content: TextPromptContent("hello"), Metadata: map[string]any{"clientSubmitId": "submit-plan-retry"}}
+	if _, err := service.SendInput(context.Background(), "ws-1", "78787878-7878-4878-8878-787878787878", input); err != nil {
+		t.Fatalf("first SendInput() error = %v", err)
+	}
+	updated := &countingPlanSource{staticPlanSource: staticPlanSource{plan: modelplanbiz.Plan{
+		ID: "mp-1", WorkspaceID: "ws-1", Revision: 8, Protocol: modelplanbiz.ProtocolOpenAI, Enabled: true,
+		BaseURL: "https://new.example/v1", APIKey: "new-secret", Models: []modelplanbiz.Model{{ID: "plan-default"}},
+	}}}
+	service.ConfigureModelPlanBinding(staticBindingSource{binding: modelbindingbiz.Binding{
+		WorkspaceID: "ws-1", AgentTargetID: agenttargetbiz.IDLocalOpenCode,
+		ModelPlanID: "mp-1", DefaultModel: "plan-default",
+	}}, updated)
+	if _, err := service.SendInput(context.Background(), "ws-1", "78787878-7878-4878-8878-787878787878", input); !errors.Is(err, ErrSubmitDeliveryUnknown) {
+		t.Fatalf("duplicate SendInput() error = %v, want delivery replay outcome", err)
+	}
+	if updated.calls != 0 {
+		t.Fatalf("updated Model Plan reads = %d, want 0 for an existing submit claim", updated.calls)
+	}
+}
+
+func TestModelPlanRebindAdvancesSnapshotToCurrentRevision(t *testing.T) {
+	tests := []struct {
+		provider  string
+		targetID  string
+		protocol  modelplanbiz.Protocol
+		wantModel string
+	}{
+		{provider: "claude-code", targetID: "local:claude-code", protocol: modelplanbiz.ProtocolAnthropic, wantModel: "plan-alt"},
+		{provider: "codex", targetID: "local:codex", protocol: modelplanbiz.ProtocolOpenAI, wantModel: "plan-alt"},
+		{provider: "tutti-agent", targetID: "local:tutti-agent", protocol: modelplanbiz.ProtocolOpenAI, wantModel: "plan-alt"},
+		{provider: "opencode", targetID: "local:opencode", protocol: modelplanbiz.ProtocolOpenAI, wantModel: "tutti-model-plan/plan-alt"},
+	}
+	for _, test := range tests {
+		t.Run(test.provider, func(t *testing.T) {
+			initial := newPlanBoundService(test.protocol, true)
+			initialResolution := initial.resolveModelPlan(context.Background(), "ws", test.targetID, test.provider, "plan-alt")
+			runtimeContext := runtimeContextWithSessionRuntimeSnapshot(nil, CreateSessionInput{
+				AgentTargetID: test.targetID, HarnessAgentTargetID: test.targetID,
+				Model: stringPointer("plan-alt"),
+			}, test.provider, initialResolution)
+			current := newPlanBoundService(test.protocol, true)
+			current.modelPlanBinding.Plans = staticPlanSource{plan: modelplanbiz.Plan{
+				ID: "mp-1", WorkspaceID: "ws", Revision: 8, Name: "Updated relay",
+				Protocol: test.protocol, APIKey: "new-secret", BaseURL: "https://new.example/v1", Enabled: true,
+				Models: []modelplanbiz.Model{{ID: "plan-default"}, {ID: "plan-alt"}},
+			}}
+			input, needed, err := current.modelPlanRebindInput(context.Background(), "ws", storesqlite.Session{
+				ID: "session-1", WorkspaceID: "ws", AgentTargetID: test.targetID, Provider: test.provider,
+				InternalRuntimeContext: runtimeContext,
+			})
+			if err != nil || !needed {
+				t.Fatalf("modelPlanRebindInput() needed=%v error=%v", needed, err)
+			}
+			rebound, exists, err := sessionRuntimeSnapshotFromContext(input.ReplacementRuntimeContext, test.provider)
+			if err != nil || !exists || rebound.ModelPlanRevision != 8 || rebound.Model != test.wantModel {
+				t.Fatalf("rebound snapshot=%#v exists=%v error=%v", rebound, exists, err)
+			}
+			original, _, err := sessionRuntimeSnapshotFromContext(input.ExpectedRuntimeContext, test.provider)
+			if err != nil || original.ModelPlanRevision != 7 {
+				t.Fatalf("expected snapshot mutated: %#v error=%v", original, err)
+			}
+			endpoint, err := current.modelEndpointFromSessionRuntimeSnapshot(context.Background(), "ws", rebound, rebound.Model)
+			if err != nil || endpoint == nil || endpoint.BaseURL != "https://new.example/v1" || endpoint.APIKey != "new-secret" {
+				t.Fatalf("rebound endpoint=%#v error=%v", endpoint, err)
+			}
+		})
+	}
+}
+
+func TestModelPlanRebindSkipsProviderNativeAgents(t *testing.T) {
+	for _, provider := range []string{"cursor", "nexight", "openclaw", "acp:kimi-code", "acp:hermes"} {
+		t.Run(provider, func(t *testing.T) {
+			input, needed, err := (&Service{}).modelPlanRebindInput(context.Background(), "ws", storesqlite.Session{
+				ID: "session-1", Provider: provider,
+				InternalRuntimeContext: map[string]any{
+					"sessionRuntimeSnapshot": map[string]any{
+						"version": float64(1), "provider": provider,
+						"agentTargetId": "local:" + provider, "harnessAgentTargetId": "local:" + provider,
+						"modelConfiguration": map[string]any{
+							"source": "provider-native", "fingerprint": newProviderNativeModelConfiguration(provider, "local:"+provider).Fingerprint,
+						},
+					},
+				},
+			})
+			if err != nil || needed || input.AgentSessionID != "" {
+				t.Fatalf("modelPlanRebindInput() = %#v needed=%v error=%v", input, needed, err)
+			}
+		})
+	}
 }
 
 func (s staticBindingSource) GetAgentModelBinding(context.Context, string, string) (modelbindingbiz.Binding, error) {
@@ -50,6 +171,16 @@ func TestApplyRequestedModelPlanOverridesAgentDefault(t *testing.T) {
 
 func (s staticPlanSource) GetModelPlan(context.Context, string, string) (modelplanbiz.Plan, error) {
 	return s.plan, s.err
+}
+
+func (s staticPlanSource) GetModelPlanRevision(_ context.Context, _ string, _ string, revision uint64) (modelplanbiz.Plan, error) {
+	if s.err != nil {
+		return modelplanbiz.Plan{}, s.err
+	}
+	if s.plan.Revision != revision {
+		return modelplanbiz.Plan{}, errors.New("model plan revision not found")
+	}
+	return s.plan, nil
 }
 
 type recordingModelCatalog struct {

--- a/services/tuttid/service/agent/model_plan_rebind.go
+++ b/services/tuttid/service/agent/model_plan_rebind.go
@@ -1,0 +1,65 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+// modelPlanRebindInput resolves the latest immutable revision of the exact
+// Model Plan already bound to a Session. Provider-native and Agent Extension
+// sessions never enter this path.
+func (s *Service) modelPlanRebindInput(
+	ctx context.Context,
+	workspaceID string,
+	session storesqlite.Session,
+) (agenthost.ReprepareRuntimeSessionInput, bool, error) {
+	snapshot, exists, err := sessionRuntimeSnapshotFromContext(session.InternalRuntimeContext, session.Provider)
+	if err != nil || !exists {
+		return agenthost.ReprepareRuntimeSessionInput{}, false, err
+	}
+	if snapshot.ModelConfigurationSource != modelConfigurationSourceModelPlan {
+		return agenthost.ReprepareRuntimeSessionInput{}, false, nil
+	}
+	runtime := s.modelPlanRuntime()
+	if runtime.Plans == nil {
+		return agenthost.ReprepareRuntimeSessionInput{}, false, fmt.Errorf("%w: model plan resolver is unavailable", ErrSessionRuntimeSnapshotUnavailable)
+	}
+	plan, err := runtime.Plans.GetModelPlan(ctx, strings.TrimSpace(workspaceID), snapshot.ModelPlanID)
+	if err != nil {
+		return agenthost.ReprepareRuntimeSessionInput{}, false, fmt.Errorf("%w: current model plan no longer exists", ErrSessionRuntimeAccessRevoked)
+	}
+	if plan.Revision == snapshot.ModelPlanRevision {
+		return agenthost.ReprepareRuntimeSessionInput{}, false, nil
+	}
+	resolution, err := resolveProvidedModelPlan(
+		snapshot.Provider,
+		snapshot.AgentTargetID,
+		plan,
+		snapshot.ModelDefaultModel,
+		snapshot.Model,
+	)
+	if err != nil {
+		return agenthost.ReprepareRuntimeSessionInput{}, false, err
+	}
+	replacement := clonePayload(session.InternalRuntimeContext)
+	rawSnapshot, ok := replacement[sessionRuntimeSnapshotContextKey].(map[string]any)
+	if !ok {
+		return agenthost.ReprepareRuntimeSessionInput{}, false, ErrSessionRuntimeSnapshotUnavailable
+	}
+	configuration := resolution.ModelConfiguration.runtimeContext()
+	delete(configuration, "agentTargetId")
+	rawSnapshot["modelConfiguration"] = configuration
+	if resolution.Endpoint != nil && strings.TrimSpace(resolution.Endpoint.Model) != "" {
+		rawSnapshot["model"] = strings.TrimSpace(resolution.Endpoint.Model)
+	}
+	return agenthost.ReprepareRuntimeSessionInput{
+		WorkspaceID:               strings.TrimSpace(workspaceID),
+		AgentSessionID:            strings.TrimSpace(session.ID),
+		ExpectedRuntimeContext:    clonePayload(session.InternalRuntimeContext),
+		ReplacementRuntimeContext: replacement,
+	}, true, nil
+}

--- a/services/tuttid/service/agent/service_send_input.go
+++ b/services/tuttid/service/agent/service_send_input.go
@@ -60,13 +60,16 @@ func (s *Service) SendInput(ctx context.Context, workspaceID string, agentSessio
 	}
 	var preparedTurnID string
 	var preparedSnapshot tuttimodeactivationbiz.TurnSnapshot
-	if _, typedGoal := agenthost.ParseTypedGoalControl(normalizedContent, input.Guidance); !typedGoal {
+	existingSubmit := false
+	_, typedGoal := agenthost.ParseTypedGoalControl(normalizedContent, input.Guidance)
+	if !typedGoal {
 		runtimeSession, _ := s.controller().Session(workspaceID, agentSessionID)
 		existingCanonicalTurnID, claimErr := s.existingSubmitCanonicalTurnID(ctx, workspaceID, agentSessionID, input.ClientSubmitID, input.Metadata)
 		if claimErr != nil {
 			return SendInputResult{}, claimErr
 		}
 		if existingCanonicalTurnID != "" {
+			existingSubmit = true
 			// A durable claim already owns this submit: reuse its canonical
 			// turn so a retry reconciles instead of redispatching.
 			if input.Guidance && strings.TrimSpace(input.TurnID) != existingCanonicalTurnID {
@@ -83,10 +86,25 @@ func (s *Service) SendInput(ctx context.Context, workspaceID string, agentSessio
 			hostInput.TuttiModeSnapshot = runtimeTuttiModeTurnSnapshot(preparedSnapshot)
 		}
 	}
-	hostResult, err := s.ApplicationHost().SendInput(ctx,
-		agenthost.SessionRef{WorkspaceID: workspaceID, AgentSessionID: agentSessionID},
-		hostInput,
-	)
+	ref := agenthost.SessionRef{WorkspaceID: workspaceID, AgentSessionID: agentSessionID}
+	var hostResult agenthost.SendInputResult
+	if !input.Guidance && !typedGoal && !existingSubmit {
+		current, getErr := s.ApplicationHost().GetSession(ctx, ref)
+		if getErr != nil {
+			err = getErr
+		} else if rebind, needed, rebindErr := s.modelPlanRebindInput(ctx, workspaceID, current.Canonical); rebindErr != nil {
+			err = rebindErr
+		} else if needed {
+			hostResult, err = s.ApplicationHost().ReprepareRuntimeSessionAndSendInput(ctx, agenthost.ReprepareRuntimeSessionAndSendInputInput{
+				Reprepare: rebind,
+				Send:      hostInput,
+			})
+		} else {
+			hostResult, err = s.ApplicationHost().SendInput(ctx, ref, hostInput)
+		}
+	} else {
+		hostResult, err = s.ApplicationHost().SendInput(ctx, ref, hostInput)
+	}
 	if err != nil {
 		if preparedTurnID != "" {
 			abandonErr := s.abandonPreparedTuttiModeExec(context.WithoutCancel(ctx), workspaceID, agentSessionID, preparedTurnID, preparedSnapshot, input.Guidance)

--- a/services/tuttid/service/agent/service_test_runtime_test.go
+++ b/services/tuttid/service/agent/service_test_runtime_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"sort"
 	"strconv"
@@ -295,6 +296,26 @@ type fakeSessionReader struct {
 	children           map[string][]PersistedSession
 	recoverableDeleted []agentactivitybiz.DeletedSessionResource
 	runtime            RuntimeController
+}
+
+func (f *fakeSessionReader) CompareAndSwapSessionRuntimeContext(
+	_ context.Context,
+	workspaceID string,
+	sessionID string,
+	expected map[string]any,
+	replacement map[string]any,
+) (PersistedSession, bool, error) {
+	if f == nil {
+		return PersistedSession{}, false, nil
+	}
+	key := strings.TrimSpace(workspaceID) + ":" + strings.TrimSpace(sessionID)
+	session, found := f.sessions[key]
+	if !found || !reflect.DeepEqual(session.InternalRuntimeContext, expected) {
+		return session, false, nil
+	}
+	session.InternalRuntimeContext = clonePayload(replacement)
+	f.sessions[key] = session
+	return session, true, nil
 }
 
 type fakeSessionInitializer struct {

--- a/services/tuttid/service/agentstatus/remote_auth.go
+++ b/services/tuttid/service/agentstatus/remote_auth.go
@@ -89,12 +89,21 @@ func (s Service) resolveProviderUsageRemoteAuthEvidence(
 		Host: agentruntime.HostMetadata{ClientInfo: agentruntime.ClientInfo{
 			Name: "tutti-desktop", Title: "Tutti", Version: "0.1.0",
 		}},
+		ReadAccount:      true,
 		ReadRateLimits:   true,
 		StartupTimeout:   timeout,
 		HandshakeTimeout: timeout,
 		ShutdownTimeout:  s.probeReadyAfter(),
 	})
-	evidence := providerstatus.CodexRemoteAuthEvidence(result.RateLimitsRead, result.Message)
+	var evidence providerstatus.AuthEvidence
+	switch result.AccountState {
+	case agentruntime.CodexAppServerAccountRequired:
+		evidence = providerstatus.AuthEvidence{Kind: providerstatus.AuthEvidenceRemoteAuthFailure, Reason: providerstatus.AuthReasonAuthRequired}
+	case agentruntime.CodexAppServerAccountAuthenticated:
+		evidence = providerstatus.AuthEvidence{Kind: providerstatus.AuthEvidenceRemoteSuccess}
+	default:
+		evidence = providerstatus.AuthEvidence{Kind: providerstatus.AuthEvidenceProbeFailure, Reason: providerstatus.AuthReasonProbeFailed}
+	}
 	level := slog.LevelDebug
 	if evidence.Kind == providerstatus.AuthEvidenceRemoteAuthFailure {
 		level = slog.LevelWarn


### PR DESCRIPTION
## Summary

- normalize Claude, Codex, and ACP runtime failures into a shared structured contract while preserving sanitized provider messages
- restrict provider-global auth invalidation to typed root-provider failures from eligible provider-native sessions
- rebind Model Plan sessions to the latest plan revision atomically before the next new Turn
- cover Claude Code, Codex, Tutti Agent, and OpenCode Model Plan rebinding while leaving provider-native Cursor, Nexight, OpenClaw, Kimi, and Hermes sessions unchanged

## Behavior

- relay 408/522/524 failures are timeouts, not authentication failures
- Model Plan and extension failures cannot trigger a provider login CTA
- ACP setup keeps its narrowly scoped compatibility for the exact `authentication required` rejection, while unrelated relay/provider errors remain visible
- changing a Model Plan key or endpoint affects the next new Turn without mutating an in-flight Turn
- duplicate `clientSubmitId` replay does not rebind or create another Turn
- no new model inference probe or billable detection request is introduced

## Validation

- `pnpm check:changed -- --push-ready` — passed 25/25 lanes
- AgentGUI Vitest — 336 files / 3030 tests passed
- AgentGUI typecheck — passed
- `go build ./...` in the agent daemon — passed
- related Go packages (runtime, provider status, SQLite store, Host, tuttird service, agent service, agent status) — passed
- Model Plan N→N+1 endpoint/key rebinding and Host/SQLite conformance tests — passed
- post-review ACP setup compatibility and non-auth relay regression tests — passed
- independent agent review — no remaining blocking/high/medium findings

An earlier full `check:changed` run reached 60/61 lanes; the remaining Workspace App port-retry healthcheck test also failed repeatedly in a clean detached `origin/main` worktree. The later push-ready suite passed all 25 selected lanes.

## Risk

- runtime replacement is CAS-protected and only commits the new context before Turn admission; if replacement preparation fails, the session remains readable and the next send may resume, but this change does not add a dual-live-runtime rollback guarantee
- live paid-provider validation was intentionally not run because it would require production credentials and could create inference charges; provider contracts are covered with deterministic fixtures
