### PR TITLE
feat(runtimeprep): support explicit provider state homes

### DIFF
--- a/packages/agent/claude-sdk-sidecar/src/options.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/options.test.ts
@@ -91,13 +91,18 @@ test("sidecarClaudeOptionsFromPayload resolves prepared metadata in the sidecar 
   t.after(() => rmSync(runtimeRoot, { recursive: true, force: true }));
   const systemPromptPath = join(runtimeRoot, "claude-system-prompt.md");
   const pluginDir = join(runtimeRoot, "claude-plugin", "tutti-cli");
+  const additionalDirectory = join(runtimeRoot, "claude-personal-skills");
   writeFileSync(systemPromptPath, "Use Tutti CLI for issue context.\n", "utf8");
   mkdirSync(pluginDir, { recursive: true });
+  mkdirSync(additionalDirectory, { recursive: true });
 
   const options = sidecarClaudeOptionsFromPayload({
     env: {
       TUTTI_CLAUDE_SYSTEM_PROMPT_FILE: systemPromptPath,
-      TUTTI_CLAUDE_PLUGIN_DIR: pluginDir
+      TUTTI_CLAUDE_PLUGIN_DIR: pluginDir,
+      TUTTI_CLAUDE_ADDITIONAL_DIRECTORIES_JSON: JSON.stringify([
+        additionalDirectory
+      ])
     },
     extraArgs: { model: "MiniMax-M2.7" }
   });
@@ -109,10 +114,30 @@ test("sidecarClaudeOptionsFromPayload resolves prepared metadata in the sidecar 
     append: "Use Tutti CLI for issue context."
   });
   assert.deepEqual(overrides.plugins, [{ type: "local", path: pluginDir }]);
+  assert.deepEqual(overrides.additionalDirectories, [additionalDirectory]);
   assert.deepEqual(overrides.extraArgs, {
     model: "MiniMax-M2.7",
     "plugin-dir": pluginDir
   });
+});
+
+test("sidecarClaudeOptionsFromPayload rejects invalid additional directories", () => {
+  assert.throws(
+    () =>
+      sidecarClaudeOptionsFromPayload({
+        env: { TUTTI_CLAUDE_ADDITIONAL_DIRECTORIES_JSON: "not-json" }
+      }),
+    /decode claude additional directories/u
+  );
+  assert.throws(
+    () =>
+      sidecarClaudeOptionsFromPayload({
+        env: {
+          TUTTI_CLAUDE_ADDITIONAL_DIRECTORIES_JSON: JSON.stringify(["relative"])
+        }
+      }),
+    /must be absolute/u
+  );
 });
 
 test("sidecarClaudeOptionsFromPayload reports missing prepared metadata", () => {

--- a/packages/agent/claude-sdk-sidecar/src/options.ts
+++ b/packages/agent/claude-sdk-sidecar/src/options.ts
@@ -1,4 +1,5 @@
 import { readFileSync, statSync } from "node:fs";
+import { isAbsolute, normalize } from "node:path";
 import type {
   Options as ClaudeQueryOptions,
   SdkPluginConfig
@@ -6,6 +7,8 @@ import type {
 
 const claudeSystemPromptFileEnv = "TUTTI_CLAUDE_SYSTEM_PROMPT_FILE";
 const claudePluginDirEnv = "TUTTI_CLAUDE_PLUGIN_DIR";
+const claudeAdditionalDirectoriesEnv =
+  "TUTTI_CLAUDE_ADDITIONAL_DIRECTORIES_JSON";
 
 export type ClaudeToolsOption = NonNullable<ClaudeQueryOptions["tools"]>;
 
@@ -14,6 +17,7 @@ export type SidecarClaudeOptions = {
   planModeInstructions: string;
   allowedTools: string[];
   disallowedTools: string[];
+  additionalDirectories: string[];
   plugins: SdkPluginConfig[];
   extraArgs: Record<string, string | null>;
   tools: ClaudeToolsOption;
@@ -28,6 +32,9 @@ export function sidecarClaudeOptionsFromPayload(
   const explicitPlugins = pluginListValue(payload.plugins);
   const extraArgs = stringRecordValue(payload.extraArgs);
   const pluginDir = explicitPlugins.length > 0 ? "" : env[claudePluginDirEnv];
+  const additionalDirectories = claudeAdditionalDirectories(
+    env[claudeAdditionalDirectoriesEnv]
+  );
 
   if (pluginDir) {
     let info;
@@ -51,6 +58,7 @@ export function sidecarClaudeOptionsFromPayload(
     planModeInstructions: stringValue(payload.planModeInstructions),
     allowedTools: stringArrayValue(payload.allowedTools),
     disallowedTools: stringArrayValue(payload.disallowedTools),
+    additionalDirectories,
     plugins:
       explicitPlugins.length > 0
         ? explicitPlugins
@@ -90,6 +98,7 @@ export function claudeQueryOptionOverrides(
   | "allowedTools"
   | "planModeInstructions"
   | "disallowedTools"
+  | "additionalDirectories"
   | "plugins"
   | "extraArgs"
   | "mcpServers"
@@ -112,6 +121,9 @@ export function claudeQueryOptionOverrides(
     ...(options.disallowedTools.length > 0
       ? { disallowedTools: options.disallowedTools }
       : {}),
+    ...(options.additionalDirectories.length > 0
+      ? { additionalDirectories: options.additionalDirectories }
+      : {}),
     ...(options.plugins.length > 0 ? { plugins: options.plugins } : {}),
     ...(Object.keys(options.extraArgs).length > 0
       ? { extraArgs: options.extraArgs }
@@ -120,6 +132,54 @@ export function claudeQueryOptionOverrides(
       ? { mcpServers: options.mcpServers }
       : {})
   };
+}
+
+function claudeAdditionalDirectories(
+  encoded: string | null | undefined
+): string[] {
+  if (!encoded) {
+    return [];
+  }
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(encoded);
+  } catch (error) {
+    throw new Error(
+      `decode claude additional directories: ${errorMessage(error)}`
+    );
+  }
+  if (!Array.isArray(decoded) || decoded.length === 0 || decoded.length > 32) {
+    throw new Error(
+      "claude additional directories must be a non-empty array with at most 32 entries"
+    );
+  }
+  const directories: string[] = [];
+  const seen = new Set<string>();
+  for (const item of decoded) {
+    const directory = normalize(stringValue(item));
+    if (!directory || !isAbsolute(directory)) {
+      throw new Error("claude additional directory must be absolute");
+    }
+    if (seen.has(directory)) {
+      continue;
+    }
+    let info;
+    try {
+      info = statSync(directory);
+    } catch (error) {
+      throw new Error(
+        `stat claude additional directory: ${errorMessage(error)}`
+      );
+    }
+    if (!info.isDirectory()) {
+      throw new Error(
+        `claude additional directory is not a directory: ${directory}`
+      );
+    }
+    seen.add(directory);
+    directories.push(directory);
+  }
+  return directories;
 }
 
 function mcpServersValue(

--- a/packages/agent/runtimeprep/README.md
+++ b/packages/agent/runtimeprep/README.md
@@ -47,12 +47,15 @@ closed on invalid or incompatible config instead of maintaining provider-specifi
 line parsers.
 
 Codex preparation keeps session state isolated under the run-scoped
-`CODEX_HOME`, while linking its writable `models_cache.json` to the provider
-user's process-default `~/.codex/models_cache.json`. The link may initially be
-dangling: the first Codex refresh creates the shared VM- or host-local cache,
-and later sessions reuse it. Hosts must therefore run preparation with `HOME`
-set to the provider user's stable local Home, never a session runtime directory
-or a remote filesystem projection.
+`CODEX_HOME`. Hosts whose provider state does not live under the operating
+system user Home pass its absolute provider-native root through
+`PrepareInput.ProviderStateHome`; runtimeprep uses that root for auth, config,
+models cache, plugins, Skills, and imported rollout validation. An empty value
+preserves the native `~/.codex` default for existing embedders, including its
+existing symlink behavior and the legacy tolerance for an unavailable user
+Home. Strict path and filesystem-shape validation applies only to an explicit
+value. VM-backed hosts must pass the explicit stable root and must not create a
+compatibility facade under the Linux login Home.
 
 Desktop composition also supplies the provider user's stable personal Skill
 root. Runtime preparation exposes that directory directly as

--- a/packages/agent/runtimeprep/README.md
+++ b/packages/agent/runtimeprep/README.md
@@ -66,6 +66,14 @@ Session Skills remain under the run root and are registered through
 `skills/extraRoots/set`; they are never written into the personal root. Hosts
 that do not explicitly supply a personal root keep the isolated layout.
 
+When an embedder supplies both `ProviderStateHome` and a distinct Codex
+`PersonalSkillRoot`, the provider-native `skills/` directory remains an
+explicit app-server Skill root while the personal root is the writable
+`CODEX_HOME/skills` projection. Claude Code can likewise receive a distinct
+`PersonalSkillRoot`; runtimeprep exposes it through a session-scoped SDK
+additional directory whose `.claude/skills` entry points at the stable root.
+Empty personal roots preserve the native Host behavior for both providers.
+
 `TuttiAgentPreparer.ResolveAuthSource` lets a host expose one explicit absolute
 credential authority into the session-scoped `TUTTI_AGENT_HOME`. When omitted,
 the Tutti desktop keeps its existing `~/.tutti-agent/auth.json` behavior. An

--- a/packages/agent/runtimeprep/claude.go
+++ b/packages/agent/runtimeprep/claude.go
@@ -13,6 +13,7 @@ import (
 
 const claudeSystemPromptFileEnv = "TUTTI_CLAUDE_SYSTEM_PROMPT_FILE"
 const claudePluginDirEnv = "TUTTI_CLAUDE_PLUGIN_DIR"
+const claudeAdditionalDirectoriesEnv = "TUTTI_CLAUDE_ADDITIONAL_DIRECTORIES_JSON"
 const claudeSkillListingBudgetEnv = "SLASH_COMMAND_TOOL_CHAR_BUDGET"
 const claudeSkillListingBudgetChars = "20000"
 
@@ -34,6 +35,10 @@ type ClaudeCodePreparer struct {
 	// StateDir is the tutti state root that hosts the managed claude binary
 	// pointer; empty disables the managed-binary fallback.
 	StateDir string
+	// PersonalSkillRoot is an optional stable user Skill root outside Claude's
+	// native config home. It is projected as an SDK additional directory so
+	// Claude loads the Skills with their ordinary, un-namespaced slash commands.
+	PersonalSkillRoot string
 }
 
 func (ClaudeCodePreparer) Provider() string {
@@ -74,6 +79,20 @@ func (p ClaudeCodePreparer) Prepare(_ context.Context, input ProviderPrepareInpu
 			claudePluginDirEnv+"="+pluginDir,
 			claudeSkillListingBudgetEnv+"="+claudeSkillListingBudgetChars,
 		)
+		additionalDirectory, err := prepareClaudePersonalSkillDirectory(input.RuntimeRoot, p.PersonalSkillRoot)
+		if err != nil {
+			return ProviderPrepareResult{}, err
+		}
+		if additionalDirectory != "" {
+			encodedDirectories, err := json.Marshal([]string{additionalDirectory})
+			if err != nil {
+				return ProviderPrepareResult{}, fmt.Errorf("encode Claude additional directories: %w", err)
+			}
+			env = append(env, claudeAdditionalDirectoriesEnv+"="+string(encodedDirectories))
+			if input.Manifest != nil {
+				input.Manifest.RecordManagedFile(additionalDirectory, "provider-personal-skills", true)
+			}
+		}
 	}
 	env = append(env, p.claudeCodeExecutableEnv()...)
 	env = append(env, modelEndpointClaudeEnv(input.ModelEndpoint)...)

--- a/packages/agent/runtimeprep/claude_personal_skill.go
+++ b/packages/agent/runtimeprep/claude_personal_skill.go
@@ -1,0 +1,47 @@
+package runtimeprep
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func prepareClaudePersonalSkillDirectory(runtimeRoot string, personalSkillRoot string) (string, error) {
+	personalSkillRoot = filepath.Clean(strings.TrimSpace(personalSkillRoot))
+	if personalSkillRoot == "." {
+		return "", nil
+	}
+	if !filepath.IsAbs(personalSkillRoot) || personalSkillRoot == string(filepath.Separator) {
+		return "", fmt.Errorf("claude personal skill root must be an absolute non-root path")
+	}
+	if err := os.MkdirAll(personalSkillRoot, 0o700); err != nil {
+		return "", fmt.Errorf("create Claude personal skill root: %w", err)
+	}
+	personalInfo, err := os.Lstat(personalSkillRoot)
+	if err != nil {
+		return "", fmt.Errorf("inspect Claude personal skill root: %w", err)
+	}
+	if personalInfo.Mode()&os.ModeSymlink != 0 || !personalInfo.IsDir() {
+		return "", fmt.Errorf("claude personal skill root must be a real directory: %s", personalSkillRoot)
+	}
+
+	additionalDirectory := filepath.Join(runtimeRoot, "claude-personal-skills")
+	claudeDirectory := filepath.Join(additionalDirectory, ".claude")
+	if err := os.MkdirAll(claudeDirectory, 0o700); err != nil {
+		return "", fmt.Errorf("create Claude personal skill projection: %w", err)
+	}
+	target := filepath.Join(claudeDirectory, "skills")
+	if targetInfo, err := os.Stat(target); err == nil {
+		if os.SameFile(targetInfo, personalInfo) {
+			return additionalDirectory, nil
+		}
+		return "", fmt.Errorf("claude personal skill projection targets a different directory: %s", target)
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("inspect Claude personal skill projection: %w", err)
+	}
+	if err := exposeCodexSharedDirectory(personalSkillRoot, target); err != nil {
+		return "", fmt.Errorf("expose Claude personal skill root: %w", err)
+	}
+	return additionalDirectory, nil
+}

--- a/packages/agent/runtimeprep/claude_test.go
+++ b/packages/agent/runtimeprep/claude_test.go
@@ -96,3 +96,41 @@ func TestClaudeCodeExecutableEnvFallsBackToPathClaude(t *testing.T) {
 		t.Fatalf("env = %v, want PATH fallback %s", env, claudePath)
 	}
 }
+
+func TestClaudePrepareExposesPersonalSkillsAsAdditionalDirectory(t *testing.T) {
+	personalSkillRoot := filepath.Join(t.TempDir(), "shared", "skills")
+	skillPath := filepath.Join(personalSkillRoot, "shared-skill", "SKILL.md")
+	writeSidecarTestFile(t, skillPath, "---\nname: shared-skill\n---\nshared\n")
+
+	preparer := newTestPreparer(t.TempDir())
+	preparer.RegisterProvider(ClaudeCodePreparer{PersonalSkillRoot: personalSkillRoot})
+	prepared, err := preparer.Prepare(t.Context(), PrepareInput{
+		WorkspaceID:    "workspace-1",
+		AgentSessionID: "session-1",
+		AgentTargetID:  "local:claude-code",
+		Provider:       "claude-code",
+		Cwd:            t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var directories []string
+	if err := json.Unmarshal([]byte(envValue(prepared.Env, claudeAdditionalDirectoriesEnv)), &directories); err != nil {
+		t.Fatalf("decode Claude additional directories: %v", err)
+	}
+	if len(directories) != 1 {
+		t.Fatalf("Claude additional directories = %#v, want one projection", directories)
+	}
+	projectedSkill := filepath.Join(directories[0], ".claude", "skills", "shared-skill", "SKILL.md")
+	projectedInfo, err := os.Stat(projectedSkill)
+	if err != nil {
+		t.Fatalf("projected Claude personal Skill missing: %v", err)
+	}
+	sourceInfo, err := os.Stat(skillPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(projectedInfo, sourceInfo) {
+		t.Fatal("Claude personal Skill projection is not backed by the stable source")
+	}
+}

--- a/packages/agent/runtimeprep/codex.go
+++ b/packages/agent/runtimeprep/codex.go
@@ -28,17 +28,22 @@ func (CodexPreparer) Provider() string {
 
 func (p CodexPreparer) Prepare(ctx context.Context, input ProviderPrepareInput) (result ProviderPrepareResult, err error) {
 	codexHome := filepath.Join(input.RuntimeRoot, "codex-home")
+	providerStateHome, err := resolveCodexProviderStateHome(input.PrepareInput)
+	if err != nil {
+		return ProviderPrepareResult{}, err
+	}
 	logRuntimePrepareTrace("runtime_prepare.codex.entered", input.PrepareInput, nil)
 	extraSkillRoots, err := prepareCodexHome(
 		codexHome,
 		filepath.Join(input.RuntimeRoot, "codex-session-skills"),
 		p.PersonalSkillRoot,
+		providerStateHome,
 		input.PrepareInput,
 	)
 	if err != nil {
 		return ProviderPrepareResult{}, err
 	}
-	cleanup, err := projectCodexAuth(ctx, codexHome, p.AuthProjector)
+	cleanup, err := projectCodexAuth(ctx, codexHome, providerStateHome, p.AuthProjector)
 	if err != nil {
 		return ProviderPrepareResult{}, err
 	}
@@ -101,15 +106,11 @@ func (p CodexPreparer) Prepare(ctx context.Context, input ProviderPrepareInput) 
 	}, nil
 }
 
-func projectCodexAuth(ctx context.Context, codexHome string, projector AuthFileProjector) (func(context.Context) error, error) {
-	if projector == nil {
+func projectCodexAuth(ctx context.Context, codexHome, providerStateHome string, projector AuthFileProjector) (func(context.Context) error, error) {
+	if projector == nil || strings.TrimSpace(providerStateHome) == "" {
 		return nil, nil
 	}
-	userHome, err := os.UserHomeDir()
-	if err != nil || strings.TrimSpace(userHome) == "" {
-		return nil, nil
-	}
-	source := filepath.Join(userHome, ".codex", "auth.json")
+	source := filepath.Join(providerStateHome, "auth.json")
 	if _, err := os.Stat(source); err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -137,6 +138,7 @@ func prepareCodexHome(
 	codexHome string,
 	sessionSkillRoot string,
 	personalSkillRoot string,
+	providerStateHome string,
 	input PrepareInput,
 ) ([]string, error) {
 	var extraSkillRoots []string
@@ -146,12 +148,12 @@ func prepareCodexHome(
 	}
 	logRuntimePrepareTrace("runtime_prepare.codex.home_dir_resolved", input, nil)
 	logRuntimePrepareTrace("runtime_prepare.codex.user_files_requested", input, nil)
-	if err := exposeUserCodexFiles(codexHome); err != nil {
+	if err := exposeUserCodexFiles(codexHome, providerStateHome); err != nil {
 		return nil, err
 	}
 	logRuntimePrepareTrace("runtime_prepare.codex.user_files_resolved", input, nil)
 	logRuntimePrepareTrace("runtime_prepare.codex.imported_rollout_requested", input, nil)
-	if err := exposeCodexImportedRolloutFile(codexHome, input.ExternalRolloutSourcePath); err != nil {
+	if err := exposeCodexImportedRolloutFile(codexHome, providerStateHome, input.ExternalRolloutSourcePath); err != nil {
 		return nil, err
 	}
 	logRuntimePrepareTrace("runtime_prepare.codex.imported_rollout_resolved", input, nil)
@@ -163,7 +165,7 @@ func prepareCodexHome(
 	if !input.SkipSkills {
 		logRuntimePrepareTrace("runtime_prepare.codex.user_skills_requested", input, nil)
 		if strings.TrimSpace(personalSkillRoot) == "" {
-			if err := exposeUserCodexSkillFolders(filepath.Join(codexHome, "skills"), input); err != nil {
+			if err := exposeUserCodexSkillFolders(filepath.Join(codexHome, "skills"), providerStateHome, input); err != nil {
 				return nil, err
 			}
 		} else if err := exposePersonalCodexSkillRoot(
@@ -252,12 +254,10 @@ func codexApprovalRule(pattern []string) string {
 		"], decision=\"allow\")\n"
 }
 
-func exposeUserCodexFiles(codexHome string) error {
-	userHome, err := os.UserHomeDir()
-	if err != nil || strings.TrimSpace(userHome) == "" {
+func exposeUserCodexFiles(codexHome, userCodexHome string) error {
+	if strings.TrimSpace(userCodexHome) == "" {
 		return nil
 	}
-	userCodexHome := filepath.Join(userHome, ".codex")
 	for _, name := range []string{"auth.json"} {
 		source := filepath.Join(userCodexHome, name)
 		if _, err := os.Stat(source); err != nil {
@@ -290,14 +290,14 @@ func exposeUserCodexFiles(codexHome string) error {
 
 // exposeCodexImportedRolloutFile symlinks the single Codex CLI rollout
 // (conversation transcript) file that an imported session was read from into
-// the sandboxed CODEX_HOME, at the same path it has relative to the real
-// `~/.codex` tree (e.g. `sessions/2026/07/04/rollout-...jsonl` or
+// the sandboxed CODEX_HOME, at the same path it has relative to the stable
+// provider state home (e.g. `sessions/2026/07/04/rollout-...jsonl` or
 // `archived_sessions/...`). Codex CLI resolves rollouts for `thread/resume`
 // relative to CODEX_HOME, so mirroring the real relative layout lets it find
 // the transcript by thread id without needing this code to know or guess
 // Codex's internal sharding/naming scheme, and without exposing any other
-// unrelated conversation under ~/.codex/sessions into a sandbox scoped to
-// this one session/run.
+// unrelated conversation under the provider sessions directory into a
+// sandbox scoped to this one session/run.
 //
 // sourcePath is empty for every non-imported session, so this is a no-op for
 // the overwhelming majority of sessions. When it is set but the file can't be
@@ -306,19 +306,14 @@ func exposeUserCodexFiles(codexHome string) error {
 // time), this intentionally returns nil rather than an error: resume still
 // falls back to the existing documented "recreatable" path (a fresh thread
 // with a visible notice) exactly as it did before this file existed.
-func exposeCodexImportedRolloutFile(codexHome string, sourcePath string) error {
+func exposeCodexImportedRolloutFile(codexHome, userCodexHome, sourcePath string) error {
 	sourcePath = strings.TrimSpace(sourcePath)
-	if sourcePath == "" {
+	if sourcePath == "" || strings.TrimSpace(userCodexHome) == "" {
 		return nil
 	}
-	userHome, err := os.UserHomeDir()
-	if err != nil || strings.TrimSpace(userHome) == "" {
-		return nil
-	}
-	userCodexHome := filepath.Join(userHome, ".codex")
 	rel, err := filepath.Rel(userCodexHome, sourcePath)
 	if err != nil || rel == ".." || rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		// Not under the real ~/.codex tree we know how to mirror - leave it to
+		// Not under the stable provider state tree we know how to mirror - leave it to
 		// the recreate fallback rather than guessing at a different layout.
 		return nil
 	}
@@ -439,7 +434,7 @@ func ensureCodexSessionConfig(configPath string, input PrepareInput) error {
 // codexConfigWithTuttiWindowsSandbox pins Tutti-owned Codex session homes to
 // the unelevated Windows sandbox implementation. This is intentionally applied
 // only on Windows and only to the copied per-session config, never to the
-// user's global ~/.codex/config.toml.
+// provider's stable global config.toml.
 func codexConfigWithTuttiWindowsSandbox(content string) (string, bool) {
 	if runtime.GOOS != "windows" {
 		return content, false
@@ -771,12 +766,11 @@ func codexConfigStringAssignmentValueAt(lines []string, index int, key string) (
 	return "", index, false
 }
 
-func exposeUserCodexSkillFolders(targetRoot string, input PrepareInput) error {
-	userHome, err := os.UserHomeDir()
-	if err != nil || strings.TrimSpace(userHome) == "" {
+func exposeUserCodexSkillFolders(targetRoot, providerStateHome string, input PrepareInput) error {
+	if strings.TrimSpace(providerStateHome) == "" {
 		return nil
 	}
-	sourceRoot := filepath.Join(userHome, ".codex", "skills")
+	sourceRoot := filepath.Join(providerStateHome, "skills")
 	entries, err := os.ReadDir(sourceRoot)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/packages/agent/runtimeprep/codex.go
+++ b/packages/agent/runtimeprep/codex.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -168,12 +167,21 @@ func prepareCodexHome(
 			if err := exposeUserCodexSkillFolders(filepath.Join(codexHome, "skills"), providerStateHome, input); err != nil {
 				return nil, err
 			}
-		} else if err := exposePersonalCodexSkillRoot(
-			filepath.Join(codexHome, "skills"),
-			personalSkillRoot,
-			sessionSkillRoot,
-		); err != nil {
-			return nil, err
+		} else {
+			if err := exposePersonalCodexSkillRoot(
+				filepath.Join(codexHome, "skills"),
+				personalSkillRoot,
+				sessionSkillRoot,
+			); err != nil {
+				return nil, err
+			}
+			providerSkillRoot, err := distinctCodexProviderSkillRoot(providerStateHome, personalSkillRoot)
+			if err != nil {
+				return nil, err
+			}
+			if providerSkillRoot != "" {
+				extraSkillRoots = append(extraSkillRoots, providerSkillRoot)
+			}
 		}
 		logRuntimePrepareTrace("runtime_prepare.codex.user_skills_resolved", input, nil)
 		logRuntimePrepareTrace("runtime_prepare.codex.native_skills_requested", input, nil)
@@ -195,7 +203,7 @@ func prepareCodexHome(
 			"skill_count": len(skillPaths),
 		})
 		if strings.TrimSpace(personalSkillRoot) != "" && len(skillPaths) > 0 {
-			extraSkillRoots = []string{nativeSkillRoot}
+			extraSkillRoots = append(extraSkillRoots, nativeSkillRoot)
 		}
 	}
 	logRuntimePrepareTrace("runtime_prepare.codex.approval_rules_requested", input, nil)
@@ -767,86 +775,6 @@ func codexConfigStringAssignmentValueAt(lines []string, index int, key string) (
 		builder.WriteString(lineValue)
 	}
 	return "", index, false
-}
-
-func exposeUserCodexSkillFolders(targetRoot, providerStateHome string, input PrepareInput) error {
-	if strings.TrimSpace(providerStateHome) == "" {
-		return nil
-	}
-	sourceRoot := filepath.Join(providerStateHome, "skills")
-	entries, err := os.ReadDir(sourceRoot)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("read user codex skills: %w", err)
-	}
-	if err := os.MkdirAll(targetRoot, 0o755); err != nil {
-		return fmt.Errorf("create codex skills directory: %w", err)
-	}
-	for _, entry := range entries {
-		name := strings.TrimSpace(entry.Name())
-		if name == "" || strings.HasPrefix(name, ".") {
-			continue
-		}
-		if shouldSkipUserCodexSkillForTuttiBrowserUse(name, input) {
-			continue
-		}
-		source := filepath.Join(sourceRoot, name)
-		sourceInfo, err := os.Stat(source)
-		if err != nil || !sourceInfo.IsDir() {
-			continue
-		}
-		skillPath := filepath.Join(source, "SKILL.md")
-		skillInfo, err := os.Stat(skillPath)
-		if err != nil || skillInfo.IsDir() {
-			continue
-		}
-		if !hasDelimitedSkillFrontmatter(skillPath) {
-			slog.Warn(
-				"user codex skill skipped; invalid frontmatter",
-				"error_code", "skill_frontmatter_invalid",
-				"skillName", name,
-				"skillPath", skillPath,
-				"reason", "missing_delimited_yaml_frontmatter",
-			)
-			continue
-		}
-		target := filepath.Join(targetRoot, name)
-		if _, err := os.Lstat(target); err == nil {
-			continue
-		} else if !os.IsNotExist(err) {
-			return fmt.Errorf("inspect codex skill %s: %w", name, err)
-		}
-		if err := exposeCodexDirectory(source, target); err != nil {
-			return fmt.Errorf("expose codex skill %s: %w", name, err)
-		}
-	}
-	return nil
-}
-
-func hasDelimitedSkillFrontmatter(path string) bool {
-	content, err := os.ReadFile(path)
-	if err != nil {
-		return false
-	}
-	lines := strings.Split(string(content), "\n")
-	if len(lines) == 0 || strings.TrimSpace(strings.TrimPrefix(lines[0], "\ufeff")) != "---" {
-		return false
-	}
-	for _, line := range lines[1:] {
-		if strings.TrimSpace(line) == "---" {
-			return true
-		}
-	}
-	return false
-}
-
-func shouldSkipUserCodexSkillForTuttiBrowserUse(name string, input PrepareInput) bool {
-	if !input.BrowserUse || !BrowserUseDefaultEnabled() {
-		return false
-	}
-	return strings.EqualFold(strings.TrimSpace(name), "browser")
 }
 
 func copyFile(source string, target string, mode os.FileMode) error {

--- a/packages/agent/runtimeprep/codex_provider_state_home.go
+++ b/packages/agent/runtimeprep/codex_provider_state_home.go
@@ -1,0 +1,37 @@
+package runtimeprep
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func resolveCodexProviderStateHome(input PrepareInput) (string, error) {
+	configured := strings.TrimSpace(input.ProviderStateHome)
+	if configured == "" {
+		userHome, err := os.UserHomeDir()
+		if err != nil || strings.TrimSpace(userHome) == "" {
+			// Preserve the existing Host behavior: an unavailable native user
+			// home omits optional Codex state projection without preventing the
+			// run-scoped runtime from being prepared.
+			return "", nil
+		}
+		// The implicit Host path keeps native filesystem semantics, including
+		// an existing ~/.codex symlink. Strict shape checks below apply only to
+		// an embedder-provided provider state root.
+		return filepath.Join(userHome, ".codex"), nil
+	}
+	configured = filepath.Clean(configured)
+	if !filepath.IsAbs(configured) || configured == string(filepath.Separator) {
+		return "", fmt.Errorf("codex provider state home must be an absolute non-root path: %q", input.ProviderStateHome)
+	}
+	info, err := os.Lstat(configured)
+	if err != nil {
+		return "", fmt.Errorf("inspect Codex provider state home: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return "", fmt.Errorf("codex provider state home must be a real directory: %s", configured)
+	}
+	return configured, nil
+}

--- a/packages/agent/runtimeprep/codex_provider_state_home_test.go
+++ b/packages/agent/runtimeprep/codex_provider_state_home_test.go
@@ -1,11 +1,61 @@
 package runtimeprep
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestCodexPrepareExposesStableProviderAndPersonalSkillRoots(t *testing.T) {
+	providerStateHome := filepath.Join(t.TempDir(), "codex-state")
+	personalSkillRoot := filepath.Join(t.TempDir(), "personal-skills")
+	writeSidecarTestFile(t, filepath.Join(providerStateHome, "skills", "provider-skill", "SKILL.md"), "---\nname: provider-skill\n---\nprovider\n")
+	writeSidecarTestFile(t, filepath.Join(personalSkillRoot, "personal-skill", "SKILL.md"), "---\nname: personal-skill\n---\npersonal\n")
+
+	preparer := newTestPreparer(t.TempDir())
+	preparer.RegisterProvider(CodexPreparer{PersonalSkillRoot: personalSkillRoot})
+	prepared, err := preparer.Prepare(t.Context(), PrepareInput{
+		WorkspaceID:       "workspace-1",
+		AgentSessionID:    "session-1",
+		AgentTargetID:     "local:codex",
+		Provider:          "codex",
+		ProviderStateHome: providerStateHome,
+		Cwd:               t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runHome := envValue(prepared.Env, "CODEX_HOME")
+	for _, path := range []string{
+		filepath.Join(runHome, "skills", "personal-skill", "SKILL.md"),
+		filepath.Join(providerStateHome, "skills", "provider-skill", "SKILL.md"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("prepared Skill %s is unavailable: %v", path, err)
+		}
+	}
+	var extraRoots []string
+	if err := json.Unmarshal([]byte(envValue(prepared.Env, tuttiAgentExtraSkillRootsEnv)), &extraRoots); err != nil {
+		t.Fatalf("decode Codex extra skill roots: %v", err)
+	}
+	wantProviderRoot := filepath.Join(providerStateHome, "skills")
+	foundProviderRoot := false
+	for _, root := range extraRoots {
+		foundProviderRoot = foundProviderRoot || root == wantProviderRoot
+	}
+	if !foundProviderRoot {
+		t.Fatalf("Codex extra skill roots = %#v, want stable provider root %q", extraRoots, wantProviderRoot)
+	}
+	cacheTarget, err := os.Readlink(filepath.Join(runHome, "models_cache.json"))
+	if err != nil {
+		t.Fatalf("read run-scoped models cache link: %v", err)
+	}
+	if want := filepath.Join(providerStateHome, "models_cache.json"); cacheTarget != want {
+		t.Fatalf("models cache link = %q, want %q", cacheTarget, want)
+	}
+}
 
 func TestCodexPrepareUsesExplicitProviderStateHome(t *testing.T) {
 	hostHome := t.TempDir()

--- a/packages/agent/runtimeprep/codex_provider_state_home_test.go
+++ b/packages/agent/runtimeprep/codex_provider_state_home_test.go
@@ -1,0 +1,138 @@
+package runtimeprep
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCodexPrepareUsesExplicitProviderStateHome(t *testing.T) {
+	hostHome := t.TempDir()
+	setTestHome(t, hostHome)
+	providerStateHome := filepath.Join(t.TempDir(), "codex-state")
+	if err := os.MkdirAll(providerStateHome, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(providerStateHome, "auth.json"), []byte("{\"token\":\"stable\"}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(providerStateHome, "config.toml"), []byte("model = \"stable-model\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeSidecarTestFile(t, filepath.Join(providerStateHome, "skills", "stable-skill", "SKILL.md"), "---\nname: stable-skill\n---\nstable\n")
+
+	prepared, err := newTestPreparer(t.TempDir()).Prepare(t.Context(), PrepareInput{
+		WorkspaceID:       "workspace-1",
+		AgentSessionID:    "session-1",
+		AgentTargetID:     "local:codex",
+		Provider:          "codex",
+		ProviderStateHome: providerStateHome,
+		Cwd:               t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runHome := envValue(prepared.Env, "CODEX_HOME")
+	if runHome == "" {
+		t.Fatalf("prepared env = %#v, want CODEX_HOME", prepared.Env)
+	}
+	auth, err := os.ReadFile(filepath.Join(runHome, "auth.json"))
+	if err != nil || !strings.Contains(string(auth), "stable") {
+		t.Fatalf("run auth = %q, err=%v", auth, err)
+	}
+	config, err := os.ReadFile(filepath.Join(runHome, "config.toml"))
+	if err != nil || !strings.Contains(string(config), "stable-model") {
+		t.Fatalf("run config = %q, err=%v", config, err)
+	}
+	if _, err := os.Stat(filepath.Join(runHome, "skills", "stable-skill", "SKILL.md")); err != nil {
+		t.Fatalf("stable provider skill missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(hostHome, ".codex")); !os.IsNotExist(err) {
+		t.Fatalf("legacy user HOME was consulted or materialized: %v", err)
+	}
+}
+
+func TestCodexPrepareRejectsInvalidExplicitProviderStateHome(t *testing.T) {
+	type invalidHomeTest struct {
+		name     string
+		home     string
+		wantText string
+	}
+	tests := []invalidHomeTest{
+		{name: "relative", home: "relative/codex", wantText: "absolute non-root path"},
+		{name: "root", home: string(filepath.Separator), wantText: "absolute non-root path"},
+		{name: "missing", home: filepath.Join(t.TempDir(), "missing"), wantText: "inspect Codex provider state home"},
+	}
+	symlinkHome := filepath.Join(t.TempDir(), "codex-symlink")
+	if err := os.Symlink(t.TempDir(), symlinkHome); err == nil {
+		tests = append(tests, invalidHomeTest{name: "symlink", home: symlinkHome, wantText: "must be a real directory"})
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := newTestPreparer(t.TempDir()).Prepare(t.Context(), PrepareInput{
+				WorkspaceID:       "workspace-1",
+				AgentSessionID:    "session-1",
+				AgentTargetID:     "local:codex",
+				Provider:          "codex",
+				ProviderStateHome: tc.home,
+				Cwd:               t.TempDir(),
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.wantText) {
+				t.Fatalf("Prepare() error = %v, want substring %q", err, tc.wantText)
+			}
+		})
+	}
+}
+
+func TestCodexPrepareWithoutProviderStateHomePreservesNativeSymlink(t *testing.T) {
+	hostHome := t.TempDir()
+	nativeCodexHome := filepath.Join(t.TempDir(), "native-codex")
+	if err := os.MkdirAll(nativeCodexHome, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(nativeCodexHome, filepath.Join(hostHome, ".codex")); err != nil {
+		t.Skipf("native Codex home symlink is unavailable: %v", err)
+	}
+	setTestHome(t, hostHome)
+	if err := os.WriteFile(filepath.Join(nativeCodexHome, "config.toml"), []byte("model = \"native-model\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	prepared, err := newTestPreparer(t.TempDir()).Prepare(t.Context(), PrepareInput{
+		WorkspaceID:    "workspace-1",
+		AgentSessionID: "session-1",
+		AgentTargetID:  "local:codex",
+		Provider:       "codex",
+		Cwd:            t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	config, err := os.ReadFile(filepath.Join(envValue(prepared.Env, "CODEX_HOME"), "config.toml"))
+	if err != nil || !strings.Contains(string(config), "native-model") {
+		t.Fatalf("run config = %q, err=%v", config, err)
+	}
+}
+
+func TestCodexPrepareWithoutProviderStateHomeToleratesUnavailableUserHome(t *testing.T) {
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
+		t.Skipf("platform still resolves a native user Home at %q", home)
+	}
+
+	prepared, err := newTestPreparer(t.TempDir()).Prepare(t.Context(), PrepareInput{
+		WorkspaceID:    "workspace-1",
+		AgentSessionID: "session-1",
+		AgentTargetID:  "local:codex",
+		Provider:       "codex",
+		Cwd:            t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Prepare() should preserve the legacy no-Home behavior: %v", err)
+	}
+	if envValue(prepared.Env, "CODEX_HOME") == "" {
+		t.Fatalf("prepared env = %#v, want run-scoped CODEX_HOME", prepared.Env)
+	}
+}

--- a/packages/agent/runtimeprep/codex_skill_roots.go
+++ b/packages/agent/runtimeprep/codex_skill_roots.go
@@ -1,0 +1,115 @@
+package runtimeprep
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func exposeUserCodexSkillFolders(targetRoot, providerStateHome string, input PrepareInput) error {
+	if strings.TrimSpace(providerStateHome) == "" {
+		return nil
+	}
+	sourceRoot := filepath.Join(providerStateHome, "skills")
+	entries, err := os.ReadDir(sourceRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read user codex skills: %w", err)
+	}
+	if err := os.MkdirAll(targetRoot, 0o755); err != nil {
+		return fmt.Errorf("create codex skills directory: %w", err)
+	}
+	for _, entry := range entries {
+		name := strings.TrimSpace(entry.Name())
+		if name == "" || strings.HasPrefix(name, ".") {
+			continue
+		}
+		if shouldSkipUserCodexSkillForTuttiBrowserUse(name, input) {
+			continue
+		}
+		source := filepath.Join(sourceRoot, name)
+		sourceInfo, err := os.Stat(source)
+		if err != nil || !sourceInfo.IsDir() {
+			continue
+		}
+		skillPath := filepath.Join(source, "SKILL.md")
+		skillInfo, err := os.Stat(skillPath)
+		if err != nil || skillInfo.IsDir() {
+			continue
+		}
+		if !hasDelimitedSkillFrontmatter(skillPath) {
+			slog.Warn(
+				"user codex skill skipped; invalid frontmatter",
+				"error_code", "skill_frontmatter_invalid",
+				"skillName", name,
+				"skillPath", skillPath,
+				"reason", "missing_delimited_yaml_frontmatter",
+			)
+			continue
+		}
+		target := filepath.Join(targetRoot, name)
+		if _, err := os.Lstat(target); err == nil {
+			continue
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("inspect codex skill %s: %w", name, err)
+		}
+		if err := exposeCodexDirectory(source, target); err != nil {
+			return fmt.Errorf("expose codex skill %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func hasDelimitedSkillFrontmatter(path string) bool {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	lines := strings.Split(string(content), "\n")
+	if len(lines) == 0 || strings.TrimSpace(strings.TrimPrefix(lines[0], "\ufeff")) != "---" {
+		return false
+	}
+	for _, line := range lines[1:] {
+		if strings.TrimSpace(line) == "---" {
+			return true
+		}
+	}
+	return false
+}
+
+func shouldSkipUserCodexSkillForTuttiBrowserUse(name string, input PrepareInput) bool {
+	if !input.BrowserUse || !BrowserUseDefaultEnabled() {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(name), "browser")
+}
+
+func distinctCodexProviderSkillRoot(providerStateHome string, personalSkillRoot string) (string, error) {
+	providerStateHome = strings.TrimSpace(providerStateHome)
+	if providerStateHome == "" {
+		return "", nil
+	}
+	providerSkillRoot := filepath.Join(providerStateHome, "skills")
+	providerInfo, err := os.Stat(providerSkillRoot)
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("inspect Codex provider skill root: %w", err)
+	}
+	if !providerInfo.IsDir() {
+		return "", fmt.Errorf("codex provider skill root is not a directory: %s", providerSkillRoot)
+	}
+	personalInfo, err := os.Stat(filepath.Clean(strings.TrimSpace(personalSkillRoot)))
+	if err == nil && os.SameFile(providerInfo, personalInfo) {
+		return "", nil
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("inspect Codex personal skill root: %w", err)
+	}
+	return providerSkillRoot, nil
+}

--- a/packages/agent/runtimeprep/preparer_test.go
+++ b/packages/agent/runtimeprep/preparer_test.go
@@ -2375,7 +2375,7 @@ func TestExposeCodexImportedRolloutFileSymlinksMatchingRelativePath(t *testing.T
 	writeSidecarTestFile(t, sourcePath, `{"type":"session_meta"}`)
 
 	codexHome := t.TempDir()
-	if err := exposeCodexImportedRolloutFile(codexHome, sourcePath); err != nil {
+	if err := exposeCodexImportedRolloutFile(codexHome, filepath.Join(home, ".codex"), sourcePath); err != nil {
 		t.Fatalf("exposeCodexImportedRolloutFile() error = %v", err)
 	}
 
@@ -2402,7 +2402,7 @@ func TestExposeCodexImportedRolloutFileNoopWhenSourcePathEmpty(t *testing.T) {
 	home := t.TempDir()
 	setTestHome(t, home)
 	codexHome := t.TempDir()
-	if err := exposeCodexImportedRolloutFile(codexHome, ""); err != nil {
+	if err := exposeCodexImportedRolloutFile(codexHome, filepath.Join(home, ".codex"), ""); err != nil {
 		t.Fatalf("exposeCodexImportedRolloutFile() error = %v", err)
 	}
 	entries, err := os.ReadDir(codexHome)
@@ -2420,7 +2420,7 @@ func TestExposeCodexImportedRolloutFileGracefulWhenSourceFileMissing(t *testing.
 	sourcePath := filepath.Join(home, ".codex", "sessions", "2026", "07", "04", "rollout-gone.jsonl")
 
 	codexHome := t.TempDir()
-	if err := exposeCodexImportedRolloutFile(codexHome, sourcePath); err != nil {
+	if err := exposeCodexImportedRolloutFile(codexHome, filepath.Join(home, ".codex"), sourcePath); err != nil {
 		t.Fatalf("exposeCodexImportedRolloutFile() error = %v, want graceful nil when source is gone", err)
 	}
 	if _, err := os.Lstat(filepath.Join(codexHome, "sessions", "2026", "07", "04", "rollout-gone.jsonl")); !os.IsNotExist(err) {
@@ -2435,7 +2435,7 @@ func TestExposeCodexImportedRolloutFileGracefulWhenSourceOutsideRealCodexHome(t 
 	writeSidecarTestFile(t, outsidePath, `{"type":"session_meta"}`)
 
 	codexHome := t.TempDir()
-	if err := exposeCodexImportedRolloutFile(codexHome, outsidePath); err != nil {
+	if err := exposeCodexImportedRolloutFile(codexHome, filepath.Join(home, ".codex"), outsidePath); err != nil {
 		t.Fatalf("exposeCodexImportedRolloutFile() error = %v, want graceful nil for a path outside ~/.codex", err)
 	}
 	entries, err := os.ReadDir(codexHome)

--- a/packages/agent/runtimeprep/types.go
+++ b/packages/agent/runtimeprep/types.go
@@ -35,6 +35,11 @@ type PrepareInput struct {
 	AgentTargetID  string
 	Provider       string
 	Cwd            string
+	// ProviderStateHome is the provider-native stable state root used as the
+	// source for session preparation. For Codex this is the process-default
+	// CODEX_HOME. Empty preserves the host user's legacy native-Home behavior;
+	// VM-backed hosts should always pass an explicit absolute path.
+	ProviderStateHome string
 	// SkipSkills keeps provider preparation limited to the runtime data needed
 	// by a model-only probe. It must not be used when launching a live Agent
 	// Session or when the caller needs the provider's Skill catalog.
@@ -110,8 +115,8 @@ type PrepareInput struct {
 	commandCapabilities *CommandResolver
 	// ExternalRolloutSourcePath is the absolute path to the original provider
 	// CLI rollout/transcript file this session was imported from (Codex CLI's
-	// own on-disk conversation transcript under the user's real
-	// `~/.codex/sessions/...`), when known. It lets a provider preparer expose
+	// own on-disk conversation transcript under the provider's stable
+	// `sessions/...` tree), when known. It lets a provider preparer expose
 	// that one specific file into the sandboxed provider home so a native
 	// `thread/resume` can find it, without exposing any other unrelated
 	// conversation. Empty for non-imported sessions or when the source path


### PR DESCRIPTION
## Summary

- allow embedders to provide an explicit stable Codex provider state home while preserving the native host `~/.codex` behavior when unset
- expose both provider-native and embedder-owned Codex skill roots through the app-server extra-roots contract
- project Claude personal skills through a session-scoped additional directory and forward it to the Claude SDK
- keep the shared skill projection live across sessions, including the existing Windows symlink/junction boundary

This lets VM-backed hosts keep provider state outside the Linux user home without changing Tutti's normal host-local agent behavior.

## Verification

- `go test ./packages/agent/runtimeprep`
- `pnpm --filter @tutti-os/claude-sdk-sidecar test`
- `pnpm --filter @tutti-os/claude-sdk-sidecar typecheck`
- real Linux VM smoke: Codex app-server reported 64 visible skills; Claude launched with the projected additional directory
- local `pnpm check:changed -- --push-ready` repeatedly completed 59/60 lanes; the remaining lane was an unrelated, timing-sensitive existing `services/tuttid` test and changed between runs. PR CI is the authoritative clean-run gate.

Windows impact: path validation uses native `filepath` semantics, and the stable writable skill projection reuses the existing Windows symlink-or-junction implementation rather than copying or introducing POSIX-only paths.

## Checklist

- [x] This PR does not change agent lifecycle semantics; it changes provider runtime preparation and SDK launch projection only.
- [x] I kept the change focused on one concern.
- [x] I updated runtimeprep documentation for the new embedder contract.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required.
