### PR TITLE
fix(connector): gate market requests behind lab flag

### DIFF
--- a/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
+++ b/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
@@ -10,6 +10,7 @@ import {
 import { startPredefinePageviewAnalytics } from "@renderer/features/analytics/predefinePageviewAnalytics.ts";
 import { registerAppUpdateServices } from "@renderer/features/app-update/services/registerAppUpdateServices";
 import {
+  canRequestDesktopConnectorMarket,
   registerConnectorMarketModule,
   requestDesktopConnectorInstallAdmission
 } from "@renderer/features/connector";
@@ -229,7 +230,11 @@ export async function createWorkspaceWindowContainer(): Promise<WorkspaceWindowC
     tuttidClient
   });
   const connectorMarketModule = registerConnectorMarketModule(registry, {
-    canRequest: () => accountService.store.user !== null,
+    canRequest: () =>
+      canRequestDesktopConnectorMarket(
+        accountService.store.user !== null,
+        desktopPreferencesService.store.featureFlags
+      ),
     client: tuttidClient,
     eventStreamClient: tuttidEventStreamClient,
     openAuthorizationUrl: (url) =>

--- a/apps/desktop/src/renderer/src/features/connector/adapters/desktopConnectorAdmission.test.ts
+++ b/apps/desktop/src/renderer/src/features/connector/adapters/desktopConnectorAdmission.test.ts
@@ -1,7 +1,26 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { requestDesktopConnectorInstallAdmission } from "./desktopConnectorAdmission.ts";
+import {
+  canRequestDesktopConnectorMarket,
+  requestDesktopConnectorInstallAdmission
+} from "./desktopConnectorAdmission.ts";
+
+test("connector market requests require authentication and the lab flag", () => {
+  assert.equal(canRequestDesktopConnectorMarket(true, {}), false);
+  assert.equal(
+    canRequestDesktopConnectorMarket(true, { "lab.connectors": false }),
+    false
+  );
+  assert.equal(
+    canRequestDesktopConnectorMarket(false, { "lab.connectors": true }),
+    false
+  );
+  assert.equal(
+    canRequestDesktopConnectorMarket(true, { "lab.connectors": true }),
+    true
+  );
+});
 
 test("connector install admission starts account login without reporting a successful launch", async () => {
   let loginCalls = 0;

--- a/apps/desktop/src/renderer/src/features/connector/adapters/desktopConnectorAdmission.ts
+++ b/apps/desktop/src/renderer/src/features/connector/adapters/desktopConnectorAdmission.ts
@@ -1,7 +1,19 @@
 import type { NotificationService } from "@tutti-os/ui-notifications";
+import {
+  isFeatureEnabled,
+  LAB_CONNECTORS_FLAG
+} from "../../../../../shared/featureFlags/catalog.ts";
+import type { DesktopFeatureFlags } from "../../../../../shared/preferences/index.ts";
 
 export interface DesktopConnectorAccountLogin {
   startLogin(): Promise<{ error: string | null }>;
+}
+
+export function canRequestDesktopConnectorMarket(
+  authenticated: boolean,
+  featureFlags: DesktopFeatureFlags
+): boolean {
+  return authenticated && isFeatureEnabled(featureFlags, LAB_CONNECTORS_FLAG);
 }
 
 export async function requestDesktopConnectorInstallAdmission(

--- a/apps/desktop/src/renderer/src/features/connector/index.ts
+++ b/apps/desktop/src/renderer/src/features/connector/index.ts
@@ -1,2 +1,5 @@
 export { registerConnectorMarketModule } from "./registration/registerConnectorModule.ts";
-export { requestDesktopConnectorInstallAdmission } from "./adapters/desktopConnectorAdmission.ts";
+export {
+  canRequestDesktopConnectorMarket,
+  requestDesktopConnectorInstallAdmission
+} from "./adapters/desktopConnectorAdmission.ts";


### PR DESCRIPTION
## Summary

Authenticated desktop renderers initialized and refreshed the connector market even when the `lab.connectors` feature flag was disabled. On deployments where connector-market support is unavailable, normal startup and window focus therefore produced repeated `503` requests and `connector_market.service_error` diagnostics.

Gate connector-market requests on both account authentication and the live `lab.connectors` preference. The connector module remains registered so the existing architecture and runtime lifecycle stay intact, while its backend request admission now follows the renderer feature gate. Add coverage for missing, disabled, unauthenticated, and enabled states.

## Verification

- `pnpm --filter @tutti-os/desktop exec tsx --test src/renderer/src/features/connector/adapters/desktopConnectorAdmission.test.ts` — 3 passed.
- `pnpm --filter @tutti-os/connector-renderer exec tsx --test src/application/services/core/connectorMarketRuntime.test.ts` — 5 passed.
- `pnpm --filter @tutti-os/desktop typecheck` — passed.
- Manual desktop check with an authenticated account and `lab.connectors=false`: restart plus window refocus produced zero `/v1/connector-market` requests and zero `connector_market.service_error` diagnostics.

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
