### PR TITLE
fix(computer): accept usable Windows fallback

### DIFF
--- a/docs/conventions/troubleshooting/computer-use.md
+++ b/docs/conventions/troubleshooting/computer-use.md
@@ -104,10 +104,11 @@ the installed driver can perform the core Win32 actions.
 
 The Windows doctor probes both the optional UIA adapter and the native Win32
 path. A broken accessibility provider can make the optional probe slow or
-degraded even when native input remains usable. The desktop bounds the doctor
-process at 10 seconds, classifies the explicit UIA-to-Win32 fallback as a
-degraded-but-usable result, and preserves its diagnostic message with reason
-`driver-doctor-failed`. A real timeout, malformed response, or missing driver
+degraded even when native input remains usable. The desktop and daemon bound
+the doctor process at 10 seconds and classify the explicit UIA-to-Win32
+fallback as a degraded-but-usable result. The desktop preserves its diagnostic
+message with reason `driver-doctor-failed`, while the daemon keeps host-managed
+computer tools available. A real timeout, malformed response, or missing driver
 remains an unknown/not-ready result; do not silently treat those as healthy.
 
 ### Validation

--- a/services/tuttid/service/computer/permissions.go
+++ b/services/tuttid/service/computer/permissions.go
@@ -84,22 +84,58 @@ func checkComputerPermissions(ctx context.Context, executable string) error {
 }
 
 type windowsDriverDoctor struct {
-	OK bool `json:"ok"`
+	OK      bool   `json:"ok"`
+	Message string `json:"message"`
+	Reason  string `json:"reason"`
+	Probes  []struct {
+		Message string `json:"message"`
+		Detail  string `json:"detail"`
+	} `json:"probes"`
 }
 
 func checkWindowsDriver(ctx context.Context, executable string) error {
 	output, err := exec.CommandContext(ctx, executable, "doctor", "--json").CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("cua-driver doctor failed: %w%s", err, stderrSuffix(output))
+	return evaluateWindowsDriverDoctor(output, err, ctx.Err())
+}
+
+func evaluateWindowsDriverDoctor(output []byte, commandErr, contextErr error) error {
+	// A timed-out or cancelled probe is never usable, even if its partial output
+	// happens to contain the fallback diagnostic.
+	if contextErr != nil {
+		return fmt.Errorf("cua-driver doctor failed: %w%s", contextErr, stderrSuffix(output))
 	}
 	doctor, err := parseWindowsDriverDoctor(output)
 	if err != nil {
+		if commandErr != nil {
+			return fmt.Errorf("cua-driver doctor failed: %w%s", commandErr, stderrSuffix(output))
+		}
 		return err
 	}
-	if !doctor.OK {
-		return errors.New("cua-driver Windows desktop readiness check failed")
+	if doctor.hasUsableWin32Fallback() {
+		return nil
 	}
-	return nil
+	if commandErr != nil {
+		return fmt.Errorf("cua-driver doctor failed: %w%s", commandErr, stderrSuffix(output))
+	}
+	if doctor.OK {
+		return nil
+	}
+	return errors.New("cua-driver Windows desktop readiness check failed")
+}
+
+func (doctor windowsDriverDoctor) hasUsableWin32Fallback() bool {
+	const fallbackDiagnostic = "falling back to win32-only window tools"
+	if strings.Contains(strings.ToLower(doctor.Message), fallbackDiagnostic) ||
+		strings.Contains(strings.ToLower(doctor.Reason), fallbackDiagnostic) {
+		return true
+	}
+	for _, probe := range doctor.Probes {
+		if strings.Contains(strings.ToLower(probe.Message), fallbackDiagnostic) ||
+			strings.Contains(strings.ToLower(probe.Detail), fallbackDiagnostic) {
+			return true
+		}
+	}
+	return false
 }
 
 func parseWindowsDriverDoctor(output []byte) (windowsDriverDoctor, error) {

--- a/services/tuttid/service/computer/permissions_test.go
+++ b/services/tuttid/service/computer/permissions_test.go
@@ -1,6 +1,8 @@
 package computer
 
 import (
+	"context"
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -61,6 +63,57 @@ func TestParseWindowsDriverDoctor(t *testing.T) {
 	}
 	if _, err := parseWindowsDriverDoctor([]byte(`{"ok":false}`)); err != nil {
 		t.Fatalf("parseWindowsDriverDoctor false result: %v", err)
+	}
+}
+
+func TestEvaluateWindowsDriverDoctorAcceptsUsableWin32Fallback(t *testing.T) {
+	output := []byte("\x1b[33mwarning\x1b[0m\n" + `{
+		"ok": false,
+		"message": "UIA health probe exceeded 2000ms; falling back to Win32-only window tools"
+	}`)
+	if err := evaluateWindowsDriverDoctor(output, errors.New("exit status 1"), nil); err != nil {
+		t.Fatalf("evaluateWindowsDriverDoctor degraded fallback: %v", err)
+	}
+}
+
+func TestEvaluateWindowsDriverDoctorRejectsOrdinaryFailure(t *testing.T) {
+	err := evaluateWindowsDriverDoctor(
+		[]byte(`{"ok":false,"message":"interactive desktop unavailable"}`),
+		errors.New("exit status 1"),
+		nil,
+	)
+	if err == nil {
+		t.Fatal("evaluateWindowsDriverDoctor ordinary failure returned nil")
+	}
+}
+
+func TestEvaluateWindowsDriverDoctorRejectsUnexpectedHealthyNonzeroExit(t *testing.T) {
+	err := evaluateWindowsDriverDoctor(
+		[]byte(`{"ok":true}`),
+		errors.New("exit status 1"),
+		nil,
+	)
+	if err == nil {
+		t.Fatal("evaluateWindowsDriverDoctor healthy nonzero exit returned nil")
+	}
+}
+
+func TestEvaluateWindowsDriverDoctorRejectsMalformedOutput(t *testing.T) {
+	if err := evaluateWindowsDriverDoctor([]byte("not json"), nil, nil); err == nil {
+		t.Fatal("evaluateWindowsDriverDoctor malformed output returned nil")
+	}
+	if err := evaluateWindowsDriverDoctor(nil, nil, nil); err == nil {
+		t.Fatal("evaluateWindowsDriverDoctor empty output returned nil")
+	}
+}
+
+func TestEvaluateWindowsDriverDoctorRejectsCancelledProbe(t *testing.T) {
+	output := []byte(`{
+		"ok": false,
+		"message": "falling back to Win32-only window tools"
+	}`)
+	if err := evaluateWindowsDriverDoctor(output, errors.New("signal: killed"), context.DeadlineExceeded); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("evaluateWindowsDriverDoctor deadline error = %v, want deadline exceeded", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Align tuttidd Windows computer readiness with the Desktop interpretation of the same cua-driver doctor result.
- Treat only the explicit UIA-to-Win32 fallback diagnostic as degraded-but-usable, including when doctor exits non-zero.
- Keep timeouts, cancellation, malformed output, ordinary failures, and unexpected healthy non-zero exits fail-closed.
- Update the computer-use troubleshooting contract.

## Evidence and root cause

Production logs oscillate between authorized and driver-doctor-failed. Every degraded sample contains "UIA health probe exceeded 2000ms; falling back to Win32-only window tools"; the active affected session is Cursor immediately before such a probe.

Direct cause: Desktop already classifies that exact response as authorized/degraded, while services/tuttid/service/computer/permissions.go rejected every doctor ok=false result. Composer preparation therefore returned supportsComputerUse=false and the slash row correctly selected Settings instead of inserting the capability.

Systemic cause: Desktop and daemon independently interpreted the external doctor protocol and had drifted. This PR restores the current shared semantic contract at the owning Go readiness boundary; it does not force the GUI to expose an unavailable capability.

The supplied logs do not contain a Codex capability snapshot. Any explanation based on a prior Codex session snapshot remains an inference, not a logged fact.

## Verification

Passed:
- go test ./service/computer
- focused readiness evaluator tests, including non-zero degraded output and timeout/malformed negative controls
- pnpm build:go
- git diff --check

Not completed locally:
- pnpm test:go exceeded the 15 minute local Windows limit without emitting a failing assertion; the changed package passed independently.
- pnpm lint:go was stopped by an existing proxy-funnel violation in packages/agent/daemon/httpx/client.go before golangci reached this change.
- The opt-in real Windows driver E2E remains a release/manual gate.

## Fallback Three Questions

- Source: cua-driver reports optional UIA degradation as ok=false even while explicitly retaining usable Win32 window tools.
- Why can it not be fixed at that source? cua-driver is external, and Tutti Desktop already consumes this released diagnostic contract.
- Removal condition: replace the diagnostic string contract when cua-driver exposes a structured usable/degraded capability field consumed by both Desktop and daemon.

## Risk

Recognition intentionally matches the same explicit English fallback phrase already used by Desktop. Other failures remain unavailable. A follow-up should centralize a structured readiness snapshot and consider short-TTL/singleflight probing; that broader change is not required for this incident.

## Checklist

- [x] No agent lifecycle semantics are changed; this is platform readiness policy.
- [x] I kept the change focused on one concern.
- [x] I updated the durable troubleshooting documentation.
- [x] No multilingual source requires synchronization.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] The commit is signed off with DCO.

AI/LLM assistance was used for investigation, implementation, and review.