### PR TITLE
fix(agent-gui): refine custom model plan setup

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentStatusSource.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentStatusSource.test.ts
@@ -95,6 +95,60 @@ test("desktop status combines an exact canonical session with one host probe rea
   assert.deepEqual(observed.errors, []);
 });
 
+for (const [sourceKind, createSource] of [
+  ["surface", createDesktopAgentStatusSource],
+  ["workspace", createDesktopWorkspaceAgentStatusSource]
+] as const) {
+  test(`${sourceKind} desktop status treats provider account usage as inapplicable for a Model Plan Agent`, async () => {
+    let listCalls = 0;
+    const observed = createObserver();
+    const source = createSource({
+      agentActivityRuntime: runtimeWithSessions([]),
+      agents: [
+        {
+          ...agent,
+          agentTargetId: "workspace-agent:kimi-code",
+          name: "Kimi Code - Codex",
+          providerAccountUsageApplicable: false
+        }
+      ] as never,
+      workspaceAgentProbes: {
+        list: async () => {
+          listCalls += 1;
+          return probeSnapshot(500);
+        }
+      } as never,
+      workspaceId: "workspace-1"
+    });
+
+    source.open(
+      {
+        scopeKey: "workspace-agent:kimi-code",
+        reason: "agent-config"
+      },
+      observed.observer
+    );
+    await observed.completed;
+
+    assert.equal(listCalls, 0);
+    assert.deepEqual(observed.frames, [
+      {
+        kind: "refreshed",
+        value: {
+          agentSessionId: null,
+          contextState: "unavailable",
+          contextWindow: null,
+          quotas: [],
+          limitsState: "unavailable",
+          limitsCapturedAtUnixMs: null,
+          limitsStale: false
+        }
+      }
+    ]);
+    assert.deepEqual(observed.errors, []);
+  });
+}
+
 test("desktop status treats an unsupported extension usage probe as unavailable", async () => {
   const extensionAgent = {
     agentTargetId: "extension:example",

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentStatusSource.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentStatusSource.ts
@@ -24,6 +24,28 @@ type WorkspaceAgentProbeSnapshot = Awaited<
   ReturnType<NonNullable<AgentHostInputApi["workspaceAgentProbes"]>["list"]>
 >;
 
+type DesktopAgentStatusContext = Pick<
+  AgentStatusValue,
+  "agentSessionId" | "contextState" | "contextWindow"
+>;
+
+type ResolvedDesktopAgentStatusRequest =
+  | {
+      agent: AgentGUIAgent;
+      context: DesktopAgentStatusContext;
+      providerAccountUsageApplicable: false;
+      workspaceId: string;
+    }
+  | {
+      agent: AgentGUIAgent;
+      context: DesktopAgentStatusContext;
+      providerAccountUsageApplicable: true;
+      workspaceAgentProbes: NonNullable<
+        AgentHostInputApi["workspaceAgentProbes"]
+      >;
+      workspaceId: string;
+    };
+
 const desktopStatusRetainedSnapshotMs = 60 * 60_000;
 const desktopStatusForcedRefreshDebounceMs = 5_000;
 
@@ -41,6 +63,16 @@ export function createDesktopAgentStatusSource(
       const request = resolveDesktopAgentStatusRequest(input, query);
       if ("errorCode" in request) {
         observer.onError({ code: request.errorCode });
+        return () => {
+          closed = true;
+        };
+      }
+      if (!request.providerAccountUsageApplicable) {
+        observer.onFrame({
+          kind: "refreshed",
+          value: statusValueWithoutProviderAccountUsage(request.context)
+        });
+        observer.onComplete();
         return () => {
           closed = true;
         };
@@ -104,6 +136,16 @@ export function createDesktopWorkspaceAgentStatusSource(
       const request = resolveDesktopAgentStatusRequest(input, query);
       if ("errorCode" in request) {
         observer.onError({ code: request.errorCode });
+        return () => {
+          closed = true;
+        };
+      }
+      if (!request.providerAccountUsageApplicable) {
+        observer.onFrame({
+          kind: "refreshed",
+          value: statusValueWithoutProviderAccountUsage(request.context)
+        });
+        observer.onComplete();
         return () => {
           closed = true;
         };
@@ -198,18 +240,10 @@ function resolveDesktopAgentStatusRequest(
   input: DesktopAgentStatusSourceInput,
   query: { agentSessionId?: string | null; scopeKey: string }
 ):
+  | ResolvedDesktopAgentStatusRequest
   | {
-      agent: AgentGUIAgent;
-      context: Pick<
-        AgentStatusValue,
-        "agentSessionId" | "contextState" | "contextWindow"
-      >;
-      workspaceAgentProbes: NonNullable<
-        AgentHostInputApi["workspaceAgentProbes"]
-      >;
-      workspaceId: string;
-    }
-  | { errorCode: "invalid_target" | "unavailable" } {
+      errorCode: "invalid_target" | "unavailable";
+    } {
   const workspaceId = input.workspaceId.trim();
   const agents =
     typeof input.agents === "function" ? input.agents() : input.agents;
@@ -218,9 +252,6 @@ function resolveDesktopAgentStatusRequest(
   );
   if (!workspaceId || !agent) {
     return { errorCode: "invalid_target" };
-  }
-  if (!input.workspaceAgentProbes) {
-    return { errorCode: "unavailable" };
   }
   const context = resolveDesktopAgentStatusContext({
     agentActivityRuntime: input.agentActivityRuntime,
@@ -232,11 +263,35 @@ function resolveDesktopAgentStatusRequest(
   if (context === null) {
     return { errorCode: "invalid_target" };
   }
+  if (agent.providerAccountUsageApplicable === false) {
+    return {
+      agent,
+      context,
+      providerAccountUsageApplicable: false,
+      workspaceId
+    };
+  }
+  if (!input.workspaceAgentProbes) {
+    return { errorCode: "unavailable" };
+  }
   return {
     agent,
     context,
+    providerAccountUsageApplicable: true,
     workspaceAgentProbes: input.workspaceAgentProbes,
     workspaceId
+  };
+}
+
+function statusValueWithoutProviderAccountUsage(
+  context: DesktopAgentStatusContext
+): AgentStatusValue {
+  return {
+    ...context,
+    quotas: [],
+    limitsState: "unavailable",
+    limitsCapturedAtUnixMs: null,
+    limitsStale: false
   };
 }
 

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderReadinessGate.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderReadinessGate.test.ts
@@ -7,7 +7,11 @@ import type {
 import { projectDesktopAgentProviderReadinessGates } from "./desktopAgentProviderReadinessGate.ts";
 
 test("projectDesktopAgentProviderReadinessGates maps provider availability to AgentGUI gates", () => {
+  let modelPlanSetupProvider: string | null = null;
   const gates = projectDesktopAgentProviderReadinessGates({
+    onModelPlanSetup: (provider) => {
+      modelPlanSetupProvider = provider;
+    },
     snapshot: {
       capturedAt: "2026-07-03T00:00:00.000Z",
       defaultProvider: "codex",
@@ -26,10 +30,16 @@ test("projectDesktopAgentProviderReadinessGates maps provider availability to Ag
 
   assert.equal(gates.codex?.status, "not_installed");
   assert.equal(gates.codex?.pendingAction, "install");
+  assert.equal(typeof gates.codex?.onModelPlanSetup, "function");
   assert.equal(gates["claude-code"]?.status, "auth_required");
+  assert.equal(typeof gates["claude-code"]?.onModelPlanSetup, "function");
   assert.equal(gates["tutti-agent"]?.status, "auth_required");
   assert.equal(gates.opencode, null);
   assert.equal(gates.openclaw?.status, "unavailable");
+  assert.equal(gates.openclaw?.onModelPlanSetup, undefined);
+
+  gates.codex?.onModelPlanSetup?.();
+  assert.equal(modelPlanSetupProvider, "codex");
 });
 
 test("projectDesktopAgentProviderReadinessGates gates missing provider statuses while loading", () => {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderReadinessGate.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderReadinessGate.ts
@@ -5,6 +5,7 @@ import type {
   AgentGUIProviderReadinessGateAction
 } from "@tutti-os/agent-gui";
 import type { WorkspaceAgentProvider } from "@tutti-os/client-tuttid-ts";
+import { resolveAgentGUIProviderCatalogIdentity } from "@tutti-os/agent-gui/provider-catalog";
 import type { AgentProviderStatusSnapshot } from "../agentProviderStatusService.interface";
 import {
   desktopManagedAgentProviders,
@@ -14,6 +15,10 @@ import {
 export type DesktopAgentProviderReadinessGateActionHandler = (
   provider: AgentGUIProvider,
   action: AgentGUIProviderReadinessGateAction
+) => void;
+
+export type DesktopAgentProviderModelPlanSetupHandler = (
+  provider: AgentGUIProvider
 ) => void;
 
 // Availability stays "unknown" while the daemon waits for the user to pick
@@ -26,6 +31,7 @@ const runtimeSelectionReasonCodes = new Set<string>([
 
 export function projectDesktopAgentProviderReadinessGates(input: {
   onAction?: DesktopAgentProviderReadinessGateActionHandler;
+  onModelPlanSetup?: DesktopAgentProviderModelPlanSetupHandler;
   snapshot: AgentProviderStatusSnapshot;
 }): Partial<Record<AgentGUIProvider, AgentGUIProviderReadinessGate | null>> {
   const statusByProvider = new Map(
@@ -49,6 +55,13 @@ export function projectDesktopAgentProviderReadinessGates(input: {
     gates[agentGuiProvider] = gate
       ? {
           ...gate,
+          ...(resolveAgentGUIProviderCatalogIdentity(provider)
+            ?.modelPlanProtocol && input.onModelPlanSetup
+            ? {
+                onModelPlanSetup: () =>
+                  input.onModelPlanSetup?.(agentGuiProvider)
+              }
+            : {}),
           ...(input.onAction
             ? {
                 onAction: (_provider, action) =>

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentsService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentsService.test.ts
@@ -224,7 +224,8 @@ test("desktop agents service lists a custom Agent with its Harness target catalo
                 iconKey: null,
                 name: "Codex",
                 provider: "codex"
-              }
+              },
+              modelPlanId: "plan-1"
             })
           ]
         };
@@ -244,6 +245,7 @@ test("desktop agents service lists a custom Agent with its Harness target catalo
 
   assert.equal(listedWorkspaceId, "workspace-1");
   assert.equal(customAgent?.iconUrl, "catalog://codex-target");
+  assert.equal(customAgent?.providerAccountUsageApplicable, false);
   assert.deepEqual(
     service.getAgentPresentation({
       agentTargetId: "workspace-agent:reviewer"
@@ -261,6 +263,7 @@ test("desktop agents service lists a custom Agent with its Harness target catalo
     label: "Reviewer",
     ownership: "self",
     provider: "codex",
+    providerAccountUsageApplicable: false,
     ref: {
       agentTargetId: "workspace-agent:reviewer",
       kind: "agent-directory",

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentsService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentsService.ts
@@ -421,7 +421,10 @@ export function mapWorkspaceAgentsToAgents(
           }) ?? "",
         name: agent.name,
         ownership: "self" as const,
-        provider: provider as AgentGUIProvider
+        provider: provider as AgentGUIProvider,
+        ...(agent.modelPlanId?.trim()
+          ? { providerAccountUsageApplicable: false }
+          : {})
       }
     ];
   });

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -691,6 +691,7 @@ function DesktopAgentGUISurfaceImpl({
       visibleErrorPresentationOverrides,
       comingSoonProviders: comingSoonAgentProviders,
       providerReadinessGates,
+      accountUsageRefreshInline: true,
       defaultAgentTargetId,
       providerAuthAccountLabels,
       mentionService,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/useDesktopAgentGUIReadiness.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/useDesktopAgentGUIReadiness.ts
@@ -13,6 +13,7 @@ import type {
   AgentGUIProviderReadinessGateAction,
   AgentGUIProps
 } from "@tutti-os/agent-gui";
+import { openWorkspaceSettingsPanel } from "@tutti-os/agent-gui/workspace-settings-panel";
 import type { WorkbenchHostNodeBodyContext } from "@tutti-os/workbench-surface";
 import type { DesktopComputerUseApi } from "@preload/types";
 import {
@@ -287,10 +288,14 @@ export function useDesktopAgentGUIReadiness(input: {
     },
     [agentEnvService, agentProviderStatusService, host, workspaceId]
   );
+  const handleModelPlanSetup = useCallback(() => {
+    openWorkspaceSettingsPanel({ pane: "managed-models" });
+  }, []);
   const providerReadinessGates = useMemo(() => {
     const gates = projectDesktopAgentProviderReadinessGates({
       snapshot: effectiveProviderStatusSnapshot,
-      onAction: handleProviderReadinessGateAction
+      onAction: handleProviderReadinessGateAction,
+      onModelPlanSetup: handleModelPlanSetup
     });
     if (!suppressNotReadyProjection) {
       return gates;
@@ -302,6 +307,7 @@ export function useDesktopAgentGUIReadiness(input: {
     return provider ? { ...gates, [provider]: checkingGate } : gates;
   }, [
     effectiveProviderStatusSnapshot,
+    handleModelPlanSetup,
     handleProviderReadinessGateAction,
     provider,
     suppressNotReadyProjection

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/useStableDesktopAgentGUIHostProps.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/useStableDesktopAgentGUIHostProps.ts
@@ -32,6 +32,7 @@ export type DesktopAgentGUIHostProps = {
     | "visibleErrorPresentationOverrides"
     | "comingSoonProviders"
     | "providerReadinessGates"
+    | "accountUsageRefreshInline"
     | "defaultAgentTargetId"
     | "providerAuthAccountLabels"
     | "mentionService"
@@ -125,6 +126,7 @@ export function useStableDesktopAgentGUIHostProps({
         nextHostCapabilities.visibleErrorPresentationOverrides,
       comingSoonProviders: nextHostCapabilities.comingSoonProviders,
       providerReadinessGates: nextHostCapabilities.providerReadinessGates,
+      accountUsageRefreshInline: nextHostCapabilities.accountUsageRefreshInline,
       defaultAgentTargetId: nextHostCapabilities.defaultAgentTargetId,
       providerAuthAccountLabels: nextHostCapabilities.providerAuthAccountLabels,
       mentionService: nextHostCapabilities.mentionService,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentsController.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentsController.test.ts
@@ -324,6 +324,7 @@ test("workspaceAgentDraftToPutInput passes dormant contract fields through verba
     workspaceAgentDraftToPutInput({
       agentId: null,
       name: " Reviewer ",
+      nameEdited: true,
       description: " Reviews changes ",
       harnessAgentTargetId: " local:codex ",
       modelPlanId: "",
@@ -382,6 +383,64 @@ test("workspace agents controller prefills a compatible runtime and plan for the
 
   assert.equal(store.agents.draft?.harnessAgentTargetId, "local:claude-code");
   assert.equal(store.agents.draft?.modelPlanId, "plan-1");
+  assert.equal(store.agents.draft?.name, "plan-1 - Claude Code");
+});
+
+test("workspace agents controller derives a new Agent name from the selected plan and runtime", () => {
+  const store = createWorkspaceSettingsStore();
+  store.workspaceID = "workspace-1";
+  store.agents.harnessTargets = [
+    { enabled: true, id: "local:codex", name: "Codex", provider: "codex" }
+  ];
+  store.modelPlans.plans = [
+    {
+      ...createStoredModelPlan("plan-openai", "openai"),
+      name: "Team Gateway"
+    }
+  ];
+  const controller = new WorkspaceAgentsController({
+    client: createClient(),
+    store
+  });
+
+  controller.beginDraft();
+  assert.equal(store.agents.draft?.name, "Codex");
+
+  controller.updateDraft({ modelPlanId: "plan-openai" });
+  assert.equal(store.agents.draft?.name, "Team Gateway - Codex");
+});
+
+test("workspace agents controller preserves an edited name across plan and runtime changes", () => {
+  const store = createWorkspaceSettingsStore();
+  store.workspaceID = "workspace-1";
+  store.agents.harnessTargets = [
+    { enabled: true, id: "local:codex", name: "Codex", provider: "codex" },
+    {
+      enabled: true,
+      id: "local:claude-code",
+      name: "Claude Code",
+      provider: "claude-code"
+    }
+  ];
+  store.modelPlans.plans = [
+    createStoredModelPlan("plan-openai", "openai"),
+    createStoredModelPlan("plan-anthropic", "anthropic")
+  ];
+  const controller = new WorkspaceAgentsController({
+    client: createClient(),
+    store
+  });
+
+  controller.beginDraft();
+  controller.updateDraft({ modelPlanId: "plan-openai" });
+  controller.updateDraft({ name: "My reviewer" });
+  controller.updateDraft({ modelPlanId: "plan-anthropic" });
+  controller.updateDraft({
+    harnessAgentTargetId: "local:claude-code",
+    modelPlanId: "plan-anthropic"
+  });
+
+  assert.equal(store.agents.draft?.name, "My reviewer");
 });
 
 test("workspace agents controller leaves the plan empty when no runtime is compatible", () => {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentsController.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentsController.ts
@@ -105,7 +105,8 @@ export class WorkspaceAgentsController implements IWorkspaceAgentsController {
     const harness = this.state.harnessTargets.find((target) => target.enabled);
     this.state.draft = {
       agentId: null,
-      name: "",
+      name: this.resolveGeneratedDraftName(harness?.id ?? "", ""),
+      nameEdited: false,
       description: "",
       harnessAgentTargetId: harness?.id ?? "",
       modelPlanId: "",
@@ -158,7 +159,11 @@ export class WorkspaceAgentsController implements IWorkspaceAgentsController {
       modelPlanProtocolForAgentProvider(harness.provider) === plan.protocol;
     this.state.draft = {
       agentId: null,
-      name: "",
+      name: this.resolveGeneratedDraftName(
+        harness?.id ?? "",
+        planCompatible ? plan.id : ""
+      ),
+      nameEdited: false,
       description: "",
       harnessAgentTargetId: harness?.id ?? "",
       modelPlanId: planCompatible ? plan.id : "",
@@ -184,11 +189,38 @@ export class WorkspaceAgentsController implements IWorkspaceAgentsController {
   }
 
   updateDraft(patch: Partial<WorkspaceAgentDraft>): void {
-    if (!this.state.draft) {
+    const draft = this.state.draft;
+    if (!draft) {
       return;
     }
-    this.state.draft = { ...this.state.draft, ...patch };
+    const nameEdited =
+      draft.nameEdited || Object.prototype.hasOwnProperty.call(patch, "name");
+    const nextDraft = { ...draft, ...patch, nameEdited };
+    this.state.draft = nameEdited
+      ? nextDraft
+      : {
+          ...nextDraft,
+          name: this.resolveGeneratedDraftName(
+            nextDraft.harnessAgentTargetId,
+            nextDraft.modelPlanId
+          )
+        };
     this.state.feedback = null;
+  }
+
+  private resolveGeneratedDraftName(
+    harnessAgentTargetID: string,
+    modelPlanID: string
+  ): string {
+    const planName =
+      this.store.modelPlans.plans
+        .find((plan) => plan.id === modelPlanID)
+        ?.name.trim() ?? "";
+    const harnessName =
+      this.state.harnessTargets
+        .find((target) => target.id === harnessAgentTargetID)
+        ?.name.trim() ?? "";
+    return [planName, harnessName].filter(Boolean).join(" - ");
   }
 
   cancelDraft(): void {
@@ -353,6 +385,7 @@ function workspaceAgentToDraft(
   return {
     agentId: agent.id,
     name: agent.name,
+    nameEdited: true,
     description: agent.description ?? "",
     harnessAgentTargetId: agent.harness.agentTargetId,
     modelPlanId: agent.modelPlanId ?? "",

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceSettingsTypes.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceSettingsTypes.ts
@@ -223,6 +223,8 @@ export type WorkspaceAgentDefinition =
 export interface WorkspaceAgentDraft {
   agentId: string | null;
   name: string;
+  /** Once true, runtime/plan changes must never replace the user's name. */
+  nameEdited: boolean;
   description: string;
   harnessAgentTargetId: string;
   modelPlanId: string;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentEditor.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentEditor.tsx
@@ -1,6 +1,8 @@
+import { useId, useState } from "react";
 import { useComposedInputValue } from "@tutti-os/ui-react-hooks";
 import {
   Button,
+  ChevronDownIcon,
   CloseIcon,
   Input,
   Select,
@@ -8,7 +10,8 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Textarea
+  Textarea,
+  cn
 } from "@tutti-os/ui-system";
 import { useTranslation } from "@renderer/i18n";
 import { workspaceAgentCompatibleModelPlans } from "../services/workspaceAgentModelPlans";
@@ -90,6 +93,8 @@ export function WorkspaceAgentEditor({
   const selectedPlan =
     compatiblePlans.find((plan) => plan.id === draft.modelPlanId) ?? null;
   const editing = draft.agentId !== null;
+  const advancedOptionsId = useId();
+  const [advancedOptionsOpen, setAdvancedOptionsOpen] = useState(false);
 
   return (
     <section className="flex w-full flex-col gap-4 rounded-[6px] border border-[var(--border-1)] bg-[var(--transparency-block)] p-4">
@@ -256,55 +261,77 @@ export function WorkspaceAgentEditor({
         </label>
       </div>
 
-      <label className="flex flex-col gap-1.5">
-        <span className="text-[11px] font-medium text-[var(--text-secondary)]">
-          {t("workspace.settings.apps.agents.descriptionLabel")}
-        </span>
-        <Input
-          placeholder={t(
-            "workspace.settings.apps.agents.descriptionPlaceholder"
-          )}
-          type="text"
-          value={draft.description}
-          onChange={(event) =>
-            onUpdate({ description: event.currentTarget.value })
-          }
-        />
-      </label>
-
-      <div className="grid gap-3">
-        <label className="flex flex-col gap-1.5">
-          <span className="text-[11px] font-medium text-[var(--text-secondary)]">
-            {t("workspace.settings.apps.agents.instructionsLabel")}
-          </span>
-          <Textarea
-            placeholder={t(
-              "workspace.settings.apps.agents.instructionsPlaceholder"
+      <div className="flex flex-col gap-3 border-t border-[var(--border-1)] pt-1">
+        <Button
+          aria-controls={advancedOptionsId}
+          aria-expanded={advancedOptionsOpen}
+          className="w-full justify-between px-0 hover:bg-transparent active:bg-transparent aria-expanded:bg-transparent"
+          type="button"
+          variant="ghost"
+          onClick={() => setAdvancedOptionsOpen((open) => !open)}
+        >
+          {t("workspace.settings.apps.agents.advancedOptionsTitle")}
+          <ChevronDownIcon
+            aria-hidden="true"
+            className={cn(
+              "size-3.5 transition-transform duration-150",
+              advancedOptionsOpen && "rotate-180"
             )}
-            value={draft.instructions}
-            onChange={(event) =>
-              onUpdate({ instructions: event.currentTarget.value })
-            }
           />
-        </label>
+        </Button>
 
-        <label className="flex flex-col gap-1.5">
-          <span className="text-[11px] font-medium text-[var(--text-secondary)]">
-            {t("workspace.settings.apps.agents.callConditionsLabel")}
-          </span>
-          <Textarea
-            placeholder={t(
-              "workspace.settings.apps.agents.callConditionsPlaceholder"
-            )}
-            value={draft.callConditions}
-            onChange={(event) =>
-              onUpdate({ callConditions: event.currentTarget.value })
-            }
-          />
-          <span className="text-[10px] leading-[1.3] text-[var(--text-tertiary)]">
-            {t("workspace.settings.apps.agents.onePerLine")}
-          </span>
-        </label>
+        {advancedOptionsOpen ? (
+          <div id={advancedOptionsId} className="grid gap-3">
+            <label className="flex flex-col gap-1.5">
+              <span className="text-[11px] font-medium text-[var(--text-secondary)]">
+                {t("workspace.settings.apps.agents.descriptionLabel")}
+              </span>
+              <Input
+                placeholder={t(
+                  "workspace.settings.apps.agents.descriptionPlaceholder"
+                )}
+                type="text"
+                value={draft.description}
+                onChange={(event) =>
+                  onUpdate({ description: event.currentTarget.value })
+                }
+              />
+            </label>
+
+            <label className="flex flex-col gap-1.5">
+              <span className="text-[11px] font-medium text-[var(--text-secondary)]">
+                {t("workspace.settings.apps.agents.instructionsLabel")}
+              </span>
+              <Textarea
+                placeholder={t(
+                  "workspace.settings.apps.agents.instructionsPlaceholder"
+                )}
+                value={draft.instructions}
+                onChange={(event) =>
+                  onUpdate({ instructions: event.currentTarget.value })
+                }
+              />
+            </label>
+
+            <label className="flex flex-col gap-1.5">
+              <span className="text-[11px] font-medium text-[var(--text-secondary)]">
+                {t("workspace.settings.apps.agents.callConditionsLabel")}
+              </span>
+              <Textarea
+                placeholder={t(
+                  "workspace.settings.apps.agents.callConditionsPlaceholder"
+                )}
+                value={draft.callConditions}
+                onChange={(event) =>
+                  onUpdate({ callConditions: event.currentTarget.value })
+                }
+              />
+              <span className="text-[10px] leading-[1.3] text-[var(--text-tertiary)]">
+                {t("workspace.settings.apps.agents.onePerLine")}
+              </span>
+            </label>
+          </div>
+        ) : null}
       </div>
 
       <div className="flex items-center justify-end gap-2">

--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -1060,7 +1060,7 @@ export const en = {
           ready: "Ready",
           harnessLabel: "Agent Runtime",
           harnessUnavailable: "Agent Runtime unavailable",
-          behaviorDetailsTitle: "Instructions and call conditions",
+          advancedOptionsTitle: "Advanced options",
           callConditionsLabel: "Call conditions",
           callConditionsPlaceholder:
             "Use before a release decision\nUse when architecture risk is high",

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -999,7 +999,7 @@ export const zhCN = {
           ready: "可用",
           harnessLabel: "Agent Runtime",
           harnessUnavailable: "Agent Runtime 不可用",
-          behaviorDetailsTitle: "完整指令与调用条件",
+          advancedOptionsTitle: "进阶选项",
           callConditionsLabel: "调用条件",
           callConditionsPlaceholder: "发布决策前调用\n架构风险较高时调用",
           instructionsLabel: "指令",

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -577,6 +577,21 @@ quotas and `limitsState: unavailable`; it must not become a refresh failure.
 Only real authentication, transport, parsing, timeout, or execution failures
 project `limitsState: error`.
 
+A Custom Agent bound to a Model Plan does not use the Agent Runtime provider's
+native account for model access, so provider-native account usage is not
+applicable to that exact target. Desktop projects
+`providerAccountUsageApplicable: false` from the Workspace Agent binding;
+AgentGUI preserves the optional capability through its target projection. The
+Desktop status source then completes the bounded read with unavailable limits
+without calling the provider usage probe, and AgentGUI disables manual usage
+refresh for that target. An absent capability keeps the existing provider
+account behavior for other hosts and ordinary Runtime targets.
+
+Account-config refresh placement is also host-scoped presentation. Tutti
+Desktop opts into `accountUsageRefreshInline` so the refresh control shares the
+limits header row. The capability defaults to false; TSH/VN and other hosts that
+omit it retain the established standalone menu row.
+
 Closing `/status`, Agent Info, or Agent Config cancels only the request owned
 by that surface. Replaced requests remain fenced. A stream that completes
 without a frame is a failed refresh: a retained value may remain visible, but
@@ -2210,6 +2225,18 @@ pinned to the verified active installation.
 
 Target-managed setup uses exact `agentTargetId`; daemon persists its state and actions. Setup gates only the empty new-conversation surface. Active/history conversations follow host-projected Session runtime availability for exact-target capability and transport reachability. A blocked Session runtime disables both composer editing and submit until the host reports the Session available again.
 
+For a built-in Runtime that is not installed or still requires authentication,
+the Desktop readiness projection may additionally declare the host-owned
+`onModelPlanSetup` action. AgentGUI then keeps the ordinary install/login
+action and offers a secondary route to the host's Model Plan settings. Desktop
+derives the capability from the provider descriptor's Model Plan protocol and
+injects its managed-model settings route; shared AgentGUI does not name or open
+that product destination. Unknown or unsupported providers omit it and keep the
+single setup action. The capability is fail-closed: non-Tutti hosts, including
+TSH/VN, omit it and never render the Model Plan route when they consume the
+shared AgentGUI package. This route is navigation only: it does not rewrite
+readiness, create a Session, or bypass activation-time Model Plan validation.
+
 Provider-declared terminal authentication remains a Host capability, not React
 or Session lifecycle. AgentGUI's target-setup controller owns the local
 `idle`/`waiting`/`error` projection and terminal handle, while the Desktop host
@@ -3360,6 +3387,14 @@ Runtime destination also bumps `agentFocus` to scroll and briefly highlight the 
 a link to a hidden preview agent surfaces an "enable Preview Agents" hint rather
 than failing silently. This is a settings surface, not a second Agent Target
 state store.
+
+New Custom Agent drafts derive an untouched display name from the selected
+Model Plan and Agent Runtime, joined as `Model Plan - Runtime` when both are
+present. Runtime or plan changes may refresh that suggestion only until the
+user edits the name; after the first edit, the draft preserves the user's value
+across later selection changes. Description, instructions, and call conditions
+remain draft fields but are grouped under a collapsed-by-default Advanced
+options disclosure.
 
 ### 8.2 Deleted-conversation settings surface
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.labels.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.labels.ts
@@ -165,6 +165,9 @@ export function useAgentGUIViewLabels(input: {
         { provider: displayProviderLabel }
       ),
       providerGateLoginAction: t("agentHost.agentGui.providerGateLoginAction"),
+      providerGateModelPlanAction: t(
+        "agentHost.agentGui.providerGateModelPlanAction"
+      ),
       providerGateComingSoonTitle: t(
         "agentHost.agentGui.providerGateComingSoonTitle",
         { provider: displayProviderLabel }

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.status.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.status.spec.tsx
@@ -321,6 +321,37 @@ describe("AgentGUINode status controller integration", () => {
     );
   });
 
+  it("disables provider-account usage refresh for a Model Plan target", () => {
+    const target = {
+      ...createLocalAgentGUIAgentTarget("codex"),
+      agentTargetId: "workspace-agent:kimi-code",
+      targetId: "workspace-agent:kimi-code",
+      providerAccountUsageApplicable: false
+    };
+    mockViewModel = createViewModel({
+      selectedAgentTarget: target,
+      agentTargets: [target],
+      conversationFilter: {
+        kind: "agentTarget",
+        agentTargetId: "workspace-agent:kimi-code"
+      }
+    });
+    render(
+      <AgentGUINode
+        {...createProps({
+          runtimeRequests: {
+            agentStatusController: createAgentStatusController({
+              source: { open: vi.fn(() => vi.fn()) }
+            })
+          }
+        })}
+      />
+    );
+
+    expect(latestViewProps().onAgentUsageRefresh).toBeUndefined();
+    expect(latestViewProps().onSlashStatusRefresh).toBeUndefined();
+  });
+
   it("projects the host billing label into the rail config menu", () => {
     mockViewModel = createViewModel({
       conversationFilter: {
@@ -485,9 +516,11 @@ interface CapturedViewProps {
   agentConfigSystemActionsContent?: React.ReactNode;
   onAgentConfigMenuOpen?: () => void;
   onAgentConfigMenuClose?: () => void;
+  onAgentUsageRefresh?: () => void;
   providerAuthAccountLabels?: Partial<Record<string, string>>;
   onSlashStatusOpen?: () => void;
   onSlashStatusClose?: () => void;
+  onSlashStatusRefresh?: () => void;
   slashStatusUsageErrorMessage?: string | null;
   slashStatusOverride?: {
     contextWindow?: { usedTokens?: number | null } | null;

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -109,6 +109,7 @@ export const AgentGUINode = memo(function AgentGUINode({
     providerRailMode = "catalog",
     comingSoonProviders,
     providerReadinessGates = null,
+    accountUsageRefreshInline = false,
     targetConnectionSource = null,
     interactionReadinessSource = null,
     observationGapSource = null,
@@ -521,6 +522,7 @@ export const AgentGUINode = memo(function AgentGUINode({
               onAgentConfigMenuClose={handleAgentConfigMenuClose}
               onAgentConfigMenuOpen={handleAgentConfigMenuOpen}
               onAgentUsageRefresh={handleAgentUsageRefresh}
+              accountUsageRefreshInline={accountUsageRefreshInline}
               onSlashStatusOpen={handleSlashStatusOpen}
               onSlashStatusClose={handleSlashStatusClose}
               onSlashStatusRefresh={handleSlashStatusRefresh}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
@@ -175,6 +175,8 @@ export interface AgentGUINodeHostCapabilities {
   providerReadinessGates?: Partial<
     Record<AgentGUIProvider, AgentGUIProviderReadinessGate | null>
   > | null;
+  /** Tutti-only presentation opt-in for placing usage refresh in the limits header. */
+  accountUsageRefreshInline?: boolean;
   /** Target-level connection for new-conversation and ordinary Composer admission. */
   targetConnectionSource?: AgentGUITargetConnectionSource | null;
   /**
@@ -493,6 +495,7 @@ export function areAgentGUINodePropsEqual(
     pc.providerRailMode === nc.providerRailMode &&
     pc.comingSoonProviders === nc.comingSoonProviders &&
     pc.providerReadinessGates === nc.providerReadinessGates &&
+    pc.accountUsageRefreshInline === nc.accountUsageRefreshInline &&
     pc.targetConnectionSource === nc.targetConnectionSource &&
     pc.interactionReadinessSource === nc.interactionReadinessSource &&
     pc.observationGapSource === nc.observationGapSource &&

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.usage.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.usage.ts
@@ -166,24 +166,28 @@ export function resolveAgentGUIRailStatusTarget(input: {
   if (filter.kind !== "agentTarget") {
     return null;
   }
+  return resolveAgentGUIStatusTarget({
+    agentTargets: input.agentTargets,
+    scopeKey: filter.agentTargetId
+  });
+}
+
+export function resolveAgentGUIStatusTarget(input: {
+  agentTargets: readonly AgentGUIAgentTarget[];
+  scopeKey: string;
+}): AgentGUIAgentTarget | null {
+  const scopeKey = input.scopeKey.trim();
+  if (!scopeKey) {
+    return null;
+  }
   return (
     input.agentTargets.find(
       (candidate) =>
         candidate.disabled !== true &&
-        ((candidate.agentTargetId?.trim() ?? "") === filter.agentTargetId ||
-          candidate.targetId.trim() === filter.agentTargetId)
+        ((candidate.agentTargetId?.trim() ?? "") === scopeKey ||
+          candidate.targetId.trim() === scopeKey)
     ) ?? null
   );
-}
-
-export function resolveAgentGUIRailStatusProvider(input: {
-  conversationFilter: ReturnType<
-    typeof useAgentGUINodeController
-  >["viewModel"]["rail"]["conversationFilter"];
-  agentTargets: readonly AgentGUIAgentTarget[];
-}): AgentGUIProvider | null {
-  const target = resolveAgentGUIRailStatusTarget(input);
-  return target?.provider ?? null;
 }
 
 export function resolveAgentGUIRailConfigProvider(

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -117,6 +117,7 @@ export function AgentGUINodeView({
   onAgentConfigMenuClose,
   onAgentConfigMenuOpen,
   onAgentUsageRefresh,
+  accountUsageRefreshInline = false,
   onSlashStatusOpen,
   onSlashStatusClose,
   onSlashStatusRefresh,
@@ -377,8 +378,6 @@ export function AgentGUINodeView({
     viewModel.shell.data.provider
   );
   const railConfigTarget = resolveAgentGUIRailStatusTarget(viewModel.rail);
-  const effectiveRailSlashStatusLimits =
-    railSlashStatusLimits ?? slashStatusLimits;
   const shouldShowProviderRailConfigButton =
     viewModel.rail.conversationFilter.kind === "all" ||
     viewModel.rail.selectedAgentTarget?.disabled !== true;
@@ -595,7 +594,7 @@ export function AgentGUINodeView({
                   providerScopedActionsVisible={
                     viewModel.rail.conversationFilter.kind !== "all"
                   }
-                  slashStatusLimits={effectiveRailSlashStatusLimits}
+                  slashStatusLimits={railSlashStatusLimits ?? slashStatusLimits}
                   slashStatusLimitsLoading={slashStatusLimitsLoading}
                   slashStatusLimitsResolvedEmpty={
                     slashStatusLimitsResolvedEmpty
@@ -618,6 +617,7 @@ export function AgentGUINodeView({
                   onAgentConfigMenuClose={onAgentConfigMenuClose}
                   onAgentConfigMenuOpen={onAgentConfigMenuOpen}
                   onAgentUsageRefresh={onAgentUsageRefresh}
+                  usageRefreshInline={accountUsageRefreshInline}
                   onOpenAgentEnvSetup={openAgentEnvSetup}
                   onOpenAgentSettings={openAgentSettings}
                 />

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIStatus.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIStatus.ts
@@ -5,7 +5,8 @@ import { buildDockAgentProbeTooltipLines } from "../../workspaceDesktop/view/des
 import type { AgentComposerSlashStatus } from "../AgentComposer";
 import type { AgentGUINodeProps } from "../AgentGUINode.types";
 import {
-  resolveAgentGUIRailStatusProvider,
+  resolveAgentGUIRailStatusTarget,
+  resolveAgentGUIStatusTarget,
   slashStatusLimitsFromQuotas,
   slashStatusUsageErrorMessage
 } from "../AgentGUINode.usage";
@@ -63,14 +64,23 @@ export function useAgentGUIStatus(input: {
     viewModel.rail.activeConversationId?.trim() ||
     viewModel.interaction.sessionChrome.rawState?.agentSessionId?.trim() ||
     null;
-  const railStatusProvider = useMemo(
+  const activeStatusTarget = useMemo(
     () =>
-      resolveAgentGUIRailStatusProvider({
+      resolveAgentGUIStatusTarget({
+        agentTargets: viewModel.rail.agentTargets,
+        scopeKey: activeStatusScopeKey
+      }),
+    [activeStatusScopeKey, viewModel.rail.agentTargets]
+  );
+  const railStatusTarget = useMemo(
+    () =>
+      resolveAgentGUIRailStatusTarget({
         conversationFilter: viewModel.rail.conversationFilter,
         agentTargets: viewModel.rail.agentTargets
       }),
     [viewModel.rail.conversationFilter, viewModel.rail.agentTargets]
   );
+  const railStatusProvider = railStatusTarget?.provider ?? null;
   const railStatusScopeKey =
     viewModel.rail.conversationFilter.kind === "agentTarget"
       ? viewModel.rail.conversationFilter.agentTargetId.trim()
@@ -306,10 +316,16 @@ export function useAgentGUIStatus(input: {
     handleAgentConfigMenuOpen,
     handleAgentProbeInfoClose,
     handleAgentProbeInfoOpen,
-    handleAgentUsageRefresh,
+    handleAgentUsageRefresh:
+      railStatusTarget?.providerAccountUsageApplicable === false
+        ? undefined
+        : handleAgentUsageRefresh,
     handleSlashStatusClose,
     handleSlashStatusOpen,
-    handleSlashStatusRefresh,
+    handleSlashStatusRefresh:
+      activeStatusTarget?.providerAccountUsageApplicable === false
+        ? undefined
+        : handleSlashStatusRefresh,
     railStatusProvider,
     slashStatusLimits: agentStatusLimits,
     slashStatusLimitsUnavailable:

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiProviderReadiness.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiProviderReadiness.spec.ts
@@ -17,6 +17,7 @@ const labels = {
   providerGateLoginTitle: "login-title",
   providerGateLoginDescription: "login-description",
   providerGateLoginAction: "login-action",
+  providerGateModelPlanAction: "model-plan-action",
   providerGateComingSoonTitle: "coming-soon-title",
   providerGateComingSoonDescription: "coming-soon-description",
   providerGateComingSoonAction: "coming-soon-action",

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiProviderReadiness.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiProviderReadiness.ts
@@ -14,6 +14,7 @@ export interface AgentGUIProviderReadinessLabels {
   providerGateLoginTitle: string;
   providerGateLoginDescription: string;
   providerGateLoginAction: string;
+  providerGateModelPlanAction: string;
   providerGateComingSoonTitle: string;
   providerGateComingSoonDescription: string;
   providerGateComingSoonAction: string;

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.spec.tsx
@@ -202,45 +202,58 @@ describe("AgentGUIConfigMenu", () => {
     expect(screen.getByText("Settings")).toBeInTheDocument();
   });
 
-  it("preserves the provider account and quota fallback without Host content", () => {
-    render(
-      <AgentGUIConfigMenu
-        environmentSetupVisible={false}
-        labels={labels}
-        providerScopedActionsVisible
-        provider="codex"
-        providerAuthAccountLabel="provider@example.test"
-        slashStatusLimits={[
-          {
-            id: "weekly",
-            label: "Weekly",
-            percentRemaining: 50,
-            value: "50%",
-            reset: null
-          }
-        ]}
-        slashStatusLimitsLoading={false}
-        slashStatusLimitsResolvedEmpty={false}
-        slashStatusUsageCapturedAtUnixMs={null}
-        slashStatusUsageDidFail={false}
-        slashStatusUsageAttempted
-        onAgentConfigMenuOpen={vi.fn()}
-        onAgentUsageRefresh={vi.fn()}
-        onOpenAgentEnvSetup={vi.fn()}
-        onOpenAgentSettings={vi.fn()}
-      />
-    );
+  it.each([
+    {
+      expectedRole: "menuitem",
+      usageRefreshInline: undefined
+    },
+    {
+      expectedRole: "button",
+      usageRefreshInline: true
+    }
+  ] as const)(
+    "preserves provider account fallback with the refresh exposed as a $expectedRole",
+    ({ expectedRole, usageRefreshInline }) => {
+      render(
+        <AgentGUIConfigMenu
+          environmentSetupVisible={false}
+          labels={labels}
+          providerScopedActionsVisible
+          provider="codex"
+          providerAuthAccountLabel="provider@example.test"
+          slashStatusLimits={[
+            {
+              id: "weekly",
+              label: "Weekly",
+              percentRemaining: 50,
+              value: "50%",
+              reset: null
+            }
+          ]}
+          slashStatusLimitsLoading={false}
+          slashStatusLimitsResolvedEmpty={false}
+          slashStatusUsageCapturedAtUnixMs={null}
+          slashStatusUsageDidFail={false}
+          slashStatusUsageAttempted
+          usageRefreshInline={usageRefreshInline}
+          onAgentConfigMenuOpen={vi.fn()}
+          onAgentUsageRefresh={vi.fn()}
+          onOpenAgentEnvSetup={vi.fn()}
+          onOpenAgentSettings={vi.fn()}
+        />
+      );
 
-    openConfigMenu();
+      openConfigMenu();
 
-    expect(screen.getByText("provider@example.test")).toBeInTheDocument();
-    expect(screen.getByText("Limits")).toBeInTheDocument();
-    expect(screen.getByText("Weekly")).toBeInTheDocument();
-    const usageRefresh = screen.getByRole("menuitem", {
-      name: "Refresh usage"
-    });
-    expect(usageRefresh).toHaveAttribute("aria-describedby");
-  });
+      expect(screen.getByText("provider@example.test")).toBeInTheDocument();
+      expect(screen.getByText("Limits")).toBeInTheDocument();
+      expect(screen.getByText("Weekly")).toBeInTheDocument();
+      const usageRefresh = screen.getByRole(expectedRole, {
+        name: "Refresh usage"
+      });
+      expect(usageRefresh).toHaveAttribute("aria-describedby");
+    }
+  );
 
   it("uses the Agent Target label and original icon for Kimi billing", () => {
     render(

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.tsx
@@ -39,6 +39,7 @@ interface AgentGUIConfigMenuProps {
   onAgentConfigMenuOpen?: () => void;
   onAgentConfigMenuClose?: () => void;
   onAgentUsageRefresh?: () => void;
+  usageRefreshInline?: boolean;
   onOpenAgentEnvSetup: () => void;
   onOpenAgentSettings: () => void;
 }
@@ -68,6 +69,7 @@ export function AgentGUIConfigMenu({
   onAgentConfigMenuOpen,
   onAgentConfigMenuClose,
   onAgentUsageRefresh,
+  usageRefreshInline = false,
   onOpenAgentEnvSetup,
   onOpenAgentSettings
 }: AgentGUIConfigMenuProps): React.JSX.Element {
@@ -96,6 +98,26 @@ export function AgentGUIConfigMenu({
     typeof accountContent !== "boolean";
   const providerAccountFallbackVisible =
     !accountFallbackSuppressed && !hasAccountContent;
+  const usageFreshness = (
+    <AgentProbeUsageFreshness
+      ariaDescribedBy={usageDescriptionId}
+      capturedAtUnixMs={slashStatusUsageCapturedAtUnixMs}
+      didFail={slashStatusUsageDidFail}
+      disabled={!onAgentUsageRefresh}
+      isLoading={slashStatusLimitsLoading}
+      labels={{
+        justUpdated: labels.slashStatusUsageJustUpdated,
+        minutesAgo: labels.slashStatusUsageMinutesAgo,
+        hoursAgo: labels.slashStatusUsageHoursAgo,
+        updating: labels.slashStatusUsageUpdating,
+        refreshFailed: labels.slashStatusUsageRefreshFailed,
+        refreshAria: labels.slashStatusUsageRefreshAria
+      }}
+      onRefresh={() => onAgentUsageRefresh?.()}
+      presentation={usageRefreshInline ? "button" : "menu-item"}
+      testId="agent-gui-config-usage-refresh"
+    />
+  );
   return (
     <DropdownMenu
       open={open}
@@ -181,10 +203,13 @@ export function AgentGUIConfigMenu({
             <>
               <DropdownMenuLabel
                 className="flex min-w-0 flex-col gap-2 p-2 text-[var(--text-primary)]"
-                id={usageDescriptionId}
+                id={usageRefreshInline ? undefined : usageDescriptionId}
               >
                 <div className="flex min-w-0 items-center justify-between gap-2">
-                  <div className="flex min-w-0 items-center gap-2">
+                  <div
+                    className="flex min-w-0 items-center gap-2"
+                    id={usageRefreshInline ? usageDescriptionId : undefined}
+                  >
                     <Gauge
                       aria-hidden="true"
                       className="shrink-0"
@@ -207,6 +232,7 @@ export function AgentGUIConfigMenu({
                       </span>
                     ) : null}
                   </div>
+                  {usageRefreshInline ? usageFreshness : null}
                 </div>
                 {slashStatusLimits.length > 0
                   ? slashStatusLimits.map((limit) => (
@@ -233,24 +259,7 @@ export function AgentGUIConfigMenu({
                   </div>
                 ) : null}
               </DropdownMenuLabel>
-              <AgentProbeUsageFreshness
-                ariaDescribedBy={usageDescriptionId}
-                capturedAtUnixMs={slashStatusUsageCapturedAtUnixMs}
-                didFail={slashStatusUsageDidFail}
-                disabled={!onAgentUsageRefresh}
-                isLoading={slashStatusLimitsLoading}
-                labels={{
-                  justUpdated: labels.slashStatusUsageJustUpdated,
-                  minutesAgo: labels.slashStatusUsageMinutesAgo,
-                  hoursAgo: labels.slashStatusUsageHoursAgo,
-                  updating: labels.slashStatusUsageUpdating,
-                  refreshFailed: labels.slashStatusUsageRefreshFailed,
-                  refreshAria: labels.slashStatusUsageRefreshAria
-                }}
-                onRefresh={() => onAgentUsageRefresh?.()}
-                presentation="menu-item"
-                testId="agent-gui-config-usage-refresh"
-              />
+              {usageRefreshInline ? null : usageFreshness}
               <DropdownMenuSeparator />
             </>
           ) : null}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.readiness.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.readiness.spec.tsx
@@ -1,0 +1,84 @@
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentGUIProviderReadinessGate } from "../../../types.ts";
+import type { AgentGUIViewLabels } from "../AgentGUINodeView.tsx";
+import { AgentGUIProviderReadinessGatePane } from "./AgentGUIEmptyState.tsx";
+
+vi.mock("./AgentGUIEmptyHeroCarouselStage.tsx", () => ({
+  AgentGUIEmptyHeroCarouselStage: ({
+    children
+  }: {
+    children: React.ReactNode;
+  }) => <>{children}</>
+}));
+
+const labels = {
+  providerGateCheckingTitle: "Checking",
+  providerGateCheckingDescription: "Checking provider",
+  providerGateCheckingAgentsDescription: "Checking agents",
+  providerGateInstallTitle: "Connect provider",
+  providerGateInstallDescription: "Connect before chatting",
+  providerGateInstallAction: "Connect",
+  providerGateLoginTitle: "Log in",
+  providerGateLoginDescription: "Log in before chatting",
+  providerGateLoginAction: "Log in",
+  providerGateModelPlanAction: "Configure model plan",
+  providerGateComingSoonTitle: "Coming soon",
+  providerGateComingSoonDescription: "Coming soon",
+  providerGateComingSoonAction: "Coming soon",
+  providerGateUnavailableTitle: "Unavailable",
+  providerGateUnavailableDescription: "Unavailable",
+  providerGateRetryAction: "Retry",
+  providerGateRuntimeSelectionTitle: "Choose runtime",
+  providerGateRuntimeSelectionDescription: "Choose runtime",
+  providerGateRuntimeSelectionAction: "Choose",
+  providerGatePendingInstall: "Connecting",
+  providerGatePendingLogin: "Opening login",
+  providerGatePendingRefresh: "Checking",
+  sharedAgentOwnerSeparator: "'s"
+} as unknown as AgentGUIViewLabels;
+
+describe("AgentGUI provider readiness model-plan action", () => {
+  it.each(["auth_required", "not_installed"] as const)(
+    "opens model-plan settings from the %s gate when the provider supports Tutti model plans",
+    (status) => {
+      const onModelPlanSetup = vi.fn();
+
+      renderGate({
+        status,
+        onModelPlanSetup
+      });
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "Configure model plan" })
+      );
+
+      expect(onModelPlanSetup).toHaveBeenCalledOnce();
+    }
+  );
+
+  it("keeps model-plan settings hidden when a non-Tutti host omits the capability", () => {
+    renderGate({ status: "auth_required" });
+
+    expect(
+      screen.queryByRole("button", { name: "Configure model plan" })
+    ).not.toBeInTheDocument();
+  });
+});
+
+function renderGate(gate: AgentGUIProviderReadinessGate): void {
+  render(
+    <AgentGUIProviderReadinessGatePane
+      provider="claude-code"
+      gate={gate}
+      emptyLabel="What can Claude Code help you with?"
+      agentTargets={[]}
+      avatarPresentations={[]}
+      providerLabel="Claude Code"
+      providerSelectLabel="Select Agent"
+      selectedAgentTarget={null}
+      labels={labels}
+    />
+  );
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.tsx
@@ -368,6 +368,7 @@ interface AgentGUIProviderReadinessGatePaneProps {
     | "providerGateLoginTitle"
     | "providerGateLoginDescription"
     | "providerGateLoginAction"
+    | "providerGateModelPlanAction"
     | "providerGateComingSoonTitle"
     | "providerGateComingSoonDescription"
     | "providerGateComingSoonAction"
@@ -430,6 +431,9 @@ export const AgentGUIProviderReadinessGatePane = memo(
         ? emptyLabel
         : content.title;
     const action = resolveAgentGUIProviderReadinessAction(gate.status);
+    const modelPlanActionAvailable =
+      typeof gate.onModelPlanSetup === "function" &&
+      (gate.status === "not_installed" || gate.status === "auth_required");
     const pendingLabel =
       pendingAction === "install"
         ? labels.providerGatePendingInstall
@@ -491,38 +495,66 @@ export const AgentGUIProviderReadinessGatePane = memo(
               {pendingLabel}
             </div>
           ) : null}
-          {action ? (
-            <Button
-              type="button"
+          {action || content.actionLabel || modelPlanActionAvailable ? (
+            <div
               className={cn(
-                styles.emptyProviderGateAction,
-                "nodrag tsh-desktop-no-drag [-webkit-app-region:no-drag]"
+                "items-center justify-center gap-2",
+                modelPlanActionAvailable
+                  ? "grid w-full max-w-[320px] grid-cols-2"
+                  : "flex flex-wrap"
               )}
-              data-testid="agent-gui-provider-readiness-gate-action"
-              disabled={isPending}
-              onPointerDown={(event) => event.stopPropagation()}
-              onClick={() => {
-                if (isPending) {
-                  return;
-                }
-                gate.onAction?.(provider, action);
-              }}
             >
-              {isPending && pendingLabel ? pendingLabel : content.actionLabel}
-            </Button>
-          ) : content.actionLabel ? (
-            <Button
-              type="button"
-              className={cn(
-                styles.emptyProviderGateAction,
-                "nodrag tsh-desktop-no-drag [-webkit-app-region:no-drag]"
-              )}
-              data-testid="agent-gui-provider-readiness-gate-action"
-              disabled
-              onPointerDown={(event) => event.stopPropagation()}
-            >
-              {content.actionLabel}
-            </Button>
+              {action ? (
+                <Button
+                  type="button"
+                  className={cn(
+                    styles.emptyProviderGateAction,
+                    "nodrag tsh-desktop-no-drag [-webkit-app-region:no-drag]"
+                  )}
+                  data-testid="agent-gui-provider-readiness-gate-action"
+                  disabled={isPending}
+                  onPointerDown={(event) => event.stopPropagation()}
+                  onClick={() => {
+                    if (isPending) {
+                      return;
+                    }
+                    gate.onAction?.(provider, action);
+                  }}
+                >
+                  {isPending && pendingLabel
+                    ? pendingLabel
+                    : content.actionLabel}
+                </Button>
+              ) : content.actionLabel ? (
+                <Button
+                  type="button"
+                  className={cn(
+                    styles.emptyProviderGateAction,
+                    "nodrag tsh-desktop-no-drag [-webkit-app-region:no-drag]"
+                  )}
+                  data-testid="agent-gui-provider-readiness-gate-action"
+                  disabled
+                  onPointerDown={(event) => event.stopPropagation()}
+                >
+                  {content.actionLabel}
+                </Button>
+              ) : null}
+              {modelPlanActionAvailable ? (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  className={cn(
+                    styles.emptyProviderGateAction,
+                    "nodrag tsh-desktop-no-drag [-webkit-app-region:no-drag]"
+                  )}
+                  data-testid="agent-gui-provider-readiness-model-plan-action"
+                  onPointerDown={(event) => event.stopPropagation()}
+                  onClick={() => gate.onModelPlanSetup?.()}
+                >
+                  {labels.providerGateModelPlanAction}
+                </Button>
+              ) : null}
+            </div>
           ) : null}
         </div>
       </div>

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
@@ -644,6 +644,8 @@ export interface AgentGUINodeViewProps extends AgentGUIComposerExternalPromptPro
   onAgentConfigMenuOpen?: () => void;
   /** Forces a fresh usage probe from the config menu's refresh control. */
   onAgentUsageRefresh?: () => void;
+  /** Places the usage refresh control in the limits header when explicitly enabled. */
+  accountUsageRefreshInline?: boolean;
   onSlashStatusOpen?: AgentComposerProps["onSlashStatusOpen"];
   onSlashStatusClose?: AgentComposerProps["onSlashStatusClose"];
   onSlashStatusRefresh?: AgentComposerProps["onSlashStatusRefresh"];

--- a/packages/agent/gui/agents.test.ts
+++ b/packages/agent/gui/agents.test.ts
@@ -145,6 +145,18 @@ describe("projectAgentGUIAgentsToTargets", () => {
     });
     expect(target?.availability?.status).not.toBe("coming_soon");
   });
+
+  it("preserves an explicit provider-account usage opt-out", () => {
+    const [target] = projectAgentGUIAgentsToTargets(
+      normalizeAgentGUIAgents([
+        createAgent("workspace-agent:kimi-code", {
+          providerAccountUsageApplicable: false
+        })
+      ])
+    );
+
+    expect(target?.providerAccountUsageApplicable).toBe(false);
+  });
 });
 
 describe("resolveAgentGUISelectedDirectoryAgent", () => {

--- a/packages/agent/gui/agents.ts
+++ b/packages/agent/gui/agents.ts
@@ -54,6 +54,9 @@ export function normalizeAgentGUIAgents(
           : {})
       },
       provider: agent.provider,
+      ...(agent.providerAccountUsageApplicable === false
+        ? { providerAccountUsageApplicable: false }
+        : {}),
       ...(agent.setupKind === "target_runtime"
         ? { setupKind: "target_runtime" as const }
         : {})
@@ -103,6 +106,9 @@ export function projectAgentGUIAgentsToTargets(
     },
     label: agent.name,
     availability: agent.availability,
+    ...(agent.providerAccountUsageApplicable === false
+      ? { providerAccountUsageApplicable: false }
+      : {}),
     ...(agent.description ? { description: agent.description } : {}),
     iconUrl: agent.iconUrl,
     ...(agent.maskIconUrl ? { maskIconUrl: agent.maskIconUrl } : {}),

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
@@ -36,6 +36,7 @@ export const enAgentGui = {
   providerGateLoginDescription:
     "Log in with your account to start chatting with {{provider}}.",
   providerGateLoginAction: "Log in",
+  providerGateModelPlanAction: "Use your own model",
   providerGateComingSoonTitle: "{{provider}} is coming soon",
   providerGateComingSoonDescription:
     "{{provider}} is not available yet. We will enable this agent when it is ready.",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
@@ -36,6 +36,7 @@ export const zhCNAgentGui = {
   providerGateLoginTitle: "登录 {{provider}}",
   providerGateLoginDescription: "使用账号登录后即可开始使用 {{provider}} 对话",
   providerGateLoginAction: "登录",
+  providerGateModelPlanAction: "使用自己的模型",
   providerGateComingSoonTitle: "{{provider}} 即将上线",
   providerGateComingSoonDescription:
     "{{provider}} 暂未开放。准备好后即可在这里使用这个 Agent。",

--- a/packages/agent/gui/types.ts
+++ b/packages/agent/gui/types.ts
@@ -175,6 +175,12 @@ export interface AgentGUIAgent {
   sharedAccess?: AgentGUISharedAgentAccess | null;
   availability: AgentGUIAgentAvailability;
   provider: AgentGUIProvider;
+  /**
+   * False when this exact target routes model access through a Host-owned
+   * Model Plan, so the Runtime provider's native account usage is unrelated.
+   * Omitted values preserve the ordinary provider account-usage behavior.
+   */
+  providerAccountUsageApplicable?: boolean;
   setupKind?: "target_runtime" | null;
 }
 
@@ -226,6 +232,8 @@ export interface AgentGUIAgentTarget {
   ownerDeviceLabel?: string;
   ownership?: AgentGUIAgentOwnership;
   availability?: AgentGUIAgentAvailability;
+  /** Host projection of whether provider-native account usage applies here. */
+  providerAccountUsageApplicable?: boolean;
   disabled?: boolean;
   unavailableReason?: string;
 }
@@ -379,6 +387,11 @@ export type AgentGUIProviderReadinessGateAction =
 export interface AgentGUIProviderReadinessGate {
   status: AgentGUIProviderReadinessGateStatus;
   pendingAction?: AgentGUIProviderReadinessGateAction | null;
+  /**
+   * Opens the host-owned model-plan setup route for this blocked provider.
+   * Absent stays hidden; non-Tutti hosts should omit the capability.
+   */
+  onModelPlanSetup?: () => void;
   onAction?: (
     provider: AgentGUIProvider,
     action: AgentGUIProviderReadinessGateAction


### PR DESCRIPTION
## Summary

- offer a Tutti Desktop-only "Use your own model" CTA when a supported agent needs installation or login, with equal-width actions
- derive new custom Agent names from the selected model plan and runtime until the user edits the name
- move optional custom Agent fields into a collapsed Advanced options section and correct its expanded styling
- mark provider-native account usage as inapplicable for custom model-plan Agents, and align the Desktop refresh control with the usage row
- keep every new shared AgentGUI behavior fail-closed behind host capabilities so TSH/VN retains its existing CTA and account-menu behavior
- document the AgentGUI host capability and consumer-degradation contract

This does not change session, turn, goal, or runtime-operation lifecycle semantics.

## Verification

- `pnpm check:changed` — passed 16 selected lanes
- `pnpm check:changed -- --push-ready` — passed 18 selected lanes through the pre-push hook
- `pnpm --filter @tutti-os/desktop build` — passed, including renderer CSS contracts
- focused AgentGUI readiness and account configuration tests — 20 passed
- focused Desktop readiness projection tests — 6 passed
- TSH host-composition regression suite — 34 passed and continues to omit `providerReadinessGates`
- negative controls confirmed that treating an omitted host capability as enabled fails the consumer-isolation tests
- `git diff --check` — passed

Windows impact: none. The change only adds TypeScript/React capability projections and presentation logic; it does not affect paths, filesystem behavior, process creation, shells, environment variables, packaging, or native dependencies. The fail-closed capability defaults are platform-neutral.

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. No README or CONTRIBUTING source changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.