### PR TITLE
feat(app-release): add non-publishing candidate mode

### DIFF
--- a/.github/workflows/publish-tutti-app-release.yml
+++ b/.github/workflows/publish-tutti-app-release.yml
@@ -75,6 +75,31 @@ on:
         required: false
         type: boolean
         default: false
+      prepare_only:
+        description: Build and upload an Actions release candidate without mutating cloud release state.
+        required: false
+        type: boolean
+        default: false
+      candidate_run_id:
+        description: Actions run containing an approved production release candidate.
+        required: false
+        type: string
+        default: ""
+      expected_version:
+        description: Approved candidate version.
+        required: false
+        type: string
+        default: ""
+      expected_artifact_sha256:
+        description: Approved candidate artifact SHA-256.
+        required: false
+        type: string
+        default: ""
+      expected_git_sha:
+        description: Approved candidate source commit.
+        required: false
+        type: string
+        default: ""
       catalog_cloudfront_distribution_id:
         required: false
         type: string
@@ -88,12 +113,54 @@ jobs:
     if: ${{ inputs.catalog_only || !contains(github.event.head_commit.message || '', '[skip release]') }}
     runs-on: ${{ inputs.runner }}
     concurrency:
-      group: ${{ (inputs.publish_catalog || inputs.catalog_only) && format('tutti-app-catalog-{0}-{1}', inputs.s3_bucket, inputs.s3_prefix) || format('tutti-app-release-{0}-{1}', inputs.app_id, github.ref_name) }}
+      group: ${{ (!inputs.prepare_only && (inputs.publish_catalog || inputs.catalog_only)) && format('tutti-app-catalog-{0}-{1}', inputs.s3_bucket, inputs.s3_prefix) || format('tutti-app-release-{0}-{1}', inputs.app_id, github.ref_name) }}
       cancel-in-progress: false
 
     steps:
       - name: Checkout app repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: ${{ !inputs.prepare_only }}
+
+      - name: Validate release mode
+        shell: bash
+        env:
+          CATALOG_ONLY: ${{ inputs.catalog_only }}
+          PREPARE_ONLY: ${{ inputs.prepare_only }}
+          CANDIDATE_RUN_ID: ${{ inputs.candidate_run_id }}
+          EXPECTED_VERSION: ${{ inputs.expected_version }}
+          EXPECTED_ARTIFACT_SHA256: ${{ inputs.expected_artifact_sha256 }}
+          EXPECTED_GIT_SHA: ${{ inputs.expected_git_sha }}
+        run: |
+          if [ "${CATALOG_ONLY}" = "true" ] && [ "${PREPARE_ONLY}" = "true" ]; then
+            echo "catalog_only and prepare_only are mutually exclusive." >&2
+            exit 1
+          fi
+          candidate_values=(
+            "${CANDIDATE_RUN_ID}"
+            "${EXPECTED_VERSION}"
+            "${EXPECTED_ARTIFACT_SHA256}"
+            "${EXPECTED_GIT_SHA}"
+          )
+          candidate_value_count=0
+          for value in "${candidate_values[@]}"; do
+            if [ -n "${value}" ]; then
+              candidate_value_count=$((candidate_value_count + 1))
+            fi
+          done
+          if [ "${candidate_value_count}" -ne 0 ] && [ "${candidate_value_count}" -ne 4 ]; then
+            echo "candidate_run_id, expected_version, expected_artifact_sha256, and expected_git_sha must be supplied together." >&2
+            exit 1
+          fi
+          if [ "${PREPARE_ONLY}" = "true" ] && [ "${candidate_value_count}" -ne 0 ]; then
+            echo "prepare_only cannot promote an existing candidate." >&2
+            exit 1
+          fi
+          if [ "${CATALOG_ONLY}" = "true" ] && [ "${candidate_value_count}" -ne 0 ]; then
+            echo "catalog_only cannot promote a release candidate." >&2
+            exit 1
+          fi
 
       - name: Validate release inputs
         if: ${{ !inputs.catalog_only }}
@@ -104,6 +171,7 @@ jobs:
           RELEASE_ASSETS_BASE_URL: ${{ inputs.release_assets_base_url }}
           RELEASE_BUMP: ${{ inputs.release_bump }}
           CREATE_RELEASE_TAG: ${{ inputs.create_release_tag }}
+          PREPARE_ONLY: ${{ inputs.prepare_only }}
           MIN_TUTTI_VERSION: ${{ inputs.min_tutti_version }}
         run: |
           if [ -z "${PACKAGE_COMMAND}" ]; then
@@ -126,7 +194,7 @@ jobs:
             echo "release_bump must be one of major, minor, or patch when provided." >&2
             exit 1
           fi
-          if [ -n "${RELEASE_BUMP}" ] && [ "${CREATE_RELEASE_TAG}" != "true" ]; then
+          if [ -n "${RELEASE_BUMP}" ] && [ "${CREATE_RELEASE_TAG}" != "true" ] && [ "${PREPARE_ONLY}" != "true" ]; then
             echo "release_bump requires create_release_tag." >&2
             exit 1
           fi
@@ -144,12 +212,21 @@ jobs:
           node-version: ${{ inputs.node_version }}
           cache: pnpm
 
+      - name: Download approved production release candidate
+        if: ${{ inputs.candidate_run_id != '' }}
+        uses: actions/download-artifact@v5
+        with:
+          name: ${{ format('{0}-{1}-production-candidate', inputs.app_id, inputs.expected_version) }}
+          path: tutti-app-release
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.candidate_run_id }}
+
       - name: Install app dependencies
-        if: ${{ !inputs.catalog_only }}
+        if: ${{ !inputs.catalog_only && inputs.candidate_run_id == '' }}
         run: pnpm install --frozen-lockfile
 
       - name: Build app package
-        if: ${{ !inputs.catalog_only }}
+        if: ${{ !inputs.catalog_only && inputs.candidate_run_id == '' }}
         run: ${{ inputs.package_command }}
 
       - name: Resolve release version
@@ -162,6 +239,10 @@ jobs:
           CREATE_RELEASE_TAG: ${{ inputs.create_release_tag }}
           APP_ID: ${{ inputs.app_id }}
           PACKAGE_DIR: ${{ inputs.package_dir }}
+          CANDIDATE_RUN_ID: ${{ inputs.candidate_run_id }}
+          EXPECTED_VERSION: ${{ inputs.expected_version }}
+          EXPECTED_ARTIFACT_SHA256: ${{ inputs.expected_artifact_sha256 }}
+          EXPECTED_GIT_SHA: ${{ inputs.expected_git_sha }}
         run: |
           node <<'NODE'
           const fs = require("fs");
@@ -252,34 +333,53 @@ jobs:
             fail(`release_bump must be one of major, minor, or patch when provided, got ${bump}.`);
           }
 
-          const gitSha = execFileSync("git", ["rev-parse", "HEAD"], {
+          let gitSha = execFileSync("git", ["rev-parse", "HEAD"], {
             encoding: "utf8"
           }).trim();
           const releaseBump = process.env.RELEASE_BUMP;
           const shouldCreateTag = process.env.CREATE_RELEASE_TAG === "true";
-          const manifest = JSON.parse(
-            fs.readFileSync(`${process.env.PACKAGE_DIR}/tutti.app.json`, "utf8")
-          );
           let releaseVersion = "";
           let tagName = "";
 
-          if (releaseBump) {
-            const tagPrefix = defaultTagPrefix();
-            releaseVersion = nextVersionFromSources(
-              tagPrefix,
-              releaseBump,
-              manifest.version
-            );
-            tagName = `${tagPrefix}${releaseVersion}`;
-          } else {
-            if (shouldCreateTag) {
-              fail("create_release_tag requires release_bump.");
+          if (process.env.CANDIDATE_RUN_ID) {
+            const expectedVersion = process.env.EXPECTED_VERSION;
+            const expectedArtifactSha256 = process.env.EXPECTED_ARTIFACT_SHA256;
+            const expectedGitSha = process.env.EXPECTED_GIT_SHA;
+            const releasePath = `tutti-app-release/apps/${process.env.APP_ID}/${expectedVersion}/release.json`;
+            const candidate = JSON.parse(fs.readFileSync(releasePath, "utf8"));
+            const mismatches = [];
+            if (candidate.appId !== process.env.APP_ID) mismatches.push("appId");
+            if (candidate.version !== expectedVersion) mismatches.push("version");
+            if (candidate.artifactSha256 !== expectedArtifactSha256) mismatches.push("artifactSha256");
+            if (candidate.gitSha !== expectedGitSha) mismatches.push("gitSha");
+            if (mismatches.length > 0) {
+              fail(`Approved release candidate mismatch: ${mismatches.join(", ")}`);
             }
-            // Staging publishes do not bump. Seed from max(manifest, release tags)
-            // so staging stays on the same product line as production tags.
-            const tagPrefix = defaultTagPrefix();
-            const seed = latestVersionSeed(tagPrefix, manifest.version, false);
-            releaseVersion = `${seed.version}+${gitSha.slice(0, 12)}`;
+            releaseVersion = expectedVersion;
+            gitSha = expectedGitSha;
+            tagName = `${defaultTagPrefix()}${releaseVersion}`;
+          } else {
+            const manifest = JSON.parse(
+              fs.readFileSync(`${process.env.PACKAGE_DIR}/tutti.app.json`, "utf8")
+            );
+            if (releaseBump) {
+              const tagPrefix = defaultTagPrefix();
+              releaseVersion = nextVersionFromSources(
+                tagPrefix,
+                releaseBump,
+                manifest.version
+              );
+              tagName = `${tagPrefix}${releaseVersion}`;
+            } else {
+              if (shouldCreateTag) {
+                fail("create_release_tag requires release_bump.");
+              }
+              // Staging publishes do not bump. Seed from max(manifest, release tags)
+              // so staging stays on the same product line as production tags.
+              const tagPrefix = defaultTagPrefix();
+              const seed = latestVersionSeed(tagPrefix, manifest.version, false);
+              releaseVersion = `${seed.version}+${gitSha.slice(0, 12)}`;
+            }
           }
 
           if (!semverPattern.test(releaseVersion)) {
@@ -292,7 +392,7 @@ jobs:
           NODE
 
       - name: Build release metadata
-        if: ${{ !inputs.catalog_only }}
+        if: ${{ !inputs.catalog_only && inputs.candidate_run_id == '' }}
         shell: bash
         env:
           APP_ID: ${{ inputs.app_id }}
@@ -315,14 +415,82 @@ jobs:
           fi
           pnpm --package "${RELEASE_TOOLS_PACKAGE}" dlx build-tutti-app-release "${args[@]}"
 
+      - name: Verify local app release candidate
+        if: ${{ !inputs.catalog_only }}
+        shell: bash
+        env:
+          APP_ID: ${{ inputs.app_id }}
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          node <<'NODE'
+          const fs = require("fs");
+          const path = require("path");
+          const { createHash } = require("crypto");
+
+          const root = path.resolve("tutti-app-release");
+          const releaseDir = path.join(root, "apps", process.env.APP_ID, process.env.RELEASE_VERSION);
+          const versionedPath = path.join(releaseDir, "release.json");
+          const latestPath = path.join(root, "apps", process.env.APP_ID, "latest.json");
+          const release = JSON.parse(fs.readFileSync(versionedPath, "utf8"));
+          const latest = JSON.parse(fs.readFileSync(latestPath, "utf8"));
+          if (JSON.stringify(release) !== JSON.stringify(latest)) {
+            throw new Error("versioned release.json and latest.json must match exactly");
+          }
+          if (release.appId !== process.env.APP_ID || release.version !== process.env.RELEASE_VERSION) {
+            throw new Error("local release identity does not match the resolved app and version");
+          }
+          const artifactName = decodeURIComponent(path.basename(new URL(release.artifactUrl).pathname));
+          const expectedArtifactName = `${release.appId}-${release.version}.zip`;
+          if (artifactName !== expectedArtifactName) {
+            throw new Error(`local release artifact name mismatch: want ${expectedArtifactName} got ${artifactName}`);
+          }
+          const artifactPath = path.join(releaseDir, artifactName);
+          const data = fs.readFileSync(artifactPath);
+          const sha256 = createHash("sha256").update(data).digest("hex");
+          if (sha256 !== release.artifactSha256.toLowerCase()) {
+            throw new Error(`local release artifact sha256 mismatch: want ${release.artifactSha256} got ${sha256}`);
+          }
+          if (data.length !== release.artifactSizeBytes) {
+            throw new Error(`local release artifact size mismatch: want ${release.artifactSizeBytes} got ${data.length}`);
+          }
+          console.log(`Verified local release candidate ${release.appId}@${release.version} ${sha256}`);
+          NODE
+
+      - name: Preflight release tag
+        if: ${{ !inputs.catalog_only && !inputs.prepare_only && inputs.create_release_tag }}
+        shell: bash
+        env:
+          RELEASE_TAG_NAME: ${{ steps.release.outputs.tag_name }}
+          RELEASE_GIT_SHA: ${{ steps.release.outputs.git_sha }}
+        run: |
+          git rev-parse --verify "${RELEASE_GIT_SHA}^{commit}" >/dev/null
+          git fetch --tags --force
+          if git rev-parse -q --verify "refs/tags/${RELEASE_TAG_NAME}" >/dev/null; then
+            existing_sha="$(git rev-list -n 1 "${RELEASE_TAG_NAME}")"
+            if [ "${existing_sha}" != "${RELEASE_GIT_SHA}" ]; then
+              echo "Release tag ${RELEASE_TAG_NAME} already points to ${existing_sha}, expected ${RELEASE_GIT_SHA}." >&2
+              exit 1
+            fi
+          fi
+
+      - name: Upload production release candidate
+        if: ${{ inputs.prepare_only }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ format('{0}-{1}-production-candidate', inputs.app_id, steps.release.outputs.version) }}
+          path: tutti-app-release
+          if-no-files-found: error
+          retention-days: 7
+
       - name: Configure AWS credentials
+        if: ${{ !inputs.prepare_only }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ inputs.aws_region }}
           role-to-assume: ${{ inputs.aws_role_arn }}
 
       - name: Upload app release to S3
-        if: ${{ !inputs.catalog_only }}
+        if: ${{ !inputs.catalog_only && !inputs.prepare_only }}
         shell: bash
         env:
           APP_ID: ${{ inputs.app_id }}
@@ -378,7 +546,7 @@ jobs:
           fi
 
       - name: Verify published app release artifact
-        if: ${{ !inputs.catalog_only }}
+        if: ${{ !inputs.catalog_only && !inputs.prepare_only }}
         shell: bash
         env:
           APP_ID: ${{ inputs.app_id }}
@@ -388,6 +556,7 @@ jobs:
             --release-file "tutti-app-release/apps/${APP_ID}/latest.json"
 
       - name: Publish app release metadata
+        if: ${{ !inputs.prepare_only }}
         shell: bash
         env:
           APP_ID: ${{ inputs.app_id }}
@@ -419,6 +588,7 @@ jobs:
           pnpm --package "${RELEASE_TOOLS_PACKAGE}" dlx publish-tutti-app-metadata "${args[@]}"
 
       - name: Verify published app metadata
+        if: ${{ !inputs.prepare_only }}
         shell: bash
         env:
           CATALOG_ONLY: ${{ inputs.catalog_only }}
@@ -435,7 +605,7 @@ jobs:
           pnpm --package "${RELEASE_TOOLS_PACKAGE}" dlx verify-tutti-app-release-artifacts "${args[@]}"
 
       - name: Create release tag
-        if: ${{ !inputs.catalog_only && inputs.create_release_tag }}
+        if: ${{ !inputs.catalog_only && !inputs.prepare_only && inputs.create_release_tag }}
         shell: bash
         env:
           APP_ID: ${{ inputs.app_id }}
@@ -469,7 +639,7 @@ jobs:
           git push origin "refs/tags/${RELEASE_TAG_NAME}"
 
       - name: Invalidate app catalog
-        if: ${{ (inputs.publish_catalog || inputs.catalog_only) && inputs.catalog_cloudfront_distribution_id != '' }}
+        if: ${{ !inputs.prepare_only && (inputs.publish_catalog || inputs.catalog_only) && inputs.catalog_cloudfront_distribution_id != '' }}
         shell: bash
         env:
           CATALOG_CLOUDFRONT_DISTRIBUTION_ID: ${{ inputs.catalog_cloudfront_distribution_id }}

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/references/github-actions-release.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/references/github-actions-release.md
@@ -23,6 +23,8 @@ uses: tutti-os/tutti/.github/workflows/publish-tutti-app-release.yml@main
 
 This reusable workflow builds, publishes, and verifies the app package. It can also create a release tag and publish the App Center catalog.
 
+Production callers should expose `prepare_only`. In this mode the reusable workflow builds the exact release version on the production runner, verifies it, and uploads `tutti-app-release` as a short-lived GitHub Actions artifact. It does not configure AWS, upload to the release bucket, update `latest.json` or `versions.json`, create a tag, publish the catalog, or invalidate CloudFront. Use the candidate `release.json` to show the target version and `artifactSha256` for release approval. The subsequent production dispatch must pass that candidate's Actions run ID, version, artifact SHA-256, and source Git SHA. The workflow downloads and publishes the same candidate without rebuilding it, then rejects any identity mismatch before configuring AWS.
+
 ## Version compatibility contract
 
 Declare one exact stable SemVer in `min_tutti_version` for every normal release. Choose the earliest Tutti version that contains every host API and runtime contract used by the app. Use `0.0.0` only when the app requires no minimum Tutti version. Publish a new app version when this minimum changes.
@@ -58,8 +60,34 @@ on:
         required: false
         type: boolean
         default: false
+      prepare_only:
+        description: Whether to build a production release candidate without publishing it.
+        required: false
+        type: boolean
+        default: false
+      candidate_run_id:
+        description: Actions run containing the approved production candidate.
+        required: false
+        type: string
+        default: ""
+      expected_version:
+        description: Approved production candidate version.
+        required: false
+        type: string
+        default: ""
+      expected_artifact_sha256:
+        description: Approved production candidate artifact SHA-256.
+        required: false
+        type: string
+        default: ""
+      expected_git_sha:
+        description: Approved production candidate source commit.
+        required: false
+        type: string
+        default: ""
 
 permissions:
+  actions: read
   contents: write
   id-token: write
 
@@ -74,9 +102,10 @@ jobs:
       icon_path: build/tutti-app/package/icon.png
       release_tag_prefix: <app-id>-v
       release_bump: ${{ inputs.release_bump }}
-      create_release_tag: ${{ !inputs.catalog_only }}
+      create_release_tag: ${{ !inputs.catalog_only && !inputs.prepare_only }}
       runner: ubuntu-latest
       pnpm_version: 10.26.2
+      release_tools_package: "@tutti-os/app-release-tools@<validated-version>"
       aws_region: ${{ vars.TUTTI_APP_RELEASES_PRODUCTION_AWS_REGION || vars.TUTTI_APP_RELEASES_AWS_REGION }}
       aws_role_arn: ${{ vars.TUTTI_APP_RELEASES_PRODUCTION_AWS_ROLE_ARN || vars.TUTTI_APP_RELEASES_AWS_ROLE_ARN }}
       s3_bucket: ${{ vars.TUTTI_APP_RELEASES_PRODUCTION_S3_BUCKET || vars.TUTTI_APP_RELEASES_S3_BUCKET }}
@@ -84,10 +113,17 @@ jobs:
       release_assets_base_url: ${{ vars.TUTTI_APP_RELEASES_PRODUCTION_BASE_URL || vars.TUTTI_APP_RELEASES_BASE_URL }}
       publish_catalog: ${{ inputs.publish_catalog }}
       catalog_only: ${{ inputs.catalog_only }}
+      prepare_only: ${{ inputs.prepare_only }}
+      candidate_run_id: ${{ inputs.candidate_run_id }}
+      expected_version: ${{ inputs.expected_version }}
+      expected_artifact_sha256: ${{ inputs.expected_artifact_sha256 }}
+      expected_git_sha: ${{ inputs.expected_git_sha }}
       catalog_cloudfront_distribution_id: ${{ vars.TUTTI_APP_RELEASES_PRODUCTION_CLOUDFRONT_DISTRIBUTION_ID || vars.TUTTI_APP_RELEASES_CLOUDFRONT_DISTRIBUTION_ID || '' }}
 ```
 
 Use `macos-latest` only when packaging depends on macOS-only tooling. Prefer `ubuntu-latest` for web/server-only apps.
+
+Pin `release_tools_package` to one exact published version. Candidate promotion reuses the already-built archive, while the pin keeps candidate verification reproducible. `catalog_only` and `prepare_only` are mutually exclusive; candidate identity inputs must be supplied together and are valid only on the mutating production dispatch.
 
 ## Staging Workflow Template
 
@@ -175,6 +211,7 @@ Before considering the release workflows ready:
 - Confirm `package_dir` contains `tutti.app.json`, `bootstrap.sh`, icon assets, built web assets, server bundle, and locales.
 - Confirm the app id in `tutti.app.json`, `app_id`, and `release_tag_prefix` are consistent.
 - Confirm the selected runner can build the app package.
+- Run production with `prepare_only: true`, download the candidate artifact, and verify its `release.json` version, `artifactSha256`, and `gitSha` before requesting approval. Confirm that this run created no release tag and changed no cloud metadata. After approval, dispatch production again with the candidate run ID and all three approved identity values; confirm the publishing run downloads the candidate and skips app installation, packaging, and archive rebuilding.
 - Confirm the organization or repository variables are visible to the app repository.
 - When `min_tutti_version` is greater than `0.0.0`, confirm a lower Tutti version does not select the release.
 - Confirm the declared minimum or a newer Tutti version selects the release. For `0.0.0`, also test the oldest supported Tutti version.

--- a/tools/scripts/build-tutti-app-release.test.mjs
+++ b/tools/scripts/build-tutti-app-release.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   chmod,
@@ -759,6 +760,11 @@ test("Tutti app release workflow is reusable by external app repositories", asyn
   assert.match(workflow, /create_release_tag:/);
   assert.match(workflow, /publish_catalog:/);
   assert.match(workflow, /catalog_only:/);
+  assert.match(workflow, /prepare_only:/);
+  assert.match(workflow, /candidate_run_id:/);
+  assert.match(workflow, /expected_version:/);
+  assert.match(workflow, /expected_artifact_sha256:/);
+  assert.match(workflow, /expected_git_sha:/);
   assert.match(workflow, /catalog_cloudfront_distribution_id:/);
   assert.match(workflow, /Validate release inputs/);
   assert.match(
@@ -803,6 +809,10 @@ test("Tutti app release workflow is reusable by external app repositories", asyn
     /Resolved release version seed \$\{latest\.version\} from \$\{latest\.source\}/
   );
   assert.match(workflow, /release_bump requires create_release_tag/);
+  assert.match(
+    workflow,
+    /\[ "\$\{PREPARE_ONLY\}" != "true" \]/
+  );
   assert.match(workflow, /create_release_tag requires release_bump/);
   assert.match(
     workflow,
@@ -844,6 +854,78 @@ test("Tutti app release workflow is reusable by external app repositories", asyn
   );
   assert.match(workflow, /Publish app release metadata/);
   assert.match(workflow, /publish-tutti-app-metadata/);
+  assert.match(workflow, /name: Upload production release candidate/);
+  assert.match(workflow, /uses: actions\/upload-artifact@v4/);
+  assert.match(workflow, /uses: actions\/download-artifact@v5/);
+  assert.match(workflow, /run-id: \$\{\{ inputs\.candidate_run_id \}\}/);
+  assert.match(workflow, /Approved release candidate mismatch/);
+  assert.match(workflow, /candidate\.artifactSha256 !== expectedArtifactSha256/);
+  assert.match(workflow, /candidate\.gitSha !== expectedGitSha/);
+  assert.match(workflow, /catalog_only and prepare_only are mutually exclusive/);
+  assert.match(
+    workflow,
+    /if: \$\{\{ inputs\.prepare_only \}\}[\s\S]*path: tutti-app-release/
+  );
+  assert.match(
+    workflow,
+    /name: Configure AWS credentials\n\s+if: \$\{\{ !inputs\.prepare_only \}\}/
+  );
+  assert.match(
+    workflow,
+    /name: Upload app release to S3\n\s+if: \$\{\{ !inputs\.catalog_only && !inputs\.prepare_only \}\}/
+  );
+  assert.match(
+    workflow,
+    /name: Publish app release metadata\n\s+if: \$\{\{ !inputs\.prepare_only \}\}/
+  );
+  assert.match(
+    workflow,
+    /name: Verify published app metadata\n\s+if: \$\{\{ !inputs\.prepare_only \}\}/
+  );
+  assert.match(
+    workflow,
+    /name: Create release tag\n\s+if: \$\{\{ !inputs\.catalog_only && !inputs\.prepare_only && inputs\.create_release_tag \}\}/
+  );
+  assert.match(
+    workflow,
+    /name: Invalidate app catalog\n\s+if: \$\{\{ !inputs\.prepare_only && \(inputs\.publish_catalog \|\| inputs\.catalog_only\)/
+  );
+  const verifyCandidateIndex = workflow.indexOf(
+    "name: Verify local app release candidate"
+  );
+  const uploadCandidateIndex = workflow.indexOf(
+    "name: Upload production release candidate"
+  );
+  const configureAwsIndex = workflow.indexOf("name: Configure AWS credentials");
+  const identityCheckIndex = workflow.indexOf(
+    "Approved release candidate mismatch"
+  );
+  assert.notEqual(verifyCandidateIndex, -1);
+  assert.notEqual(uploadCandidateIndex, -1);
+  assert.notEqual(configureAwsIndex, -1);
+  assert.notEqual(identityCheckIndex, -1);
+  assert.ok(
+    verifyCandidateIndex < uploadCandidateIndex,
+    "candidate verification must precede candidate artifact upload"
+  );
+  assert.ok(
+    verifyCandidateIndex < configureAwsIndex,
+    "candidate verification must precede AWS credentials and cloud mutation"
+  );
+  assert.ok(
+    identityCheckIndex < configureAwsIndex,
+    "approved candidate identity checks must precede AWS credentials"
+  );
+  const uploadToS3Index = workflow.indexOf("name: Upload app release to S3");
+  const verifyPublishedIndex = workflow.indexOf(
+    "name: Verify published app release artifact"
+  );
+  assert.notEqual(uploadToS3Index, -1);
+  assert.notEqual(verifyPublishedIndex, -1);
+  assert.ok(
+    uploadToS3Index < verifyPublishedIndex,
+    "remote artifact verification must run after the immutable upload"
+  );
   assert.match(workflow, /CATALOG_ONLY:/);
   assert.match(workflow, /--min-tutti-version "\$\{MIN_TUTTI_VERSION\}"/);
   assert.doesNotMatch(workflow, /required_tutti_capabilities:/);
@@ -852,6 +934,76 @@ test("Tutti app release workflow is reusable by external app repositories", asyn
   assert.match(workflow, /Invalidate app catalog/);
   assert.match(workflow, /cloudfront create-invalidation/);
 });
+
+test("production candidate verification hashes the local archive before cloud access", async () => {
+  const workflow = await readFile(reusableWorkflowPath, "utf8");
+  const script = extractWorkflowNodeScript(
+    workflow,
+    "Verify local app release candidate"
+  );
+  const root = await mkdtemp(path.join(tmpdir(), "tutti-local-candidate-"));
+  const appId = "candidate-test";
+  const version = "1.2.3";
+  const releaseDir = path.join(root, "tutti-app-release", "apps", appId, version);
+  const latestDir = path.dirname(releaseDir);
+  const artifactName = `${appId}-${version}.zip`;
+  const artifact = Buffer.from("approved candidate archive", "utf8");
+  const release = {
+    appId,
+    version,
+    artifactUrl: `https://example.invalid/tutti-app-releases/apps/${appId}/${version}/${artifactName}`,
+    artifactSha256: createHash("sha256").update(artifact).digest("hex"),
+    artifactSizeBytes: artifact.length
+  };
+  await mkdir(releaseDir, { recursive: true });
+  await writeFile(path.join(releaseDir, artifactName), artifact);
+  await writeFile(
+    path.join(releaseDir, "release.json"),
+    `${JSON.stringify(release)}\n`
+  );
+  await writeFile(
+    path.join(latestDir, "latest.json"),
+    `${JSON.stringify(release)}\n`
+  );
+
+  const verified = runWorkflowNodeScript(script, root, { appId, version });
+  assert.equal(verified.status, 0, verified.stderr);
+  assert.match(verified.stdout, /Verified local release candidate/);
+
+  await writeFile(path.join(releaseDir, artifactName), "tampered archive");
+  const rejected = runWorkflowNodeScript(script, root, { appId, version });
+  assert.notEqual(rejected.status, 0);
+  assert.match(rejected.stderr, /local release artifact sha256 mismatch/);
+});
+
+function extractWorkflowNodeScript(workflow, stepName) {
+  const normalized = workflow.replaceAll("\r\n", "\n");
+  const stepIndex = normalized.indexOf(`name: ${stepName}`);
+  assert.notEqual(stepIndex, -1, `missing workflow step ${stepName}`);
+  const heredocIndex = normalized.indexOf("node <<'NODE'\n", stepIndex);
+  assert.notEqual(heredocIndex, -1, `missing Node heredoc for ${stepName}`);
+  const scriptStart = heredocIndex + "node <<'NODE'\n".length;
+  const scriptEnd = normalized.indexOf("\n          NODE", scriptStart);
+  assert.notEqual(scriptEnd, -1, `unterminated Node heredoc for ${stepName}`);
+  return normalized
+    .slice(scriptStart, scriptEnd)
+    .split("\n")
+    .map((line) => line.replace(/^          /u, ""))
+    .join("\n");
+}
+
+function runWorkflowNodeScript(script, cwd, { appId, version }) {
+  return spawnSync(process.execPath, ["-"], {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      APP_ID: appId,
+      RELEASE_VERSION: version
+    },
+    input: script
+  });
+}
 
 test("Tutti app catalog workflow aggregates version indexes", async () => {
   const workflow = await readFile(catalogWorkflowPath, "utf8");


### PR DESCRIPTION
## Summary
- add a reusable `prepare_only` mode that builds and verifies the exact production release candidate on the configured app runner
- upload candidate metadata and ZIP only as a short-lived Actions artifact
- skip AWS credentials, S3 writes, mutable metadata, release tags, catalog publication, and CloudFront invalidation
- document candidate approval and exact release-tools pinning

## Test evidence
- Protected contract: release approval can inspect target version and artifact SHA before any cloud latest/catalog mutation
- Credible failure: omitting a mutation guard would let candidate preparation configure AWS, upload, tag, or publish metadata
- Negative control: the focused test failed on the pre-change workflow because `prepare_only` was absent
- Owner/level: reusable release workflow source contract in the existing repository tooling test
- Validation: focused `build-tutti-app-release.test.mjs` workflow test; `git diff --check`
- Native OS: the workflow executes later on each app's configured production runner; this PR itself does not build Desktop

## Windows impact
No process, path, or Desktop runtime behavior changes. The candidate artifact is built on each caller's configured production runner.

## Documentation
Updated the durable Workspace App GitHub Actions release reference with the prepare/approval flow and exact release-tools pin requirement.
