### PR TITLE
feat(analytics): track Agent, model, and Tutti Mode adoption

### DIFF
--- a/docs/architecture/analytics-tracking.md
+++ b/docs/architecture/analytics-tracking.md
@@ -125,6 +125,97 @@ lifecycle writes. Non-AgentGUI prompt-session integrations keep their explicit
 tracker because they call the activity service without entering the shared
 engine.
 
+### Agent configuration usage dimensions
+
+The canonical root user-turn terminal events `agent.turn_completed`,
+`agent.turn_failed`, and `agent.turn_cancelled` carry three low-cardinality
+configuration and feature-use dimensions:
+
+| Param                 | Values                                       | Meaning                                              |
+| --------------------- | -------------------------------------------- | ---------------------------------------------------- |
+| `agent_config_source` | `workspace_agent`, `agent_target`, `unknown` | Whether the turn used a user-defined workspace Agent |
+| `model_config_source` | `model_plan`, `provider_native`, `unknown`   | Whether the turn used a user-defined Model Plan      |
+| `tutti_mode_state`    | `active`, `inactive`, `unknown`              | Whether Tutti Mode was active for that accepted Turn |
+
+The daemon resolves the two configuration-source dimensions at terminal-event delivery from the
+canonical session and its immutable `sessionRuntimeSnapshot`. It must not infer
+Model Plan use from a model name or provider, and it must not report Agent IDs,
+Model Plan IDs, names, endpoints, or credentials. Missing legacy sessions and
+invalid snapshots keep the terminal event but report `unknown`.
+
+The daemon resolves `tutti_mode_state` from the immutable Turn snapshot only
+after that snapshot has been durably accepted by the provider-dispatch path.
+It must not read the session's current activation when the Turn settles: the
+user may have changed the badge while the Turn was running. Missing,
+unaccepted, or unreadable snapshots report `unknown`. Analytics never includes
+activation/revision IDs or the effect and speed preferences.
+
+These events cover root, non-backfilled user-prompt turns with durable submit
+provenance. They exclude child/subagent turns, goal or automation turns, and
+provider-initiated turns. Recommended DataFinder metrics are:
+
+- Custom Agent user adoption: distinct DataFinder user identity with
+  `agent_config_source=workspace_agent`, divided by distinct identities whose
+  source is either `workspace_agent` or `agent_target`
+- Custom model user adoption: distinct DataFinder user identity with
+  `model_config_source=model_plan`, divided by distinct identities whose source
+  is either `model_plan` or `provider_native`
+- Turn share: use the same filters with event count instead of distinct identity
+- Tutti Mode user adoption: distinct identity with `tutti_mode_state=active`,
+  divided by distinct identities whose state is either `active` or `inactive`
+- Tutti Mode Turn share: count terminal events with `tutti_mode_state=active`,
+  divided by terminal events whose state is either `active` or `inactive`
+- Data quality: monitor each dimension's `unknown` share separately and do not
+  include `unknown` in adoption denominators
+
+DataFinder user identity is the authenticated account ID when available and the
+stable device ID for anonymous sessions. Use `uid` plus
+`login_state=authenticated` only when an authenticated-user-only view is
+intended; custom Model Plans are also available to anonymous users.
+
+The renderer's legacy `agent.session_started.has_custom_model` field classifies
+only explicit `custom` model-string aliases. It does not identify Model Plan
+sessions and is not the source for Model Plan adoption reporting.
+
+### Agent and Model Plan configuration funnels
+
+Configuration funnels are reported from the daemon operation that owns the
+durable mutation, not from renderer button clicks. Validation failures, store
+failures, reference-blocked deletion, and semantic no-op enable changes do not
+emit an event.
+
+| Event                                   | Params                                                                 | Meaning                                      |
+| --------------------------------------- | ---------------------------------------------------------------------- | -------------------------------------------- |
+| `workspace_agent.configuration_changed` | `action`, `model_config_source`                                        | Workspace Agent created, updated, or deleted |
+| `model_plan.configuration_changed`      | `action`, `protocol`, `template_kind`                                  | Model Plan durable configuration changed     |
+| `model_plan.detection_completed`        | `scope`, `result`, `protocol`, `template_kind`, optional failure enums | Draft or saved detection attempt completed   |
+
+Workspace Agent `action` is `created`, `updated`, or `deleted`.
+Model Plan configuration `action` is `created`, `updated`, `duplicated`,
+`enabled`, `disabled`, or `deleted`. Detection `scope` is `draft` or `saved`,
+and `result` is `passed` only when every core detection stage passed or was
+explicitly skipped. A failed detection includes only the bounded
+`failure_stage` and `failure_reason` enums; it never includes provider detail.
+
+These events never include workspace, Agent, or Model Plan identity, user-entered
+names, model IDs, endpoints, credentials, or raw error strings. Use the
+daemon-injected DataFinder identity to count users across the configuration
+funnel, then join at aggregate cohort level with the terminal-event dimensions
+above to measure configured-versus-used adoption.
+
+### Tutti Mode activation funnel
+
+`tutti_mode.activation_changed` is emitted only after a durable user-controlled
+activation transition. Its bounded params are `action=activated|deactivated`,
+`state=active|inactive`, and `source=slash_command|badge_remove`. No-op writes,
+conflicts, invalid legacy Agent-command sources, and persistence failures do not
+emit it. This event measures intent and retained activation; terminal
+`tutti_mode_state` measures actual accepted Turn use.
+
+The activation event and terminal dimension are wired only in the Tutti daemon
+composition. Shared Agent Host consumers, including TSH/VN, do not receive
+these product analytics contracts.
+
 ## Event Naming Convention
 
 Event names follow the product analytics spec's dot-separated domain action

--- a/services/tuttid/service/agent/activity_projection_turn_terminal.go
+++ b/services/tuttid/service/agent/activity_projection_turn_terminal.go
@@ -10,6 +10,7 @@ import (
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	agentactivitybiz "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 	agentturnanalyticsbiz "github.com/tutti-os/tutti/services/tuttid/biz/agentturnanalytics"
+	tuttimodeactivationbiz "github.com/tutti-os/tutti/services/tuttid/biz/tuttimodeactivation"
 	agentturnterminal "github.com/tutti-os/tutti/services/tuttid/service/reporter/events/agent/turn_terminal"
 )
 
@@ -26,6 +27,11 @@ type turnTerminalAnalyticsStore interface {
 	CompleteAgentTurnTerminalAnalytics(context.Context, string, string, string, string, int64) (bool, error)
 	IgnoreAgentTurnTerminalAnalytics(context.Context, string, string, string, string, string, int64) (bool, error)
 	RequeueAgentTurnTerminalAnalytics(context.Context, int64) (int64, error)
+}
+
+type tuttiModeTurnSnapshotReader interface {
+	GetTuttiModeTurnSnapshot(context.Context, string, string, string) (tuttimodeactivationbiz.TurnSnapshot, bool, error)
+	IsTuttiModeTurnSnapshotAccepted(context.Context, string, string, string) (bool, error)
 }
 
 func (p *ActivityProjection) reportRootTurnTerminalEvent(ctx context.Context, settled agenthost.RootTurnSettled) {
@@ -222,11 +228,16 @@ func (p *ActivityProjection) trackTurnTerminalAnalytics(
 	if !ok {
 		return false, "submission_mode_invalid"
 	}
+	agentConfigSource, modelConfigSource := p.turnTerminalConfigSources(ctx, delivery)
+	tuttiModeState := p.turnTerminalTuttiModeState(ctx, delivery)
 	eventName, params, ok := agentturnterminal.Build(agentturnterminal.Input{
 		AgentSessionID:    delivery.AgentSessionID,
+		AgentConfigSource: agentConfigSource,
 		ClientSubmitID:    delivery.ClientSubmitID,
 		ErrorCode:         delivery.ErrorCode,
 		Mode:              mode,
+		ModelConfigSource: modelConfigSource,
+		TuttiModeState:    tuttiModeState,
 		Origin:            delivery.Origin,
 		Outcome:           delivery.Outcome,
 		Provider:          delivery.Provider,
@@ -241,6 +252,82 @@ func (p *ActivityProjection) trackTurnTerminalAnalytics(
 	params["event_id"] = delivery.EventID
 	agentturnterminal.Track(ctx, p.analyticsReporter, eventName, params)
 	return true, ""
+}
+
+func (p *ActivityProjection) turnTerminalTuttiModeState(
+	ctx context.Context,
+	delivery agentturnanalyticsbiz.Delivery,
+) string {
+	if p == nil || p.repo == nil {
+		return agentturnterminal.TuttiModeStateUnknown
+	}
+	reader, ok := p.repo.(tuttiModeTurnSnapshotReader)
+	if !ok {
+		return agentturnterminal.TuttiModeStateUnknown
+	}
+	accepted, err := reader.IsTuttiModeTurnSnapshotAccepted(
+		ctx,
+		delivery.WorkspaceID,
+		delivery.AgentSessionID,
+		delivery.TurnID,
+	)
+	if err != nil || !accepted {
+		return agentturnterminal.TuttiModeStateUnknown
+	}
+	snapshot, found, err := reader.GetTuttiModeTurnSnapshot(
+		ctx,
+		delivery.WorkspaceID,
+		delivery.AgentSessionID,
+		delivery.TurnID,
+	)
+	if err != nil || !found {
+		return agentturnterminal.TuttiModeStateUnknown
+	}
+	switch snapshot.State {
+	case tuttimodeactivationbiz.StateActive:
+		return agentturnterminal.TuttiModeStateActive
+	case tuttimodeactivationbiz.StateInactive:
+		return agentturnterminal.TuttiModeStateInactive
+	default:
+		return agentturnterminal.TuttiModeStateUnknown
+	}
+}
+
+func (p *ActivityProjection) turnTerminalConfigSources(
+	ctx context.Context,
+	delivery agentturnanalyticsbiz.Delivery,
+) (string, string) {
+	agentSource := agentturnterminal.AgentConfigSourceUnknown
+	modelSource := agentturnterminal.ModelConfigSourceUnknown
+	if p == nil || p.repo == nil {
+		return agentSource, modelSource
+	}
+	session, found, err := p.repo.GetSession(ctx, delivery.WorkspaceID, delivery.AgentSessionID)
+	if err != nil || !found {
+		return agentSource, modelSource
+	}
+	agentTargetID := strings.TrimSpace(session.AgentTargetID)
+	if agentTargetID != "" {
+		if strings.HasPrefix(agentTargetID, workspaceAgentIDPrefix) {
+			agentSource = agentturnterminal.AgentConfigSourceWorkspaceAgent
+		} else {
+			agentSource = agentturnterminal.AgentConfigSourceAgentTarget
+		}
+	}
+	snapshot, exists, err := sessionRuntimeSnapshotFromContext(
+		session.InternalRuntimeContext,
+		session.Provider,
+	)
+	if err != nil || !exists {
+		return agentSource, modelSource
+	}
+	switch snapshot.ModelConfigurationSource {
+	case modelConfigurationSourceModelPlan:
+		modelSource = agentturnterminal.ModelConfigSourceModelPlan
+	case modelConfigurationSourceProviderNative:
+		modelSource = agentturnterminal.ModelConfigSourceProviderNative
+	}
+	return agentSource, modelSource
 }
 
 func terminalSubmissionMode(metadataJSON string) (string, bool) {

--- a/services/tuttid/service/agent/activity_projection_turn_terminal_integration_test.go
+++ b/services/tuttid/service/agent/activity_projection_turn_terminal_integration_test.go
@@ -10,16 +10,33 @@ import (
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	agentactivitybiz "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 	agentturnanalyticsbiz "github.com/tutti-os/tutti/services/tuttid/biz/agentturnanalytics"
+	tuttimodeactivationbiz "github.com/tutti-os/tutti/services/tuttid/biz/tuttimodeactivation"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
 	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
+	agentturnterminal "github.com/tutti-os/tutti/services/tuttid/service/reporter/events/agent/turn_terminal"
 )
 
 func TestSettleStaleTurnsOnStartupDeliversDurableTerminalAnalyticsOnce(t *testing.T) {
 	ctx := context.Background()
 	store := openTerminalAnalyticsIntegrationStore(t, "ws-startup")
-	seedTerminalAnalyticsIntegrationSession(t, store, "ws-startup", "root")
+	seedTerminalAnalyticsIntegrationConfiguredSession(t, store, "ws-startup", "root")
 	seedTerminalAnalyticsIntegrationTurn(t, store, "ws-startup", "root", "turn-startup", 100)
+	activeSnapshot := tuttimodeactivationbiz.TurnSnapshot{
+		ActivationID: "activation-private", RevisionID: "revision-private", Revision: 1,
+		State: tuttimodeactivationbiz.StateActive, Source: tuttimodeactivationbiz.SourceSlashCommand,
+		Effect: 75, Speed: 25,
+	}
+	if _, created, err := store.PutTuttiModeTurnSnapshot(
+		ctx, "ws-startup", "root", "turn-startup", activeSnapshot, time.UnixMilli(105),
+	); err != nil || !created {
+		t.Fatalf("PutTuttiModeTurnSnapshot() created=%v err=%v", created, err)
+	}
+	if accepted, err := store.AcceptTuttiModeTurnSnapshot(
+		ctx, "ws-startup", "root", "turn-startup", time.UnixMilli(106),
+	); err != nil || !accepted {
+		t.Fatalf("AcceptTuttiModeTurnSnapshot() accepted=%v err=%v", accepted, err)
+	}
 	if _, created, err := store.PrepareSubmitClaim(ctx, agentactivitybiz.SubmitClaimPrepare{
 		WorkspaceID: "ws-startup", AgentSessionID: "root", CanonicalTurnID: "turn-startup",
 		ClientSubmitID: "submit-startup", MetadataJSON: `{"uiMode":"agent"}`, NowUnixMS: 110,
@@ -41,6 +58,22 @@ func TestSettleStaleTurnsOnStartupDeliversDurableTerminalAnalyticsOnce(t *testin
 	if params["startup_reconciled"] != true || params["client_submit_id"] != "submit-startup" ||
 		params["event_id"] != agentturnanalyticsbiz.StableEventID("ws-startup", "root", "turn-startup") {
 		t.Fatalf("startup params=%#v", params)
+	}
+	if params["agent_config_source"] != agentturnterminal.AgentConfigSourceWorkspaceAgent ||
+		params["model_config_source"] != agentturnterminal.ModelConfigSourceModelPlan ||
+		params["tutti_mode_state"] != agentturnterminal.TuttiModeStateActive {
+		t.Fatalf("startup configuration sources=%#v", params)
+	}
+	if _, exists := params["agent_target_id"]; exists {
+		t.Fatalf("startup params contain agent target identity: %#v", params)
+	}
+	if _, exists := params["model_plan_id"]; exists {
+		t.Fatalf("startup params contain model plan identity: %#v", params)
+	}
+	for _, forbidden := range []string{"activation_id", "revision_id", "effect", "speed"} {
+		if _, exists := params[forbidden]; exists {
+			t.Fatalf("startup params contain Tutti mode %s: %#v", forbidden, params)
+		}
 	}
 	if err := projection.SettleStaleTurnsOnStartup(ctx); err != nil {
 		t.Fatal(err)
@@ -317,6 +350,31 @@ func seedTerminalAnalyticsIntegrationSession(t *testing.T, store *workspacedata.
 		WorkspaceID: workspaceID, AgentSessionID: sessionID, Kind: agentactivitybiz.SessionKindRoot,
 		Origin: "runtime", Provider: "codex", Status: "active", CurrentPhase: "working",
 		OccurredAtUnixMS: 10,
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func seedTerminalAnalyticsIntegrationConfiguredSession(t *testing.T, store *workspacedata.SQLiteStore, workspaceID, sessionID string) {
+	t.Helper()
+	if _, err := store.ReportSessionState(context.Background(), agentactivitybiz.SessionStateReport{
+		WorkspaceID: workspaceID, AgentSessionID: sessionID, Kind: agentactivitybiz.SessionKindRoot,
+		Origin: "runtime", AgentTargetID: "workspace-agent:reviewer", Provider: "codex",
+		RuntimeContext: map[string]any{
+			"sessionRuntimeSnapshot": map[string]any{
+				"version":              1,
+				"agentTargetId":        "workspace-agent:reviewer",
+				"harnessAgentTargetId": "local:codex",
+				"provider":             "codex",
+				"modelConfiguration": map[string]any{
+					"source":            "model-plan",
+					"modelPlanId":       "plan-1",
+					"modelPlanRevision": uint64(1),
+					"fingerprint":       "model-fingerprint",
+				},
+			},
+		},
+		Status: "active", CurrentPhase: "working", OccurredAtUnixMS: 10,
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/services/tuttid/service/agent/activity_projection_turn_terminal_test.go
+++ b/services/tuttid/service/agent/activity_projection_turn_terminal_test.go
@@ -7,6 +7,7 @@ import (
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	agentactivitybiz "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 	agentturnanalyticsbiz "github.com/tutti-os/tutti/services/tuttid/biz/agentturnanalytics"
+	tuttimodeactivationbiz "github.com/tutti-os/tutti/services/tuttid/biz/tuttimodeactivation"
 )
 
 func TestActivityProjectionReportsCanonicalUserTurnOutcomes(t *testing.T) {
@@ -73,6 +74,197 @@ func TestActivityProjectionReportsCanonicalUserTurnOutcomes(t *testing.T) {
 				t.Fatalf("params contain workspace identity: %#v", params)
 			}
 		})
+	}
+}
+
+func TestActivityProjectionReportsAgentAndModelConfigSources(t *testing.T) {
+	tests := []struct {
+		name            string
+		session         agentactivitybiz.Session
+		sessionFound    bool
+		wantAgentSource string
+		wantModelSource string
+	}{
+		{
+			name: "workspace agent with model plan",
+			session: terminalAnalyticsSession(
+				"workspace-agent:reviewer",
+				"model-plan",
+			),
+			sessionFound:    true,
+			wantAgentSource: "workspace_agent",
+			wantModelSource: "model_plan",
+		},
+		{
+			name: "workspace agent with provider native model",
+			session: terminalAnalyticsSession(
+				"workspace-agent:reviewer",
+				"provider-native",
+			),
+			sessionFound:    true,
+			wantAgentSource: "workspace_agent",
+			wantModelSource: "provider_native",
+		},
+		{
+			name: "built in agent target",
+			session: terminalAnalyticsSession(
+				"local:codex",
+				"provider-native",
+			),
+			sessionFound:    true,
+			wantAgentSource: "agent_target",
+			wantModelSource: "provider_native",
+		},
+		{
+			name: "legacy session without runtime snapshot",
+			session: agentactivitybiz.Session{
+				AgentTargetID: "local:codex",
+			},
+			sessionFound:    true,
+			wantAgentSource: "agent_target",
+			wantModelSource: "unknown",
+		},
+		{
+			name:            "missing session",
+			wantAgentSource: "unknown",
+			wantModelSource: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &activityProjectionRepoStub{
+				session:      tt.session,
+				sessionFound: tt.sessionFound,
+				submission: agentactivitybiz.TurnSubmission{
+					ClientSubmitID: "submit-1",
+					MetadataJSON:   `{"uiMode":"agent"}`,
+				},
+				submissionFound: true,
+			}
+			reporter := &recordingAgentAnalyticsReporter{}
+			projection := NewActivityProjection(repo)
+			projection.SetAnalyticsReporter(reporter)
+
+			err := projection.ObserveCommitted(context.Background(), agenthost.CommittedDelta{
+				RootTurnsSettled: []agenthost.RootTurnSettled{{
+					WorkspaceID: "ws-1", AgentSessionID: "session-1", Provider: "codex",
+					Turn: agentactivitybiz.Turn{
+						TurnID: "turn-1", Origin: agentactivitybiz.TurnOriginUserPrompt,
+						Outcome: agentactivitybiz.TurnOutcomeCompleted,
+					},
+				}},
+			})
+			if err != nil {
+				t.Fatalf("ObserveCommitted() error=%v", err)
+			}
+			if len(reporter.events) != 1 {
+				t.Fatalf("events=%#v, want one terminal event", reporter.events)
+			}
+			params := reporter.events[0].Params
+			if got := params["agent_config_source"]; got != tt.wantAgentSource {
+				t.Fatalf("agent_config_source=%#v, want %q in %#v", got, tt.wantAgentSource, params)
+			}
+			if got := params["model_config_source"]; got != tt.wantModelSource {
+				t.Fatalf("model_config_source=%#v, want %q in %#v", got, tt.wantModelSource, params)
+			}
+			if _, exists := params["agent_target_id"]; exists {
+				t.Fatalf("params contain agent target identity: %#v", params)
+			}
+			if _, exists := params["model_plan_id"]; exists {
+				t.Fatalf("params contain model plan identity: %#v", params)
+			}
+		})
+	}
+}
+
+func TestActivityProjectionReportsAcceptedTuttiModeTurnState(t *testing.T) {
+	tests := []struct {
+		name     string
+		snapshot tuttimodeactivationbiz.TurnSnapshot
+		found    bool
+		accepted bool
+		readErr  error
+		want     string
+	}{
+		{
+			name: "accepted active snapshot",
+			snapshot: tuttimodeactivationbiz.TurnSnapshot{
+				ActivationID: "activation-secret", RevisionID: "revision-secret", Revision: 1,
+				State: tuttimodeactivationbiz.StateActive, Source: tuttimodeactivationbiz.SourceSlashCommand,
+				Effect: 80, Speed: 20,
+			},
+			found: true, accepted: true, want: "active",
+		},
+		{
+			name: "accepted inactive unconfigured snapshot",
+			snapshot: tuttimodeactivationbiz.TurnSnapshot{
+				State: tuttimodeactivationbiz.StateInactive,
+			},
+			found: true, accepted: true, want: "inactive",
+		},
+		{name: "prepared but not accepted", found: true, want: "unknown"},
+		{name: "snapshot missing", accepted: true, want: "unknown"},
+		{name: "snapshot read failed", found: true, accepted: true, readErr: context.Canceled, want: "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &activityProjectionRepoStub{
+				submission: agentactivitybiz.TurnSubmission{
+					ClientSubmitID: "submit-1", MetadataJSON: `{"uiMode":"agent"}`,
+				},
+				submissionFound:               true,
+				tuttiModeTurnSnapshot:         tt.snapshot,
+				tuttiModeTurnSnapshotFound:    tt.found,
+				tuttiModeTurnSnapshotAccepted: tt.accepted,
+				tuttiModeTurnSnapshotErr:      tt.readErr,
+			}
+			reporter := &recordingAgentAnalyticsReporter{}
+			projection := NewActivityProjection(repo)
+			projection.SetAnalyticsReporter(reporter)
+			_ = projection.ObserveCommitted(context.Background(), agenthost.CommittedDelta{
+				RootTurnsSettled: []agenthost.RootTurnSettled{{
+					WorkspaceID: "ws-1", AgentSessionID: "session-1", Provider: "codex",
+					Turn: agentactivitybiz.Turn{
+						TurnID: "turn-1", Origin: agentactivitybiz.TurnOriginUserPrompt,
+						Outcome: agentactivitybiz.TurnOutcomeCompleted,
+					},
+				}},
+			})
+			if len(reporter.events) != 1 || reporter.events[0].Params["tutti_mode_state"] != tt.want {
+				t.Fatalf("events=%#v, want tutti_mode_state=%q", reporter.events, tt.want)
+			}
+			for _, forbidden := range []string{"activation_id", "revision_id", "effect", "speed"} {
+				if _, exists := reporter.events[0].Params[forbidden]; exists {
+					t.Fatalf("terminal event leaked %s: %#v", forbidden, reporter.events[0])
+				}
+			}
+		})
+	}
+}
+
+func terminalAnalyticsSession(agentTargetID string, modelSource string) agentactivitybiz.Session {
+	modelConfiguration := map[string]any{
+		"source":      modelSource,
+		"fingerprint": "model-fingerprint",
+	}
+	if modelSource == "model-plan" {
+		modelConfiguration["modelPlanId"] = "plan-1"
+		modelConfiguration["modelPlanRevision"] = uint64(1)
+	}
+	return agentactivitybiz.Session{
+		AgentTargetID: agentTargetID,
+		Provider:      "codex",
+		InternalRuntimeContext: map[string]any{
+			"sessionRuntimeSnapshot": map[string]any{
+				"version":              1,
+				"agentTargetId":        agentTargetID,
+				"harnessAgentTargetId": "local:codex",
+				"provider":             "codex",
+				"modelConfiguration":   modelConfiguration,
+			},
+		},
 	}
 }
 

--- a/services/tuttid/service/agent/service_test_support_test.go
+++ b/services/tuttid/service/agent/service_test_support_test.go
@@ -8,6 +8,7 @@ import (
 
 	agentactivitybiz "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
+	tuttimodeactivationbiz "github.com/tutti-os/tutti/services/tuttid/biz/tuttimodeactivation"
 	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
 	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
 )
@@ -25,26 +26,33 @@ func (f fakeAgentTargetLookup) GetAgentTarget(_ context.Context, id string) (age
 }
 
 type activityProjectionRepoStub struct {
-	clearResult     agentactivitybiz.ClearSessionsResult
-	settleStaleErr  error
-	settlements     []agentactivitybiz.StaleTurnSettlement
-	stateResult     agentactivitybiz.StateReportResult
-	stateInput      agentactivitybiz.SessionStateReport
-	messageInput    agentactivitybiz.SessionMessageReport
-	messageResult   agentactivitybiz.MessageReportResult
-	messagePage     agentactivitybiz.MessagePage
-	messagePageOK   bool
-	messagePageErr  error
-	turnResult      agentactivitybiz.Turn
-	turnResults     map[string]agentactivitybiz.Turn
-	turnFound       bool
-	turnErr         error
-	sectionsPage    agentactivitybiz.SessionSectionsPage
-	sectionsOK      bool
-	sectionsErr     error
-	submission      agentactivitybiz.TurnSubmission
-	submissionFound bool
-	submissionErr   error
+	clearResult                   agentactivitybiz.ClearSessionsResult
+	session                       agentactivitybiz.Session
+	sessionFound                  bool
+	sessionErr                    error
+	settleStaleErr                error
+	settlements                   []agentactivitybiz.StaleTurnSettlement
+	stateResult                   agentactivitybiz.StateReportResult
+	stateInput                    agentactivitybiz.SessionStateReport
+	messageInput                  agentactivitybiz.SessionMessageReport
+	messageResult                 agentactivitybiz.MessageReportResult
+	messagePage                   agentactivitybiz.MessagePage
+	messagePageOK                 bool
+	messagePageErr                error
+	turnResult                    agentactivitybiz.Turn
+	turnResults                   map[string]agentactivitybiz.Turn
+	turnFound                     bool
+	turnErr                       error
+	sectionsPage                  agentactivitybiz.SessionSectionsPage
+	sectionsOK                    bool
+	sectionsErr                   error
+	submission                    agentactivitybiz.TurnSubmission
+	submissionFound               bool
+	submissionErr                 error
+	tuttiModeTurnSnapshot         tuttimodeactivationbiz.TurnSnapshot
+	tuttiModeTurnSnapshotFound    bool
+	tuttiModeTurnSnapshotAccepted bool
+	tuttiModeTurnSnapshotErr      error
 }
 
 func (r *activityProjectionRepoStub) ClearSessions(context.Context, string) (agentactivitybiz.ClearSessionsResult, error) {
@@ -67,8 +75,16 @@ func (*activityProjectionRepoStub) ListRecoverableDeletedSessionResources(contex
 	return []agentactivitybiz.DeletedSessionResource{}, nil
 }
 
-func (*activityProjectionRepoStub) GetSession(context.Context, string, string) (agentactivitybiz.Session, bool, error) {
-	return agentactivitybiz.Session{}, false, nil
+func (r *activityProjectionRepoStub) GetSession(context.Context, string, string) (agentactivitybiz.Session, bool, error) {
+	return r.session, r.sessionFound, r.sessionErr
+}
+
+func (r *activityProjectionRepoStub) GetTuttiModeTurnSnapshot(context.Context, string, string, string) (tuttimodeactivationbiz.TurnSnapshot, bool, error) {
+	return r.tuttiModeTurnSnapshot, r.tuttiModeTurnSnapshotFound, r.tuttiModeTurnSnapshotErr
+}
+
+func (r *activityProjectionRepoStub) IsTuttiModeTurnSnapshotAccepted(context.Context, string, string, string) (bool, error) {
+	return r.tuttiModeTurnSnapshotAccepted, r.tuttiModeTurnSnapshotErr
 }
 
 func (*activityProjectionRepoStub) ListChildSessions(context.Context, string, string) ([]agentactivitybiz.Session, error) {

--- a/services/tuttid/service/modelplan/analytics.go
+++ b/services/tuttid/service/modelplan/analytics.go
@@ -1,0 +1,102 @@
+package modelplan
+
+import (
+	"context"
+
+	modelplanbiz "github.com/tutti-os/tutti/services/tuttid/biz/modelplan"
+	reporterevents "github.com/tutti-os/tutti/services/tuttid/service/reporter/events"
+)
+
+const (
+	modelPlanConfigurationChangedEvent = "model_plan.configuration_changed"
+	modelPlanDetectionCompletedEvent   = "model_plan.detection_completed"
+)
+
+func (s *Service) reportConfigurationChanged(
+	ctx context.Context,
+	action string,
+	plan modelplanbiz.Plan,
+) {
+	if s == nil || s.AnalyticsReporter == nil {
+		return
+	}
+	switch action {
+	case "created", "updated", "duplicated", "enabled", "disabled", "deleted":
+	default:
+		return
+	}
+	reporterevents.Track(ctx, s.AnalyticsReporter, modelPlanConfigurationChangedEvent, map[string]any{
+		"action":        action,
+		"protocol":      normalizedAnalyticsProtocol(plan.Protocol),
+		"template_kind": normalizedAnalyticsTemplateKind(plan.TemplateKind),
+	})
+}
+
+func (s *Service) reportDetectionCompleted(
+	ctx context.Context,
+	scope string,
+	protocol modelplanbiz.Protocol,
+	templateKind modelplanbiz.TemplateKind,
+	snapshot modelplanbiz.DetectionSnapshot,
+) {
+	if s == nil || s.AnalyticsReporter == nil {
+		return
+	}
+	if scope != "draft" && scope != "saved" {
+		scope = "unknown"
+	}
+	params := map[string]any{
+		"protocol":      normalizedAnalyticsProtocol(protocol),
+		"result":        "passed",
+		"scope":         scope,
+		"template_kind": normalizedAnalyticsTemplateKind(templateKind),
+	}
+	if !snapshot.CorePassed() {
+		params["result"] = "failed"
+		failureStage, failureReason := detectionFailure(snapshot)
+		params["failure_stage"] = failureStage
+		params["failure_reason"] = failureReason
+	}
+	reporterevents.Track(ctx, s.AnalyticsReporter, modelPlanDetectionCompletedEvent, params)
+}
+
+func detectionFailure(snapshot modelplanbiz.DetectionSnapshot) (string, string) {
+	for _, stage := range modelplanbiz.DetectionStages() {
+		result, ok := snapshot.StageOutcome(stage)
+		if ok && result.Status == modelplanbiz.StageFailed {
+			return string(stage), normalizedDetectionFailureReason(result.FailureReason)
+		}
+	}
+	return "unknown", "unknown"
+}
+
+func normalizedAnalyticsProtocol(protocol modelplanbiz.Protocol) string {
+	if modelplanbiz.IsProtocol(string(protocol)) {
+		return string(protocol)
+	}
+	return "unknown"
+}
+
+func normalizedAnalyticsTemplateKind(kind modelplanbiz.TemplateKind) string {
+	if modelplanbiz.IsTemplateKind(string(kind)) {
+		return string(kind)
+	}
+	return "unknown"
+}
+
+func normalizedDetectionFailureReason(reason string) string {
+	switch reason {
+	case FailureConnection,
+		FailureUnauthorized,
+		FailureCatalogNotFound,
+		FailureCatalogDecode,
+		FailureNoModel,
+		FailureModelRejected,
+		FailureInference,
+		FailureProviderRuntime,
+		FailureProviderAuth:
+		return reason
+	default:
+		return "unknown"
+	}
+}

--- a/services/tuttid/service/modelplan/detection.go
+++ b/services/tuttid/service/modelplan/detection.go
@@ -177,6 +177,11 @@ func (s *Service) Detect(ctx context.Context, input DetectInput) (DetectResult, 
 		}
 		s.publishChanged(stored.WorkspaceID)
 	}
+	scope := "draft"
+	if hasStored {
+		scope = "saved"
+	}
+	s.reportDetectionCompleted(ctx, scope, protocol, templateKind, snapshot)
 
 	return DetectResult{Detection: snapshot, DiscoveredModels: discovered}, nil
 }

--- a/services/tuttid/service/modelplan/service.go
+++ b/services/tuttid/service/modelplan/service.go
@@ -17,6 +17,7 @@ import (
 
 	modelplanbiz "github.com/tutti-os/tutti/services/tuttid/biz/modelplan"
 	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
+	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
 
 	"github.com/tutti-os/tutti/packages/agent/daemon/httpx"
 )
@@ -55,6 +56,7 @@ type Service struct {
 	NativeSubscriptionProbe NativeSubscriptionProbe
 	Publisher               ChangePublisher
 	ConfigurationPublisher  ConfigurationChangePublisher
+	AnalyticsReporter       reporterservice.Reporter
 	Now                     func() time.Time
 	HTTPClient              *http.Client
 	NewID                   func() string
@@ -120,6 +122,7 @@ func (s *Service) CreatePlan(ctx context.Context, input PutPlanInput) (modelplan
 	if err := s.Store.PutModelPlan(ctx, normalized); err != nil {
 		return modelplanbiz.PublicPlan{}, err
 	}
+	s.reportConfigurationChanged(ctx, "created", normalized)
 	return modelplanbiz.Public(normalized), nil
 }
 
@@ -155,6 +158,7 @@ func (s *Service) UpdatePlan(ctx context.Context, input PutPlanInput) (modelplan
 	if err := s.Store.PutModelPlan(ctx, normalized); err != nil {
 		return modelplanbiz.PublicPlan{}, err
 	}
+	s.reportConfigurationChanged(ctx, "updated", normalized)
 	s.publishConfigurationChanged(
 		ctx,
 		normalized.WorkspaceID,
@@ -191,6 +195,7 @@ func (s *Service) DuplicatePlan(ctx context.Context, workspaceID string, planID 
 	if err := s.Store.PutModelPlan(ctx, normalized); err != nil {
 		return modelplanbiz.PublicPlan{}, err
 	}
+	s.reportConfigurationChanged(ctx, "duplicated", normalized)
 	return modelplanbiz.Public(normalized), nil
 }
 
@@ -206,6 +211,13 @@ func (s *Service) SetPlanEnabled(ctx context.Context, workspaceID string, planID
 	if err := s.Store.PutModelPlan(ctx, plan); err != nil {
 		return modelplanbiz.PublicPlan{}, err
 	}
+	if resetComposerModel {
+		action := "disabled"
+		if enabled {
+			action = "enabled"
+		}
+		s.reportConfigurationChanged(ctx, action, plan)
+	}
 	s.publishConfigurationChanged(ctx, plan.WorkspaceID, plan.ID, resetComposerModel)
 	s.publishChanged(plan.WorkspaceID)
 	return modelplanbiz.Public(plan), nil
@@ -216,6 +228,10 @@ func (s *Service) SetPlanEnabled(ctx context.Context, workspaceID string, planID
 func (s *Service) DeletePlan(ctx context.Context, workspaceID string, planID string) error {
 	workspaceID = strings.TrimSpace(workspaceID)
 	planID = strings.TrimSpace(planID)
+	plan, err := s.Store.GetModelPlan(ctx, workspaceID, planID)
+	if err != nil {
+		return err
+	}
 	references, err := s.PlanReferences(ctx, workspaceID, planID)
 	if err != nil {
 		return err
@@ -229,6 +245,7 @@ func (s *Service) DeletePlan(ctx context.Context, workspaceID string, planID str
 		}
 		return err
 	}
+	s.reportConfigurationChanged(ctx, "deleted", plan)
 	return nil
 }
 

--- a/services/tuttid/service/modelplan/service_test.go
+++ b/services/tuttid/service/modelplan/service_test.go
@@ -13,11 +13,14 @@ import (
 
 	modelplanbiz "github.com/tutti-os/tutti/services/tuttid/biz/modelplan"
 	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
+	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
 )
 
 type memoryPlanStore struct {
-	mu    sync.Mutex
-	plans map[string]modelplanbiz.Plan
+	mu        sync.Mutex
+	plans     map[string]modelplanbiz.Plan
+	putErr    error
+	deleteErr error
 }
 
 func newMemoryPlanStore() *memoryPlanStore {
@@ -53,6 +56,9 @@ func (s *memoryPlanStore) GetModelPlan(_ context.Context, workspaceID string, pl
 func (s *memoryPlanStore) PutModelPlan(_ context.Context, plan modelplanbiz.Plan) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.putErr != nil {
+		return s.putErr
+	}
 	s.plans[s.key(plan.WorkspaceID, plan.ID)] = plan
 	return nil
 }
@@ -60,6 +66,9 @@ func (s *memoryPlanStore) PutModelPlan(_ context.Context, plan modelplanbiz.Plan
 func (s *memoryPlanStore) DeleteModelPlan(_ context.Context, workspaceID string, planID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
 	key := s.key(workspaceID, planID)
 	if _, ok := s.plans[key]; !ok {
 		return workspacedata.ErrModelPlanNotFound
@@ -71,6 +80,16 @@ func (s *memoryPlanStore) DeleteModelPlan(_ context.Context, workspaceID string,
 type staticReferences struct {
 	references []modelplanbiz.Reference
 }
+
+type recordingAnalyticsReporter struct {
+	events []reporterservice.Event
+}
+
+func (r *recordingAnalyticsReporter) Track(_ context.Context, events ...reporterservice.Event) {
+	r.events = append(r.events, events...)
+}
+
+func (*recordingAnalyticsReporter) Close() error { return nil }
 
 func (s staticReferences) ListModelPlanReferences(context.Context, string, string) ([]modelplanbiz.Reference, error) {
 	return s.references, nil
@@ -243,6 +262,75 @@ func TestDeletePlanBlockedWhileReferenced(t *testing.T) {
 	}
 }
 
+func TestServiceReportsCommittedModelPlanConfigurationChanges(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newMemoryPlanStore()
+	service := newTestService(store)
+	reporter := &recordingAnalyticsReporter{}
+	service.AnalyticsReporter = reporter
+	apiKey := "do-not-report"
+	created, err := service.CreatePlan(ctx, PutPlanInput{
+		WorkspaceID: "ws", Name: "Relay", TemplateKind: "relay", Protocol: "openai",
+		APIKey: &apiKey, BaseURL: "https://relay.example/v1", Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("CreatePlan() error = %v", err)
+	}
+	if _, err := service.UpdatePlan(ctx, PutPlanInput{
+		WorkspaceID: "ws", PlanID: created.ID, Name: "Relay 2", TemplateKind: "relay",
+		Protocol: "openai", BaseURL: "https://relay.example/v1", Enabled: true,
+	}); err != nil {
+		t.Fatalf("UpdatePlan() error = %v", err)
+	}
+	duplicate, err := service.DuplicatePlan(ctx, "ws", created.ID, "Relay copy")
+	if err != nil {
+		t.Fatalf("DuplicatePlan() error = %v", err)
+	}
+	if _, err := service.SetPlanEnabled(ctx, "ws", duplicate.ID, true); err != nil {
+		t.Fatalf("SetPlanEnabled() error = %v", err)
+	}
+	if _, err := service.SetPlanEnabled(ctx, "ws", duplicate.ID, true); err != nil {
+		t.Fatalf("SetPlanEnabled(no-op) error = %v", err)
+	}
+	if err := service.DeletePlan(ctx, "ws", created.ID); err != nil {
+		t.Fatalf("DeletePlan() error = %v", err)
+	}
+
+	wantActions := []string{"created", "updated", "duplicated", "enabled", "deleted"}
+	if len(reporter.events) != len(wantActions) {
+		t.Fatalf("analytics events = %#v, want actions %#v", reporter.events, wantActions)
+	}
+	for index, action := range wantActions {
+		event := reporter.events[index]
+		if event.Name != "model_plan.configuration_changed" || event.Params["action"] != action ||
+			event.Params["template_kind"] != "relay" || event.Params["protocol"] != "openai" {
+			t.Fatalf("event[%d] = %#v, want bounded %q relay/openai", index, event, action)
+		}
+		for _, forbidden := range []string{"model_plan_id", "name", "base_url", "api_key"} {
+			if _, exists := event.Params[forbidden]; exists {
+				t.Fatalf("event[%d] leaked %s: %#v", index, forbidden, event)
+			}
+		}
+	}
+	service.References = staticReferences{references: []modelplanbiz.Reference{{
+		Kind: modelplanbiz.ReferenceWorkspaceAgent, ID: "private", Role: "default",
+	}}}
+	if err := service.DeletePlan(ctx, "ws", duplicate.ID); !errors.Is(err, ErrPlanReferenced) {
+		t.Fatalf("DeletePlan(referenced) error = %v, want ErrPlanReferenced", err)
+	}
+	store.putErr = errors.New("store write failed")
+	if _, err := service.CreatePlan(ctx, PutPlanInput{
+		WorkspaceID: "ws", Name: "Not persisted", Protocol: "openai",
+	}); err == nil {
+		t.Fatal("CreatePlan(store failure) error = nil")
+	}
+	if len(reporter.events) != len(wantActions) {
+		t.Fatalf("failed mutations emitted analytics: %#v", reporter.events)
+	}
+}
+
 func TestPlanReferencesReturnsNotFoundForMissingPlan(t *testing.T) {
 	t.Parallel()
 
@@ -299,6 +387,8 @@ func TestDetectStagesAgainstFakeOpenAIProvider(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreatePlan() error = %v", err)
 	}
+	reporter := &recordingAnalyticsReporter{}
+	service.AnalyticsReporter = reporter
 
 	result, err := service.Detect(ctx, DetectInput{WorkspaceID: "ws", PlanID: created.ID})
 	if err != nil {
@@ -333,6 +423,75 @@ func TestDetectStagesAgainstFakeOpenAIProvider(t *testing.T) {
 	authStage, _ := badResult.Detection.StageOutcome(modelplanbiz.StageAuth)
 	if authStage.FailureReason != FailureUnauthorized || authStage.Remedy != RemedyCheckAPIKey {
 		t.Fatalf("auth stage = %#v, want unauthorized/check_api_key", authStage)
+	}
+	if len(reporter.events) != 2 || reporter.events[0].Params["scope"] != "saved" ||
+		reporter.events[0].Params["result"] != "passed" ||
+		reporter.events[1].Params["scope"] != "saved" || reporter.events[1].Params["result"] != "failed" {
+		t.Fatalf("saved detection analytics = %#v", reporter.events)
+	}
+}
+
+func TestDetectReportsBoundedCompletedOutcomes(t *testing.T) {
+	t.Parallel()
+
+	fake := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer sk-good" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/models":
+			_, _ = w.Write([]byte(`{"data":[{"id":"fake-mini"}]}`))
+		case "/v1/chat/completions":
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer fake.Close()
+
+	service := newTestService(newMemoryPlanStore())
+	service.HTTPClient = fake.Client()
+	reporter := &recordingAnalyticsReporter{}
+	service.AnalyticsReporter = reporter
+	goodKey := "sk-good"
+	badKey := "sk-secret"
+	input := DetectInput{
+		WorkspaceID: "ws", TemplateKind: "relay", Protocol: "openai",
+		BaseURL: fake.URL + "/v1", Models: []modelplanbiz.Model{{ID: "fake-mini"}}, Model: "fake-mini",
+	}
+	input.APIKey = &goodKey
+	if _, err := service.Detect(context.Background(), input); err != nil {
+		t.Fatalf("Detect(success) error = %v", err)
+	}
+	input.APIKey = &badKey
+	if _, err := service.Detect(context.Background(), input); err != nil {
+		t.Fatalf("Detect(failure) error = %v", err)
+	}
+	if _, err := service.Detect(context.Background(), DetectInput{Protocol: "unsupported"}); !errors.Is(err, ErrDetectionInput) {
+		t.Fatalf("Detect(invalid) error = %v", err)
+	}
+
+	if len(reporter.events) != 2 {
+		t.Fatalf("analytics events = %#v, want successful and failed attempts", reporter.events)
+	}
+	if event := reporter.events[0]; event.Name != "model_plan.detection_completed" ||
+		event.Params["scope"] != "draft" || event.Params["result"] != "passed" ||
+		event.Params["protocol"] != "openai" || event.Params["template_kind"] != "relay" {
+		t.Fatalf("success event = %#v", event)
+	}
+	if event := reporter.events[1]; event.Name != "model_plan.detection_completed" ||
+		event.Params["scope"] != "draft" || event.Params["result"] != "failed" ||
+		event.Params["failure_stage"] != "auth" || event.Params["failure_reason"] != "unauthorized" {
+		t.Fatalf("failure event = %#v", event)
+	}
+	for _, event := range reporter.events {
+		for _, forbidden := range []string{"workspace_id", "model_plan_id", "base_url", "api_key", "model"} {
+			if _, exists := event.Params[forbidden]; exists {
+				t.Fatalf("event leaked %s: %#v", forbidden, event)
+			}
+		}
 	}
 }
 

--- a/services/tuttid/service/reporter/events/agent/turn_terminal/params.go
+++ b/services/tuttid/service/reporter/events/agent/turn_terminal/params.go
@@ -2,13 +2,28 @@ package turn_terminal
 
 import "strings"
 
-const unknownErrorCode = "agent_unknown_error"
+const (
+	unknownErrorCode = "agent_unknown_error"
+
+	AgentConfigSourceAgentTarget    = "agent_target"
+	AgentConfigSourceUnknown        = "unknown"
+	AgentConfigSourceWorkspaceAgent = "workspace_agent"
+	ModelConfigSourceModelPlan      = "model_plan"
+	ModelConfigSourceProviderNative = "provider_native"
+	ModelConfigSourceUnknown        = "unknown"
+	TuttiModeStateActive            = "active"
+	TuttiModeStateInactive          = "inactive"
+	TuttiModeStateUnknown           = "unknown"
+)
 
 type Input struct {
 	AgentSessionID    string
+	AgentConfigSource string
 	ClientSubmitID    string
 	ErrorCode         string
 	Mode              string
+	ModelConfigSource string
+	TuttiModeState    string
 	Outcome           string
 	Origin            string
 	Provider          string
@@ -34,6 +49,7 @@ func Build(input Input) (string, Params, bool) {
 	}
 	turnID := strings.TrimSpace(input.TurnID)
 	params := Params{
+		"agent_config_source": normalizeAgentConfigSource(input.AgentConfigSource),
 		"agent_kind":          "local-agent",
 		"agent_session_id":    strings.TrimSpace(input.AgentSessionID),
 		"client_submit_id":    strings.TrimSpace(input.ClientSubmitID),
@@ -42,11 +58,13 @@ func Build(input Input) (string, Params, bool) {
 		"invocation_id":       turnID,
 		"is_child_session":    false,
 		"mode":                mode,
+		"model_config_source": normalizeModelConfigSource(input.ModelConfigSource),
 		"operation_id":        turnID,
 		"provider":            provider,
 		"startup_reconciled":  input.StartupReconciled,
 		"status":              status,
 		"surface":             "direct_session",
+		"tutti_mode_state":    normalizeTuttiModeState(input.TuttiModeState),
 		"turn_id":             turnID,
 		"turn_origin":         strings.TrimSpace(input.Origin),
 		"turn_outcome":        outcome,
@@ -72,6 +90,39 @@ func Build(input Input) (string, Params, bool) {
 		}
 	}
 	return eventName, params, true
+}
+
+func normalizeTuttiModeState(value string) string {
+	switch strings.TrimSpace(value) {
+	case TuttiModeStateActive:
+		return TuttiModeStateActive
+	case TuttiModeStateInactive:
+		return TuttiModeStateInactive
+	default:
+		return TuttiModeStateUnknown
+	}
+}
+
+func normalizeAgentConfigSource(value string) string {
+	switch strings.TrimSpace(value) {
+	case AgentConfigSourceAgentTarget:
+		return AgentConfigSourceAgentTarget
+	case AgentConfigSourceWorkspaceAgent:
+		return AgentConfigSourceWorkspaceAgent
+	default:
+		return AgentConfigSourceUnknown
+	}
+}
+
+func normalizeModelConfigSource(value string) string {
+	switch strings.TrimSpace(value) {
+	case ModelConfigSourceModelPlan:
+		return ModelConfigSourceModelPlan
+	case ModelConfigSourceProviderNative:
+		return ModelConfigSourceProviderNative
+	default:
+		return ModelConfigSourceUnknown
+	}
 }
 
 func terminalEvent(outcome string) (string, string) {

--- a/services/tuttid/service/reporter/events/agent/turn_terminal/params_test.go
+++ b/services/tuttid/service/reporter/events/agent/turn_terminal/params_test.go
@@ -19,8 +19,10 @@ func TestBuildMapsTerminalOutcomes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			eventName, params, ok := Build(Input{
-				AgentSessionID: "session-1", ClientSubmitID: "submit-1", ErrorCode: "runtime_failed",
-				Mode: "agent", Origin: "user_prompt", Outcome: tt.outcome, Provider: "codex",
+				AgentSessionID: "session-1", AgentConfigSource: AgentConfigSourceWorkspaceAgent,
+				ClientSubmitID: "submit-1", ErrorCode: "runtime_failed", Mode: "agent",
+				ModelConfigSource: ModelConfigSourceModelPlan, Origin: "user_prompt", Outcome: tt.outcome, Provider: "codex",
+				TuttiModeState:    TuttiModeStateActive,
 				StartupReconciled: tt.outcome == "interrupted", StartedAtUnixMS: 1_000,
 				SettledAtUnixMS: 11_000, TurnID: "turn-1",
 			})
@@ -28,9 +30,11 @@ func TestBuildMapsTerminalOutcomes(t *testing.T) {
 				t.Fatalf("Build() event=%q ok=%v, want %q true", eventName, ok, tt.eventName)
 			}
 			for key, want := range map[string]any{
-				"agent_session_id": "session-1", "client_submit_id": "submit-1",
+				"agent_config_source": AgentConfigSourceWorkspaceAgent,
+				"agent_session_id":    "session-1", "client_submit_id": "submit-1",
 				"duration_bucket": "10s_to_30s", "duration_ms": int64(10_000),
-				"mode": "agent", "provider": "codex", "status": tt.status,
+				"mode": "agent", "model_config_source": ModelConfigSourceModelPlan, "tutti_mode_state": TuttiModeStateActive,
+				"provider": "codex", "status": tt.status,
 				"turn_id": "turn-1", "turn_origin": "user_prompt", "turn_outcome": tt.outcome,
 				tt.extraKey: tt.extraValue,
 			} {
@@ -39,6 +43,21 @@ func TestBuildMapsTerminalOutcomes(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestBuildDefaultsUnrecognizedConfigurationSourcesToUnknown(t *testing.T) {
+	_, params, ok := Build(Input{
+		AgentConfigSource: "workspace-agent:secret",
+		Mode:              "agent",
+		ModelConfigSource: "plan-secret",
+		Outcome:           "completed",
+		TuttiModeState:    "active:secret",
+	})
+	if !ok || params["agent_config_source"] != AgentConfigSourceUnknown ||
+		params["model_config_source"] != ModelConfigSourceUnknown ||
+		params["tutti_mode_state"] != TuttiModeStateUnknown {
+		t.Fatalf("params=%#v ok=%v, want content-free unknown sources", params, ok)
 	}
 }
 

--- a/services/tuttid/service/tuttimodeactivation/analytics.go
+++ b/services/tuttid/service/tuttimodeactivation/analytics.go
@@ -1,0 +1,34 @@
+package tuttimodeactivation
+
+import (
+	"context"
+
+	activationbiz "github.com/tutti-os/tutti/services/tuttid/biz/tuttimodeactivation"
+	reporterevents "github.com/tutti-os/tutti/services/tuttid/service/reporter/events"
+)
+
+const tuttiModeActivationChangedEvent = "tutti_mode.activation_changed"
+
+func (s *Service) reportActivationChanged(ctx context.Context, activation activationbiz.Activation) {
+	if s == nil || s.AnalyticsReporter == nil {
+		return
+	}
+	revision := activation.CurrentRevision
+	action := ""
+	switch revision.State {
+	case activationbiz.StateActive:
+		action = "activated"
+	case activationbiz.StateInactive:
+		action = "deactivated"
+	default:
+		return
+	}
+	if !activationbiz.IsUserStateSource(revision.State, revision.Source) {
+		return
+	}
+	reporterevents.Track(ctx, s.AnalyticsReporter, tuttiModeActivationChangedEvent, map[string]any{
+		"action": action,
+		"source": string(revision.Source),
+		"state":  string(revision.State),
+	})
+}

--- a/services/tuttid/service/tuttimodeactivation/service.go
+++ b/services/tuttid/service/tuttimodeactivation/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	activationbiz "github.com/tutti-os/tutti/services/tuttid/biz/tuttimodeactivation"
 	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
+	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
 )
 
 var (
@@ -40,10 +41,11 @@ type Publisher interface {
 }
 
 type Service struct {
-	Store     Store
-	Publisher Publisher
-	Now       func() time.Time
-	NewID     func() string
+	Store             Store
+	Publisher         Publisher
+	AnalyticsReporter reporterservice.Reporter
+	Now               func() time.Time
+	NewID             func() string
 }
 
 type SetInput struct {
@@ -146,6 +148,7 @@ func (s *Service) Set(ctx context.Context, input SetInput) (SetResult, error) {
 	}
 	result := SetResult{Activation: cloneActivation(activation), Changed: changed}
 	if changed {
+		s.reportActivationChanged(ctx, activation)
 		s.publish(ctx, activationbiz.Update{
 			WorkspaceID:    activation.WorkspaceID,
 			AgentSessionID: activation.AgentSessionID,

--- a/services/tuttid/service/tuttimodeactivation/service_test.go
+++ b/services/tuttid/service/tuttimodeactivation/service_test.go
@@ -8,7 +8,18 @@ import (
 
 	activationbiz "github.com/tutti-os/tutti/services/tuttid/biz/tuttimodeactivation"
 	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
+	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
 )
+
+type recordingAnalyticsReporter struct {
+	events []reporterservice.Event
+}
+
+func (r *recordingAnalyticsReporter) Track(_ context.Context, events ...reporterservice.Event) {
+	r.events = append(r.events, events...)
+}
+
+func (*recordingAnalyticsReporter) Close() error { return nil }
 
 func TestServiceSetPublishesCommittedIndependentActivation(t *testing.T) {
 	t.Parallel()
@@ -39,6 +50,74 @@ func TestServiceSetPublishesCommittedIndependentActivation(t *testing.T) {
 	}
 	if store.lastSetInput.Effect == nil || *store.lastSetInput.Effect != 73 {
 		t.Fatalf("legacy effect mapping = %#v", store.lastSetInput)
+	}
+}
+
+func TestServiceSetReportsOnlyCommittedActivationChanges(t *testing.T) {
+	t.Parallel()
+	store := newMemoryStore()
+	reporter := &recordingAnalyticsReporter{}
+	service := &Service{Store: store, AnalyticsReporter: reporter}
+
+	active, err := service.Set(context.Background(), SetInput{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1",
+		State: activationbiz.StateActive, Source: activationbiz.SourceSlashCommand,
+	})
+	if err != nil || !active.Changed {
+		t.Fatalf("Set(active) = %#v, %v", active, err)
+	}
+	unchanged, err := service.Set(context.Background(), SetInput{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1",
+		State: activationbiz.StateActive, Source: activationbiz.SourceSlashCommand,
+	})
+	if err != nil || unchanged.Changed {
+		t.Fatalf("Set(no-op) = %#v, %v", unchanged, err)
+	}
+	inactive, err := service.Set(context.Background(), SetInput{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1",
+		State: activationbiz.StateInactive, Source: activationbiz.SourceBadgeRemove,
+	})
+	if err != nil || !inactive.Changed {
+		t.Fatalf("Set(inactive) = %#v, %v", inactive, err)
+	}
+	if _, err := service.Set(context.Background(), SetInput{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1",
+		State: activationbiz.StateActive, Source: activationbiz.SourceBadgeRemove,
+	}); !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("Set(invalid) error = %v", err)
+	}
+
+	if len(reporter.events) != 2 {
+		t.Fatalf("analytics events = %#v, want activate/deactivate only", reporter.events)
+	}
+	for index, want := range []map[string]any{
+		{"action": "activated", "state": "active", "source": "slash_command"},
+		{"action": "deactivated", "state": "inactive", "source": "badge_remove"},
+	} {
+		event := reporter.events[index]
+		if event.Name != "tutti_mode.activation_changed" {
+			t.Fatalf("event[%d] = %#v", index, event)
+		}
+		for key, value := range want {
+			if event.Params[key] != value {
+				t.Fatalf("event[%d].Params[%s] = %#v, want %#v", index, key, event.Params[key], value)
+			}
+		}
+		for _, forbidden := range []string{"workspace_id", "agent_session_id", "activation_id", "effect", "speed"} {
+			if _, exists := event.Params[forbidden]; exists {
+				t.Fatalf("event[%d] leaked %s: %#v", index, forbidden, event)
+			}
+		}
+	}
+	store.setErr = errors.New("store write failed")
+	if _, err := service.Set(context.Background(), SetInput{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1",
+		State: activationbiz.StateActive, Source: activationbiz.SourceSlashCommand,
+	}); err == nil {
+		t.Fatal("Set(store failure) error = nil")
+	}
+	if len(reporter.events) != 2 {
+		t.Fatalf("failed store write emitted analytics: %#v", reporter.events)
 	}
 }
 

--- a/services/tuttid/service/workspaceagent/analytics.go
+++ b/services/tuttid/service/workspaceagent/analytics.go
@@ -1,0 +1,34 @@
+package workspaceagent
+
+import (
+	"context"
+	"strings"
+
+	workspaceagentbiz "github.com/tutti-os/tutti/services/tuttid/biz/workspaceagent"
+	reporterevents "github.com/tutti-os/tutti/services/tuttid/service/reporter/events"
+)
+
+const workspaceAgentConfigurationChangedEvent = "workspace_agent.configuration_changed"
+
+func (s *Service) reportConfigurationChanged(
+	ctx context.Context,
+	action string,
+	agent workspaceagentbiz.Agent,
+) {
+	if s == nil || s.AnalyticsReporter == nil {
+		return
+	}
+	switch action {
+	case "created", "updated", "deleted":
+	default:
+		return
+	}
+	modelConfigSource := "provider_native"
+	if strings.TrimSpace(agent.ModelPlanID) != "" {
+		modelConfigSource = "model_plan"
+	}
+	reporterevents.Track(ctx, s.AnalyticsReporter, workspaceAgentConfigurationChangedEvent, map[string]any{
+		"action":              action,
+		"model_config_source": modelConfigSource,
+	})
+}

--- a/services/tuttid/service/workspaceagent/service.go
+++ b/services/tuttid/service/workspaceagent/service.go
@@ -19,6 +19,7 @@ import (
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 	workspaceagentbiz "github.com/tutti-os/tutti/services/tuttid/biz/workspaceagent"
 	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
+	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
 )
 
 var (
@@ -58,13 +59,14 @@ type ConfigurationChangePublisher interface {
 // strict runtime boundary, while List/Get remain repair-friendly when a
 // referenced Harness target has disappeared.
 type Service struct {
-	Store      Store
-	Targets    TargetResolver
-	Plans      PlanResolver
-	Workspaces WorkspaceResolver
-	Publisher  ConfigurationChangePublisher
-	Now        func() time.Time
-	NewID      func() string
+	Store             Store
+	Targets           TargetResolver
+	Plans             PlanResolver
+	Workspaces        WorkspaceResolver
+	Publisher         ConfigurationChangePublisher
+	AnalyticsReporter reporterservice.Reporter
+	Now               func() time.Time
+	NewID             func() string
 }
 
 type PutInput struct {
@@ -155,6 +157,7 @@ func (s *Service) Create(ctx context.Context, input PutInput) (workspaceagentbiz
 		return workspaceagentbiz.View{}, err
 	}
 	logWorkspaceAgentLifecycle("created", normalized)
+	s.reportConfigurationChanged(ctx, "created", normalized)
 	s.publishConfigurationChanged(ctx, normalized, s.configurationDefaultModel(ctx, normalized), true)
 	return s.view(ctx, normalized)
 }
@@ -188,6 +191,7 @@ func (s *Service) Update(ctx context.Context, input PutInput) (workspaceagentbiz
 		return workspaceagentbiz.View{}, err
 	}
 	logWorkspaceAgentLifecycle("updated", normalized)
+	s.reportConfigurationChanged(ctx, "updated", normalized)
 	resetComposerModel := existing.HarnessAgentTargetID != normalized.HarnessAgentTargetID ||
 		existing.ModelPlanID != normalized.ModelPlanID ||
 		existing.DefaultModel != normalized.DefaultModel ||
@@ -231,6 +235,7 @@ func (s *Service) Delete(ctx context.Context, workspaceID string, agentID string
 	// "agent_target_id.dropped" ingestion warnings back to a user action, so
 	// it logs the full pre-delete configuration rather than a zero-value row.
 	logWorkspaceAgentLifecycle("deleted", existing)
+	s.reportConfigurationChanged(ctx, "deleted", existing)
 	s.publishConfigurationChanged(ctx, existing, "", true)
 	return nil
 }

--- a/services/tuttid/service/workspaceagent/service_test.go
+++ b/services/tuttid/service/workspaceagent/service_test.go
@@ -12,10 +12,12 @@ import (
 	modelplanbiz "github.com/tutti-os/tutti/services/tuttid/biz/modelplan"
 	workspaceagentbiz "github.com/tutti-os/tutti/services/tuttid/biz/workspaceagent"
 	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
+	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
 )
 
 type memoryAgentStore struct {
 	agents map[string]workspaceagentbiz.Agent
+	putErr error
 }
 
 func (*memoryAgentStore) key(workspaceID string, agentID string) string {
@@ -23,6 +25,9 @@ func (*memoryAgentStore) key(workspaceID string, agentID string) string {
 }
 
 func (s *memoryAgentStore) PutWorkspaceAgent(_ context.Context, agent workspaceagentbiz.Agent) error {
+	if s.putErr != nil {
+		return s.putErr
+	}
 	if s.agents == nil {
 		s.agents = map[string]workspaceagentbiz.Agent{}
 	}
@@ -97,6 +102,16 @@ type recordingConfigurationPublisher struct {
 	defaultModel  string
 	resetModel    bool
 }
+
+type recordingAnalyticsReporter struct {
+	events []reporterservice.Event
+}
+
+func (r *recordingAnalyticsReporter) Track(_ context.Context, events ...reporterservice.Event) {
+	r.events = append(r.events, events...)
+}
+
+func (*recordingAnalyticsReporter) Close() error { return nil }
 
 func (p *recordingConfigurationPublisher) PublishAgentModelConfigurationChanged(_ context.Context, workspaceID string, agentTargetIDs []string, defaultModels map[string]string, resetModel bool) error {
 	p.workspaceID = workspaceID
@@ -236,6 +251,77 @@ func TestServiceLogsWorkspaceAgentLifecycleEvents(t *testing.T) {
 
 	if err := service.Delete(context.Background(), "ws", created.Agent.ID); !errors.Is(err, workspacedata.ErrWorkspaceAgentNotFound) {
 		t.Fatalf("Delete() missing agent error = %v, want not found", err)
+	}
+}
+
+func TestServiceReportsCommittedWorkspaceAgentConfigurationChanges(t *testing.T) {
+	service, store := testWorkspaceAgentService()
+	reporter := &recordingAnalyticsReporter{}
+	service.AnalyticsReporter = reporter
+
+	created, err := service.Create(context.Background(), PutInput{
+		WorkspaceID:          "ws",
+		Name:                 "Builder",
+		HarnessAgentTargetID: "local:codex",
+		ModelPlanID:          "mp-one",
+		DefaultModel:         "gpt-5",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if _, err := service.Update(context.Background(), PutInput{
+		WorkspaceID:          "ws",
+		AgentID:              created.Agent.ID,
+		Name:                 "Builder v2",
+		HarnessAgentTargetID: "local:codex",
+	}); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if err := service.Delete(context.Background(), "ws", created.Agent.ID); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	if len(reporter.events) != 3 {
+		t.Fatalf("analytics events = %#v, want create/update/delete", reporter.events)
+	}
+	for index, action := range []string{"created", "updated", "deleted"} {
+		event := reporter.events[index]
+		if event.Name != "workspace_agent.configuration_changed" ||
+			event.Params["action"] != action {
+			t.Fatalf("event[%d] = %#v, want action %q", index, event, action)
+		}
+		if _, exists := event.Params["workspace_agent_id"]; exists {
+			t.Fatalf("event[%d] leaked workspace Agent identity: %#v", index, event)
+		}
+		if _, exists := event.Params["name"]; exists {
+			t.Fatalf("event[%d] leaked workspace Agent name: %#v", index, event)
+		}
+	}
+	if reporter.events[0].Params["model_config_source"] != "model_plan" ||
+		reporter.events[1].Params["model_config_source"] != "provider_native" ||
+		reporter.events[2].Params["model_config_source"] != "provider_native" {
+		t.Fatalf("model configuration sources = %#v", reporter.events)
+	}
+
+	if _, err := service.Create(context.Background(), PutInput{
+		WorkspaceID: "ws",
+		Name:        "Invalid",
+	}); err == nil {
+		t.Fatal("Create(invalid) error = nil")
+	}
+	if len(reporter.events) != 3 {
+		t.Fatalf("invalid create emitted analytics: %#v", reporter.events)
+	}
+	store.putErr = errors.New("store write failed")
+	if _, err := service.Create(context.Background(), PutInput{
+		WorkspaceID:          "ws",
+		Name:                 "Not persisted",
+		HarnessAgentTargetID: "local:codex",
+	}); err == nil {
+		t.Fatal("Create(store failure) error = nil")
+	}
+	if len(reporter.events) != 3 {
+		t.Fatalf("failed store write emitted analytics: %#v", reporter.events)
 	}
 }
 

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -44,10 +44,13 @@ import (
 	managedruntimeservice "github.com/tutti-os/tutti/services/tuttid/service/managedruntime"
 	mobileremoteservice "github.com/tutti-os/tutti/services/tuttid/service/mobileremote"
 	modelgatewayservice "github.com/tutti-os/tutti/services/tuttid/service/modelgateway"
+	modelplanservice "github.com/tutti-os/tutti/services/tuttid/service/modelplan"
 	preferencesservice "github.com/tutti-os/tutti/services/tuttid/service/preferences"
 	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
+	tuttimodeactivationservice "github.com/tutti-os/tutti/services/tuttid/service/tuttimodeactivation"
 	tuttimodeexecutionservice "github.com/tutti-os/tutti/services/tuttid/service/tuttimodeexecution"
 	workspaceservice "github.com/tutti-os/tutti/services/tuttid/service/workspace"
+	workspaceagentservice "github.com/tutti-os/tutti/services/tuttid/service/workspaceagent"
 	tuttitypes "github.com/tutti-os/tutti/services/tuttid/types"
 )
 
@@ -681,6 +684,15 @@ func attachAnalyticsReporter(api *tuttiapi.DaemonAPI, analyticsReporter reporter
 		service.SetAnalyticsReporter(analyticsReporter)
 	}
 	if service, ok := api.PreferencesService.(*preferencesservice.Service); ok {
+		service.AnalyticsReporter = analyticsReporter
+	}
+	if service, ok := api.WorkspaceAgentService.(*workspaceagentservice.Service); ok {
+		service.AnalyticsReporter = analyticsReporter
+	}
+	if service, ok := api.ModelPlanService.(*modelplanservice.Service); ok {
+		service.AnalyticsReporter = analyticsReporter
+	}
+	if service, ok := api.TuttiModeActivationService.(*tuttimodeactivationservice.Service); ok {
 		service.AnalyticsReporter = analyticsReporter
 	}
 }

--- a/services/tuttid/wiring_test.go
+++ b/services/tuttid/wiring_test.go
@@ -8,10 +8,14 @@ import (
 
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+	tuttiapi "github.com/tutti-os/tutti/services/tuttid/api"
 	workspaceagentbiz "github.com/tutti-os/tutti/services/tuttid/biz/workspaceagent"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
+	modelplanservice "github.com/tutti-os/tutti/services/tuttid/service/modelplan"
 	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
+	tuttimodeactivationservice "github.com/tutti-os/tutti/services/tuttid/service/tuttimodeactivation"
 	workspaceservice "github.com/tutti-os/tutti/services/tuttid/service/workspace"
+	workspaceagentservice "github.com/tutti-os/tutti/services/tuttid/service/workspaceagent"
 	tuttitypes "github.com/tutti-os/tutti/services/tuttid/types"
 )
 
@@ -222,6 +226,31 @@ func TestResolveAnalyticsDebugPublisherSkipsDisabledAnalytics(t *testing.T) {
 
 	if got != nil {
 		t.Fatalf("debug publisher = %T, want nil", got)
+	}
+}
+
+func TestAttachAnalyticsReporterWiresTuttiConfigurationAndModeServices(t *testing.T) {
+	reporter := &reporterservice.NoopReporter{}
+	workspaceAgents := &workspaceagentservice.Service{}
+	modelPlans := &modelplanservice.Service{}
+	tuttiModeActivations := &tuttimodeactivationservice.Service{}
+	api := tuttiapi.DaemonAPI{
+		WorkspaceAgentService:      workspaceAgents,
+		ModelPlanService:           modelPlans,
+		TuttiModeActivationService: tuttiModeActivations,
+	}
+
+	attachAnalyticsReporter(&api, reporter)
+
+	if workspaceAgents.AnalyticsReporter != reporter ||
+		modelPlans.AnalyticsReporter != reporter ||
+		tuttiModeActivations.AnalyticsReporter != reporter {
+		t.Fatalf(
+			"reporter wiring: workspace Agent=%T model Plan=%T Tutti Mode=%T",
+			workspaceAgents.AnalyticsReporter,
+			modelPlans.AnalyticsReporter,
+			tuttiModeActivations.AnalyticsReporter,
+		)
 	}
 }
 


### PR DESCRIPTION
## Summary

- report confirmed Workspace Agent and Model Plan configuration changes plus completed Model Plan detection outcomes from tuttid
- add agent and model configuration-source dimensions to canonical root user-Turn terminal events
- attribute actual Tutti Mode use from the immutable, durably accepted Turn snapshot and report durable activation transitions
- keep all new analytics Tutti-only; shared Agent Host consumers such as TSH/VN do not receive these contracts

## Measurement

- Custom Agent adoption: agent_config_source = workspace_agent
- Custom model adoption: model_config_source = model_plan
- Tutti Mode intent: tutti_mode.activation_changed
- Tutti Mode actual use: tutti_mode_state = active on terminal Turn events
- configuration and detection funnels use bounded enums and exclude Agent/Plan names, IDs, endpoints, model names, credentials, preferences, and raw provider errors

## Validation

- pnpm check:changed (6 relevant lanes passed)
- pnpm check:changed -- --push-ready (7 lanes passed)
- focused Workspace Agent, Model Plan, Tutti Mode activation, terminal analytics, SQLite integration, and wiring tests passed
- git diff --check

## Compatibility

- Windows impact: none; the change is platform-neutral reporter and query logic with no path, process, shell, or filesystem behavior
- TSH/VN: unaffected because the reporter wiring and event ownership remain under services/tuttid

## Documentation

- updated docs/architecture/analytics-tracking.md with event contracts, privacy boundaries, and recommended DataFinder adoption metrics
