### PR TITLE
fix(connector): keep device code visible during authorization

### DIFF
--- a/docs/conventions/troubleshooting/connector-market.md
+++ b/docs/conventions/troubleshooting/connector-market.md
@@ -1,5 +1,28 @@
 # Connector Market Troubleshooting
 
+### Device code is missed when authorization moves focus to the browser
+
+**Symptoms**
+
+- the Connector authorization dialog enters a pending state, but the user does
+  not see the device code before the browser gains focus
+- reopening the desktop makes the code visible in the existing dialog
+- the authorization operation and broker session are healthy
+
+**Check**
+
+Confirm the broker result contains a `device_code` Authorization View and the
+renderer stores that View under the current Connector dialog. Then distinguish
+the View transition from its explicit `activate` event: receiving the View must
+not invoke the host's external-navigation callback.
+
+**Rule**
+
+Keep device-code authorization in the existing dialog. Receiving the View only
+renders its code; the user-owned `activate` action opens the verification URL.
+Continue to auto-open ordinary `external_link` Views, whose URL is itself the
+next authorization step.
+
 ### A second authorize click starts another OAuth session
 
 **Symptoms**
@@ -19,8 +42,8 @@ Trace the renderer Promise separately from the Host Start. While
 `beginAuthorization` must return that Promise and must not increment Host
 starts. The dialog Authorize control stays disabled on
 `actionWaitingAuthorization`; browser OAuth must not swap that control for
-Continue when Start returns a synthesized `external_link` view. Only Cancel
-ends the round. After Cancel, the
+Continue when Start returns a synthesized `external_link` view. Cancel and the
+authorization dialog's close button both end the round. After either action, the
 next Authorize may send `replacementPolicy=replace_active` with a new
 `clientRequestId`. Continuation polling inside the same action still reuses one
 identity. Do not re-relay a provider `code` after Complete.

--- a/packages/connector/renderer/README.md
+++ b/packages/connector/renderer/README.md
@@ -46,6 +46,12 @@ the neutral Renderer UI contracts. Neither host is imported by this package.
 Wire authorization schemas and the OpenAPI fragment are published by
 `@tutti-os/connector-contracts`.
 
+When a newly received Authorization View is an `external_link`, Connector
+Renderer opens its activation URL once. A `device_code` View instead replaces
+the contents of the existing authorization dialog without opening the browser.
+The user can copy its code and explicitly activate the dialog action when they
+are ready to open the verification URL.
+
 Hosts that compile Tailwind utilities from published packages must include the
 Renderer build output as a source, for example:
 

--- a/packages/connector/renderer/src/application/services/connectorMarketService.test.ts
+++ b/packages/connector/renderer/src/application/services/connectorMarketService.test.ts
@@ -1895,7 +1895,7 @@ test("keeps QR authorization in app state without opening its payload", async ()
   service.dispose();
 });
 
-test("opens a device-code verification page once while keeping the code visible", async () => {
+test("keeps device-code authorization in the existing dialog until the user activates it", async () => {
   const continueAuthorization = deferred<void>();
   const openedUrls: string[] = [];
   let step = 0;
@@ -1947,7 +1947,7 @@ test("opens a device-code verification page once while keeping the code visible"
       service.dataStore.authorizationViewsByConnectorKey["github-cli"]?.view
         .type === "device_code"
   );
-  assert.deepEqual(openedUrls, ["https://github.com/login/device"]);
+  assert.deepEqual(openedUrls, []);
   assert.equal(
     service.dataStore.authorizationViewsByConnectorKey["github-cli"]?.view
       .type === "device_code"
@@ -1959,7 +1959,7 @@ test("opens a device-code verification page once while keeping the code visible"
 
   continueAuthorization.resolve();
   await authorization;
-  assert.deepEqual(openedUrls, ["https://github.com/login/device"]);
+  assert.deepEqual(openedUrls, []);
   service.dispose();
 });
 

--- a/packages/connector/renderer/src/application/services/connectorMarketService.ts
+++ b/packages/connector/renderer/src/application/services/connectorMarketService.ts
@@ -605,14 +605,8 @@ export class ConnectorMarketService implements IConnectorMarketService {
           seenAuthorizationViewIds.add(authorizationView.viewId);
           this.dataStore.authorizationViewsByConnectorKey[connectorKey] =
             authorizationView;
-          const activationUrl =
-            authorizationView.view.type === "external_link"
-              ? authorizationView.view.url
-              : authorizationView.view.type === "device_code"
-                ? authorizationView.view.verificationUrl
-                : null;
-          if (activationUrl) {
-            await this.openAuthorizationUrl(activationUrl);
+          if (authorizationView.view.type === "external_link") {
+            await this.openAuthorizationUrl(authorizationView.view.url);
           }
         }
         if (this.authorizationState(connectorKey) === "connected") {

--- a/packages/connector/renderer/src/ui/dialogs/ConnectorMarketDialogs.spec.tsx
+++ b/packages/connector/renderer/src/ui/dialogs/ConnectorMarketDialogs.spec.tsx
@@ -116,7 +116,56 @@ describe("ConnectorMarketDialogs", () => {
     expect(onTryConnector).toHaveBeenCalledWith("gmail");
   });
 
-  it("keeps one authorization action until the user finishes or cancels", async () => {
+  it("shows a device code while authorization remains pending", () => {
+    const viewState = proxy(
+      emptyView({
+        ...authorizationDialog,
+        authorizing: true,
+        pending: true,
+        authorizationView: {
+          protocol: "tutti.connector.authorization.view.v1",
+          viewId: "github-device-code-1",
+          view: {
+            type: "device_code",
+            verificationUrl: "https://github.com/login/device",
+            userCode: "ABCD-EFGH"
+          }
+        }
+      })
+    );
+    const root = {
+      market: {
+        dataStore: proxy({
+          pendingUninstallNotificationsByOperationId: {}
+        })
+      },
+      uiState: {
+        dataStore: proxy({
+          dialog: { connectorKey: "github-cli", kind: "connector" },
+          query: "",
+          scope: {},
+          started: true
+        })
+      },
+      view: { dataStore: viewState }
+    } as unknown as IConnectorMarketRoot;
+
+    render(
+      <ConnectorMarketRootProvider i18n={i18n} root={root}>
+        <ConnectorMarketDialogs />
+      </ConnectorMarketRootProvider>
+    );
+
+    expect(screen.getByText("ABCD-EFGH")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "actionContinueAuthorization" })
+    ).toBeEnabled();
+    expect(
+      screen.queryByRole("button", { name: "actionWaitingAuthorization" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps one authorization action until the user finishes or closes it", async () => {
     const viewState = proxy(
       emptyView({
         ...authorizationDialog,
@@ -172,8 +221,11 @@ describe("ConnectorMarketDialogs", () => {
     fireEvent.click(waiting);
     fireEvent.click(screen.getByRole("button", { name: "Close" }));
     expect(beginAuthorization).not.toHaveBeenCalled();
-    expect(closeDialog).not.toHaveBeenCalled();
+    expect(cancelAuthorization).toHaveBeenCalledWith("gmail");
+    await waitFor(() => expect(closeDialog).toHaveBeenCalledTimes(1));
 
+    cancelAuthorization.mockClear();
+    closeDialog.mockClear();
     fireEvent.click(screen.getByRole("button", { name: "cancel" }));
     expect(cancelAuthorization).toHaveBeenCalledWith("gmail");
     await waitFor(() => expect(closeDialog).toHaveBeenCalledTimes(1));

--- a/packages/connector/renderer/src/ui/dialogs/ConnectorMarketDialogs.tsx
+++ b/packages/connector/renderer/src/ui/dialogs/ConnectorMarketDialogs.tsx
@@ -172,11 +172,11 @@ export function ConnectorMarketDialogs() {
         <Dialog
           open
           onOpenChange={(open) => {
-            if (
-              open ||
-              (dialog.kind === "installation" && dialog.installing) ||
-              (dialog.kind === "authorization" && dialog.authorizing)
-            ) {
+            if (open || (dialog.kind === "installation" && dialog.installing)) {
+              return;
+            }
+            if (dialog.kind === "authorization") {
+              cancelAuthorizationDialog();
               return;
             }
             uiState.closeDialog();
@@ -233,7 +233,7 @@ export function ConnectorMarketDialogs() {
               onAuthorize={(secret) =>
                 authorizeConnector(dialog.connectorKey, secret)
               }
-              onClose={() => uiState.closeDialog()}
+              onClose={cancelAuthorizationDialog}
               onOpenAuthorizationUrl={(url) => market.openAuthorizationUrl(url)}
             />
           ) : dialog.kind === "management" ? (


### PR DESCRIPTION
## Summary

- keep `device_code` authorization inside the existing Connector dialog instead of opening the verification URL as soon as the View arrives
- let the explicit Continue action open the browser after the user can read or copy the code
- route the authorization dialog close control through the same cancellation path as Cancel
- document the device-code interaction and troubleshooting flow

The first incorrect state was in `ConnectorMarketService`: it stored the `device_code` View and immediately awaited host navigation, moving focus away before the renderer could present the user code. Ordinary `external_link` authorization keeps its existing automatic navigation behavior.

## Verification

- `corepack pnpm --filter @tutti-os/connector-renderer test -- ConnectorMarketDialogs.spec.tsx`
- `corepack pnpm check:changed`
- `corepack pnpm release:pack:check -- --packages-json '["@tutti-os/connector-renderer"]'`\n- `corepack pnpm check:changed -- --push-ready`\n\nAll checks passed. The packed `@tutti-os/connector-renderer` consumer artifact was verified.\n\nWindows impact: none. The change is host-neutral renderer state and callback routing with no path, process, shell, filesystem, or platform-specific behavior.\n\n## Checklist\n\n- [x] Agent lifecycle semantics are unchanged.\n- [x] I kept the change focused on one concern.\n- [x] I updated documentation for the authorization interaction and troubleshooting flow.\n- [x] README/CONTRIBUTING language variants are not affected.\n- [x] I ran the lowest meaningful local checks for the changed surface.\n- [x] The commit is signed off with DCO.