### PR TITLE
fix(agent): restore Cursor ACP user questions

### DIFF
--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -23,7 +23,8 @@ Use the focused runtime index or open one area directly:
   Also covers Kimi Code ACP sessions that advertise no model or hide provider
   failures behind an empty `end_turn`.
   Also covers Cursor ACP session-service startup races and tool results that
-  hide aborted/TLS failures in provider-specific output fields.
+  hide aborted/TLS failures in provider-specific output fields, plus Cursor CLI
+  questions that are absent from the ACP tool catalog.
   Also covers focus-driven provider CLI scans, repeated Extension Target version
   probes, Windows managed-runtime adoption sharing violations, optional Provider
   absence misclassified as an environment failure, extension release refresh

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -938,6 +938,48 @@ cannot find the path specified`, while the same repository is searchable
   [acp_provider_cursor.go](../../../packages/agent/daemon/runtime/acp_provider_cursor.go)
   [standard_acp_adapter_test.go](../../../packages/agent/daemon/runtime/standard_acp_adapter_test.go)
 
+### Cursor CLI can ask questions but Cursor ACP cannot
+
+- Symptom:
+  `cursor-agent` in its interactive CLI can pause and ask the user a structured
+  question, while the same prompt through `cursor-agent acp` either continues
+  without asking or reports that no question tool is available.
+- Quick checks:
+  Probe the raw ACP `initialize` and `session/new` exchange before changing
+  Tutti's interaction projection. Changing ACP `clientInfo`, advertising extra
+  client capabilities, or passing a root `-H x-cursor-client-type: cli` header
+  does not add the tool. If an injected HTTP MCP exposes `AskUserQuestion`,
+  confirm Cursor emits `session/request_permission` with kind `other`, then a
+  Tutti question interaction whose metadata reports
+  `providerMethod=mcp/tools/call`.
+- Root cause:
+  Cursor's ACP transport identifies itself internally as client type `acp` and
+  currently omits the interactive CLI's built-in question tool. The ACP bridge
+  contains a native `cursor/ask_question` request path, but changing initialize
+  metadata does not enable it; the transport middleware also overwrites a
+  caller-supplied client-type header.
+- Fix:
+  Preserve the native `cursor/ask_question` handler for Cursor versions that
+  expose it. For affected versions, bind Tutti's `AskUserQuestion` through the
+  session-scoped HTTP MCP capability advertised by ACP. Keep the bridge on a
+  loopback listener with a per-session bearer token, activate it only for the
+  exact running turn, and route the blocking call through the existing Tutti
+  interactive state machine. Auto-approve only Cursor's exact non-mutating
+  permission titles for this Tutti-owned tool; all other tool permissions must
+  continue through the configured permission tier.
+- Validation:
+  First assert `session/new` contains the HTTP MCP binding and that a real HTTP
+  `tools/call` blocks until `SubmitInteractive` supplies structured answers.
+  Keep native question and normal permission-tier regression coverage. Finally,
+  run a real Cursor ACP turn: require the model to call `AskUserQuestion`,
+  answer the emitted Tutti interaction, and verify the provider turn completes.
+  On Windows, this also verifies the loopback listener and local process
+  transport; retain POSIX coverage for the same platform-neutral socket path.
+- References:
+  [cursor_acp_question_mcp.go](../../../packages/agent/daemon/runtime/cursor_acp_question_mcp.go)
+  [cursor_acp_interactive.go](../../../packages/agent/daemon/runtime/cursor_acp_interactive.go)
+  [standard_acp_session.go](../../../packages/agent/daemon/runtime/standard_acp_session.go)
+
 ### Codex provider appears logged in with an empty auth.json
 
 - Symptom:

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -2767,24 +2767,30 @@ invalid_grant`. Search `tuttid.log` for
 
 - Symptom:
   Cursor ACP sometimes reports `Cursor failed to start` even though
-  `initialize` succeeded. A file-read tool can also appear completed while its
-  result is `Error: Aborted` and the raw diagnostic reports a disconnected TLS
-  socket.
+  `initialize` succeeded. Newer Cursor releases can instead reach the generic
+  30-second `session/new` deadline while attaching a session-scoped HTTP MCP
+  server. A file-read tool can also appear completed while its result is
+  `Error: Aborted` and the raw diagnostic reports a disconnected TLS socket.
 - Quick checks:
   Correlate the same `agent_session` in the daemon log. The startup signature is
   `session/new` returning JSON-RPC `-32603` with
   `Failed to initialize session services`. For the read signature, inspect the
   ACP tool update's `result` and `rawErrorMessages`; do not rely only on
-  `isError`/`is_error`.
+  `isError`/`is_error`. A timeout exactly 30 seconds after `session/new` with no
+  provider response is the slower MCP-client initialization signature.
 - Root cause:
   Cursor can transiently fail its session services after the ACP initialize
   handshake. Standard ACP startup previously returned that first failure
-  immediately. Cursor can also return a successful-looking tool envelope with
-  the failure text in provider-specific fields, which the status and error
-  projection did not inspect or preserve.
+  immediately. Cursor 2026.08 can also take longer than the generic ACP startup
+  budget while it establishes the supplied HTTP MCP transport. Cursor can
+  return a successful-looking tool envelope with the failure text in
+  provider-specific fields, which the status and error projection did not
+  inspect or preserve.
 - Fix:
   Retry only the matching Cursor `session/new` error once on the same
   initialized connection, before a provider session id or user Turn exists.
+  Give Cursor a provider-scoped 75-second initialize/session-new window; do not
+  increase the shared ACP timeout for every provider.
   Normalize known aborted/socket-disconnect markers in output/error envelopes
   as `call.failed`, and promote both the result and raw transport diagnostics
   into the failed payload. Do not automatically replay an arbitrary file tool
@@ -2792,7 +2798,8 @@ invalid_grant`. Search `tuttid.log` for
 - Validation:
   Cover a transient Cursor session-service error followed by success, assert
   one process and two `session/new` calls, and reject retries for authentication,
-  unrelated internal errors, and other methods. Cover aborted/TLS tool output,
+  unrelated internal errors, and other methods. Assert the Cursor-only startup
+  bound without changing the generic ACP bound. Cover aborted/TLS tool output,
   preserve its diagnostic text, and keep normal output and input-side error
   strings from changing the status. Run the native Windows runtime lane for
   process/ACP behavior.

--- a/packages/agent/daemon/runtime/acp_provider_cursor.go
+++ b/packages/agent/daemon/runtime/acp_provider_cursor.go
@@ -35,6 +35,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
@@ -58,6 +59,7 @@ const cursorPluginDirEnv = "TUTTI_CURSOR_PLUGIN_DIR"
 const cursorPromptContextFileEnv = "TUTTI_CURSOR_PROMPT_CONTEXT_FILE"
 
 const cursorACPSessionNewRetryLimit = 1
+const cursorACPStartupTimeout = 75 * time.Second
 
 func cursorACPShouldRetrySessionNew(err error) bool {
 	var callErr *acpCallError
@@ -162,6 +164,10 @@ func newCursorAdapterFromProviderDescriptor(
 	adapter.config.automaticPermissionDecision = cursorAutoApprovePermissionDecision
 	adapter.config.providerPermissionRequestDecision = cursorACPQuestionMCPPermissionDecision
 	adapter.config.localToolBridge = newCursorACPQuestionMCPBridge(adapter)
+	// Cursor 2026.08 can spend about a minute initializing session-scoped HTTP
+	// MCP clients, beyond the generic 30-second ACP budget. Keep the wider bound local
+	// to Cursor so other providers retain the shared fail-fast behavior.
+	adapter.config.startupTimeout = cursorACPStartupTimeout
 	adapter.config.autoContinueRetriableTurnError = true
 	adapter.config.retrySessionNewError = cursorACPShouldRetrySessionNew
 	adapter.config.sessionNewRetryLimit = cursorACPSessionNewRetryLimit

--- a/packages/agent/daemon/runtime/acp_provider_cursor.go
+++ b/packages/agent/daemon/runtime/acp_provider_cursor.go
@@ -160,6 +160,8 @@ func newCursorAdapterFromProviderDescriptor(
 	adapter.config.commandWithSettings = cursorACPCommandWithPluginDir
 	adapter.config.initialPromptContext = cursorACPInitialPromptContext
 	adapter.config.automaticPermissionDecision = cursorAutoApprovePermissionDecision
+	adapter.config.providerPermissionRequestDecision = cursorACPQuestionMCPPermissionDecision
+	adapter.config.localToolBridge = newCursorACPQuestionMCPBridge(adapter)
 	adapter.config.autoContinueRetriableTurnError = true
 	adapter.config.retrySessionNewError = cursorACPShouldRetrySessionNew
 	adapter.config.sessionNewRetryLimit = cursorACPSessionNewRetryLimit

--- a/packages/agent/daemon/runtime/cursor_acp_question_mcp.go
+++ b/packages/agent/daemon/runtime/cursor_acp_question_mcp.go
@@ -1,0 +1,456 @@
+package agentruntime
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+)
+
+const (
+	cursorACPQuestionMCPServerName = "tutti-interaction"
+	cursorACPQuestionMCPToolName   = "AskUserQuestion"
+	cursorACPQuestionMCPPath       = "/mcp/cursor-interaction"
+	cursorACPQuestionMCPVersion    = "2025-06-18"
+	cursorACPQuestionMCPMaxBody    = 1 << 20
+)
+
+type cursorACPQuestionMCPActiveTurn struct {
+	generation uint64
+	session    Session
+	turnID     string
+	emit       EventSink
+}
+
+// cursorACPQuestionMCPBridge supplies the AskUserQuestion capability that the
+// Cursor CLI exposes on its interactive CLI surface but currently omits from
+// its ACP tool catalog. It uses Cursor's supported session-scoped HTTP MCP
+// extension rather than patching or impersonating the provider binary.
+type cursorACPQuestionMCPBridge struct {
+	adapter *standardACPAdapter
+
+	mu            sync.Mutex
+	listener      net.Listener
+	server        *http.Server
+	baseURL       string
+	authorities   map[string]Session
+	activeTurns   map[string]cursorACPQuestionMCPActiveTurn
+	nextTurnEpoch uint64
+}
+
+func newCursorACPQuestionMCPBridge(adapter *standardACPAdapter) *cursorACPQuestionMCPBridge {
+	return &cursorACPQuestionMCPBridge{
+		adapter:     adapter,
+		authorities: make(map[string]Session),
+		activeTurns: make(map[string]cursorACPQuestionMCPActiveTurn),
+	}
+}
+
+func (bridge *cursorACPQuestionMCPBridge) Bind(_ context.Context, session Session) (MCPServerBinding, func(), error) {
+	if bridge == nil || bridge.adapter == nil || strings.TrimSpace(session.AgentSessionID) == "" {
+		return MCPServerBinding{}, nil, errors.New("cursor interaction MCP binding identity is required")
+	}
+	token, err := cursorACPQuestionMCPToken(32)
+	if err != nil {
+		return MCPServerBinding{}, nil, err
+	}
+	bridge.mu.Lock()
+	if err := bridge.startLocked(); err != nil {
+		bridge.mu.Unlock()
+		return MCPServerBinding{}, nil, err
+	}
+	bridge.authorities[token] = session
+	baseURL := bridge.baseURL
+	bridge.mu.Unlock()
+
+	var once sync.Once
+	release := func() { once.Do(func() { bridge.releaseToken(token) }) }
+	return MCPServerBinding{
+		Name: cursorACPQuestionMCPServerName,
+		Type: "http",
+		URL:  baseURL,
+		Headers: map[string]string{
+			"Authorization": "Bearer " + token,
+		},
+	}, release, nil
+}
+
+func (bridge *cursorACPQuestionMCPBridge) startLocked() error {
+	if bridge.server != nil && bridge.listener != nil {
+		return nil
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return fmt.Errorf("listen for Cursor interaction MCP: %w", err)
+	}
+	server := &http.Server{Handler: bridge, ReadHeaderTimeout: 5 * time.Second}
+	bridge.listener = listener
+	bridge.server = server
+	bridge.baseURL = "http://" + listener.Addr().String() + cursorACPQuestionMCPPath
+	go func() { _ = server.Serve(listener) }()
+	return nil
+}
+
+func (bridge *cursorACPQuestionMCPBridge) releaseToken(token string) {
+	if bridge == nil || token == "" {
+		return
+	}
+	bridge.mu.Lock()
+	delete(bridge.authorities, token)
+	if len(bridge.authorities) != 0 {
+		bridge.mu.Unlock()
+		return
+	}
+	server := bridge.server
+	bridge.listener = nil
+	bridge.server = nil
+	bridge.baseURL = ""
+	bridge.activeTurns = make(map[string]cursorACPQuestionMCPActiveTurn)
+	bridge.mu.Unlock()
+	if server != nil {
+		_ = server.Close()
+	}
+}
+
+func (bridge *cursorACPQuestionMCPBridge) ActivateTurn(session Session, turnID string, emit EventSink) func() {
+	if bridge == nil || strings.TrimSpace(session.AgentSessionID) == "" || strings.TrimSpace(turnID) == "" {
+		return func() {}
+	}
+	bridge.mu.Lock()
+	bridge.nextTurnEpoch++
+	active := cursorACPQuestionMCPActiveTurn{
+		generation: bridge.nextTurnEpoch,
+		session:    session,
+		turnID:     strings.TrimSpace(turnID),
+		emit:       emit,
+	}
+	bridge.activeTurns[session.AgentSessionID] = active
+	bridge.mu.Unlock()
+	return func() {
+		bridge.mu.Lock()
+		current, ok := bridge.activeTurns[session.AgentSessionID]
+		if ok && current.generation == active.generation {
+			delete(bridge.activeTurns, session.AgentSessionID)
+		}
+		bridge.mu.Unlock()
+	}
+}
+
+func (bridge *cursorACPQuestionMCPBridge) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	if bridge == nil || request.URL.Path != cursorACPQuestionMCPPath || !cursorACPQuestionMCPLoopbackHost(request.Host) {
+		http.NotFound(writer, request)
+		return
+	}
+	if !cursorACPQuestionMCPLoopbackOrigin(request.Header.Get("Origin")) {
+		cursorACPQuestionMCPWriteError(writer, http.StatusForbidden, nil, -32020, "Origin is not allowed")
+		return
+	}
+	if request.Method != http.MethodPost {
+		writer.Header().Set("Allow", http.MethodPost)
+		cursorACPQuestionMCPWriteError(writer, http.StatusMethodNotAllowed, nil, -32600, "Cursor interaction MCP only accepts POST")
+		return
+	}
+	session, active, ok := bridge.authorize(request.Header.Get("Authorization"))
+	if !ok {
+		writer.Header().Set("WWW-Authenticate", "Bearer")
+		cursorACPQuestionMCPWriteError(writer, http.StatusUnauthorized, nil, -32001, "Cursor interaction MCP authentication is required")
+		return
+	}
+
+	decoder := json.NewDecoder(http.MaxBytesReader(writer, request.Body, cursorACPQuestionMCPMaxBody))
+	decoder.DisallowUnknownFields()
+	var rpc cursorACPQuestionMCPRequest
+	if err := decoder.Decode(&rpc); err != nil || decoder.Decode(&struct{}{}) != io.EOF || rpc.JSONRPC != "2.0" || strings.TrimSpace(rpc.Method) == "" {
+		cursorACPQuestionMCPWriteError(writer, http.StatusBadRequest, cursorACPQuestionMCPNullID(rpc.ID), -32600, "Invalid MCP request")
+		return
+	}
+
+	switch rpc.Method {
+	case "notifications/initialized", "notifications/cancelled":
+		writer.WriteHeader(http.StatusAccepted)
+	case "initialize":
+		cursorACPQuestionMCPWriteResult(writer, rpc.ID, map[string]any{
+			"protocolVersion": cursorACPQuestionMCPVersion,
+			"capabilities":    map[string]any{"tools": map[string]any{"listChanged": false}},
+			"serverInfo":      map[string]any{"name": cursorACPQuestionMCPServerName, "version": "1"},
+		})
+	case "ping":
+		cursorACPQuestionMCPWriteResult(writer, rpc.ID, map[string]any{})
+	case "resources/list":
+		cursorACPQuestionMCPWriteResult(writer, rpc.ID, map[string]any{"resources": []any{}})
+	case "resources/templates/list":
+		cursorACPQuestionMCPWriteResult(writer, rpc.ID, map[string]any{"resourceTemplates": []any{}})
+	case "tools/list":
+		cursorACPQuestionMCPWriteResult(writer, rpc.ID, map[string]any{"tools": []any{cursorACPQuestionMCPTool()}})
+	case "tools/call":
+		if active.turnID == "" || active.session.AgentSessionID != session.AgentSessionID {
+			cursorACPQuestionMCPWriteError(writer, http.StatusOK, rpc.ID, -32000, "AskUserQuestion is only available during an active Cursor turn")
+			return
+		}
+		var params struct {
+			Name      string         `json:"name"`
+			Arguments map[string]any `json:"arguments"`
+		}
+		if json.Unmarshal(rpc.Params, &params) != nil || params.Name != cursorACPQuestionMCPToolName {
+			cursorACPQuestionMCPWriteError(writer, http.StatusOK, rpc.ID, -32602, "Invalid AskUserQuestion arguments")
+			return
+		}
+		result, err := bridge.adapter.handleCursorMCPAskQuestion(request.Context(), active.session, active.turnID, params.Arguments, active.emit)
+		if err != nil {
+			cursorACPQuestionMCPWriteError(writer, http.StatusOK, rpc.ID, -32000, err.Error())
+			return
+		}
+		cursorACPQuestionMCPWriteResult(writer, rpc.ID, result)
+	default:
+		cursorACPQuestionMCPWriteError(writer, http.StatusOK, rpc.ID, -32601, "Method not found")
+	}
+}
+
+func (bridge *cursorACPQuestionMCPBridge) authorize(header string) (Session, cursorACPQuestionMCPActiveTurn, bool) {
+	token, ok := strings.CutPrefix(strings.TrimSpace(header), "Bearer ")
+	if !ok || token == "" {
+		return Session{}, cursorACPQuestionMCPActiveTurn{}, false
+	}
+	bridge.mu.Lock()
+	defer bridge.mu.Unlock()
+	session, exists := bridge.authorities[token]
+	if !exists {
+		return Session{}, cursorACPQuestionMCPActiveTurn{}, false
+	}
+	return session, bridge.activeTurns[session.AgentSessionID], true
+}
+
+func (a *standardACPAdapter) handleCursorMCPAskQuestion(
+	ctx context.Context,
+	session Session,
+	turnID string,
+	arguments map[string]any,
+	emit EventSink,
+) (map[string]any, error) {
+	callID, requestID := newID(), newID()
+	input := clonePayload(arguments)
+	input["toolCallId"] = callID
+	raw, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("encode AskUserQuestion arguments: %w", err)
+	}
+	parsed, normalized, err := parseCursorAskQuestionRequest(raw)
+	if err != nil {
+		return nil, err
+	}
+	normalized["requestId"] = requestID
+	title := firstNonEmpty(strings.TrimSpace(parsed.Title), cursorACPQuestionMCPToolName)
+	pending := &pendingACPApproval{
+		agentSessionID:       strings.TrimSpace(session.AgentSessionID),
+		requestID:            requestID,
+		eventID:              newID(),
+		callID:               callID,
+		callType:             "interactive",
+		turnID:               strings.TrimSpace(turnID),
+		input:                clonePayload(normalized),
+		kind:                 "ask-user",
+		providerMethod:       cursorACPMethodAskQuestion,
+		name:                 title,
+		toolName:             cursorACPQuestionMCPToolName,
+		response:             make(chan pendingInteractiveResponse, 1),
+		interactionRequested: true,
+	}
+	pending.prompt = &SessionInteractivePrompt{
+		Kind:      "ask-user",
+		RequestID: requestID,
+		ToolName:  cursorACPQuestionMCPToolName,
+		Status:    "waiting_input",
+		Input:     clonePayload(normalized),
+		Metadata: map[string]any{
+			"callType":        "interactive",
+			"interactiveKind": "ask-user",
+			"toolName":        cursorACPQuestionMCPToolName,
+			"providerMethod":  "mcp/tools/call",
+		},
+	}
+	a.storePendingApproval(pending)
+	if a.getPendingApproval(session.AgentSessionID, turnID, requestID) != pending {
+		return nil, errors.New("cursor AskUserQuestion session is no longer active")
+	}
+	if emit != nil {
+		emit([]activityshared.Event{
+			newTurnActivityEvent(session, EventTurnUpdated, turnID, SessionStatusWaiting, "", "", map[string]any{
+				"phase": string(activityshared.TurnPhaseWaitingApproval), "requestId": requestID,
+			}),
+			newTurnActivityEventWithID(session, pending.eventID, EventCallStarted, turnID, SessionStatusWaiting, "", title, map[string]any{
+				"callId": callID, "callType": "interactive", "name": title,
+				"toolName": cursorACPQuestionMCPToolName, "status": "waiting_input", "input": clonePayload(normalized),
+			}),
+			normalizedInteractionRequestedEvent(session, turnID, pending),
+		})
+	}
+
+	selection, err := pending.wait(ctx)
+	if err != nil {
+		pending.finish(pendingInteractiveRequestStateInterrupted)
+		if emit != nil {
+			events := normalizedPermissionResolvedEvents(session, turnID, pending, pendingInteractiveResponse{}, err)
+			events = append(events, newTurnActivityEvent(session, EventTurnUpdated, turnID, SessionStatusWorking, "", "", map[string]any{
+				"phase": string(activityshared.TurnPhaseWorking), "requestId": requestID,
+			}))
+			emit(events)
+		}
+		return nil, err
+	}
+	if !pending.finish(pendingInteractiveRequestStateAnswered) {
+		return nil, errors.New("cursor AskUserQuestion response is no longer live")
+	}
+	if emit != nil {
+		emit(normalizedPermissionResolvedEvents(session, turnID, pending, selection, nil))
+	}
+	return cursorACPQuestionMCPResult(selection), nil
+}
+
+func cursorACPQuestionMCPResult(selection pendingInteractiveResponse) map[string]any {
+	outcome := normalizePermissionOptionToken(selection.action)
+	payload := map[string]any{"outcome": firstNonEmpty(outcome, "answered")}
+	if answers := payloadObject(selection.payload["answersByQuestionId"]); len(answers) > 0 {
+		payload["outcome"] = "answered"
+		payload["answersByQuestionId"] = answers
+	}
+	raw, _ := json.Marshal(payload)
+	return map[string]any{"content": []any{map[string]any{"type": "text", "text": string(raw)}}}
+}
+
+func cursorACPQuestionMCPPermissionDecision(raw json.RawMessage) string {
+	var request struct {
+		ToolCall struct {
+			Title string `json:"title"`
+			Kind  string `json:"kind"`
+		} `json:"toolCall"`
+	}
+	if json.Unmarshal(raw, &request) != nil || !strings.EqualFold(strings.TrimSpace(request.ToolCall.Kind), "other") {
+		return ""
+	}
+	title := strings.TrimSpace(request.ToolCall.Title)
+	plainTitle := cursorACPQuestionMCPServerName + ": " + cursorACPQuestionMCPToolName
+	cursorTitle := cursorACPQuestionMCPServerName + "-" + cursorACPQuestionMCPToolName + ": " + cursorACPQuestionMCPToolName
+	if strings.EqualFold(title, plainTitle) || strings.EqualFold(title, cursorTitle) {
+		return "approved"
+	}
+	return ""
+}
+
+func cursorACPQuestionMCPTool() map[string]any {
+	option := map[string]any{
+		"type": "object", "additionalProperties": false,
+		"properties": map[string]any{
+			"id":    map[string]any{"type": "string", "minLength": 1},
+			"label": map[string]any{"type": "string", "minLength": 1},
+		},
+		"required": []string{"id", "label"},
+	}
+	question := map[string]any{
+		"type": "object", "additionalProperties": false,
+		"properties": map[string]any{
+			"id":       map[string]any{"type": "string", "minLength": 1},
+			"question": map[string]any{"type": "string", "minLength": 1},
+			"options":  map[string]any{"type": "array", "minItems": 2, "maxItems": 3, "items": option},
+		},
+		"required": []string{"id", "question", "options"},
+	}
+	return map[string]any{
+		"name":        cursorACPQuestionMCPToolName,
+		"description": "Ask the user one to three blocking questions and wait for their answers. Use this whenever user input or a choice is needed.",
+		"inputSchema": map[string]any{
+			"type": "object", "additionalProperties": false,
+			"properties": map[string]any{
+				"title":     map[string]any{"type": "string"},
+				"questions": map[string]any{"type": "array", "minItems": 1, "maxItems": 3, "items": question},
+			},
+			"required": []string{"questions"},
+		},
+		"annotations": map[string]any{
+			"readOnlyHint": true, "destructiveHint": false, "idempotentHint": false, "openWorldHint": false,
+		},
+	}
+}
+
+type cursorACPQuestionMCPRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params"`
+}
+
+type cursorACPQuestionMCPResponse struct {
+	JSONRPC string                     `json:"jsonrpc"`
+	ID      json.RawMessage            `json:"id"`
+	Result  any                        `json:"result,omitempty"`
+	Error   *cursorACPQuestionMCPError `json:"error,omitempty"`
+}
+
+type cursorACPQuestionMCPError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func cursorACPQuestionMCPWriteResult(writer http.ResponseWriter, id json.RawMessage, result any) {
+	cursorACPQuestionMCPWrite(writer, http.StatusOK, cursorACPQuestionMCPResponse{JSONRPC: "2.0", ID: cursorACPQuestionMCPNullID(id), Result: result})
+}
+
+func cursorACPQuestionMCPWriteError(writer http.ResponseWriter, status int, id json.RawMessage, code int, message string) {
+	cursorACPQuestionMCPWrite(writer, status, cursorACPQuestionMCPResponse{
+		JSONRPC: "2.0", ID: cursorACPQuestionMCPNullID(id), Error: &cursorACPQuestionMCPError{Code: code, Message: message},
+	})
+}
+
+func cursorACPQuestionMCPWrite(writer http.ResponseWriter, status int, response cursorACPQuestionMCPResponse) {
+	writer.Header().Set("Content-Type", "application/json")
+	writer.Header().Set("Cache-Control", "private, no-store")
+	writer.WriteHeader(status)
+	_ = json.NewEncoder(writer).Encode(response)
+}
+
+func cursorACPQuestionMCPNullID(id json.RawMessage) json.RawMessage {
+	if len(id) == 0 {
+		return json.RawMessage("null")
+	}
+	return id
+}
+
+func cursorACPQuestionMCPToken(size int) (string, error) {
+	buffer := make([]byte, size)
+	if _, err := rand.Read(buffer); err != nil {
+		return "", fmt.Errorf("generate Cursor interaction MCP secret: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buffer), nil
+}
+
+func cursorACPQuestionMCPLoopbackHost(value string) bool {
+	host := value
+	if parsed, _, err := net.SplitHostPort(host); err == nil {
+		host = parsed
+	}
+	host = strings.Trim(strings.ToLower(strings.TrimSpace(host)), "[]")
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}
+
+func cursorACPQuestionMCPLoopbackOrigin(value string) bool {
+	origin := strings.TrimSpace(value)
+	if origin == "" || origin == "null" {
+		return true
+	}
+	parsed, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	host := strings.Trim(strings.ToLower(parsed.Hostname()), "[]")
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}

--- a/packages/agent/daemon/runtime/cursor_acp_question_mcp_test.go
+++ b/packages/agent/daemon/runtime/cursor_acp_question_mcp_test.go
@@ -1,0 +1,200 @@
+package agentruntime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+)
+
+func TestCursorAskUserQuestionMCPBlocksUntilInteractiveAnswer(t *testing.T) {
+	t.Parallel()
+
+	adapter := newCursorAdapterWithHostMetadata(nil, LegacyHostMetadata(), nil)
+	bridge, ok := adapter.config.localToolBridge.(*cursorACPQuestionMCPBridge)
+	if !ok || bridge == nil {
+		t.Fatal("Cursor local tool bridge is unavailable")
+	}
+	session := standardTestSession(ProviderCursor)
+	adapter.storeSession(session.AgentSessionID, &standardACPSession{
+		providerSessionID: "cursor-session-question-mcp",
+		pendingApprovals:  make(map[string]*pendingACPApproval),
+	})
+	binding, release, err := bridge.Bind(context.Background(), session)
+	if err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	defer release()
+
+	requested := make(chan string, 1)
+	var emitted []activityshared.Event
+	deactivate := bridge.ActivateTurn(session, "turn-question-mcp", func(events []activityshared.Event) {
+		emitted = append(emitted, events...)
+		for _, event := range events {
+			if event.Type == activityshared.EventInteractionRequested && event.Payload.Interaction != nil {
+				select {
+				case requested <- event.Payload.Interaction.RequestID:
+				default:
+				}
+			}
+		}
+	})
+	defer deactivate()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	initialize := cursorQuestionMCPCall(t, client, binding, map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-06-18",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "cursor-agent", "version": "test"},
+		},
+	})
+	if result := payloadMap(initialize, "result"); result["protocolVersion"] != cursorACPQuestionMCPVersion {
+		t.Fatalf("initialize response = %#v", initialize)
+	}
+	unauthorizedBinding := binding
+	unauthorizedBinding.Headers = map[string]string{"Authorization": "Bearer wrong-session-token"}
+	unauthorized := cursorQuestionMCPCall(t, client, unauthorizedBinding, map[string]any{
+		"jsonrpc": "2.0", "id": 9, "method": "tools/list", "params": map[string]any{},
+	})
+	if rpcError := payloadMap(unauthorized, "error"); rpcError["code"] != float64(-32001) {
+		t.Fatalf("unauthorized response = %#v", unauthorized)
+	}
+	listed := cursorQuestionMCPCall(t, client, binding, map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": map[string]any{},
+	})
+	tools, _ := payloadMap(listed, "result")["tools"].([]any)
+	if len(tools) != 1 {
+		t.Fatalf("tools/list response = %#v", listed)
+	}
+	tool, _ := tools[0].(map[string]any)
+	if asString(tool["name"]) != cursorACPQuestionMCPToolName {
+		t.Fatalf("tools/list response = %#v", listed)
+	}
+
+	callDone := make(chan map[string]any, 1)
+	go func() {
+		callDone <- cursorQuestionMCPCall(t, client, binding, map[string]any{
+			"jsonrpc": "2.0", "id": 3, "method": "tools/call",
+			"params": map[string]any{
+				"name": cursorACPQuestionMCPToolName,
+				"arguments": map[string]any{
+					"title": "Confirmation",
+					"questions": []any{map[string]any{
+						"id": "continue", "question": "Continue?",
+						"options": []any{
+							map[string]any{"id": "yes", "label": "Yes"},
+							map[string]any{"id": "no", "label": "No"},
+						},
+					}},
+				},
+			},
+		})
+	}()
+
+	var requestID string
+	select {
+	case requestID = <-requested:
+	case <-time.After(5 * time.Second):
+		t.Fatal("AskUserQuestion did not publish an interaction")
+	}
+	snapshot := adapter.SessionState(session)
+	if snapshot.PendingInteractive == nil || snapshot.PendingInteractive.RequestID != requestID ||
+		snapshot.PendingInteractive.ToolName != cursorACPQuestionMCPToolName {
+		t.Fatalf("pending interaction = %#v", snapshot.PendingInteractive)
+	}
+	if _, err := adapter.SubmitInteractive(context.Background(), session, SubmitInteractiveInput{
+		RoomID: session.RoomID, AgentSessionID: session.AgentSessionID,
+		TurnID: "turn-question-mcp", RequestID: requestID, Action: "submit",
+		Payload: map[string]any{
+			"answers": []any{"Yes"}, "answersByQuestionId": map[string]any{"continue": "Yes"},
+		},
+	}); err != nil {
+		t.Fatalf("SubmitInteractive: %v", err)
+	}
+
+	var response map[string]any
+	select {
+	case response = <-callDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("MCP tools/call did not resume after the answer")
+	}
+	content, _ := payloadMap(response, "result")["content"].([]any)
+	if len(content) != 1 {
+		t.Fatalf("tools/call response = %#v", response)
+	}
+	contentBlock, _ := content[0].(map[string]any)
+	if !strings.Contains(asString(contentBlock["text"]), `"continue":"Yes"`) {
+		t.Fatalf("tools/call response = %#v", response)
+	}
+	if disposition := adapter.InteractiveDisposition(session, "turn-question-mcp", requestID); disposition != InteractiveDispositionAnswered {
+		t.Fatalf("interactive disposition = %q, want answered", disposition)
+	}
+	if len(eventsOfType(emitted, activityshared.EventInteractionRequested)) != 1 ||
+		len(eventsOfType(emitted, activityshared.EventCallCompleted)) != 1 {
+		t.Fatalf("interaction events = %#v", emitted)
+	}
+}
+
+func TestCursorAskUserQuestionMCPPermissionDecisionIsNarrow(t *testing.T) {
+	t.Parallel()
+
+	for _, matching := range []json.RawMessage{
+		json.RawMessage(`{"toolCall":{"title":"tutti-interaction: AskUserQuestion","kind":"other"}}`),
+		json.RawMessage(`{"toolCall":{"title":"tutti-interaction-AskUserQuestion: AskUserQuestion","kind":"other"}}`),
+	} {
+		if got := cursorACPQuestionMCPPermissionDecision(matching); got != "approved" {
+			t.Fatalf("matching decision for %s = %q, want approved", matching, got)
+		}
+	}
+	for _, raw := range []json.RawMessage{
+		json.RawMessage(`{"toolCall":{"title":"other: AskUserQuestion","kind":"other"}}`),
+		json.RawMessage(`{"toolCall":{"title":"tutti-interaction: AskUserQuestion","kind":"execute"}}`),
+		json.RawMessage(`{"toolCall":{"title":"tutti-interaction: Shell","kind":"other"}}`),
+		json.RawMessage(`{}`),
+	} {
+		if got := cursorACPQuestionMCPPermissionDecision(raw); got != "" {
+			t.Fatalf("decision for %s = %q, want prompt", raw, got)
+		}
+	}
+}
+
+func cursorQuestionMCPCall(t *testing.T, client *http.Client, binding MCPServerBinding, payload map[string]any) map[string]any {
+	t.Helper()
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, err := http.NewRequest(http.MethodPost, binding.URL, bytes.NewReader(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json, text/event-stream")
+	for name, value := range binding.Headers {
+		request.Header.Set(name, value)
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		t.Errorf("MCP request: %v", err)
+		return nil
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Errorf("read MCP response: %v", err)
+		return nil
+	}
+	var decoded map[string]any
+	if json.Unmarshal(body, &decoded) != nil {
+		t.Errorf("decode MCP response status=%d body=%q", response.StatusCode, body)
+	}
+	return decoded
+}

--- a/packages/agent/daemon/runtime/standard_acp_adapter.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter.go
@@ -20,6 +20,15 @@ type standardACPProviderMessageHandler func(
 	EventSink,
 ) ([]activityshared.Event, bool, error)
 
+// standardACPLocalToolBridge projects provider-specific, Tutti-owned tools
+// through the ACP session's standard HTTP MCP extension point. The returned
+// release function owns the exact binding lease so a replaced process cannot
+// revoke its successor's authority.
+type standardACPLocalToolBridge interface {
+	Bind(context.Context, Session) (MCPServerBinding, func(), error)
+	ActivateTurn(Session, string, EventSink) func()
+}
+
 type standardACPConfig struct {
 	provider            string
 	adapterName         string
@@ -87,6 +96,11 @@ type standardACPConfig struct {
 	// token ("approved" / "denied") to apply automatically, or "" to prompt
 	// the user as usual. Nil (the default) always prompts.
 	automaticPermissionDecision func(permissionModeID string) string
+	// providerPermissionRequestDecision resolves a narrowly recognized
+	// provider request before the permission tier is consulted. It is used only
+	// for non-mutating, Tutti-owned local tools whose own operation presents the
+	// real user interaction.
+	providerPermissionRequestDecision func(json.RawMessage) string
 	// filterPermissionOptions narrows provider-offered approval choices before
 	// they become a durable interaction. Providers use it only when an option
 	// would conflict with live permission-tier semantics.
@@ -111,6 +125,7 @@ type standardACPConfig struct {
 	setModelReasoningEffortMeta    bool
 	messageDiagnostics             *standardACPMessageDiagnostics
 	providerMessageHandler         standardACPProviderMessageHandler
+	localToolBridge                standardACPLocalToolBridge
 	capabilities                   []string
 	agentTargetID                  string
 	installationID                 string
@@ -188,6 +203,15 @@ type standardACPSession struct {
 	// initialPromptContext remains pending until the provider accepts its first
 	// prompt. A failed transport call leaves it pending for the next attempt.
 	initialPromptContext string
+	localToolRelease     func()
+	localToolReleaseOnce sync.Once
+}
+
+func (session *standardACPSession) releaseLocalTools() {
+	if session == nil || session.localToolRelease == nil {
+		return
+	}
+	session.localToolReleaseOnce.Do(session.localToolRelease)
 }
 
 func (a *standardACPAdapter) resolveInitialPromptContext(session Session) (string, error) {

--- a/packages/agent/daemon/runtime/standard_acp_provider_contracts_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_provider_contracts_test.go
@@ -23,6 +23,9 @@ func TestCursorAdapterInjectsPreparedContextIntoFirstProviderPromptOnly(t *testi
 	}
 	transport := newStandardACPTransport("Cursor Agent", "cursor-session-context")
 	adapter := newCursorAdapterWithHostMetadata(transport, LegacyHostMetadata(), nil)
+	if got := adapter.startupCallTimeout(); got != cursorACPStartupTimeout {
+		t.Fatalf("Cursor startup timeout = %s, want %s", got, cursorACPStartupTimeout)
+	}
 	session := standardTestSession(ProviderCursor)
 	session.Env = []string{cursorPromptContextFileEnv + "=" + contextPath}
 	if _, err := adapter.Start(context.Background(), session); err != nil {

--- a/packages/agent/daemon/runtime/standard_acp_provider_contracts_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_provider_contracts_test.go
@@ -3,6 +3,7 @@ package agentruntime
 import (
 	"context"
 	"encoding/json"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -73,6 +74,38 @@ func TestCursorAdapterStartUsesInjectedProviderCommand(t *testing.T) {
 	}
 	if got := strings.Join(transport.specs[0].Command, " "); got != "/home/user/.local/bin/agent acp" {
 		t.Fatalf("command = %q, want resolved cursor binary", got)
+	}
+}
+
+func TestCursorAdapterInjectsAskUserQuestionMCPBinding(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Cursor Agent", "cursor-session-question-mcp")
+	transport.conn.supportsHTTPMCP = true
+	adapter := newCursorAdapterWithHostMetadata(transport, LegacyHostMetadata(), nil)
+	session := standardTestSession(ProviderCursor)
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = adapter.Close(context.Background(), session) }()
+
+	transport.conn.mu.Lock()
+	params := maps.Clone(transport.conn.lastNewSessionParams)
+	transport.conn.mu.Unlock()
+	servers, _ := params["mcpServers"].([]any)
+	if len(servers) != 1 {
+		t.Fatalf("session/new MCP servers = %#v, want one Cursor interaction binding", servers)
+	}
+	binding, _ := servers[0].(map[string]any)
+	if binding["name"] != "tutti-interaction" || binding["type"] != "http" {
+		t.Fatalf("Cursor interaction MCP binding = %#v", binding)
+	}
+	if url := asString(binding["url"]); !strings.HasPrefix(url, "http://127.0.0.1:") {
+		t.Fatalf("Cursor interaction MCP URL = %q, want loopback", url)
+	}
+	headers, _ := binding["headers"].([]any)
+	if len(headers) != 1 {
+		t.Fatalf("Cursor interaction MCP headers = %#v, want one bearer", headers)
 	}
 }
 

--- a/packages/agent/daemon/runtime/standard_acp_resource_ownership.go
+++ b/packages/agent/daemon/runtime/standard_acp_resource_ownership.go
@@ -31,6 +31,7 @@ func (a *standardACPAdapter) closeOrRetainSession(session Session, acpSession *s
 	}
 	// Once ownership is being retired, no late provider frame may be attributed
 	// to a replacement session or its recent Turn.
+	acpSession.releaseLocalTools()
 	acpSession.client.SetMessageHandler(nil)
 	if err := acpSession.client.Close(); err != nil {
 		a.retainRetiredSession(session.AgentSessionID, acpSession)
@@ -161,6 +162,7 @@ func (a *standardACPAdapter) ReleaseLiveSession(_ context.Context, session Sessi
 		a.logACPCloseDiagnostics("live_release.transport_close.failed", session, acpSession, err)
 		return err
 	}
+	acpSession.releaseLocalTools()
 	a.mu.Lock()
 	if a.sessions[agentSessionID] == acpSession {
 		delete(a.sessions, agentSessionID)
@@ -201,6 +203,7 @@ func (a *standardACPAdapter) DisconnectLiveSession(_ context.Context, session Se
 			a.logACPCloseDiagnostics("workspace_disconnect.transport_close.failed", session, current, err)
 			return err
 		}
+		current.releaseLocalTools()
 		a.mu.Lock()
 		if a.sessions[agentSessionID] == current {
 			delete(a.sessions, agentSessionID)
@@ -232,6 +235,7 @@ func (a *standardACPAdapter) Close(ctx context.Context, session Session) error {
 	delete(a.sessions, agentSessionID)
 	a.mu.Unlock()
 	if acpSession != nil && acpSession.client != nil {
+		acpSession.releaseLocalTools()
 		a.closeProviderSession(ctx, session, acpSession)
 		acpSession.client.SetMessageHandler(nil)
 		closeErr := acpSession.client.Close()
@@ -268,6 +272,7 @@ func (a *standardACPAdapter) closeReplacedSession(agentSessionID string, previou
 	if previousSession == nil || previousSession.client == nil || previousSession.client == currentClient {
 		return
 	}
+	previousSession.releaseLocalTools()
 	previousSession.client.SetMessageHandler(nil)
 	if err := previousSession.client.Close(); err != nil {
 		a.retainRetiredSession(agentSessionID, previousSession)
@@ -325,6 +330,7 @@ func (a *standardACPAdapter) retryOneTrackedSessionLocked(agentSessionID string)
 			a.mu.Unlock()
 			return true, err
 		}
+		current.releaseLocalTools()
 		a.mu.Lock()
 		if a.sessions[agentSessionID] == current {
 			delete(a.sessions, agentSessionID)
@@ -359,6 +365,7 @@ func (a *standardACPAdapter) retryOneTrackedSessionLocked(agentSessionID string)
 		a.mu.Unlock()
 		return true, err
 	}
+	session.releaseLocalTools()
 	a.removeRetiredSession(agentSessionID, session)
 	return true, nil
 }

--- a/packages/agent/daemon/runtime/standard_acp_session.go
+++ b/packages/agent/daemon/runtime/standard_acp_session.go
@@ -87,6 +87,14 @@ func (a *standardACPAdapter) Start(ctx context.Context, session Session) ([]acti
 		initialPromptContext: initialPromptContext,
 	}
 	a.storeSession(session.AgentSessionID, acpSession)
+	if a.config.localToolBridge != nil && standardACPHTTPMCPSupported(initializeResult) {
+		binding, release, bindErr := a.config.localToolBridge.Bind(ctx, session)
+		if bindErr != nil {
+			return nil, fmt.Errorf("bind local ACP tool bridge: %w", bindErr)
+		}
+		acpSession.localToolRelease = release
+		mcpServers = append(mcpServers, acpMCPServers([]MCPServerBinding{binding})...)
+	}
 
 	newSessionParams := map[string]any{
 		"cwd":        standardACPProtocolCWD(session.CWD),
@@ -336,6 +344,14 @@ func (a *standardACPAdapter) resumeLocked(ctx context.Context, session Session) 
 		acpSession.acpLiveState = cloneACPLiveState(previousSession.acpLiveState)
 	}
 	a.storeSession(session.AgentSessionID, acpSession)
+	if a.config.localToolBridge != nil && standardACPHTTPMCPSupported(initializeResult) {
+		binding, release, bindErr := a.config.localToolBridge.Bind(ctx, session)
+		if bindErr != nil {
+			return fmt.Errorf("bind local ACP tool bridge: %w", bindErr)
+		}
+		acpSession.localToolRelease = release
+		mcpServers = append(mcpServers, acpMCPServers([]MCPServerBinding{binding})...)
+	}
 
 	method := acpSession.resumeMethod
 	if method == "" {

--- a/packages/agent/daemon/runtime/standard_acp_stream.go
+++ b/packages/agent/daemon/runtime/standard_acp_stream.go
@@ -114,7 +114,14 @@ func (a *standardACPAdapter) handleACPMessage(
 		// Automatic tiers resolve the request from the live permission tier
 		// without prompting; the tool call still streams its own activity via
 		// session/update.
-		if decision := a.automaticPermissionDecision(session.AgentSessionID); decision != "" {
+		decision := ""
+		if a.config.providerPermissionRequestDecision != nil {
+			decision = strings.TrimSpace(a.config.providerPermissionRequestDecision(message.Params))
+		}
+		if decision == "" {
+			decision = a.automaticPermissionDecision(session.AgentSessionID)
+		}
+		if decision != "" {
 			if optionID, ok := acpPermissionRequestDecisionOptionID(
 				message.Params,
 				decision,

--- a/packages/agent/daemon/runtime/standard_acp_turn.go
+++ b/packages/agent/daemon/runtime/standard_acp_turn.go
@@ -54,6 +54,12 @@ func (a *standardACPAdapter) Exec(
 		defer eventsMu.Unlock()
 		return append([]activityshared.Event(nil), events...)
 	}
+	if a.config.localToolBridge != nil {
+		deactivate := a.config.localToolBridge.ActivateTurn(session, turnID, emitEvents)
+		if deactivate != nil {
+			defer deactivate()
+		}
+	}
 
 	startEvents := []activityshared.Event{
 		newUserPromptActivityEvent(ctx, session, content, explicitDisplayPrompt, visibleText, turnID, nil),


### PR DESCRIPTION
## Summary

- restore structured user questions for Cursor ACP through its advertised session-scoped HTTP MCP extension
- route the blocking `AskUserQuestion` call through Tutti's existing interactive state machine while preserving the native `cursor/ask_question` path
- isolate the bridge to loopback, per-session bearer authority, and the exact active turn
- auto-approve only Cursor's exact non-mutating permission request for this Tutti-owned tool
- document why CLI and ACP capabilities differ and how to diagnose the path

## Root cause

Cursor's interactive CLI exposes a built-in question tool, but `cursor-agent acp` identifies its transport as client type `acp` and currently omits that tool from the ACP catalog. Spoofing initialize metadata or passing `-H x-cursor-client-type: cli` does not change it because Cursor's ACP middleware owns that header.

A raw ACP probe with a temporary HTTP MCP proved that Cursor can invoke `AskUserQuestion` through the supported MCP extension. This PR turns that supported path into a bounded Tutti adapter fallback.

## Validation

Passed:

- real `cursor-agent 2026.08.11-e8db854` ACP turn on Windows: model invoked `tutti-interaction AskUserQuestion`, Tutti emitted the question interaction, answer `Blue` was submitted, and the provider turn completed
- focused Cursor ACP regression suite, including native question handling and normal permission tiers
- focused suite repeated with `-shuffle=on -count=10`
- incremental golangci-lint against `origin/main`: 0 issues
- `pnpm check:agent-provider-strategy-boundaries`
- `pnpm check:tutti-names`
- `pnpm check:agent-gui-degradation`
- `git diff --cached --check`

Local environment limitations:

- `pnpm test:go:agent-daemon` reached unrelated existing Windows failures in Claude managed Node selection, Codex probe timing, temporary-file sharing, verified executable handling, and runtimecmd HOME fallback, then hit the 11-minute lane limit
- final `pnpm check:changed -- --max-parallel 1` passed 3/7 lanes; its remaining lanes could not start in this Windows worktree because WSL could not resolve the Windows worktree gitdir, the clean worktree has no TypeScript `node_modules`, and bash could not resolve the Windows Go/golangci-lint paths. Equivalent native Windows incremental lint and focused tests passed as listed above.

## Windows impact

The fallback uses platform-neutral Go HTTP/socket APIs and binds only to `127.0.0.1:0`. The real Cursor ACP end-to-end test was run on Windows. No path, shell, executable-discovery, or signal behavior was added.

## Documentation

Updated the provider troubleshooting guide and index with the recurring Cursor CLI-versus-ACP capability split, unsupported spoofing attempts, supported fallback, security boundary, and validation procedure.