### PR TITLE
fix(runtimeprep): require host-owned personal skill roots

### DIFF
--- a/packages/agent/runtimeprep/README.md
+++ b/packages/agent/runtimeprep/README.md
@@ -58,7 +58,8 @@ value. VM-backed hosts must pass the explicit stable root and must not create a
 compatibility facade under the Linux login Home.
 
 Desktop composition also supplies the provider user's stable personal Skill
-root. Runtime preparation exposes that directory directly as
+root and materializes it with the provider user's ownership before preparation.
+Runtime preparation requires that root to exist and exposes it directly as
 `$CODEX_HOME/skills` (a symlink on POSIX and a directory junction on Windows),
 so Codex's native skill-creator keeps its ordinary personal-by-default behavior
 without copying or promoting content from historical Session homes. Tutti-owned

--- a/packages/agent/runtimeprep/claude_personal_skill.go
+++ b/packages/agent/runtimeprep/claude_personal_skill.go
@@ -15,9 +15,6 @@ func prepareClaudePersonalSkillDirectory(runtimeRoot string, personalSkillRoot s
 	if !filepath.IsAbs(personalSkillRoot) || personalSkillRoot == string(filepath.Separator) {
 		return "", fmt.Errorf("claude personal skill root must be an absolute non-root path")
 	}
-	if err := os.MkdirAll(personalSkillRoot, 0o700); err != nil {
-		return "", fmt.Errorf("create Claude personal skill root: %w", err)
-	}
 	personalInfo, err := os.Lstat(personalSkillRoot)
 	if err != nil {
 		return "", fmt.Errorf("inspect Claude personal skill root: %w", err)

--- a/packages/agent/runtimeprep/codex_personal_skill.go
+++ b/packages/agent/runtimeprep/codex_personal_skill.go
@@ -12,12 +12,15 @@ func exposePersonalCodexSkillRoot(targetRoot string, personalRoot string, sessio
 	if personalRoot == "." || !filepath.IsAbs(personalRoot) {
 		return fmt.Errorf("codex personal skill root must be absolute")
 	}
-	if err := os.MkdirAll(personalRoot, 0o700); err != nil {
-		return fmt.Errorf("create Codex personal skill root: %w", err)
+	personalInfo, err := os.Stat(personalRoot)
+	if err != nil {
+		return fmt.Errorf("inspect Codex personal skill root: %w", err)
+	}
+	if !personalInfo.IsDir() {
+		return fmt.Errorf("codex personal skill root must be a directory: %s", personalRoot)
 	}
 	if targetInfo, err := os.Stat(targetRoot); err == nil {
-		personalInfo, personalErr := os.Stat(personalRoot)
-		if personalErr == nil && os.SameFile(targetInfo, personalInfo) {
+		if os.SameFile(targetInfo, personalInfo) {
 			return nil
 		}
 	} else if !os.IsNotExist(err) {

--- a/packages/agent/runtimeprep/preparer_test.go
+++ b/packages/agent/runtimeprep/preparer_test.go
@@ -16,6 +16,9 @@ func TestDesktopCodexPersonalSkillCreatedInOneSessionIsVisibleInAnother(t *testi
 	home := t.TempDir()
 	setTestHome(t, home)
 	personalRoot := filepath.Join(home, ".codex", "skills")
+	if err := os.MkdirAll(personalRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
 	preparer := newTestPreparer(t.TempDir())
 	preparer.RegisterProvider(CodexPreparer{PersonalSkillRoot: personalRoot})
 
@@ -60,6 +63,46 @@ func TestDesktopCodexPersonalSkillCreatedInOneSessionIsVisibleInAnother(t *testi
 	}
 	if len(extraRoots) != 1 || filepath.Base(extraRoots[0]) != "codex-session-skills" {
 		t.Fatalf("extra Skill roots = %#v, want isolated session root", extraRoots)
+	}
+}
+
+func TestConfiguredPersonalSkillRootMustAlreadyExist(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		provider string
+		register func(*DefaultPreparer, string)
+	}{
+		{
+			name: "codex", provider: "codex",
+			register: func(preparer *DefaultPreparer, root string) {
+				preparer.RegisterProvider(CodexPreparer{PersonalSkillRoot: root})
+			},
+		},
+		{
+			name: "claude", provider: "claude-code",
+			register: func(preparer *DefaultPreparer, root string) {
+				preparer.RegisterProvider(ClaudeCodePreparer{PersonalSkillRoot: root})
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			personalRoot := filepath.Join(t.TempDir(), "missing-personal-skills")
+			preparer := newTestPreparer(t.TempDir())
+			tc.register(preparer, personalRoot)
+			_, err := preparer.Prepare(t.Context(), PrepareInput{
+				WorkspaceID:    "workspace-1",
+				AgentSessionID: "session-1",
+				AgentTargetID:  "local:" + tc.provider,
+				Provider:       tc.provider,
+				Cwd:            t.TempDir(),
+			})
+			if err == nil || !strings.Contains(strings.ToLower(err.Error()), "personal skill root") {
+				t.Fatalf("Prepare() error = %v, want missing personal skill root error", err)
+			}
+			if _, statErr := os.Lstat(personalRoot); !os.IsNotExist(statErr) {
+				t.Fatalf("runtimeprep created Host-owned personal skill root: %v", statErr)
+			}
+		})
 	}
 }
 

--- a/services/tuttid/wiring_daemon_api.go
+++ b/services/tuttid/wiring_daemon_api.go
@@ -277,10 +277,9 @@ func buildDaemonAPI(
 	if err != nil {
 		return tuttiapi.DaemonAPI{}, nil, nil, nil, fmt.Errorf("resolve user home for personal Codex Skills: %w", err)
 	}
-	agentRuntimePreparer.RegisterProvider(runtimeprep.CodexPreparer{
-		AuthProjector:     runtimeprep.MutagenAuthFileProjector{StateDir: tuttitypes.DefaultStateDir()},
-		PersonalSkillRoot: filepath.Join(userHome, ".codex", "skills"),
-	})
+	if err := registerDaemonCodexPreparer(agentRuntimePreparer, tuttitypes.DefaultStateDir(), userHome); err != nil {
+		return tuttiapi.DaemonAPI{}, nil, nil, nil, err
+	}
 	agentRuntimePreparer.RegisterProvider(tuttiagentservice.NewPreparer(tuttitypes.DefaultStateDir()))
 	configureAgentRuntimeAvailability(agentRuntimePreparer, browserService, computerService)
 	userProjectService := userprojectservice.Service{
@@ -861,4 +860,20 @@ func buildDaemonAPI(
 			}
 		},
 	}, appCenterService, agentRuntime, providerAuthWatcher, nil
+}
+
+func registerDaemonCodexPreparer(
+	preparer *runtimeprep.DefaultPreparer,
+	stateDir string,
+	userHome string,
+) error {
+	personalSkillRoot := filepath.Join(userHome, ".codex", "skills")
+	if err := os.MkdirAll(personalSkillRoot, 0o700); err != nil {
+		return fmt.Errorf("create personal Codex Skills root: %w", err)
+	}
+	preparer.RegisterProvider(runtimeprep.CodexPreparer{
+		AuthProjector:     runtimeprep.MutagenAuthFileProjector{StateDir: stateDir},
+		PersonalSkillRoot: personalSkillRoot,
+	})
+	return nil
 }

--- a/services/tuttid/wiring_daemon_api_test.go
+++ b/services/tuttid/wiring_daemon_api_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	runtimeprep "github.com/tutti-os/tutti/packages/agent/runtimeprep"
+)
+
+func TestRegisterDaemonCodexPreparerCreatesPersonalSkillRootForFreshUser(t *testing.T) {
+	userHome := t.TempDir()
+	personalSkillRoot := filepath.Join(userHome, ".codex", "skills")
+	if _, err := os.Lstat(personalSkillRoot); !os.IsNotExist(err) {
+		t.Fatalf("personal Skill root exists before Host wiring: %v", err)
+	}
+
+	preparer := runtimeprep.NewDefaultPreparer(t.TempDir())
+	preparer.CLICommand = "tutti"
+	preparer.CommandCatalog = runtimePrepCommandCatalog{}
+	if err := registerDaemonCodexPreparer(preparer, t.TempDir(), userHome); err != nil {
+		t.Fatalf("registerDaemonCodexPreparer() error = %v", err)
+	}
+	info, err := os.Stat(personalSkillRoot)
+	if err != nil {
+		t.Fatalf("stat Host-created personal Skill root: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("Host-created personal Skill root mode = %v, want directory", info.Mode())
+	}
+
+	_, err = preparer.Prepare(context.Background(), runtimeprep.PrepareInput{
+		WorkspaceID:       "workspace-1",
+		AgentSessionID:    "session-1",
+		AgentTargetID:     "local:codex",
+		Provider:          "codex",
+		Cwd:               t.TempDir(),
+		ProviderStateHome: filepath.Join(userHome, ".codex"),
+	})
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- require configured Codex and Claude personal skill roots to exist before runtime preparation
- create the standalone Tutti Desktop Codex personal Skill root in Host wiring before registering runtimeprep
- prevent privileged runtimeprep from creating Host-owned roots with the wrong owner
- document the Host/runtimeprep ownership boundary

## Validation

- go test ./packages/agent/runtimeprep ./services/tuttid -count=1
- focused fresh-user Host test passes and full Codex preparation succeeds
- regression negative controls: restoring runtimeprep MkdirAll makes both provider contract cases fail; removing Host MkdirAll makes the fresh-user Host case fail
- push-ready passed 53 of 54 lanes; the remaining services/tuttid lane repeatedly failed in the unrelated existing TestAppRunnerRetriesFreshPortAfterBindFailure timing test

## Platform assessment

The contract is platform-neutral: the Host creates the configured root with standard filepath and os.MkdirAll behavior, then runtimeprep exposes it. POSIX symlink and Windows junction behavior remain unchanged. The Host test uses portable filesystem APIs and is included in Windows Go CI.

Signed-off-by: Niuma <niuma@users.noreply.github.com>