### PR TITLE
fix(agent): project user Codex instructions

### DIFF
--- a/packages/agent/runtimeprep/codex.go
+++ b/packages/agent/runtimeprep/codex.go
@@ -282,6 +282,9 @@ func exposeUserCodexFiles(codexHome string) error {
 	if err := exposeUserCodexConfig(codexHome, userCodexHome); err != nil {
 		return err
 	}
+	if err := exposeUserCodexAgentsFile(codexHome, userCodexHome); err != nil {
+		return err
+	}
 	if err := exposeUserCodexModelCatalog(codexHome, userCodexHome); err != nil {
 		return err
 	}

--- a/packages/agent/runtimeprep/codex_user_instructions.go
+++ b/packages/agent/runtimeprep/codex_user_instructions.go
@@ -1,0 +1,110 @@
+package runtimeprep
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// exposeUserCodexAgentsFile seeds the run-scoped instruction file with the
+// user's global Codex instructions. The session-owned file must be a copy:
+// WriteManagedBlock adds Tutti's managed policy to it and must never mutate the
+// user's real ~/.codex/AGENTS.md.
+func exposeUserCodexAgentsFile(codexHome string, userCodexHome string) error {
+	source := filepath.Join(userCodexHome, "AGENTS.md")
+	sourceContent, sourceExists, err := readRegularCodexAgentsFile(source)
+	if err != nil {
+		return err
+	}
+
+	target := filepath.Join(codexHome, "AGENTS.md")
+	targetInfo, err := os.Lstat(target)
+	if os.IsNotExist(err) {
+		if !sourceExists {
+			return nil
+		}
+		if err := writeRegularCodexAgentsFile(target, sourceContent); err != nil {
+			return fmt.Errorf("copy user codex AGENTS.md: %w", err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect session codex AGENTS.md: %w", err)
+	}
+
+	// Always replace a pre-existing link with a private regular file. This
+	// prevents WriteManagedBlock from following a symlink or mutating a hardlink
+	// to the user's real ~/.codex/AGENTS.md on the next line of Prepare.
+	if targetInfo.Mode()&os.ModeSymlink != 0 {
+		if sourceExists {
+			if err := writeRegularCodexAgentsFile(target, sourceContent); err != nil {
+				return fmt.Errorf("replace session codex AGENTS.md link: %w", err)
+			}
+			return nil
+		}
+		if err := os.Remove(target); err != nil {
+			return fmt.Errorf("remove session codex AGENTS.md link: %w", err)
+		}
+		return nil
+	}
+	if !targetInfo.Mode().IsRegular() {
+		return fmt.Errorf("session codex AGENTS.md is not a regular file")
+	}
+
+	// Re-materialize an existing regular file too. A hardlink has regular-file
+	// mode, so an atomic replacement is what guarantees a new inode without
+	// discarding any session-local content already present in the file.
+	existing, err := os.ReadFile(target)
+	if err != nil {
+		return fmt.Errorf("read session codex AGENTS.md: %w", err)
+	}
+	if err := writeRegularCodexAgentsFile(target, existing); err != nil {
+		return fmt.Errorf("isolate session codex AGENTS.md: %w", err)
+	}
+	return nil
+}
+
+func readRegularCodexAgentsFile(path string) ([]byte, bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("inspect user codex AGENTS.md: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		// AGENTS.md is optional. Ignore directories, FIFOs, and other special
+		// files instead of blocking runtime preparation while reading them.
+		return nil, false, nil
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false, fmt.Errorf("read user codex AGENTS.md: %w", err)
+	}
+	return content, true, nil
+}
+
+func writeRegularCodexAgentsFile(path string, content []byte) error {
+	temporary, err := os.CreateTemp(filepath.Dir(path), ".codex-agents-*.tmp")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer func() {
+		_ = temporary.Close()
+		_ = os.Remove(temporaryPath)
+	}()
+	if err := temporary.Chmod(0o600); err != nil {
+		return err
+	}
+	if _, err := temporary.Write(content); err != nil {
+		return err
+	}
+	if err := temporary.Sync(); err != nil {
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	return os.Rename(temporaryPath, path)
+}

--- a/packages/agent/runtimeprep/preparer_test.go
+++ b/packages/agent/runtimeprep/preparer_test.go
@@ -1171,6 +1171,7 @@ func TestDefaultPreparerCodexReconcilesNativeSkillsAcrossRepeatedPrepare(t *test
 }
 
 func TestDefaultPreparerCodexSkipsSkillsForModelProbe(t *testing.T) {
+	setTestHome(t, t.TempDir())
 	preparer := newTestPreparer(t.TempDir())
 	prepared, err := preparer.Prepare(t.Context(), PrepareInput{
 		WorkspaceID:    "workspace-1",
@@ -1530,6 +1531,7 @@ func TestCodexConfigWithSupportedServiceTierSanitizesLegacyValues(t *testing.T) 
 }
 
 func TestDefaultPreparerUsesStateRootCLIShimName(t *testing.T) {
+	setTestHome(t, t.TempDir())
 	t.Setenv("PATH", "/usr/bin:/bin")
 	stateDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(stateDir, "bin"), 0o755); err != nil {
@@ -1574,6 +1576,7 @@ func TestDefaultPreparerUsesStateRootCLIShimName(t *testing.T) {
 }
 
 func TestDefaultPreparerCleanupRemovesManagedBlocksAndRuntimeRoot(t *testing.T) {
+	setTestHome(t, t.TempDir())
 	stateDir := t.TempDir()
 	cwd := t.TempDir()
 	agentsPath := filepath.Join(cwd, "AGENTS.md")
@@ -1614,6 +1617,7 @@ func TestDefaultPreparerCleanupRemovesManagedBlocksAndRuntimeRoot(t *testing.T) 
 }
 
 func TestDefaultPreparerCleanupCanPreserveRecoverableRuntimeRoot(t *testing.T) {
+	setTestHome(t, t.TempDir())
 	stateDir := t.TempDir()
 	cwd := t.TempDir()
 	preparer := newTestPreparer(stateDir)
@@ -1658,6 +1662,7 @@ func TestDefaultPreparerCleanupCanPreserveRecoverableRuntimeRoot(t *testing.T) {
 }
 
 func TestDefaultPreparerCodexUsesSessionScopedInstructionFile(t *testing.T) {
+	setTestHome(t, t.TempDir())
 	stateDir := t.TempDir()
 	cwd := t.TempDir()
 	preparer := newTestPreparer(stateDir)
@@ -1689,7 +1694,167 @@ func TestDefaultPreparerCodexUsesSessionScopedInstructionFile(t *testing.T) {
 	}
 }
 
+func TestDefaultPreparerCodexProjectsUserAgentsIntoSessionHome(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+	userCodexHome := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(userCodexHome, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	userAgentsPath := filepath.Join(userCodexHome, "AGENTS.md")
+	userAgents := "global Codex guidance\n"
+	if err := os.WriteFile(userAgentsPath, []byte(userAgents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stateDir := t.TempDir()
+	cwd := t.TempDir()
+	preparer := newTestPreparer(stateDir)
+	prepared, err := preparer.Prepare(t.Context(), PrepareInput{
+		WorkspaceID:    "workspace-1",
+		AgentSessionID: "session-1",
+		Provider:       "codex",
+		Cwd:            cwd,
+	})
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+
+	codexHome := envValue(prepared.Env, "CODEX_HOME")
+	codexAgentsPath := filepath.Join(codexHome, "AGENTS.md")
+	codexAgents, err := os.ReadFile(codexAgentsPath)
+	if err != nil {
+		t.Fatalf("read session AGENTS.md: %v", err)
+	}
+	if !strings.Contains(string(codexAgents), userAgents) {
+		t.Fatalf("session AGENTS.md = %q, want user guidance", string(codexAgents))
+	}
+	if !strings.Contains(string(codexAgents), managedBlockBegin) {
+		t.Fatalf("session AGENTS.md = %q, want Tutti managed block", string(codexAgents))
+	}
+	info, err := os.Lstat(codexAgentsPath)
+	if err != nil {
+		t.Fatalf("stat session AGENTS.md: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("session AGENTS.md is a symlink, want an isolated copy")
+	}
+	userAgentsAfter, err := os.ReadFile(userAgentsPath)
+	if err != nil {
+		t.Fatalf("read user AGENTS.md after prepare: %v", err)
+	}
+	if string(userAgentsAfter) != userAgents {
+		t.Fatalf("user AGENTS.md changed to %q", string(userAgentsAfter))
+	}
+
+	if err := preparer.Cleanup(t.Context(), CleanupInput{
+		WorkspaceID:    "workspace-1",
+		AgentSessionID: "session-1",
+	}); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+}
+
+func TestDefaultPreparerCodexReplacesPreexistingAgentsLinks(t *testing.T) {
+	for _, kind := range []string{"hardlink", "symlink"} {
+		t.Run(kind, func(t *testing.T) {
+			home := t.TempDir()
+			setTestHome(t, home)
+			userCodexHome := filepath.Join(home, ".codex")
+			if err := os.MkdirAll(userCodexHome, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			userAgentsPath := filepath.Join(userCodexHome, "AGENTS.md")
+			userAgents := "global Codex guidance\n"
+			if err := os.WriteFile(userAgentsPath, []byte(userAgents), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			stateDir := t.TempDir()
+			runtimeRoot, err := LocalStore{StateDir: stateDir}.RuntimeRoot("workspace-1", "session-1")
+			if err != nil {
+				t.Fatal(err)
+			}
+			codexHome := filepath.Join(runtimeRoot, "codex-home")
+			if err := os.MkdirAll(codexHome, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			target := filepath.Join(codexHome, "AGENTS.md")
+			switch kind {
+			case "hardlink":
+				if err := os.Link(userAgentsPath, target); err != nil {
+					t.Fatal(err)
+				}
+			case "symlink":
+				if err := os.Symlink(userAgentsPath, target); err != nil {
+					t.Skipf("symlinks unavailable: %v", err)
+				}
+			}
+
+			preparer := newTestPreparer(stateDir)
+			prepared, err := preparer.Prepare(t.Context(), PrepareInput{
+				WorkspaceID:    "workspace-1",
+				AgentSessionID: "session-1",
+				Provider:       "codex",
+				Cwd:            t.TempDir(),
+			})
+			if err != nil {
+				t.Fatalf("Prepare() error = %v", err)
+			}
+
+			gotUserAgents, err := os.ReadFile(userAgentsPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(gotUserAgents) != userAgents {
+				t.Fatalf("user AGENTS.md changed to %q", gotUserAgents)
+			}
+			gotTargetInfo, err := os.Lstat(envValue(prepared.Env, "CODEX_HOME") + string(os.PathSeparator) + "AGENTS.md")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if gotTargetInfo.Mode()&os.ModeSymlink != 0 {
+				t.Fatal("session AGENTS.md is still a symlink")
+			}
+			gotTarget, err := os.ReadFile(target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(gotTarget), managedBlockBegin) {
+				t.Fatalf("session AGENTS.md = %q, want managed block", gotTarget)
+			}
+		})
+	}
+}
+
+func TestDefaultPreparerCodexIgnoresNonRegularUserAgents(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+	if err := os.MkdirAll(filepath.Join(home, ".codex", "AGENTS.md"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	stateDir := t.TempDir()
+	prepared, err := newTestPreparer(stateDir).Prepare(t.Context(), PrepareInput{
+		WorkspaceID:    "workspace-1",
+		AgentSessionID: "session-1",
+		Provider:       "codex",
+		Cwd:            t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+	content, err := os.ReadFile(filepath.Join(envValue(prepared.Env, "CODEX_HOME"), "AGENTS.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(content), managedBlockBegin) {
+		t.Fatalf("session AGENTS.md = %q, want managed block", content)
+	}
+}
+
 func TestDefaultPreparerRejectsMissingCwd(t *testing.T) {
+	setTestHome(t, t.TempDir())
 	stateDir := t.TempDir()
 	missingCwd := filepath.Join(t.TempDir(), "deleted-project")
 


### PR DESCRIPTION
## Summary

- project the user-level `~/.codex/AGENTS.md` into the session-scoped `CODEX_HOME/AGENTS.md`
- keep the session file isolated from the user source and protect pre-existing symlink/hardlink targets
- ignore non-regular optional source files and isolate Codex runtimeprep tests from the real user HOME

## Validation

- `pnpm check:changed -- --push-ready` — passed (7 lanes)
- `GOWORK=off go test -count=1 ./packages/agent/runtimeprep` — passed
- `GOWORK=off go vet ./packages/agent/runtimeprep` — passed
- golangci-lint for `packages/agent/runtimeprep` — 0 issues
- `GOWORK=off GOOS=windows GOARCH=amd64 go test -c` — passed
- real Codex `debug prompt-input` E2E — confirmed user guidance and Tutti managed instructions are model-visible

## Review

Independent subagent review completed. Its findings around link safety, special files, and HOME isolation were fixed and covered by tests.

## Risk / scope

This is limited to user `AGENTS.md` projection. It does not add plugin registration or special RTK materialization; those remain separate follow-up scope. A forced broader `services/tuttid` failed-lane rerun still showed unrelated existing timing/runtime failures, while the final diff-scoped push-ready gate passed.