### PR TITLE
fix(agent): harden Cursor ACP startup and tool errors

### DIFF
--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -22,6 +22,8 @@ Use the focused runtime index or open one area directly:
   incompatible system Python.
   Also covers Kimi Code ACP sessions that advertise no model or hide provider
   failures behind an empty `end_turn`.
+  Also covers Cursor ACP session-service startup races and tool results that
+  hide aborted/TLS failures in provider-specific output fields.
   Also covers focus-driven provider CLI scans, repeated Extension Target version
   probes, Windows managed-runtime adoption sharing violations, optional Provider
   absence misclassified as an environment failure, extension release refresh

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -2720,3 +2720,42 @@ invalid_grant`. Search `tuttid.log` for
 - References:
   [standard_acp_setup.go](../../../packages/agent/daemon/runtime/standard_acp_setup.go)
   [desktopTerminalLoginReadinessMonitor.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopTerminalLoginReadinessMonitor.ts)
+
+### Cursor intermittently fails to start or reports a failed file read as completed
+
+- Symptom:
+  Cursor ACP sometimes reports `Cursor failed to start` even though
+  `initialize` succeeded. A file-read tool can also appear completed while its
+  result is `Error: Aborted` and the raw diagnostic reports a disconnected TLS
+  socket.
+- Quick checks:
+  Correlate the same `agent_session` in the daemon log. The startup signature is
+  `session/new` returning JSON-RPC `-32603` with
+  `Failed to initialize session services`. For the read signature, inspect the
+  ACP tool update's `result` and `rawErrorMessages`; do not rely only on
+  `isError`/`is_error`.
+- Root cause:
+  Cursor can transiently fail its session services after the ACP initialize
+  handshake. Standard ACP startup previously returned that first failure
+  immediately. Cursor can also return a successful-looking tool envelope with
+  the failure text in provider-specific fields, which the status and error
+  projection did not inspect or preserve.
+- Fix:
+  Retry only the matching Cursor `session/new` error once on the same
+  initialized connection, before a provider session id or user Turn exists.
+  Normalize known aborted/socket-disconnect markers in output/error envelopes
+  as `call.failed`, and promote both the result and raw transport diagnostics
+  into the failed payload. Do not automatically replay an arbitrary file tool
+  operation.
+- Validation:
+  Cover a transient Cursor session-service error followed by success, assert
+  one process and two `session/new` calls, and reject retries for authentication,
+  unrelated internal errors, and other methods. Cover aborted/TLS tool output,
+  preserve its diagnostic text, and keep normal output and input-side error
+  strings from changing the status. Run the native Windows runtime lane for
+  process/ACP behavior.
+- References:
+  [acp_provider_cursor.go](../../../packages/agent/daemon/runtime/acp_provider_cursor.go)
+  [standard_acp_session.go](../../../packages/agent/daemon/runtime/standard_acp_session.go)
+  [acp_tool_error_status.go](../../../packages/agent/daemon/runtime/acp_tool_error_status.go)
+  [acp_tool_normalizer.go](../../../packages/agent/daemon/runtime/acp_tool_normalizer.go)

--- a/packages/agent/daemon/runtime/acp_provider_cursor.go
+++ b/packages/agent/daemon/runtime/acp_provider_cursor.go
@@ -31,6 +31,7 @@ package agentruntime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -55,6 +56,23 @@ const (
 
 const cursorPluginDirEnv = "TUTTI_CURSOR_PLUGIN_DIR"
 const cursorPromptContextFileEnv = "TUTTI_CURSOR_PROMPT_CONTEXT_FILE"
+
+const cursorACPSessionNewRetryLimit = 1
+
+func cursorACPShouldRetrySessionNew(err error) bool {
+	var callErr *acpCallError
+	if !errors.As(err, &callErr) || callErr == nil || callErr.Method != acpMethodNewSession {
+		return false
+	}
+	if callErr.Err.Code != -32603 {
+		return false
+	}
+	detail := strings.ToLower(strings.Join([]string{
+		strings.TrimSpace(callErr.Err.Message),
+		strings.TrimSpace(string(callErr.Err.Data)),
+	}, " "))
+	return strings.Contains(detail, "failed to initialize session services")
+}
 
 // cursorACPModeID maps Tutti permission tiers onto Cursor's ACP session
 // modes (switched via session/set_mode). Approval strictness within "agent"
@@ -143,6 +161,8 @@ func newCursorAdapterFromProviderDescriptor(
 	adapter.config.initialPromptContext = cursorACPInitialPromptContext
 	adapter.config.automaticPermissionDecision = cursorAutoApprovePermissionDecision
 	adapter.config.autoContinueRetriableTurnError = true
+	adapter.config.retrySessionNewError = cursorACPShouldRetrySessionNew
+	adapter.config.sessionNewRetryLimit = cursorACPSessionNewRetryLimit
 	adapter.config.messageDiagnostics = &standardACPMessageDiagnostics{
 		method:         cursorACPMethodTask,
 		observeMessage: logCursorACPTaskExtension,

--- a/packages/agent/daemon/runtime/acp_tool_error_metadata.go
+++ b/packages/agent/daemon/runtime/acp_tool_error_metadata.go
@@ -1,0 +1,82 @@
+package agentruntime
+
+import "strings"
+
+func acpPromoteToolErrorMetadata(body map[string]any) {
+	if len(body) == 0 || !acpToolCallReportsError(body, body) {
+		return
+	}
+	message := acpToolErrorMessage(body)
+	if message == "" {
+		return
+	}
+	if _, exists := body["error"]; !exists {
+		body["error"] = message
+	}
+	if _, exists := body["errorMessage"]; !exists {
+		body["errorMessage"] = message
+	}
+}
+
+func acpToolErrorMessage(body map[string]any) string {
+	if len(body) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, 2)
+	for _, key := range []string{
+		"error",
+		"err",
+		"errorMessage",
+		"error_message",
+		"message",
+		"detail",
+		"result",
+		"rawErrorMessages",
+		"raw_error_messages",
+	} {
+		value, ok := body[key]
+		if !ok {
+			continue
+		}
+		text := acpToolErrorValueText(value, strings.ToLower(key))
+		if text == "" || containsACPString(parts, text) {
+			continue
+		}
+		parts = append(parts, text)
+	}
+	return strings.TrimSpace(strings.Join(parts, "\n"))
+}
+
+func acpToolErrorValueText(value any, field string) string {
+	switch typed := value.(type) {
+	case string:
+		text := strings.TrimSpace(typed)
+		if text == "" {
+			return ""
+		}
+		if field == "error" || field == "err" || field == "errormessage" || field == "error_message" ||
+			field == "rawerrormessages" || field == "raw_error_messages" || acpTextLooksLikeKnownToolError(text) {
+			return text
+		}
+	case []any:
+		parts := make([]string, 0, len(typed))
+		for _, nested := range typed {
+			if text := acpToolErrorValueText(nested, field); text != "" && !containsACPString(parts, text) {
+				parts = append(parts, text)
+			}
+		}
+		return strings.TrimSpace(strings.Join(parts, "\n"))
+	case map[string]any:
+		return acpToolErrorMessage(typed)
+	}
+	return ""
+}
+
+func containsACPString(values []string, candidate string) bool {
+	for _, value := range values {
+		if value == candidate {
+			return true
+		}
+	}
+	return false
+}

--- a/packages/agent/daemon/runtime/acp_tool_error_status.go
+++ b/packages/agent/daemon/runtime/acp_tool_error_status.go
@@ -1,5 +1,7 @@
 package agentruntime
 
+import "strings"
+
 const maxACPErrorEnvelopeDepth = 8
 
 func acpResolvedToolCallStatus(update map[string]any, fallback string) string {
@@ -23,8 +25,14 @@ func acpResolvedToolCallStatus(update map[string]any, fallback string) string {
 func acpToolCallReportsError(update map[string]any, rawOutput any) bool {
 	return acpMapOwnReportsError(update) ||
 		acpValueReportsError(update["error"]) ||
+		acpValueReportsTextualError(update["error"]) ||
 		acpValueReportsError(update["content"]) ||
-		acpValueReportsError(rawOutput)
+		acpValueReportsTextualError(update["content"]) ||
+		acpValueReportsError(rawOutput) ||
+		acpValueReportsTextualError(rawOutput) ||
+		acpValueReportsTextualError(update["result"]) ||
+		acpValueReportsTextualError(update["rawErrorMessages"]) ||
+		acpValueReportsTextualError(update["raw_error_messages"])
 }
 
 func acpValueReportsError(value any) bool {
@@ -66,4 +74,102 @@ func acpValueReportsErrorAtDepth(value any, depth int) bool {
 		}
 	}
 	return false
+}
+
+// acpValueReportsTextualError handles providers that return a successful
+// JSON-RPC envelope but put the actual tool failure in result/rawErrorMessages
+// instead of setting isError. It intentionally only inspects output/error
+// envelopes; tool input can legitimately contain the word "error".
+func acpValueReportsTextualError(value any) bool {
+	return acpValueReportsTextualErrorAtDepth(value, 0)
+}
+
+func acpValueReportsTextualErrorAtDepth(value any, depth int) bool {
+	if depth >= maxACPErrorEnvelopeDepth {
+		return false
+	}
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, nested := range typed {
+			normalizedKey := strings.ToLower(strings.TrimSpace(key))
+			switch normalizedKey {
+			case "error", "err", "errormessage", "error_message", "message", "detail":
+				if acpTextualToolErrorValue(nested, normalizedKey) {
+					return true
+				}
+			case "result":
+				if acpTextualToolErrorValue(nested, normalizedKey) {
+					return true
+				}
+			case "rawerrormessages", "raw_error_messages":
+				if acpTextualToolErrorValue(nested, normalizedKey) {
+					return true
+				}
+			}
+			if normalizedKey == "input" || normalizedKey == "rawinput" {
+				continue
+			}
+			if acpValueReportsTextualErrorAtDepth(nested, depth+1) {
+				return true
+			}
+		}
+	case []any:
+		for _, nested := range typed {
+			if acpValueReportsTextualErrorAtDepth(nested, depth+1) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func acpTextualToolErrorValue(value any, field string) bool {
+	switch typed := value.(type) {
+	case string:
+		text := strings.TrimSpace(typed)
+		if text == "" {
+			return false
+		}
+		if field == "rawerrormessages" || field == "raw_error_messages" || field == "error" || field == "err" ||
+			field == "errormessage" || field == "error_message" || field == "detail" {
+			return true
+		}
+		return acpTextLooksLikeKnownToolError(text)
+	case []any:
+		for _, nested := range typed {
+			if acpTextualToolErrorValue(nested, field) || acpValueReportsTextualErrorAtDepth(nested, 1) {
+				return true
+			}
+		}
+	case map[string]any:
+		return acpValueReportsTextualErrorAtDepth(typed, 1)
+	}
+	return false
+}
+
+func acpTextLooksLikeKnownToolError(text string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(text))
+	if normalized == "" {
+		return false
+	}
+	for _, marker := range []string{
+		"error: aborted",
+		"[aborted]",
+		"retriableerror",
+		"client network socket disconnected",
+		"network socket disconnected",
+		"socket disconnected before secure tls connection",
+		"socket hang up",
+		"econnreset",
+		"econnrefused",
+		"enotfound",
+		"etimedout",
+		"connection reset",
+		"connection refused",
+	} {
+		if strings.Contains(normalized, marker) {
+			return true
+		}
+	}
+	return strings.HasPrefix(normalized, "error:") && strings.Contains(normalized, "failed")
 }

--- a/packages/agent/daemon/runtime/acp_tool_normalizer.go
+++ b/packages/agent/daemon/runtime/acp_tool_normalizer.go
@@ -436,6 +436,7 @@ func acpNormalizeToolOutput(rawOutput any, content any) map[string]any {
 	}
 	body = acpSanitizeImagePayloadMap(body)
 	acpPromoteToolOutputMetadata(body)
+	acpPromoteToolErrorMetadata(body)
 	if content != nil {
 		sanitizedContent := acpSanitizeImagePayload(content)
 		body["content"] = sanitizedContent
@@ -511,7 +512,7 @@ func acpMirrorFailedToolOutput(body map[string]any) map[string]any {
 		return nil
 	}
 	mirrored := map[string]any{}
-	for _, key := range []string{"text", "stdout", "stderr", "aggregated_output", "formatted_output", "content", "structuredContent", "isError", "success", "changes", "status", "call_id", "turn_id", "cwd", "parsed_cmd", "command", "exit_code", "duration", "duration_ms", "completed_at_ms", "source", "process_id"} {
+	for _, key := range []string{"text", "stdout", "stderr", "aggregated_output", "formatted_output", "content", "structuredContent", "result", "error", "err", "errorMessage", "error_message", "message", "detail", "rawErrorMessages", "raw_error_messages", "isError", "is_error", "success", "changes", "status", "call_id", "turn_id", "cwd", "parsed_cmd", "command", "exit_code", "duration", "duration_ms", "completed_at_ms", "source", "process_id"} {
 		if value, ok := body[key]; ok && value != nil {
 			mirrored[key] = clonePayloadValue(value)
 		}

--- a/packages/agent/daemon/runtime/acp_tool_normalizer_exit_status_test.go
+++ b/packages/agent/daemon/runtime/acp_tool_normalizer_exit_status_test.go
@@ -96,6 +96,41 @@ func TestACPResolvedToolCallStatusHonorsStructuredErrorFlags(t *testing.T) {
 			},
 			want: messageStreamStateCompleted,
 		},
+		{
+			name: "aborted result overrides completed status",
+			update: map[string]any{
+				"status": "completed",
+				"output": map[string]any{"result": "Error: Aborted"},
+			},
+			want: messageStreamStateFailed,
+		},
+		{
+			name: "raw cursor transport error overrides completed status",
+			update: map[string]any{
+				"status": "completed",
+				"output": map[string]any{
+					"result":           "Error: Aborted",
+					"rawErrorMessages": []any{"[aborted] Client network socket disconnected before secure TLS connection was established"},
+				},
+			},
+			want: messageStreamStateFailed,
+		},
+		{
+			name: "normal result remains completed",
+			update: map[string]any{
+				"status": "completed",
+				"output": map[string]any{"result": "file contents"},
+			},
+			want: messageStreamStateCompleted,
+		},
+		{
+			name: "input result does not change status",
+			update: map[string]any{
+				"status": "completed",
+				"input":  map[string]any{"result": "Error: Aborted"},
+			},
+			want: messageStreamStateCompleted,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/packages/agent/daemon/runtime/standard_acp_adapter.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter.go
@@ -38,6 +38,12 @@ type standardACPConfig struct {
 	env                func(Session) []string
 	commandResolver    ProviderCommandResolver
 	beforeNewSession   func(context.Context, *acpClient, Session, json.RawMessage) error
+	// retrySessionNewError permits a provider-specific, bounded retry for a
+	// session/new failure that is known to be transient. The retry happens on
+	// the already initialized connection, before a provider session id or user
+	// turn exists, so it cannot duplicate user work.
+	retrySessionNewError func(error) bool
+	sessionNewRetryLimit int
 	// validateNewSessionResult, when set, inspects the raw session/new response
 	// right after it succeeds and may reject the start (setup probes use it to
 	// catch agents that create a session they cannot actually serve).

--- a/packages/agent/daemon/runtime/standard_acp_events_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_events_test.go
@@ -2,6 +2,7 @@ package agentruntime
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
@@ -47,6 +48,41 @@ func TestStandardACPToolCallEventInfersFailedStatusFromRawOutput(t *testing.T) {
 	}
 	if failed.Payload.Error["output"] != "Exit code 137" {
 		t.Fatalf("failed error = %#v, want raw output preserved", failed.Payload.Error)
+	}
+}
+
+func TestStandardACPToolCallEventPreservesCursorTransportFailureDetails(t *testing.T) {
+	t.Parallel()
+
+	session := standardTestSession(ProviderCursor)
+	failed, ok := standardACPToolCallEventWithID(session, "event-cursor-read-failed", "turn-1", "tool_call_update", map[string]any{
+		"sessionUpdate": "tool_call_update",
+		"toolCallId":    "read-1",
+		"title":         "Read file",
+		"status":        "completed",
+		"kind":          "read",
+		"rawOutput": map[string]any{
+			"result":           "Error: Aborted",
+			"rawErrorMessages": []any{"[aborted] Client network socket disconnected before secure TLS connection was established"},
+		},
+	})
+	if !ok {
+		t.Fatal("standardACPToolCallEventWithID(cursor read failure) returned !ok")
+	}
+	if failed.Type != activityshared.EventCallFailed {
+		t.Fatalf("failed event type = %s, want call.failed", failed.Type)
+	}
+	if got := activityshared.BestEffortErrorMessage(failed.Payload); !strings.Contains(got, "Client network socket disconnected") {
+		t.Fatalf("best-effort error = %q, want Cursor transport detail", got)
+	}
+	if got := asString(failed.Payload.Error["error"]); !strings.Contains(got, "Error: Aborted") || !strings.Contains(got, "Client network socket disconnected") {
+		t.Fatalf("normalized error = %#v, want result and raw transport details", failed.Payload.Error["error"])
+	}
+	if got := asString(failed.Payload.Output["rawErrorMessages"]); got != "" {
+		t.Fatalf("mirrored rawErrorMessages unexpectedly stringified = %q", got)
+	}
+	if _, ok := failed.Payload.Output["rawErrorMessages"]; !ok {
+		t.Fatalf("mirrored output = %#v, want rawErrorMessages preserved", failed.Payload.Output)
 	}
 }
 

--- a/packages/agent/daemon/runtime/standard_acp_provider_contracts_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_provider_contracts_test.go
@@ -76,6 +76,80 @@ func TestCursorAdapterStartUsesInjectedProviderCommand(t *testing.T) {
 	}
 }
 
+func TestCursorAdapterRetriesTransientSessionNewInitializationFailure(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Cursor Agent", "cursor-session-retry")
+	transport.conn.newSessionErrors = []*acpError{{
+		Code:    -32603,
+		Message: "Internal error",
+		Data:    json.RawMessage(`{"message":"Failed to initialize session services"}`),
+	}}
+	adapter := newCursorAdapterWithHostMetadata(transport, LegacyHostMetadata(), nil)
+
+	if _, err := adapter.Start(context.Background(), standardTestSession(ProviderCursor)); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	transport.conn.mu.Lock()
+	newSessionCalls := transport.conn.newSessionCallCount
+	transport.conn.mu.Unlock()
+	if newSessionCalls != 2 {
+		t.Fatalf("session/new calls = %d, want one bounded retry", newSessionCalls)
+	}
+	if len(transport.specs) != 1 {
+		t.Fatalf("process starts = %d, want one initialized process", len(transport.specs))
+	}
+}
+
+func TestCursorACPShouldRetrySessionNewOnlyForTransientInitializationFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "matching internal initialization failure",
+			err: &acpCallError{Method: acpMethodNewSession, Err: acpError{
+				Code:    -32603,
+				Message: "Internal error",
+				Data:    json.RawMessage(`{"message":"Failed to initialize session services"}`),
+			}},
+			want: true,
+		},
+		{
+			name: "different method",
+			err: &acpCallError{Method: acpMethodLoadSession, Err: acpError{
+				Code: -32603, Message: "Failed to initialize session services",
+			}},
+			want: false,
+		},
+		{
+			name: "different internal error",
+			err: &acpCallError{Method: acpMethodNewSession, Err: acpError{
+				Code: -32603, Message: "Invalid session settings",
+			}},
+			want: false,
+		},
+		{
+			name: "authentication error",
+			err: &acpCallError{Method: acpMethodNewSession, Err: acpError{
+				Code: -32000, Message: "authentication required",
+			}},
+			want: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := cursorACPShouldRetrySessionNew(test.err); got != test.want {
+				t.Fatalf("cursorACPShouldRetrySessionNew() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
 func TestCursorAdapterStartUsesPluginDirWithInjectedProviderCommand(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/standard_acp_session.go
+++ b/packages/agent/daemon/runtime/standard_acp_session.go
@@ -102,7 +102,7 @@ func (a *standardACPAdapter) Start(ctx context.Context, session Session) ([]acti
 		"cwd":              standardACPProtocolCWD(session.CWD),
 		"timeout_ms":       a.startupCallTimeout().Milliseconds(),
 	})
-	newSessionResult, err := client.CallWithTimeout(ctx, a.startupCallTimeout(), acpMethodNewSession, newSessionParams, func(ctx context.Context, message acpMessage) error {
+	newSessionResult, err := a.callSessionNewWithRetry(ctx, client, session, newSessionParams, func(ctx context.Context, message acpMessage) error {
 		_, err := a.handleACPMessage(ctx, client, session, "", message, nil, nil, nil)
 		return err
 	})
@@ -196,6 +196,32 @@ func (a *standardACPAdapter) Start(ctx context.Context, session Session) ([]acti
 		"agent":            acpAgentInfo(initializeResult),
 		"permissionModeId": session.PermissionModeID,
 	})}, nil
+}
+
+func (a *standardACPAdapter) callSessionNewWithRetry(
+	ctx context.Context,
+	client *acpClient,
+	session Session,
+	params map[string]any,
+	handler acpMessageHandler,
+) (json.RawMessage, error) {
+	limit := 0
+	if a != nil && a.config.retrySessionNewError != nil && a.config.sessionNewRetryLimit > 0 {
+		limit = a.config.sessionNewRetryLimit
+	}
+	for attempt := 0; ; attempt++ {
+		result, err := client.CallWithTimeout(ctx, a.startupCallTimeout(), acpMethodNewSession, params, handler)
+		if err == nil || attempt >= limit || a.config.retrySessionNewError == nil || !a.config.retrySessionNewError(err) {
+			return result, err
+		}
+		a.logStandardACPStartupDiagnostics("session_new.retry", map[string]any{
+			"room_id":          session.RoomID,
+			"agent_session_id": session.AgentSessionID,
+			"attempt":          attempt + 1,
+			"max_retries":      limit,
+			"error":            err.Error(),
+		})
+	}
 }
 
 // standardACPProtocolCWD keeps the provider protocol's working directory

--- a/packages/agent/daemon/runtime/standard_acp_test_connection_rpc_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_test_connection_rpc_test.go
@@ -107,6 +107,12 @@ func (c *standardACPConnection) Send(data []byte) error {
 			if request.Params != nil {
 				c.lastNewSessionParams = maps.Clone(request.Params)
 			}
+			c.newSessionCallCount++
+			newSessionError := c.newSessionError
+			if len(c.newSessionErrors) > 0 {
+				newSessionError = c.newSessionErrors[0]
+				c.newSessionErrors = c.newSessionErrors[1:]
+			}
 			c.mu.Unlock()
 			if c.requireAuthentication && c.authenticatedMethodID() == "" {
 				c.sendJSON(map[string]any{
@@ -115,9 +121,9 @@ func (c *standardACPConnection) Send(data []byte) error {
 				})
 				continue
 			}
-			if c.newSessionError != nil {
+			if newSessionError != nil {
 				c.sendJSON(map[string]any{
-					"jsonrpc": "2.0", "id": message.ID, "error": c.newSessionError,
+					"jsonrpc": "2.0", "id": message.ID, "error": newSessionError,
 				})
 				continue
 			}

--- a/packages/agent/daemon/runtime/standard_acp_test_transport_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_test_transport_test.go
@@ -23,6 +23,7 @@ type multiProcStandardACPTransport struct {
 	configOptions            []map[string]any
 	initializeError          *acpError
 	newSessionError          *acpError
+	newSessionErrors         []*acpError
 	loadSessionError         *acpError
 	closeFailures            int
 	specs                    []ProcessSpec
@@ -64,6 +65,7 @@ func (t *multiProcStandardACPTransport) Start(_ context.Context, spec ProcessSpe
 		configOptions:            configOptions,
 		initializeError:          t.initializeError,
 		newSessionError:          t.newSessionError,
+		newSessionErrors:         append([]*acpError(nil), t.newSessionErrors...),
 		loadSessionError:         t.loadSessionError,
 		closeFailures:            t.closeFailures,
 	}
@@ -123,6 +125,8 @@ type standardACPConnection struct {
 	closeSessionExits             bool
 	isClosed                      bool
 	lastNewSessionParams          map[string]any
+	newSessionCallCount           int
+	newSessionErrors              []*acpError
 	lastLoadSessionParams         map[string]any
 	lastCloseSessionParams        map[string]any
 	lastPromptParamsSnapshot      map[string]any


### PR DESCRIPTION
## Summary

Fixes the two Cursor ACP failures:

1. Cursor sometimes reports `Cursor failed to start` after `initialize` succeeds.
2. Cursor file reads can be reported as completed even when the result is `Error: Aborted` with a disconnected TLS socket.

## Root cause

- Cursor can transiently return JSON-RPC `-32603` / `Failed to initialize session services` from `session/new`. Standard ACP startup previously returned the first error immediately.
- Cursor can put tool failures in provider-specific `result` and `rawErrorMessages` fields without setting `isError` / `is_error`. The status resolver and failed-payload projection therefore lost the failure and its transport detail.

## Changes

- Add a Cursor-only, one-attempt retry for the exact transient `session/new` error, on the already initialized connection and before a provider session id or user turn exists.
- Detect known aborted/socket-disconnect markers in ACP output/error envelopes and classify the call as failed.
- Promote and preserve `result` and `rawErrorMessages` in failed payloads so UI/activity diagnostics retain the transport cause.
- Do not replay arbitrary file tool operations.
- Add provider-contract, status, event-payload, and normal-output/input regression tests.
- Document the troubleshooting signatures and validation guidance.

## Validation

Passed:

- `go test -mod=readonly ./packages/agent/daemon/runtime -run 'Test(CursorAdapterRetriesTransientSessionNewInitializationFailure|CursorACPShouldRetrySessionNewOnlyForTransientInitializationFailure|ACPResolvedToolCallStatusHonorsStructuredErrorFlags|StandardACPToolCallEventPreservesCursorTransportFailureDetails|StandardACPToolCallEventInfersFailedStatusFromRawOutput)' -count=1`
- `git diff --cached --check`
- `pnpm check:changed -- --dry-run` (lane selection)

The full runtime package test was also attempted on Windows, but the environment has unrelated baseline failures involving managed Node/Claude sidecars, Codex helper startup/ACL, connector executable discovery, PATH, temp-file cleanup, and user settings URL precedence. Direct `golangci-lint` reports only three existing Windows `revive/indent-error-flow` findings outside this change. The actual changed-aware runner cannot execute its Bash lanes in this Windows worktree because its mapped worktree path, Node runtime, Go, and golangci-lint are unavailable there.

A real Cursor binary/network E2E was not available in this checkout; the ACP contract tests exercise the complete startup retry and tool-error projection chain with the observed wire signatures.

## Risk

The startup retry is strictly bounded to one retry and one exact Cursor error signature. It can add at most one startup call timeout in that narrow case. Tool failures are reclassified and diagnostics are preserved; no user operation is automatically replayed.