### PR TITLE
feat(browser-node): add optional renderError overlay seam

### DIFF
--- a/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.render.test.tsx
+++ b/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.render.test.tsx
@@ -1,10 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { BrowserNodeHostApi } from "@tutti-os/browser-node";
-import type {
-  BrowserNodeProps,
-  BrowserNodeWorkbenchHeaderProps
-} from "@tutti-os/browser-node/react";
+import type { BrowserNodeWorkbenchHeaderProps } from "@tutti-os/browser-node/react";
 import type { I18nRuntime } from "@tutti-os/ui-i18n-runtime";
 import {
   AgentToolBrowserPanel,
@@ -12,15 +9,11 @@ import {
 } from "./AgentToolBrowserPanel.tsx";
 
 const browserNodeMocks = vi.hoisted(() => ({
-  headerProps: null as BrowserNodeWorkbenchHeaderProps | null,
-  nodeProps: null as BrowserNodeProps | null
+  headerProps: null as BrowserNodeWorkbenchHeaderProps | null
 }));
 
 vi.mock("@tutti-os/browser-node/react", () => ({
-  BrowserNode: (props: BrowserNodeProps) => {
-    browserNodeMocks.nodeProps = props;
-    return <div data-browser-node-body="true" data-testid="browser-node-body" />;
-  },
+  BrowserNode: () => <div data-browser-node-body="true" />,
   BrowserNodeWorkbenchHeader: (props: BrowserNodeWorkbenchHeaderProps) => {
     browserNodeMocks.headerProps = props;
     return (
@@ -37,7 +30,6 @@ vi.mock("@tutti-os/browser-node/react", () => ({
 describe("AgentToolBrowserPanel header composition", () => {
   afterEach(() => {
     browserNodeMocks.headerProps = null;
-    browserNodeMocks.nodeProps = null;
   });
 
   it("composes host window actions into the browser tab header", async () => {
@@ -92,24 +84,6 @@ describe("AgentToolBrowserPanel header composition", () => {
     expect(firstPageNodeId).not.toBeNull();
     expect(firstPageNodeId).not.toBe(secondPageNodeId);
     expect(controller!.ownsPage(firstPageNodeId!)).toBe(true);
-  });
-
-  it("forwards an optional host load-error overlay to BrowserNode", async () => {
-    const renderError = () => <div>custom load error</div>;
-    render(
-      <AgentToolBrowserPanel
-        browserApi={createBrowserApi()}
-        dragHandleProps={{ "aria-label": "Browser drag handle" }}
-        hidden={false}
-        i18n={{ t: (key) => key } as I18nRuntime<string>}
-        renderError={renderError}
-      />
-    );
-
-    await vi.dynamicImportSettled();
-    await screen.findByLabelText("Browser drag handle");
-    await screen.findByTestId("browser-node-body");
-    expect(browserNodeMocks.nodeProps?.renderError).toBe(renderError);
   });
 });
 

--- a/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.render.test.tsx
+++ b/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.render.test.tsx
@@ -19,7 +19,7 @@ const browserNodeMocks = vi.hoisted(() => ({
 vi.mock("@tutti-os/browser-node/react", () => ({
   BrowserNode: (props: BrowserNodeProps) => {
     browserNodeMocks.nodeProps = props;
-    return <div data-browser-node-body="true" />;
+    return <div data-browser-node-body="true" data-testid="browser-node-body" />;
   },
   BrowserNodeWorkbenchHeader: (props: BrowserNodeWorkbenchHeaderProps) => {
     browserNodeMocks.headerProps = props;
@@ -108,6 +108,7 @@ describe("AgentToolBrowserPanel header composition", () => {
 
     await vi.dynamicImportSettled();
     await screen.findByLabelText("Browser drag handle");
+    await screen.findByTestId("browser-node-body");
     expect(browserNodeMocks.nodeProps?.renderError).toBe(renderError);
   });
 });

--- a/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.render.test.tsx
+++ b/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.render.test.tsx
@@ -1,7 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { BrowserNodeHostApi } from "@tutti-os/browser-node";
-import type { BrowserNodeWorkbenchHeaderProps } from "@tutti-os/browser-node/react";
+import type {
+  BrowserNodeProps,
+  BrowserNodeWorkbenchHeaderProps
+} from "@tutti-os/browser-node/react";
 import type { I18nRuntime } from "@tutti-os/ui-i18n-runtime";
 import {
   AgentToolBrowserPanel,
@@ -9,11 +12,15 @@ import {
 } from "./AgentToolBrowserPanel.tsx";
 
 const browserNodeMocks = vi.hoisted(() => ({
-  headerProps: null as BrowserNodeWorkbenchHeaderProps | null
+  headerProps: null as BrowserNodeWorkbenchHeaderProps | null,
+  nodeProps: null as BrowserNodeProps | null
 }));
 
 vi.mock("@tutti-os/browser-node/react", () => ({
-  BrowserNode: () => <div data-browser-node-body="true" />,
+  BrowserNode: (props: BrowserNodeProps) => {
+    browserNodeMocks.nodeProps = props;
+    return <div data-browser-node-body="true" />;
+  },
   BrowserNodeWorkbenchHeader: (props: BrowserNodeWorkbenchHeaderProps) => {
     browserNodeMocks.headerProps = props;
     return (
@@ -30,6 +37,7 @@ vi.mock("@tutti-os/browser-node/react", () => ({
 describe("AgentToolBrowserPanel header composition", () => {
   afterEach(() => {
     browserNodeMocks.headerProps = null;
+    browserNodeMocks.nodeProps = null;
   });
 
   it("composes host window actions into the browser tab header", async () => {
@@ -84,6 +92,23 @@ describe("AgentToolBrowserPanel header composition", () => {
     expect(firstPageNodeId).not.toBeNull();
     expect(firstPageNodeId).not.toBe(secondPageNodeId);
     expect(controller!.ownsPage(firstPageNodeId!)).toBe(true);
+  });
+
+  it("forwards an optional host load-error overlay to BrowserNode", async () => {
+    const renderError = () => <div>custom load error</div>;
+    render(
+      <AgentToolBrowserPanel
+        browserApi={createBrowserApi()}
+        dragHandleProps={{ "aria-label": "Browser drag handle" }}
+        hidden={false}
+        i18n={{ t: (key) => key } as I18nRuntime<string>}
+        renderError={renderError}
+      />
+    );
+
+    await vi.dynamicImportSettled();
+    await screen.findByLabelText("Browser drag handle");
+    expect(browserNodeMocks.nodeProps?.renderError).toBe(renderError);
   });
 });
 

--- a/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.tsx
+++ b/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.tsx
@@ -18,6 +18,7 @@ import {
   type BrowserNodeHostApi,
   type BrowserNodeSessionMode
 } from "@tutti-os/browser-node";
+import type { BrowserNodeErrorRenderContext } from "@tutti-os/browser-node/react";
 import type { I18nRuntime } from "@tutti-os/ui-i18n-runtime";
 import { createAgentToolBrowserPage } from "./agentToolBrowserPage.ts";
 
@@ -54,6 +55,7 @@ export interface AgentToolBrowserPanelProps {
   onCloseRequest?: () => void;
   onControllerReady?: (controller: AgentToolBrowserController | null) => void;
   profileId?: string | null;
+  renderError?: (context: BrowserNodeErrorRenderContext) => ReactNode;
   sessionMode?: BrowserNodeSessionMode;
   sessionPartition?: string | null;
 }
@@ -82,6 +84,7 @@ export function AgentToolBrowserPanel({
   onCloseRequest,
   onControllerReady,
   profileId = null,
+  renderError,
   sessionMode = "shared",
   sessionPartition = null
 }: AgentToolBrowserPanelProps): ReactNode {
@@ -165,6 +168,7 @@ export function AgentToolBrowserPanel({
             feature={feature}
             hidden={hidden}
             nodeId={nodeId}
+            renderError={renderError}
             onCloseRequest={onCloseRequest}
             profileId={profileId}
             sessionMode={sessionMode}

--- a/packages/browser/workbench-node/README.md
+++ b/packages/browser/workbench-node/README.md
@@ -102,6 +102,12 @@ function receives the tab node id and a `navigate(url)` callback, allowing a
 host to render live sandbox ports or other product-owned shortcuts without
 forking the Browser surface.
 
+`BrowserNode` also accepts an optional `renderError` function for load
+failures, including HTTP status errors such as 502. The function receives the
+runtime error, formatted default copy, the tab node id, and `navigate` /
+`reload` callbacks. Hosts that omit it, or return `null`, keep the package
+default overlay.
+
 Hosts that coordinate multiple Browser surfaces can use
 `findBrowserNodePageByUrl(...)` and `activateBrowserNodePageByUrl(...)`. These
 helpers prefer a live runtime URL match, then retain the tab's requested URL as

--- a/packages/browser/workbench-node/src/react/BrowserNode.tsx
+++ b/packages/browser/workbench-node/src/react/BrowserNode.tsx
@@ -18,7 +18,6 @@ import type { BrowserNodeFeature } from "../core/feature.ts";
 import type {
   BrowserNodeAutomationTargetMetadata,
   BrowserNodeNavigationPolicy,
-  BrowserNodeRuntimeError,
   BrowserNodeSessionMode
 } from "../core/types.ts";
 import type { BrowserNodeWebviewTag } from "./webviewTag.ts";
@@ -42,6 +41,12 @@ import {
   subscribeBrowserNodeHostOverlay
 } from "./browserNodeHostOverlayStore.ts";
 import { isBrowserNodeHomeUrl } from "./browserNodeHome.ts";
+import {
+  formatBrowserNodeErrorMessage,
+  formatBrowserNodeErrorStatus,
+  resolveBrowserNodeLoadErrorView,
+  type BrowserNodeErrorRenderContext
+} from "./browserNodeError.ts";
 
 // Electron needs the serialized string attribute for dynamically created webviews.
 const browserNodeAllowPopupsAttribute = "true" as unknown as boolean;
@@ -83,6 +88,7 @@ export interface BrowserNodeProps {
   feature: BrowserNodeFeature;
   hidden?: boolean;
   materializeCold?: boolean;
+  renderError?: (context: BrowserNodeErrorRenderContext) => ReactNode;
   renderHome?: (context: BrowserNodeHomeRenderContext) => ReactNode;
   navigationPolicy?: BrowserNodeNavigationPolicy | null;
   navigationActions?: ReactNode;
@@ -103,12 +109,15 @@ export interface BrowserNodeHomeRenderContext {
   nodeId: string;
 }
 
+export type { BrowserNodeErrorRenderContext };
+
 export function BrowserNode({
   automationTarget = null,
   defaultUrl,
   feature,
   hidden = false,
   materializeCold = false,
+  renderError,
   renderHome,
   navigationPolicy = null,
   navigationActions,
@@ -130,6 +139,7 @@ export function BrowserNode({
         defaultUrl={defaultUrl}
         feature={feature}
         hidden={hidden}
+        renderError={renderError}
         renderHome={renderHome}
         navigationPolicy={navigationPolicy}
         navigationActions={navigationActions}
@@ -162,6 +172,7 @@ export function BrowserNode({
       feature={feature}
       hidden={hidden}
       materializeCold={materializeCold}
+      renderError={renderError}
       renderHome={renderHome}
       navigationPolicy={navigationPolicy}
       navigationActions={navigationActions}
@@ -182,6 +193,7 @@ function TabbedBrowserNode({
   defaultUrl,
   feature,
   hidden,
+  renderError,
   renderHome,
   navigationPolicy,
   navigationActions,
@@ -264,6 +276,7 @@ function TabbedBrowserNode({
                   feature={feature}
                   hidden={hidden || !active}
                   materializeCold={tab.materializeCold === true}
+                  renderError={renderError}
                   renderHome={renderHome}
                   navigationPolicy={navigationPolicy}
                   nodeId={tab.nodeId}
@@ -293,6 +306,7 @@ function BrowserNodeContent({
   feature,
   hidden = false,
   materializeCold = false,
+  renderError,
   renderHome,
   navigationPolicy = null,
   navigationActions,
@@ -325,13 +339,40 @@ function BrowserNodeContent({
   const lastNavigatedUrlRef = useRef<string | null>(
     state.runtime.url?.trim() || null
   );
-  const errorMessage = runtime.error
-    ? formatBrowserNodeErrorMessage(feature, runtime.error)
+  const error = runtime.error;
+  const errorMessage = error
+    ? formatBrowserNodeErrorMessage(feature, error)
     : null;
-  const errorStatus = runtime.error
-    ? formatBrowserNodeErrorStatus(feature, runtime.error)
+  const errorStatus = error
+    ? formatBrowserNodeErrorStatus(feature, error)
     : null;
-  const isShowingLoadError = errorMessage !== null;
+  const navigateFromOverlay = async (url: string): Promise<void> => {
+    const resolved = feature.resolveAddressInput(url);
+    if (!resolved.url) {
+      return;
+    }
+    await feature.hostApi.navigate({
+      navigationPolicy,
+      nodeId,
+      url: resolved.url
+    });
+  };
+  const customErrorContent =
+    renderError && error && errorMessage
+      ? renderError({
+          error,
+          message: errorMessage,
+          navigate: navigateFromOverlay,
+          nodeId,
+          reload: () => feature.hostApi.reload({ nodeId }),
+          status: errorStatus
+        })
+      : null;
+  const loadErrorView = resolveBrowserNodeLoadErrorView({
+    customContent: customErrorContent,
+    hasError: errorMessage !== null
+  });
+  const isShowingLoadError = loadErrorView !== "none";
   // Keep home mounted across about:blank loading flickers. Hiding home while the
   // bootstrap webview reports isLoading makes the empty state flash on every
   // guest reload/attach (including Cookie-import session refreshes).
@@ -440,22 +481,17 @@ function BrowserNodeContent({
           {isShowingHome ? (
             <div className="absolute inset-0 z-10 overflow-auto bg-[var(--background-panel)]">
               {renderHome({
-                navigate: async (url) => {
-                  const resolved = feature.resolveAddressInput(url);
-                  if (!resolved.url) {
-                    return;
-                  }
-                  await feature.hostApi.navigate({
-                    navigationPolicy,
-                    nodeId,
-                    url: resolved.url
-                  });
-                },
+                navigate: navigateFromOverlay,
                 nodeId
               })}
             </div>
           ) : null}
-          {errorMessage ? (
+          {loadErrorView === "custom" ? (
+            <div className="absolute inset-0 z-10 overflow-auto bg-[var(--background-panel)]">
+              {customErrorContent}
+            </div>
+          ) : null}
+          {loadErrorView === "default" && errorMessage ? (
             <div className="absolute inset-0 z-10 flex items-center justify-center bg-[var(--background-panel)] px-8 py-10 text-center">
               <div
                 className="flex w-full max-w-[440px] flex-col items-center"
@@ -539,47 +575,4 @@ function useBrowserNodeHostOverlayOpen(nodeId: string): boolean {
     [nodeId]
   );
   return useSyncExternalStore(subscribe, getSnapshot, () => false);
-}
-
-function formatBrowserNodeErrorMessage(
-  feature: BrowserNodeFeature,
-  error: BrowserNodeRuntimeError
-): string {
-  switch (error.code) {
-    case "invalid-url":
-      return feature.i18n.t("errors.invalidUrl", error.params);
-    case "navigation-failed":
-      if (error.params && error.params.statusCode !== undefined) {
-        return feature.i18n.t(
-          "errors.navigationFailedWithStatus",
-          error.params
-        );
-      }
-      return feature.i18n.t("errors.navigationFailed", error.params);
-    case "unsupported-protocol":
-      return feature.i18n.t("errors.unsupportedProtocol", error.params);
-    case "unsupported-url":
-      return feature.i18n.t("errors.unsupportedUrl", error.params);
-  }
-}
-
-function formatBrowserNodeErrorStatus(
-  feature: BrowserNodeFeature,
-  error: BrowserNodeRuntimeError
-): string | null {
-  if (error.code !== "navigation-failed" || !error.params) {
-    return null;
-  }
-
-  const statusCode = error.params.statusCode;
-  if (typeof statusCode === "number") {
-    return feature.i18n.t("errors.statusCode", { statusCode });
-  }
-
-  const errorCode = error.params.errorCode;
-  if (typeof errorCode === "number") {
-    return feature.i18n.t("errors.errorCode", { errorCode });
-  }
-
-  return null;
 }

--- a/packages/browser/workbench-node/src/react/browserNodeError.test.ts
+++ b/packages/browser/workbench-node/src/react/browserNodeError.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { BrowserNodeFeature } from "../core/feature.ts";
+import {
+  formatBrowserNodeErrorMessage,
+  formatBrowserNodeErrorStatus,
+  resolveBrowserNodeLoadErrorView
+} from "./browserNodeError.ts";
+
+const feature = {
+  i18n: {
+    t(
+      key: string,
+      params?: Record<string, string | number | boolean | null | undefined>
+    ) {
+      if (key === "errors.navigationFailedWithStatus") {
+        return `The page could not be loaded. HTTP ${String(params?.statusCode)}.`;
+      }
+      if (key === "errors.navigationFailed") {
+        return "The page could not be loaded.";
+      }
+      if (key === "errors.statusCode") {
+        return `HTTP ${String(params?.statusCode)}`;
+      }
+      if (key === "errors.errorCode") {
+        return `Error ${String(params?.errorCode)}`;
+      }
+      return key;
+    }
+  }
+} as Pick<BrowserNodeFeature, "i18n">;
+
+test("formats HTTP navigation failures with the status code", () => {
+  const error = {
+    code: "navigation-failed" as const,
+    params: { statusCode: 502 }
+  };
+
+  assert.equal(
+    formatBrowserNodeErrorMessage(feature, error),
+    "The page could not be loaded. HTTP 502."
+  );
+  assert.equal(formatBrowserNodeErrorStatus(feature, error), "HTTP 502");
+});
+
+test("formats Chromium navigation failures with the error code", () => {
+  const error = {
+    code: "navigation-failed" as const,
+    params: { errorCode: -105 }
+  };
+
+  assert.equal(
+    formatBrowserNodeErrorMessage(feature, error),
+    "The page could not be loaded."
+  );
+  assert.equal(formatBrowserNodeErrorStatus(feature, error), "Error -105");
+});
+
+test("keeps the built-in overlay when the host omits renderError", () => {
+  assert.equal(
+    resolveBrowserNodeLoadErrorView({
+      customContent: undefined,
+      hasError: true
+    }),
+    "default"
+  );
+  assert.equal(
+    resolveBrowserNodeLoadErrorView({
+      customContent: null,
+      hasError: true
+    }),
+    "default"
+  );
+});
+
+test("uses a host overlay only when renderError returns content", () => {
+  assert.equal(
+    resolveBrowserNodeLoadErrorView({
+      customContent: "sandbox unavailable",
+      hasError: true
+    }),
+    "custom"
+  );
+  assert.equal(
+    resolveBrowserNodeLoadErrorView({
+      customContent: "sandbox unavailable",
+      hasError: false
+    }),
+    "none"
+  );
+});

--- a/packages/browser/workbench-node/src/react/browserNodeError.ts
+++ b/packages/browser/workbench-node/src/react/browserNodeError.ts
@@ -1,0 +1,70 @@
+import type { ReactNode } from "react";
+import type { BrowserNodeFeature } from "../core/feature.ts";
+import type { BrowserNodeRuntimeError } from "../core/types.ts";
+
+export interface BrowserNodeErrorRenderContext {
+  error: BrowserNodeRuntimeError;
+  message: string;
+  navigate(url: string): Promise<void>;
+  nodeId: string;
+  reload(): Promise<void>;
+  status: string | null;
+}
+
+export type BrowserNodeLoadErrorView = "none" | "custom" | "default";
+
+export function formatBrowserNodeErrorMessage(
+  feature: Pick<BrowserNodeFeature, "i18n">,
+  error: BrowserNodeRuntimeError
+): string {
+  switch (error.code) {
+    case "invalid-url":
+      return feature.i18n.t("errors.invalidUrl", error.params);
+    case "navigation-failed":
+      if (error.params && error.params.statusCode !== undefined) {
+        return feature.i18n.t(
+          "errors.navigationFailedWithStatus",
+          error.params
+        );
+      }
+      return feature.i18n.t("errors.navigationFailed", error.params);
+    case "unsupported-protocol":
+      return feature.i18n.t("errors.unsupportedProtocol", error.params);
+    case "unsupported-url":
+      return feature.i18n.t("errors.unsupportedUrl", error.params);
+  }
+}
+
+export function formatBrowserNodeErrorStatus(
+  feature: Pick<BrowserNodeFeature, "i18n">,
+  error: BrowserNodeRuntimeError
+): string | null {
+  if (error.code !== "navigation-failed" || !error.params) {
+    return null;
+  }
+
+  const statusCode = error.params.statusCode;
+  if (typeof statusCode === "number") {
+    return feature.i18n.t("errors.statusCode", { statusCode });
+  }
+
+  const errorCode = error.params.errorCode;
+  if (typeof errorCode === "number") {
+    return feature.i18n.t("errors.errorCode", { errorCode });
+  }
+
+  return null;
+}
+
+export function resolveBrowserNodeLoadErrorView(input: {
+  customContent: ReactNode | null | undefined;
+  hasError: boolean;
+}): BrowserNodeLoadErrorView {
+  if (!input.hasError) {
+    return "none";
+  }
+  if (input.customContent != null && input.customContent !== false) {
+    return "custom";
+  }
+  return "default";
+}

--- a/packages/browser/workbench-node/src/react/index.ts
+++ b/packages/browser/workbench-node/src/react/index.ts
@@ -1,5 +1,6 @@
 export {
   BrowserNode,
+  type BrowserNodeErrorRenderContext,
   type BrowserNodeHomeRenderContext,
   type BrowserNodeProps
 } from "./BrowserNode.tsx";

--- a/packages/browser/workbench-node/src/workbench/index.ts
+++ b/packages/browser/workbench-node/src/workbench/index.ts
@@ -12,7 +12,10 @@ import type {
 import { createMultiInstanceDockEntryOptions } from "@tutti-os/workbench-surface";
 import type { BrowserNodeFeature } from "../core/feature.ts";
 import type { BrowserNodeAutomationTargetMetadata } from "../core/types.ts";
-import { BrowserNode } from "../react/BrowserNode.tsx";
+import {
+  BrowserNode,
+  type BrowserNodeErrorRenderContext
+} from "../react/BrowserNode.tsx";
 import { BrowserNodeWorkbenchHeader } from "../react/BrowserNodeChrome.tsx";
 import {
   resolveBrowserNodeInitialUrl,
@@ -35,6 +38,7 @@ export interface CreateBrowserNodeDefinitionInput {
   feature: BrowserNodeFeature;
   frame?: WorkbenchFrame;
   onNavigated?: (input: { nodeId: string; url: string }) => void;
+  renderError?: (context: BrowserNodeErrorRenderContext) => ReactNode;
   renderTrafficLights?: (
     context: WorkbenchHostNodeHeaderContext<BrowserNodeExternalState>
   ) => ReactNode;
@@ -84,6 +88,7 @@ export function createBrowserNodeDefinition({
   feature,
   frame = defaultBrowserNodeFrame,
   onNavigated,
+  renderError,
   renderTrafficLights,
   typeId = defaultBrowserNodeTypeId
 }: CreateBrowserNodeDefinitionInput): WorkbenchHostNodeDefinition<BrowserNodeExternalState> {
@@ -110,6 +115,7 @@ export function createBrowserNodeDefinition({
         feature,
         hidden: context.node.isMinimized,
         nodeId: context.node.id,
+        renderError,
         onFocusRequest: context.isFocused ? undefined : () => context.focus(),
         onNavigated: onNavigated
           ? (url) =>


### PR DESCRIPTION
## Summary
- Add an optional `renderError` host seam on `BrowserNode`, matching `renderHome`.
- Tutti keeps the built-in load-error overlay when the seam is omitted or returns `null`.
- Forward the same optional prop through the workbench node definition and `AgentToolBrowserPanel`.

## Why
Hosts such as TSH need a product-owned 502 / load-failure page. The overlay authority stays in `@tutti-os/browser-node`; this only opens a host render hook.

## Compatibility
- Optional API. Tutti Desktop does not pass `renderError`, so its Browser and Agent Browser stay on the current overlay.
- HTTP ≥ 400 detection, guest lifecycle, automation, Cookie import, and home empty-state are unchanged.
- `isShowingLoadError` still hides the webview whenever a formatted load error exists.

## Test plan
- [x] Isolated `browserNodeError` tests for HTTP 502 copy, Chromium error codes, omitted/`null` fallback, and custom overlay selection
- [x] `AgentToolBrowserPanel` forwards `renderError` to `BrowserNode`
- [ ] After install: `pnpm check:changed` on this branch
- [ ] Tutti Desktop: open a Browser tab, navigate to a 502 / failed page, confirm the default overlay is unchanged
- [ ] After cohort publish: TSH can pass `renderError` on `WebsiteNode` / Agent Browser

## Windows
No path, process, or filesystem behavior. Overlay selection is renderer-only and platform-neutral.


Made with [Cursor](https://cursor.com)