### PR TITLE
chore(agent): refresh computer use extensions

### DIFF
--- a/apps/desktop/src/main/generated/defaults.ts
+++ b/apps/desktop/src/main/generated/defaults.ts
@@ -37,7 +37,7 @@ export const generatedDefaults = {
     sources: [
       {
         key: "gemini",
-        pinnedVersion: "2.0.3",
+        pinnedVersion: "2.0.4",
         releaseIndexUrl:
           "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/gemini/versions.json",
         signingKeyId: "tutti-gemini-release-v1",
@@ -47,7 +47,7 @@ export const generatedDefaults = {
       },
       {
         key: "codebuddy",
-        pinnedVersion: "2.0.5",
+        pinnedVersion: "2.0.6",
         releaseIndexUrl:
           "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/codebuddy/versions.json",
         signingKeyId: "tutti-codebuddy-release-v1",
@@ -57,7 +57,7 @@ export const generatedDefaults = {
       },
       {
         key: "copilot",
-        pinnedVersion: "2.0.3",
+        pinnedVersion: "2.0.4",
         releaseIndexUrl:
           "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/copilot/versions.json",
         signingKeyId: "tutti-copilot-release-v1",
@@ -67,7 +67,7 @@ export const generatedDefaults = {
       },
       {
         key: "kilo",
-        pinnedVersion: "2.0.3",
+        pinnedVersion: "2.0.4",
         releaseIndexUrl:
           "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/kilo/versions.json",
         signingKeyId: "tutti-kilo-release-v1",
@@ -77,7 +77,7 @@ export const generatedDefaults = {
       },
       {
         key: "qwen",
-        pinnedVersion: "2.0.3",
+        pinnedVersion: "2.0.4",
         releaseIndexUrl:
           "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/qwen/versions.json",
         signingKeyId: "tutti-qwen-release-v1",
@@ -87,7 +87,7 @@ export const generatedDefaults = {
       },
       {
         key: "hermes",
-        pinnedVersion: "1.0.9",
+        pinnedVersion: "1.0.10",
         releaseIndexUrl:
           "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/hermes/versions.json",
         signingKeyId: "tutti-hermes-release-v1",
@@ -97,7 +97,7 @@ export const generatedDefaults = {
       },
       {
         key: "kimi-code",
-        pinnedVersion: "1.0.11",
+        pinnedVersion: "1.0.12",
         releaseIndexUrl:
           "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/kimi-code/account-usage-v1/versions.json",
         fallbackReleaseIndexUrls: [

--- a/config/tutti.defaults.json
+++ b/config/tutti.defaults.json
@@ -37,7 +37,7 @@
     "sources": [
       {
         "key": "gemini",
-        "pinnedVersion": "2.0.3",
+        "pinnedVersion": "2.0.4",
         "releaseIndexUrl": "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/gemini/versions.json",
         "signingKeyId": "tutti-gemini-release-v1",
         "signingPublicKey": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAXKvHPk/lWXqeK3Q1cg6vaOFfhqmXm3jcNgECsZ9XT/g=\n-----END PUBLIC KEY-----\n",
@@ -45,7 +45,7 @@
       },
       {
         "key": "codebuddy",
-        "pinnedVersion": "2.0.5",
+        "pinnedVersion": "2.0.6",
         "releaseIndexUrl": "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/codebuddy/versions.json",
         "signingKeyId": "tutti-codebuddy-release-v1",
         "signingPublicKey": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAfzdtf41+SN0hrZqK0JX2pdDluCwpUbn1HPDoz4D7OxA=\n-----END PUBLIC KEY-----\n",
@@ -53,7 +53,7 @@
       },
       {
         "key": "copilot",
-        "pinnedVersion": "2.0.3",
+        "pinnedVersion": "2.0.4",
         "releaseIndexUrl": "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/copilot/versions.json",
         "signingKeyId": "tutti-copilot-release-v1",
         "signingPublicKey": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA1U8JW/V2ZwXbflqpktbpC68cuI3xq0OU2yV4H5vsz+c=\n-----END PUBLIC KEY-----\n",
@@ -61,7 +61,7 @@
       },
       {
         "key": "kilo",
-        "pinnedVersion": "2.0.3",
+        "pinnedVersion": "2.0.4",
         "releaseIndexUrl": "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/kilo/versions.json",
         "signingKeyId": "tutti-kilo-release-v1",
         "signingPublicKey": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAc0h7Dl9Vw1FnNGBm612Pj/yVsQW+UKXfDskBEVHeMGI=\n-----END PUBLIC KEY-----\n",
@@ -69,7 +69,7 @@
       },
       {
         "key": "qwen",
-        "pinnedVersion": "2.0.3",
+        "pinnedVersion": "2.0.4",
         "releaseIndexUrl": "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/qwen/versions.json",
         "signingKeyId": "tutti-qwen-release-v1",
         "signingPublicKey": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEANqN38E9u53Ohnyzy8IC9lPXOmOCrZwxTb7Do2hM22t0=\n-----END PUBLIC KEY-----\n",
@@ -77,7 +77,7 @@
       },
       {
         "key": "hermes",
-        "pinnedVersion": "1.0.9",
+        "pinnedVersion": "1.0.10",
         "releaseIndexUrl": "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/hermes/versions.json",
         "signingKeyId": "tutti-hermes-release-v1",
         "signingPublicKey": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAIeel8ddNiN3b4qOq0KucF3BRxfi3zourM0BVyGuP8eY=\n-----END PUBLIC KEY-----\n",
@@ -85,7 +85,7 @@
       },
       {
         "key": "kimi-code",
-        "pinnedVersion": "1.0.11",
+        "pinnedVersion": "1.0.12",
         "releaseIndexUrl": "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/kimi-code/account-usage-v1/versions.json",
         "fallbackReleaseIndexUrls": [
           "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/kimi-code/authentication-v1/versions.json",

--- a/services/tuttid/types/defaults_generated.go
+++ b/services/tuttid/types/defaults_generated.go
@@ -36,7 +36,7 @@ var generatedDefaults = generatedDefaultsSpec{
 		Sources: []generatedAgentExtensionSourceDefaults{
 			{
 				Key:                      "gemini",
-				PinnedVersion:            "2.0.3",
+				PinnedVersion:            "2.0.4",
 				ReleaseIndexURL:          "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/gemini/versions.json",
 				FallbackReleaseIndexURLs: []string{},
 				SigningKeyID:             "tutti-gemini-release-v1",
@@ -45,7 +45,7 @@ var generatedDefaults = generatedDefaultsSpec{
 			},
 			{
 				Key:                      "codebuddy",
-				PinnedVersion:            "2.0.5",
+				PinnedVersion:            "2.0.6",
 				ReleaseIndexURL:          "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/codebuddy/versions.json",
 				FallbackReleaseIndexURLs: []string{},
 				SigningKeyID:             "tutti-codebuddy-release-v1",
@@ -54,7 +54,7 @@ var generatedDefaults = generatedDefaultsSpec{
 			},
 			{
 				Key:                      "copilot",
-				PinnedVersion:            "2.0.3",
+				PinnedVersion:            "2.0.4",
 				ReleaseIndexURL:          "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/copilot/versions.json",
 				FallbackReleaseIndexURLs: []string{},
 				SigningKeyID:             "tutti-copilot-release-v1",
@@ -63,7 +63,7 @@ var generatedDefaults = generatedDefaultsSpec{
 			},
 			{
 				Key:                      "kilo",
-				PinnedVersion:            "2.0.3",
+				PinnedVersion:            "2.0.4",
 				ReleaseIndexURL:          "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/kilo/versions.json",
 				FallbackReleaseIndexURLs: []string{},
 				SigningKeyID:             "tutti-kilo-release-v1",
@@ -72,7 +72,7 @@ var generatedDefaults = generatedDefaultsSpec{
 			},
 			{
 				Key:                      "qwen",
-				PinnedVersion:            "2.0.3",
+				PinnedVersion:            "2.0.4",
 				ReleaseIndexURL:          "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/qwen/versions.json",
 				FallbackReleaseIndexURLs: []string{},
 				SigningKeyID:             "tutti-qwen-release-v1",
@@ -81,7 +81,7 @@ var generatedDefaults = generatedDefaultsSpec{
 			},
 			{
 				Key:                      "hermes",
-				PinnedVersion:            "1.0.9",
+				PinnedVersion:            "1.0.10",
 				ReleaseIndexURL:          "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/hermes/versions.json",
 				FallbackReleaseIndexURLs: []string{},
 				SigningKeyID:             "tutti-hermes-release-v1",
@@ -90,7 +90,7 @@ var generatedDefaults = generatedDefaultsSpec{
 			},
 			{
 				Key:                      "kimi-code",
-				PinnedVersion:            "1.0.11",
+				PinnedVersion:            "1.0.12",
 				ReleaseIndexURL:          "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/kimi-code/account-usage-v1/versions.json",
 				FallbackReleaseIndexURLs: []string{"https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/kimi-code/authentication-v1/versions.json", "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/kimi-code/versions.json"},
 				SigningKeyID:             "tutti-kimi-code-release-v1",

--- a/services/tuttid/types/defaults_test.go
+++ b/services/tuttid/types/defaults_test.go
@@ -91,8 +91,8 @@ func TestResolveAgentExtensionSourcesUsesGeneratedActivationDefaults(t *testing.
 		}
 	}
 	wantPinnedVersions := map[string]string{
-		"gemini": "2.0.3", "codebuddy": "2.0.5", "copilot": "2.0.3", "kilo": "2.0.3",
-		"qwen": "2.0.3", "hermes": "1.0.9", "kimi-code": "1.0.11", "grok": "0.1.2",
+		"gemini": "2.0.4", "codebuddy": "2.0.6", "copilot": "2.0.4", "kilo": "2.0.4",
+		"qwen": "2.0.4", "hermes": "1.0.10", "kimi-code": "1.0.12", "grok": "0.1.2",
 	}
 	for key, wantVersion := range wantPinnedVersions {
 		if got := agentExtensionSourceByKey(t, sources, key).PinnedVersion; got != wantVersion {


### PR DESCRIPTION
## Summary
- pin the published computer-use-capable Gemini, CodeBuddy, Copilot, Kilo, Qwen, Hermes, and Kimi extensions
- regenerate Desktop and daemon defaults from the canonical config
- keep unsupported Grok unchanged until its macOS-only runtime is qualified

## Validation
- pnpm generate:defaults
- pnpm check:defaults-generated
- git diff --check
- pre-push changed-aware validation completed before the Git transport retry

## Windows impact
This changes signed extension catalog pins only. Windows qualification is captured in the individual extension PRs; CodeBuddy includes a passing Windows lane, while all extensions remain gated by the host computer readiness contract from #2577.