### PR TITLE
fix(connector): serialize authorization transitions

### DIFF
--- a/docs/architecture/connector.md
+++ b/docs/architecture/connector.md
@@ -611,6 +611,13 @@ synchronizing -> materializing -> ready`; failure is terminal and disposes
   `replacementPolicy=replace_active`. Continuation polling within one action
   reuses the same identity. A canceled renderer Promise cannot retain the
   Connector mutation token
+- command admission and presentation share one renderer-local per-Connector
+  mutation phase (`installing`, `updating`, `uninstalling`, `authorizing`,
+  `disconnecting`, or `updating_runtime`) in the reactive Market store. Cards
+  and dialogs remain busy until that phase is released, even when a newer
+  daemon projection has already reached `connected`. A disconnect submitted
+  through stale UI or another caller while authorization is settling waits for
+  that authorization action, rereads the projected state, and runs at most once
 - event refreshes are coalesced, daemon reconnect performs a full reload, and
   accepted commands are followed through the operation endpoint or events
 - the settings catalog toolbar Refresh control indicates an explicit

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -147,6 +147,7 @@ App Center, workspace-app lifecycle, App Factory, file references, and File Mana
 
 Connector catalog, installation, account authorization, and runtime convergence.
 
+- [Disconnect fails immediately after authorization succeeds](./connector-market.md#disconnect-fails-immediately-after-authorization-succeeds)
 - [A second authorize click starts another OAuth session](./connector-market.md#a-second-authorize-click-starts-another-oauth-session)
 - [OAuth finishes in the browser but does not return to the initiating desktop build](./connector-market.md#oauth-finishes-in-the-browser-but-does-not-return-to-the-initiating-desktop-build)
 - [Composer install stays spinning on an OAuth remote connector](./connector-market.md#composer-install-stays-spinning-on-an-oauth-remote-connector)

--- a/docs/conventions/troubleshooting/connector-market.md
+++ b/docs/conventions/troubleshooting/connector-market.md
@@ -1,5 +1,36 @@
 # Connector Market Troubleshooting
 
+### Disconnect fails immediately after authorization succeeds
+
+**Symptoms**
+
+- the Connector card changes to connected and exposes Disconnect while the
+  authorization success transition is still settling
+- clicking Disconnect shows a generic failure, but no
+  `disconnect_authorization` operation appears in SQLite and the credential
+  broker never receives a logout command
+- the connector projection and authorization operation are healthy, and the
+  renderer has no backend request failure
+
+**Check**
+
+Inspect the renderer Market store at the first bad frame. If the daemon
+projection is `connected` while the same Connector still has the local
+`authorizing` mutation phase, the failure is renderer command admission rather
+than GitHub CLI, the credential broker, or the daemon. Confirm that the rejected
+call is `ConnectorMarketBusyError` before backend dispatch.
+
+**Rule**
+
+Daemon projection and renderer command admission are separate inputs to one
+view state. Keep the per-Connector mutation phase reactive and derive every
+card and dialog action from it; do not expose Disconnect until the authorization
+phase is released. Keep the renderer token and daemon operation lane as the
+serialization fences. A Disconnect submitted while authorization is settling
+must wait for that action, reread authorization state, and execute at most once
+if the Connector is still connected. Do not solve this with a blind timeout or
+UI-only retry.
+
 ### Device code is missed when authorization moves focus to the browser
 
 **Symptoms**

--- a/packages/connector/renderer/src/application/services/connectorMarketService.interface.ts
+++ b/packages/connector/renderer/src/application/services/connectorMarketService.interface.ts
@@ -13,6 +13,14 @@ import type {
 
 export type ConnectorMarketLoadState = "idle" | "loading" | "ready" | "error";
 
+export type ConnectorMutationPhase =
+  | "authorizing"
+  | "disconnecting"
+  | "installing"
+  | "uninstalling"
+  | "updating"
+  | "updating_runtime";
+
 export interface ConnectorMarketSectionState extends ConnectorMarketCategory {
   connectorKeys: string[];
   loadState: ConnectorMarketLoadState;
@@ -34,6 +42,7 @@ export interface ConnectorMarketStoreState {
   connectorKeys: string[];
   pendingInstallationsByConnectorKey: Record<string, true>;
   pendingAuthorizationsByConnectorKey: Record<string, true>;
+  mutationPhasesByConnectorKey: Record<string, ConnectorMutationPhase>;
   operationsByConnectorKey: Record<string, ConnectorOperation>;
   pendingUninstallNotificationsByOperationId: Record<
     string,

--- a/packages/connector/renderer/src/application/services/connectorMarketService.test.ts
+++ b/packages/connector/renderer/src/application/services/connectorMarketService.test.ts
@@ -631,9 +631,11 @@ test("clears an explicit catalog refresh when the accepted operation is already 
 test("rejects overlapping mutations for one connector", async () => {
   const install =
     deferred<Awaited<ReturnType<ConnectorMarketBackend["installConnector"]>>>();
+  const diagnostics: unknown[] = [];
   const service = new ConnectorMarketService({
     backend: backendWith({ installConnector: async () => install.promise }),
-    createRequestId: () => "request-1"
+    createRequestId: () => "request-1",
+    reportDiagnostic: (error) => diagnostics.push(error)
   });
   const first = service.install("github");
   assert.equal(
@@ -641,6 +643,8 @@ test("rejects overlapping mutations for one connector", async () => {
     true
   );
   await assert.rejects(service.install("github"), ConnectorMarketBusyError);
+  assert.equal(diagnostics.length, 1);
+  assert.ok(diagnostics[0] instanceof ConnectorMarketBusyError);
   install.resolve({
     connector: connector("github", 1),
     operation: {
@@ -1357,6 +1361,86 @@ test("a second authorization command joins the in-flight attempt", async () => {
     ]
   );
   assert.deepEqual(service.dataStore.authorizingConnectorKeys, {});
+  service.dispose();
+});
+
+test("queues disconnect behind an authorization mutation after connected is projected", async () => {
+  const authorizationOperation = deferred<ConnectorOperation>();
+  const initial = connector("github", 1);
+  initial.installation = {
+    installedReleaseDigest: initial.release.releaseDigest,
+    state: "installed"
+  };
+  initial.authorization = { state: "disconnected" };
+  const connected = connector("github", 2);
+  connected.installation = initial.installation;
+  connected.authorization = { state: "connected" };
+  const disconnected = connector("github", 3);
+  disconnected.installation = initial.installation;
+  disconnected.authorization = { state: "disconnected" };
+  let disconnectCalls = 0;
+  const service = new ConnectorMarketService({
+    backend: backendWith({
+      getSnapshot: async () => snapshot(1, [initial]),
+      getConnector: async () => connected,
+      getOperation: async () => authorizationOperation.promise,
+      beginAuthorization: async () => ({
+        connector: connected,
+        operation: {
+          ...operation("start_authorization", 2),
+          stage: "authorizing",
+          state: "running"
+        },
+        revision: 2
+      }),
+      disconnectAuthorization: async () => {
+        disconnectCalls += 1;
+        return {
+          connector: disconnected,
+          operation: {
+            attempt: 1,
+            clientRequestId: "disconnect-1",
+            connectorKey: "github",
+            createdAt: "2026-08-03T00:00:02Z",
+            kind: "disconnect_authorization",
+            operationId: "disconnect-operation-1",
+            stage: "completed",
+            state: "completed",
+            updatedAt: "2026-08-03T00:00:03Z"
+          },
+          revision: 3
+        };
+      }
+    }),
+    createRequestId: () => "request-1"
+  });
+  await service.ensureLoaded();
+
+  const authorization = service.beginAuthorization("github");
+  await waitFor(
+    () =>
+      service.dataStore.connectorsByKey.github?.authorization.state ===
+        "connected" &&
+      service.dataStore.mutationPhasesByConnectorKey.github === "authorizing"
+  );
+  const disconnect = service.disconnectAuthorization("github");
+  await Promise.resolve();
+
+  assert.equal(disconnectCalls, 0);
+  authorizationOperation.resolve({
+    ...operation("start_authorization", 2),
+    stage: "completed",
+    state: "completed"
+  });
+  await authorization;
+  await disconnect;
+
+  assert.equal(disconnectCalls, 1);
+  assert.equal(
+    service.dataStore.connectorsByKey.github?.authorization.state,
+    "disconnected"
+  );
+  assert.deepEqual(service.dataStore.mutationPhasesByConnectorKey, {});
   service.dispose();
 });
 

--- a/packages/connector/renderer/src/application/services/connectorMarketService.ts
+++ b/packages/connector/renderer/src/application/services/connectorMarketService.ts
@@ -15,6 +15,7 @@ import type {
 import type {
   ConnectorMarketServiceDependencies,
   ConnectorInstallOutcome,
+  ConnectorMutationPhase,
   ConnectorMarketStoreState,
   IConnectorMarketService
 } from "./connectorMarketService.interface.ts";
@@ -328,6 +329,11 @@ export class ConnectorMarketService implements IConnectorMarketService {
 
   private installConnector(connectorKey: string): Promise<boolean> {
     const connector = this.dataStore.connectorsByKey[connectorKey];
+    const mutationPhase: ConnectorMutationPhase =
+      connector?.installation.state === "installed" &&
+      Boolean(connector.installation.installedReleaseDigest)
+        ? "updating"
+        : "installing";
     if (
       connector?.installation.state === "installed" &&
       connector.installation.installedReleaseDigest &&
@@ -339,16 +345,13 @@ export class ConnectorMarketService implements IConnectorMarketService {
         connector.release.releaseDigest
       );
     }
-    return this.runConnectorMutation(
-      connectorKey,
-      () =>
-        this.dependencies.backend.installConnector({
-          connectorKey,
-          clientRequestId: this.createRequestId(),
-          expectedRevision: this.dataStore.revision,
-          ...this.connectorRevisionFence(connectorKey)
-        }),
-      true
+    return this.runConnectorMutation(connectorKey, mutationPhase, () =>
+      this.dependencies.backend.installConnector({
+        connectorKey,
+        clientRequestId: this.createRequestId(),
+        expectedRevision: this.dataStore.revision,
+        ...this.connectorRevisionFence(connectorKey)
+      })
     );
   }
 
@@ -356,13 +359,16 @@ export class ConnectorMarketService implements IConnectorMarketService {
     if (this.disposed || !this.canRequest()) {
       throw new ConnectorMarketRequestUnavailableError();
     }
-    const result = await this.runConnectorMutationResult(connectorKey, () =>
-      this.dependencies.backend.uninstallConnector({
-        connectorKey,
-        clientRequestId: this.createRequestId(),
-        expectedRevision: this.dataStore.revision,
-        ...this.connectorRevisionFence(connectorKey)
-      })
+    const result = await this.runConnectorMutationResult(
+      connectorKey,
+      "uninstalling",
+      () =>
+        this.dependencies.backend.uninstallConnector({
+          connectorKey,
+          clientRequestId: this.createRequestId(),
+          expectedRevision: this.dataStore.revision,
+          ...this.connectorRevisionFence(connectorKey)
+        })
     );
     if (!result) {
       throw new ConnectorMarketRequestUnavailableError();
@@ -394,7 +400,10 @@ export class ConnectorMarketService implements IConnectorMarketService {
     if (this.disposed || !this.canRequest()) {
       throw new ConnectorMarketRequestUnavailableError();
     }
-    const token = this.acquireConnectorMutation(connectorKey);
+    const token = this.acquireConnectorMutation(
+      connectorKey,
+      "updating_runtime"
+    );
     const generation = this.dataGeneration;
     const update = () =>
       this.dependencies.backend.updateConnectorRuntime({
@@ -486,8 +495,7 @@ export class ConnectorMarketService implements IConnectorMarketService {
         mutationToken &&
         this.connectorMutations.get(connectorKey) === mutationToken
       ) {
-        this.connectorMutations.delete(connectorKey);
-        delete this.dataStore.authorizingConnectorKeys[connectorKey];
+        this.releaseConnectorMutation(connectorKey, mutationToken);
       }
     }
   }
@@ -501,9 +509,8 @@ export class ConnectorMarketService implements IConnectorMarketService {
     secret?: string
   ): Promise<void> {
     const token = this.authorizationAttempts.has(connectorKey)
-      ? this.replaceConnectorMutation(connectorKey)
-      : this.acquireConnectorMutation(connectorKey);
-    this.dataStore.authorizingConnectorKeys[connectorKey] = true;
+      ? this.replaceConnectorMutation(connectorKey, "authorizing")
+      : this.acquireConnectorMutation(connectorKey, "authorizing");
     delete this.dataStore.pendingAuthorizationsByConnectorKey[connectorKey];
     delete this.dataStore.authorizationViewsByConnectorKey[connectorKey];
     const generation = this.dataGeneration;
@@ -658,7 +665,6 @@ export class ConnectorMarketService implements IConnectorMarketService {
       throw error;
     } finally {
       if (this.connectorMutations.get(connectorKey) === token) {
-        delete this.dataStore.authorizingConnectorKeys[connectorKey];
         delete this.dataStore.pendingAuthorizationsByConnectorKey[connectorKey];
         delete this.dataStore.authorizationViewsByConnectorKey[connectorKey];
       }
@@ -670,7 +676,10 @@ export class ConnectorMarketService implements IConnectorMarketService {
   }
 
   async disconnectAuthorization(connectorKey: string): Promise<void> {
-    await this.runConnectorMutation(connectorKey, () =>
+    if (!(await this.waitForDisconnectAdmission(connectorKey))) {
+      return;
+    }
+    await this.runConnectorMutation(connectorKey, "disconnecting", () =>
       this.dependencies.backend.disconnectAuthorization({
         connectorKey,
         clientRequestId: this.createRequestId(),
@@ -678,6 +687,36 @@ export class ConnectorMarketService implements IConnectorMarketService {
         ...this.connectorRevisionFence(connectorKey)
       })
     );
+  }
+
+  private async waitForDisconnectAdmission(
+    connectorKey: string
+  ): Promise<boolean> {
+    let waitedForAuthorization = false;
+    let authorizationFailure: unknown;
+    while (true) {
+      const authorization = this.authorizationInFlight.get(connectorKey);
+      if (!authorization) {
+        break;
+      }
+      waitedForAuthorization = true;
+      try {
+        await authorization;
+        authorizationFailure = undefined;
+      } catch (error) {
+        authorizationFailure = error;
+      }
+    }
+    if (
+      !waitedForAuthorization ||
+      this.authorizationState(connectorKey) === "connected"
+    ) {
+      return true;
+    }
+    if (authorizationFailure) {
+      throw authorizationFailure;
+    }
+    return false;
   }
 
   private connectorRevisionFence(connectorKey: string): {
@@ -1007,13 +1046,13 @@ export class ConnectorMarketService implements IConnectorMarketService {
 
   private async runConnectorMutation(
     connectorKey: string,
-    operation: () => Promise<ConnectorMutationResult>,
-    projectPendingInstallation = false
+    mutationPhase: ConnectorMutationPhase,
+    operation: () => Promise<ConnectorMutationResult>
   ): Promise<boolean> {
     const result = await this.runConnectorMutationResult(
       connectorKey,
-      operation,
-      projectPendingInstallation
+      mutationPhase,
+      operation
     );
     if (!result) {
       return false;
@@ -1037,17 +1076,14 @@ export class ConnectorMarketService implements IConnectorMarketService {
 
   private async runConnectorMutationResult(
     connectorKey: string,
-    operation: () => Promise<ConnectorMutationResult>,
-    projectPendingInstallation = false
+    mutationPhase: ConnectorMutationPhase,
+    operation: () => Promise<ConnectorMutationResult>
   ): Promise<ConnectorMutationResult | undefined> {
     if (this.disposed || !this.canRequest()) {
       return;
     }
-    const token = this.acquireConnectorMutation(connectorKey);
+    const token = this.acquireConnectorMutation(connectorKey, mutationPhase);
     const generation = this.dataGeneration;
-    if (projectPendingInstallation) {
-      this.dataStore.pendingInstallationsByConnectorKey[connectorKey] = true;
-    }
     try {
       let result: ConnectorMutationResult;
       try {
@@ -1080,12 +1116,6 @@ export class ConnectorMarketService implements IConnectorMarketService {
       }
       throw error;
     } finally {
-      if (
-        projectPendingInstallation &&
-        this.connectorMutations.get(connectorKey) === token
-      ) {
-        delete this.dataStore.pendingInstallationsByConnectorKey[connectorKey];
-      }
       this.releaseConnectorMutation(connectorKey, token);
     }
   }
@@ -1308,24 +1338,54 @@ export class ConnectorMarketService implements IConnectorMarketService {
     );
   }
 
-  private acquireConnectorMutation(connectorKey: string): symbol {
+  private acquireConnectorMutation(
+    connectorKey: string,
+    mutationPhase: ConnectorMutationPhase
+  ): symbol {
     if (this.connectorMutations.has(connectorKey)) {
-      throw new ConnectorMarketBusyError(connectorKey);
+      const error = new ConnectorMarketBusyError(connectorKey);
+      this.reportDiagnostic(error);
+      throw error;
     }
     const token = Symbol(connectorKey);
-    this.connectorMutations.set(connectorKey, token);
+    this.projectConnectorMutation(connectorKey, token, mutationPhase);
     return token;
   }
 
-  private replaceConnectorMutation(connectorKey: string): symbol {
+  private replaceConnectorMutation(
+    connectorKey: string,
+    mutationPhase: ConnectorMutationPhase
+  ): symbol {
     const token = Symbol(connectorKey);
-    this.connectorMutations.set(connectorKey, token);
+    this.projectConnectorMutation(connectorKey, token, mutationPhase);
     return token;
+  }
+
+  private projectConnectorMutation(
+    connectorKey: string,
+    token: symbol,
+    mutationPhase: ConnectorMutationPhase
+  ): void {
+    this.connectorMutations.set(connectorKey, token);
+    this.dataStore.mutationPhasesByConnectorKey[connectorKey] = mutationPhase;
+    if (mutationPhase === "authorizing") {
+      this.dataStore.authorizingConnectorKeys[connectorKey] = true;
+    } else {
+      delete this.dataStore.authorizingConnectorKeys[connectorKey];
+    }
+    if (mutationPhase === "installing" || mutationPhase === "updating") {
+      this.dataStore.pendingInstallationsByConnectorKey[connectorKey] = true;
+    } else {
+      delete this.dataStore.pendingInstallationsByConnectorKey[connectorKey];
+    }
   }
 
   private releaseConnectorMutation(connectorKey: string, token: symbol): void {
     if (this.connectorMutations.get(connectorKey) === token) {
       this.connectorMutations.delete(connectorKey);
+      delete this.dataStore.mutationPhasesByConnectorKey[connectorKey];
+      delete this.dataStore.authorizingConnectorKeys[connectorKey];
+      delete this.dataStore.pendingInstallationsByConnectorKey[connectorKey];
     }
   }
 

--- a/packages/connector/renderer/src/application/services/connectorMarketState.ts
+++ b/packages/connector/renderer/src/application/services/connectorMarketState.ts
@@ -20,6 +20,7 @@ export function createConnectorMarketStoreState(): ConnectorMarketStoreState {
     connectorKeys: [],
     pendingInstallationsByConnectorKey: {},
     pendingAuthorizationsByConnectorKey: {},
+    mutationPhasesByConnectorKey: {},
     pendingUninstallNotificationsByOperationId: {},
     operationsByConnectorKey: {},
     authorizingConnectorKeys: {},
@@ -46,6 +47,7 @@ export function clearConnectorMarketStoreState(
     initial.pendingInstallationsByConnectorKey;
   state.pendingAuthorizationsByConnectorKey =
     initial.pendingAuthorizationsByConnectorKey;
+  state.mutationPhasesByConnectorKey = initial.mutationPhasesByConnectorKey;
   state.pendingUninstallNotificationsByOperationId =
     initial.pendingUninstallNotificationsByOperationId;
   state.operationsByConnectorKey = initial.operationsByConnectorKey;

--- a/packages/connector/renderer/src/application/services/index.ts
+++ b/packages/connector/renderer/src/application/services/index.ts
@@ -13,7 +13,8 @@ export {
   type ConnectorInstallOutcome,
   type ConnectorMarketLoadState,
   type ConnectorMarketServiceDependencies,
-  type ConnectorMarketStoreState
+  type ConnectorMarketStoreState,
+  type ConnectorMutationPhase
 } from "./connectorMarketService.interface.ts";
 export * from "./core/index.ts";
 export * from "./ui-state/index.ts";

--- a/packages/connector/renderer/src/application/services/view/connectorMarketViewBuilder.test.ts
+++ b/packages/connector/renderer/src/application/services/view/connectorMarketViewBuilder.test.ts
@@ -433,6 +433,44 @@ test("exposes disconnect directly for an authorized connector", () => {
   assert.equal(view.cardsByKey[connector.key]?.operationStage, "completed");
 });
 
+test("keeps an authorized connector busy until the renderer authorization mutation settles", () => {
+  const market = createConnectorMarketStoreState();
+  const connector = connectorFixture();
+  connector.installation = {
+    installedReleaseDigest: connector.release.releaseDigest,
+    state: "installed"
+  };
+  connector.authorization = { state: "connected" };
+  market.connectorKeys = [connector.key];
+  market.connectorsByKey[connector.key] = connector;
+  market.mutationPhasesByConnectorKey[connector.key] = "authorizing";
+  market.operationsByConnectorKey[connector.key] = {
+    attempt: 1,
+    clientRequestId: "authorize",
+    connectorKey: connector.key,
+    createdAt: "2026-08-06T00:00:00Z",
+    kind: "start_authorization",
+    operationId: "authorize-operation",
+    stage: "completed",
+    state: "completed",
+    updatedAt: "2026-08-06T00:00:01Z"
+  };
+
+  const view = buildConnectorMarketView(market, {
+    ...uiState,
+    dialog: { connectorKey: connector.key, kind: "connector" }
+  });
+
+  assert.equal(view.cardsByKey[connector.key]?.action, "busy");
+  assert.equal(view.cardsByKey[connector.key]?.canUninstall, false);
+  assert.equal(view.cardsByKey[connector.key]?.status, "connected");
+  assert.equal(view.cardsByKey[connector.key]?.mutationPhase, "authorizing");
+  assert.equal(
+    view.dialog?.kind === "management" && view.dialog.canAuthorize,
+    false
+  );
+});
+
 test("keeps authorization-free connectors on the management action", () => {
   const market = createConnectorMarketStoreState();
   const connector = connectorFixture();

--- a/packages/connector/renderer/src/application/services/view/connectorMarketViewBuilder.ts
+++ b/packages/connector/renderer/src/application/services/view/connectorMarketViewBuilder.ts
@@ -1,6 +1,9 @@
 import type { Connector } from "../../contracts/index.ts";
 import type { AuthorizationViewEnvelopeV1 } from "@tutti-os/connector-contracts/authorization/v1";
-import type { ConnectorMarketStoreState } from "../connectorMarketService.interface.ts";
+import type {
+  ConnectorMarketStoreState,
+  ConnectorMutationPhase
+} from "../connectorMarketService.interface.ts";
 import type { ConnectorMarketUiState } from "../ui-state/connectorMarketUiStateService.interface.ts";
 import type {
   ConnectorCardView,
@@ -51,7 +54,7 @@ export function buildConnectorMarketView(
       buildConnectorCardView(
         connector,
         market.operationsByConnectorKey[connector.key]?.stage ?? null,
-        market.pendingInstallationsByConnectorKey[connector.key] === true
+        connectorMutationPhase(market, connector)
       )
     ])
   );
@@ -65,15 +68,13 @@ export function buildConnectorMarketView(
         : undefined,
       uiState.dialog?.kind ?? null,
       uiState.dialog
-        ? Boolean(market.authorizingConnectorKeys[uiState.dialog.connectorKey])
-        : false,
+        ? connectorMutationPhase(
+            market,
+            market.connectorsByKey[uiState.dialog.connectorKey]
+          )
+        : null,
       uiState.dialog
         ? market.pendingAuthorizationsByConnectorKey[
-            uiState.dialog.connectorKey
-          ] === true
-        : false,
-      uiState.dialog
-        ? market.pendingInstallationsByConnectorKey[
             uiState.dialog.connectorKey
           ] === true
         : false,
@@ -130,19 +131,17 @@ function buildCatalogErrorView(
 function buildConnectorCardView(
   connector: Connector,
   operationStage: ConnectorCardView["operationStage"],
-  pendingInstallation: boolean
+  mutationPhase: ConnectorMutationPhase | null
 ): ConnectorCardView {
-  const busy = connectorMutationBusy(
-    connector,
-    operationStage,
-    pendingInstallation
-  );
+  const busy = connectorMutationBusy(connector, operationStage, mutationPhase);
   const installed = connectorHasInstalledArtifact(connector);
   const currentReleaseInstalled =
     connectorHasCurrentReleaseInstalled(connector);
   const updating =
-    connector.installation.state === "updating" ||
-    (installed && !currentReleaseInstalled && pendingInstallation);
+    connector.installation.state === "updating" || mutationPhase === "updating";
+  const installing =
+    connector.installation.state === "installing" ||
+    mutationPhase === "installing";
   const unavailable = connector.compatibility.state !== "supported";
   const connected = connector.authorization.state === "connected";
   const requiresAuthorization = !["connected", "not_required"].includes(
@@ -171,30 +170,30 @@ function buildConnectorCardView(
     iconUrl: connector.release.manifest.iconUrl,
     implementationTags: implementationTags(connector),
     installationState: connector.installation.state,
+    mutationPhase,
     operationStage,
     canUninstall: connectorCanUninstall(connector, busy),
     status: unavailable
       ? "unavailable"
-      : busy
-        ? updating
-          ? "updating"
-          : "installing"
-        : !installed
-          ? "not_installed"
-          : !currentReleaseInstalled
-            ? "update_available"
-            : requiresAuthorization
-              ? "authorization_required"
-              : "connected"
+      : updating
+        ? "updating"
+        : installing
+          ? "installing"
+          : !installed
+            ? "not_installed"
+            : !currentReleaseInstalled
+              ? "update_available"
+              : requiresAuthorization
+                ? "authorization_required"
+                : "connected"
   };
 }
 
 function buildConnectorDialogView(
   connector: Connector | undefined,
   requestKind: NonNullable<ConnectorMarketUiState["dialog"]>["kind"] | null,
-  authorizing: boolean,
+  mutationPhase: ConnectorMutationPhase | null,
   pendingAuthorization: boolean,
-  pendingInstallation: boolean,
   operationStage: ConnectorCardView["operationStage"],
   authorizationView?: AuthorizationViewEnvelopeV1
 ): ConnectorDialogView | null {
@@ -214,7 +213,7 @@ function buildConnectorDialogView(
   const mutationBusy = connectorMutationBusy(
     connector,
     operationStage,
-    pendingInstallation
+    mutationPhase
   );
   const canUninstall = connectorCanUninstall(connector, mutationBusy);
   if (requestKind === "uninstall_confirmation") {
@@ -234,10 +233,11 @@ function buildConnectorDialogView(
     return {
       ...base,
       installing:
-        pendingInstallation ||
+        mutationPhase === "installing" ||
+        mutationPhase === "updating" ||
         ["installing", "updating"].includes(connector.installation.state),
       kind: "installation",
-      updating: installed
+      updating: installed || mutationPhase === "updating"
     };
   }
   if (!["connected", "not_required"].includes(connector.authorization.state)) {
@@ -247,7 +247,7 @@ function buildConnectorDialogView(
         connector.release.manifest.authorizationInteraction,
       authorizationKind: connector.release.manifest.authorizationKind,
       authorizationView,
-      authorizing,
+      authorizing: mutationPhase === "authorizing",
       brokeredAuthorization:
         connector.release.manifest.authorizationInteractionMode === "managed",
       kind: "authorization",
@@ -257,7 +257,8 @@ function buildConnectorDialogView(
   }
   return {
     ...base,
-    canAuthorize: connector.release.manifest.authorizationKind !== "none",
+    canAuthorize:
+      connector.release.manifest.authorizationKind !== "none" && !mutationBusy,
     canUninstall,
     details: buildDetailFields(connector),
     kind: "management"
@@ -267,10 +268,10 @@ function buildConnectorDialogView(
 function connectorMutationBusy(
   connector: Connector,
   operationStage: ConnectorCardView["operationStage"],
-  pendingInstallation: boolean
+  mutationPhase: ConnectorMutationPhase | null
 ): boolean {
   return (
-    pendingInstallation ||
+    mutationPhase !== null ||
     ["installing", "updating", "uninstalling"].includes(
       connector.installation.state
     ) ||
@@ -282,6 +283,26 @@ function connectorMutationBusy(
       "disconnecting"
     ].includes(operationStage ?? "")
   );
+}
+
+function connectorMutationPhase(
+  market: ConnectorMarketStoreState,
+  connector: Connector | undefined
+): ConnectorMutationPhase | null {
+  if (!connector) {
+    return null;
+  }
+  const projected = market.mutationPhasesByConnectorKey[connector.key];
+  if (projected) {
+    return projected;
+  }
+  if (market.authorizingConnectorKeys[connector.key]) {
+    return "authorizing";
+  }
+  if (market.pendingInstallationsByConnectorKey[connector.key]) {
+    return connectorHasInstalledArtifact(connector) ? "updating" : "installing";
+  }
+  return null;
 }
 
 function connectorCanUninstall(

--- a/packages/connector/renderer/src/application/services/view/connectorMarketViewTypes.ts
+++ b/packages/connector/renderer/src/application/services/view/connectorMarketViewTypes.ts
@@ -5,6 +5,7 @@ import type {
   ConnectorOperationStage
 } from "../../contracts/index.ts";
 import type { AuthorizationViewEnvelopeV1 } from "@tutti-os/connector-contracts/authorization/v1";
+import type { ConnectorMutationPhase } from "../connectorMarketService.interface.ts";
 
 export type ConnectorMarketViewStatus = "empty" | "error" | "loading" | "ready";
 
@@ -32,6 +33,7 @@ export interface ConnectorCardView {
   iconUrl: string;
   implementationTags: string[];
   installationState: ConnectorInstallationState;
+  mutationPhase: ConnectorMutationPhase | null;
   operationStage: ConnectorOperationStage | null;
   canUninstall: boolean;
   status:

--- a/packages/connector/renderer/src/ui/catalog/ConnectorCard.test.ts
+++ b/packages/connector/renderer/src/ui/catalog/ConnectorCard.test.ts
@@ -18,9 +18,23 @@ test("labels an active connector update as updating", () => {
     connectorCardBusyActionLabelKey({
       authorizationState: "failed",
       installationState: "installed",
+      mutationPhase: null,
       operationStage: null,
       status: "updating"
     }),
     "actionUpdating"
+  );
+});
+
+test("labels a settling authorization from the local mutation phase", () => {
+  assert.equal(
+    connectorCardBusyActionLabelKey({
+      authorizationState: "connected",
+      installationState: "installed",
+      mutationPhase: "authorizing",
+      operationStage: "completed",
+      status: "connected"
+    }),
+    "actionWaitingAuthorization"
   );
 });

--- a/packages/connector/renderer/src/ui/catalog/ConnectorCard.tsx
+++ b/packages/connector/renderer/src/ui/catalog/ConnectorCard.tsx
@@ -164,6 +164,7 @@ function resolveActionLabel(
       | "action"
       | "authorizationState"
       | "installationState"
+      | "mutationPhase"
       | "operationStage"
       | "status"
     >

--- a/packages/connector/renderer/src/ui/catalog/connectorCardAction.ts
+++ b/packages/connector/renderer/src/ui/catalog/connectorCardAction.ts
@@ -10,14 +10,34 @@ export function connectorCardBusyActionLabelKey(
   card: Readonly<
     Pick<
       ConnectorCardView,
-      "authorizationState" | "installationState" | "operationStage" | "status"
+      | "authorizationState"
+      | "installationState"
+      | "mutationPhase"
+      | "operationStage"
+      | "status"
     >
   >
 ):
+  | "actionWaitingAuthorization"
   | "actionDisconnecting"
   | "actionInstalling"
   | "actionUninstalling"
   | "actionUpdating" {
+  switch (card.mutationPhase) {
+    case "authorizing":
+      return "actionWaitingAuthorization";
+    case "disconnecting":
+      return "actionDisconnecting";
+    case "installing":
+      return "actionInstalling";
+    case "uninstalling":
+      return "actionUninstalling";
+    case "updating":
+    case "updating_runtime":
+      return "actionUpdating";
+    case null:
+      break;
+  }
   if (card.status === "updating") {
     return "actionUpdating";
   }


### PR DESCRIPTION
## Summary

The daemon can project a Connector as connected before the renderer finishes releasing its local authorization mutation. During that window the card exposed Disconnect, but the service rejected it with a local busy error before the daemon or credential broker received a request.

This change makes the renderer's per-Connector mutation phase reactive and uses it as a shared input for command admission, cards, and dialogs. Disconnect submitted while authorization is settling waits for the active authorization, rereads the projected state, and runs at most once. Overlapping mutation rejection is also reported to diagnostics, and the durable Connector architecture and troubleshooting guidance now document the invariant.

## Verification

- Added a deterministic regression that holds authorization after `connected` is projected and verifies Disconnect remains queued until authorization settles
- Added view coverage that keeps the card and management dialog busy during the same transition
- `pnpm --filter @tutti-os/connector-renderer test` (91 Node tests and 28 Vitest tests passed)
- `pnpm --filter @tutti-os/connector-renderer typecheck`
- pre-push `pnpm check:changed -- --push-ready` (26 lanes passed)

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
