### PR TITLE
fix(connector): terminate and version authorization sessions

### DIFF
--- a/docs/architecture/connector.md
+++ b/docs/architecture/connector.md
@@ -428,7 +428,11 @@ preserves the projection. Runtime reconcile then performs interface readiness
 checks before any route is published.
 
 Authorization creation is serialized per account and Connector. A repeated
-`clientRequestId` resumes the same external session. Accepted or running
+`clientRequestId` resumes the same external session. Every provider presentation
+has a monotonic, non-secret authorization-step revision. A client can return the
+last revision as a cursor; the Host then waits for a later broker event for a
+bounded interval and may replay the current step. This keeps multi-step flows
+ordered without persisting authorization URLs or device codes. Accepted or running
 `start_authorization` is not recovered by replaying the operation: that would
 complete a native-secret control-plane session with an empty secret and fail
 the live command. Completed authorization receipts recover through
@@ -445,6 +449,12 @@ during convergence; restart finishes `canceling` receipts and no longer
 fabricates a permanently pending observation. Disconnect is completed only
 after the disconnected projection and exact disabled Runtime Observed state are
 durable.
+
+Managed credential brokers read process output through the context-aware
+transport when available. Cancellation closes the owned process connection as
+the termination fallback and waits for the broker consumer to finish before the
+session and route are released; an explicit cancel does not publish a transient
+authorization failure while shutdown is in progress.
 
 For account-scoped runtimes, `AccountRuntimeBindingResolver` maps `none`
 authorization to an always-active device connection. OAuth/API-key connectors

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -5136,6 +5136,10 @@ export type ConnectorMarketAuthorizationRequest = {
   clientRequestId: string;
   expectedRevision: number;
   expectedConnectorRevision?: number;
+  /**
+   * Cursor for a previously delivered authorization step. When provided, the Host resumes the same authorization attempt and waits briefly for a later step. A bounded poll may replay the current step. The cursor contains no authorization URL, user code, or credential material.
+   */
+  afterAuthorizationStepRevision?: number;
   replacementPolicy?: ConnectorMarketAuthorizationReplacementPolicy;
 };
 
@@ -5161,6 +5165,10 @@ export type ConnectorMarketAuthorizationResponse = {
     [key: string]: unknown;
   };
   authorizationExpiresAt: string;
+  /**
+   * Monotonic, non-secret revision of the provider authorization event returned by this response. Clients pass it back as afterAuthorizationStepRevision when waiting for a later step.
+   */
+  authorizationStepRevision: number;
   revision: number;
 };
 
@@ -5303,6 +5311,10 @@ export type ConnectorMarketAuthorizationRequestWritable = {
   clientRequestId: string;
   expectedRevision: number;
   expectedConnectorRevision?: number;
+  /**
+   * Cursor for a previously delivered authorization step. When provided, the Host resumes the same authorization attempt and waits briefly for a later step. A bounded poll may replay the current step. The cursor contains no authorization URL, user code, or credential material.
+   */
+  afterAuthorizationStepRevision?: number;
   replacementPolicy?: ConnectorMarketAuthorizationReplacementPolicy;
   secret?: string;
 };

--- a/packages/connector/contracts/openapi/connector-market.v1.yaml
+++ b/packages/connector/contracts/openapi/connector-market.v1.yaml
@@ -810,6 +810,16 @@ components:
           type: integer
           format: int64
           minimum: 0
+        afterAuthorizationStepRevision:
+          type: integer
+          format: int64
+          minimum: 0
+          description: >-
+            Cursor for a previously delivered authorization step. When
+            provided, the Host resumes the same authorization attempt and
+            waits briefly for a later step. A bounded poll may replay the
+            current step. The cursor contains no authorization URL, user code,
+            or credential material.
         replacementPolicy:
           $ref: "#/components/schemas/ConnectorMarketAuthorizationReplacementPolicy"
         secret:
@@ -840,7 +850,14 @@ components:
     ConnectorMarketAuthorizationResponse:
       type: object
       additionalProperties: false
-      required: [connector, operation, authorizationExpiresAt, revision]
+      required:
+        [
+          connector,
+          operation,
+          authorizationExpiresAt,
+          authorizationStepRevision,
+          revision
+        ]
       properties:
         connector:
           $ref: "#/components/schemas/ConnectorMarketConnector"
@@ -858,6 +875,14 @@ components:
         authorizationExpiresAt:
           type: string
           format: date-time
+        authorizationStepRevision:
+          type: integer
+          format: int64
+          minimum: 0
+          description: >-
+            Monotonic, non-secret revision of the provider authorization event
+            returned by this response. Clients pass it back as
+            afterAuthorizationStepRevision when waiting for a later step.
         revision:
           type: integer
           format: int64

--- a/packages/connector/daemon/adapters/controlplane/authorization_client.go
+++ b/packages/connector/daemon/adapters/controlplane/authorization_client.go
@@ -148,6 +148,7 @@ func (client *AuthorizationClient) Begin(ctx context.Context, request market.Aut
 	switch actionType {
 	case "redirect":
 		session.State = market.AuthorizationStatePending
+		session.StepRevision = max(request.StepRevisionBase, 1)
 		authorizationURL, parseErr := url.Parse(strings.TrimSpace(response.Session.NextAction.URL))
 		if parseErr != nil || authorizationURL.Scheme != "https" || authorizationURL.Host == "" || authorizationURL.User != nil {
 			return market.AuthorizationSession{}, errors.New("connector authorization start returned an unsafe redirect URL")

--- a/packages/connector/daemon/adapters/sqlite/store_test.go
+++ b/packages/connector/daemon/adapters/sqlite/store_test.go
@@ -415,7 +415,7 @@ func TestStoreKeepsAuthorizationSessionPrivateAndAvailableAfterReopen(t *testing
 		Execution: market.OperationExecution{AuthorizationSession: &market.AuthorizationSession{
 			OperationID: "authorization-1", ConnectorKey: connector.Key,
 			SessionID: "session-1", ActionType: "redirect", AuthorizationURL: "https://example.test/authorize",
-			State: market.AuthorizationStatePending,
+			StepRevision: 3, State: market.AuthorizationStatePending,
 		}},
 	}
 	if err := store.Transaction(ctx, func(tx market.Transaction) error {
@@ -453,6 +453,8 @@ func TestStoreKeepsAuthorizationSessionPrivateAndAvailableAfterReopen(t *testing
 	}
 	if len(operations) != 1 || operations[0].Execution.AuthorizationSession == nil ||
 		operations[0].Execution.AuthorizationSession.SessionID != "session-1" ||
+		operations[0].Execution.AuthorizationSession.StepRevision != 3 ||
+		operations[0].Execution.AuthorizationSession.AuthorizationURL != "" ||
 		operations[0].Execution.AuthorizationSession.Resolution != market.AuthorizationSessionResolutionCanceling {
 		t.Fatalf("authorization operations = %#v", operations)
 	}

--- a/packages/connector/daemon/core/application.go
+++ b/packages/connector/daemon/core/application.go
@@ -588,6 +588,9 @@ func (application *Application) BeginAuthorization(
 	if err != nil {
 		return AuthorizationResult{}, err
 	}
+	if !idempotentReplay && mutation.AfterAuthorizationStepRevision != 0 {
+		return AuthorizationResult{}, invalidRequest("authorization step cursor requires an existing attempt")
+	}
 	if !idempotentReplay {
 		if mutation.ReplacementPolicy == AuthorizationReplacementPolicyReplaceActive && !requestExecution.replacedLive {
 			if err := application.verifyConnectorMutationRevision(requestExecution.context, mutation); err != nil {
@@ -682,6 +685,7 @@ func (application *Application) BeginAuthorization(
 
 	session, err := application.beginAuthorizationSession(
 		requestExecution.context, accepted.Operation, secret, mutation.ReplacementPolicy,
+		mutation.AfterAuthorizationStepRevision,
 	)
 	if err != nil {
 		// Starting authorization has no durable provider receipt yet. Keep retry
@@ -721,12 +725,13 @@ func (application *Application) BeginAuthorization(
 		}
 	}
 	return AuthorizationResult{
-		Connector:              connector,
-		Operation:              operation,
-		AuthorizationURL:       session.AuthorizationURL,
-		AuthorizationView:      authorizationViewForSession(connector.Release, session),
-		AuthorizationExpiresAt: session.ExpiresAt,
-		Revision:               connector.Revision,
+		Connector:                 connector,
+		Operation:                 operation,
+		AuthorizationURL:          session.AuthorizationURL,
+		AuthorizationView:         authorizationViewForSession(connector.Release, session),
+		AuthorizationExpiresAt:    session.ExpiresAt,
+		AuthorizationStepRevision: session.StepRevision,
+		Revision:                  connector.Revision,
 	}, nil
 }
 

--- a/packages/connector/daemon/core/application_execution.go
+++ b/packages/connector/daemon/core/application_execution.go
@@ -337,6 +337,7 @@ func (application *Application) beginAuthorizationSession(
 	operation Operation,
 	secret []byte,
 	replacementPolicy AuthorizationReplacementPolicy,
+	afterStepRevision uint64,
 ) (AuthorizationSession, error) {
 	release, err := frozenRelease(operation)
 	if err != nil {
@@ -370,6 +371,10 @@ func (application *Application) beginAuthorizationSession(
 			return AuthorizationSession{}, err
 		}
 	}
+	stepRevisionBase := operationAuthorizationStepRevision(operation)
+	if afterStepRevision > stepRevisionBase {
+		return AuthorizationSession{}, invalidRequest("authorization step cursor is ahead of the durable session")
+	}
 	session, err := application.config.Authorization.Begin(ctx, AuthorizationStartRequest{
 		OperationID:       operation.OperationID,
 		ClientRequestID:   operation.ClientRequestID,
@@ -378,6 +383,8 @@ func (application *Application) beginAuthorizationSession(
 		Connector:         connector,
 		Release:           release,
 		Secret:            secret,
+		AfterStepRevision: afterStepRevision,
+		StepRevisionBase:  stepRevisionBase,
 	})
 	if err != nil {
 		return AuthorizationSession{}, NewDomainError(
@@ -389,6 +396,16 @@ func (application *Application) beginAuthorizationSession(
 	}
 	if session.ExpiresAt.IsZero() {
 		session.ExpiresAt = application.config.Now().UTC().Add(authorizationSessionTTL)
+	}
+	previousStepRevision := stepRevisionBase
+	if session.State == AuthorizationStatePending && session.StepRevision == 0 {
+		// Providers released before the versioned-step contract only expose one
+		// redirect at a time. Give that legacy presentation a stable revision;
+		// renderer view-id fallback still detects a later legacy presentation.
+		session.StepRevision = max(previousStepRevision, 1)
+	}
+	if session.StepRevision < previousStepRevision {
+		return AuthorizationSession{}, invalidOperationReceipt("authorization provider returned a regressed step revision")
 	}
 	if session.OperationID != operation.OperationID || session.ConnectorKey != operation.ConnectorKey ||
 		strings.TrimSpace(session.SessionID) == "" || !validAuthorizationSessionAction(session) {
@@ -411,6 +428,13 @@ func (application *Application) beginAuthorizationSession(
 		}
 	}
 	return session, nil
+}
+
+func operationAuthorizationStepRevision(operation Operation) uint64 {
+	if operation.Execution.AuthorizationSession == nil {
+		return 0
+	}
+	return operation.Execution.AuthorizationSession.StepRevision
 }
 
 func validAuthorizationSessionAction(session AuthorizationSession) bool {
@@ -598,7 +622,9 @@ func (application *Application) completeAuthorizationStart(
 			return err
 		}
 		stateChanged := projectDeviceState && connector.Authorization.State != session.State
-		if operation.State == OperationStateCompleted && !stateChanged {
+		stepChanged := operation.Execution.AuthorizationSession == nil ||
+			operation.Execution.AuthorizationSession.StepRevision != session.StepRevision
+		if operation.State == OperationStateCompleted && !stateChanged && !stepChanged {
 			return nil
 		}
 		if stateChanged && !CanTransitionAuthorization(connector.Authorization.State, session.State) {

--- a/packages/connector/daemon/core/application_test.go
+++ b/packages/connector/daemon/core/application_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -1457,16 +1458,25 @@ func TestApplicationManagedAuthorizationContinuationReplaysBeforeProjectionTrans
 		t.Fatal(err)
 	}
 	if first.AuthorizationURL != "https://open.feishu.cn/page/cli" ||
-		projections.projection.State != AuthorizationStatePending {
+		first.AuthorizationStepRevision != 1 || projections.projection.State != AuthorizationStatePending {
 		t.Fatalf("first result=%#v projection=%#v", first, projections.projection)
 	}
+	mutation.AfterAuthorizationStepRevision = first.AuthorizationStepRevision
 	continued, err := application.BeginAuthorization(context.Background(), mutation, nil)
 	if err != nil {
 		t.Fatalf("continue authorization: %v", err)
 	}
 	if continued.Operation.OperationID != first.Operation.OperationID ||
-		continued.AuthorizationURL != "https://accounts.feishu.cn/device" || provider.begins != 2 {
+		continued.AuthorizationURL != "https://accounts.feishu.cn/device" ||
+		continued.AuthorizationStepRevision != 2 || provider.begins != 2 {
 		t.Fatalf("continued=%#v first=%#v provider begins=%d", continued, first, provider.begins)
+	}
+	if !reflect.DeepEqual(provider.afterStepRevisions, []uint64{0, 1}) {
+		t.Fatalf("provider cursors = %v", provider.afterStepRevisions)
+	}
+	stored := repository.operations[first.Operation.OperationID].Execution.AuthorizationSession
+	if stored == nil || stored.StepRevision != 2 {
+		t.Fatalf("stored authorization session = %#v", stored)
 	}
 	if len(scheduler.operationIDs) != 0 {
 		t.Fatalf("pending authorization scheduled runtime operations: %v", scheduler.operationIDs)
@@ -2885,7 +2895,8 @@ func (connectedAuthorizationProviderStub) Begin(_ context.Context, request Autho
 
 type continuingAuthorizationProviderStub struct {
 	authorizationProviderStub
-	begins int
+	begins             int
+	afterStepRevisions []uint64
 }
 
 func (provider *continuingAuthorizationProviderStub) Begin(
@@ -2893,6 +2904,7 @@ func (provider *continuingAuthorizationProviderStub) Begin(
 	request AuthorizationStartRequest,
 ) (AuthorizationSession, error) {
 	provider.begins++
+	provider.afterStepRevisions = append(provider.afterStepRevisions, request.AfterStepRevision)
 	authorizationURL := "https://open.feishu.cn/page/cli"
 	if provider.begins > 1 {
 		authorizationURL = "https://accounts.feishu.cn/device"
@@ -2903,6 +2915,7 @@ func (provider *continuingAuthorizationProviderStub) Begin(
 		SessionID:        request.OperationID + "/credential-broker",
 		ActionType:       "redirect",
 		AuthorizationURL: authorizationURL,
+		StepRevision:     uint64(provider.begins),
 		State:            AuthorizationStatePending,
 	}, nil
 }

--- a/packages/connector/daemon/core/ports.go
+++ b/packages/connector/daemon/core/ports.go
@@ -406,6 +406,8 @@ type AuthorizationStartRequest struct {
 	Connector         Connector
 	Release           Release
 	Secret            []byte
+	AfterStepRevision uint64
+	StepRevisionBase  uint64
 }
 
 type AuthorizationCancelRequest struct {

--- a/packages/connector/daemon/core/types.go
+++ b/packages/connector/daemon/core/types.go
@@ -548,6 +548,7 @@ type AuthorizationSession struct {
 	ActionType       string                         `json:"actionType"`
 	AuthorizationURL string                         `json:"-"`
 	UserCode         string                         `json:"-"`
+	StepRevision     uint64                         `json:"stepRevision,omitempty"`
 	ExpiresAt        time.Time                      `json:"expiresAt"`
 	State            AuthorizationState             `json:"-"`
 	Resolution       AuthorizationSessionResolution `json:"resolution"`
@@ -631,10 +632,11 @@ type Mutation struct {
 
 type ConnectorMutation struct {
 	Mutation
-	ConnectorKey              string                         `json:"connectorKey"`
-	AccountID                 string                         `json:"accountId,omitempty"`
-	ExpectedConnectorRevision *uint64                        `json:"expectedConnectorRevision,omitempty"`
-	ReplacementPolicy         AuthorizationReplacementPolicy `json:"replacementPolicy,omitempty"`
+	ConnectorKey                   string                         `json:"connectorKey"`
+	AccountID                      string                         `json:"accountId,omitempty"`
+	ExpectedConnectorRevision      *uint64                        `json:"expectedConnectorRevision,omitempty"`
+	AfterAuthorizationStepRevision uint64                         `json:"afterAuthorizationStepRevision,omitempty"`
+	ReplacementPolicy              AuthorizationReplacementPolicy `json:"replacementPolicy,omitempty"`
 }
 
 type AuthorizationReplacementPolicy string
@@ -686,10 +688,11 @@ type MutationResult struct {
 }
 
 type AuthorizationResult struct {
-	Connector              Connector                  `json:"connector"`
-	Operation              Operation                  `json:"operation"`
-	AuthorizationURL       string                     `json:"authorizationUrl,omitempty"`
-	AuthorizationView      *AuthorizationViewEnvelope `json:"authorizationView,omitempty"`
-	AuthorizationExpiresAt time.Time                  `json:"authorizationExpiresAt"`
-	Revision               uint64                     `json:"revision"`
+	Connector                 Connector                  `json:"connector"`
+	Operation                 Operation                  `json:"operation"`
+	AuthorizationURL          string                     `json:"authorizationUrl,omitempty"`
+	AuthorizationView         *AuthorizationViewEnvelope `json:"authorizationView,omitempty"`
+	AuthorizationExpiresAt    time.Time                  `json:"authorizationExpiresAt"`
+	AuthorizationStepRevision uint64                     `json:"authorizationStepRevision"`
+	Revision                  uint64                     `json:"revision"`
 }

--- a/packages/connector/renderer/src/application/contracts/domain.ts
+++ b/packages/connector/renderer/src/application/contracts/domain.ts
@@ -258,6 +258,7 @@ export interface ConnectorRuntimeMutationInput extends ConnectorMutationInput {
 }
 
 export interface ConnectorAuthorizationInput extends ConnectorMutationInput {
+  afterAuthorizationStepRevision?: number;
   replacementPolicy?: "replace_active";
   secret?: string;
 }
@@ -273,6 +274,7 @@ export interface ConnectorAuthorizationResult {
   operation: ConnectorOperation;
   authorizationUrl?: string;
   authorizationExpiresAt?: string;
+  authorizationStepRevision?: number;
   authorizationView?: unknown;
   revision: number;
 }

--- a/packages/connector/renderer/src/application/services/connectorMarketService.test.ts
+++ b/packages/connector/renderer/src/application/services/connectorMarketService.test.ts
@@ -1654,16 +1654,17 @@ test("continues one authorization session, opens each URL once, and clears loadi
         requests.push(request);
         step += 1;
         const next = connector("lark-cli", step + 1);
-        next.authorization = { state: step === 3 ? "connected" : "pending" };
+        next.authorization = { state: step === 4 ? "connected" : "pending" };
         return {
           connector: next,
           operation: {
             ...operation("start_authorization", step + 1),
             connectorKey: "lark-cli",
+            operationId: "lark-cli-authorization",
             state: "completed" as const
           },
           authorizationUrl:
-            step === 2
+            step === 3
               ? "https://accounts.feishu.cn/device?user_code=authorization"
               : "https://open.feishu.cn/page/cli?user_code=configuration",
           revision: step + 1
@@ -1673,13 +1674,14 @@ test("continues one authorization session, opens each URL once, and clears loadi
     createRequestId: () => "one-authorization-request",
     openAuthorizationUrl: async (url) => {
       openedUrls.push(url);
-    }
+    },
+    waitForAuthorizationContinuation: async () => undefined
   });
   await service.ensureLoaded();
 
   await service.beginAuthorization("lark-cli");
 
-  assert.equal(step, 3);
+  assert.equal(step, 4);
   assert.deepEqual(requests, [
     {
       connectorKey: "lark-cli",
@@ -1701,6 +1703,13 @@ test("continues one authorization session, opens each URL once, and clears loadi
       replacementPolicy: "replace_active",
       expectedRevision: 1,
       expectedConnectorRevision: 3
+    },
+    {
+      connectorKey: "lark-cli",
+      clientRequestId: "one-authorization-request",
+      replacementPolicy: "replace_active",
+      expectedRevision: 1,
+      expectedConnectorRevision: 4
     }
   ]);
   assert.deepEqual(openedUrls, [
@@ -1712,6 +1721,66 @@ test("continues one authorization session, opens each URL once, and clears loadi
     "connected"
   );
   assert.deepEqual(service.dataStore.authorizingConnectorKeys, {});
+  service.dispose();
+});
+
+test("keeps consuming a versioned authorization session when the next step is delayed", async () => {
+  const requests: Array<{ afterAuthorizationStepRevision?: number }> = [];
+  const openedUrls: string[] = [];
+  let call = 0;
+  const initial = connector("generic-oauth", 1);
+  initial.authorization = { state: "disconnected" };
+  const service = new ConnectorMarketService({
+    backend: backendWith({
+      getSnapshot: async () => snapshot(1, [initial]),
+      beginAuthorization: async (request) => {
+        requests.push(request);
+        call += 1;
+        const connected = call === 4;
+        const next = connector("generic-oauth", call + 1);
+        next.authorization = { state: connected ? "connected" : "pending" };
+        const authorizationStepRevision = call < 3 ? 1 : call === 3 ? 2 : 3;
+        return {
+          connector: next,
+          operation: {
+            ...operation("start_authorization", call + 1),
+            connectorKey: "generic-oauth",
+            operationId: "generic-authorization",
+            state: "completed" as const
+          },
+          ...(connected
+            ? {}
+            : {
+                authorizationUrl:
+                  call < 3
+                    ? "https://accounts.example.com/configure"
+                    : "https://accounts.example.com/device"
+              }),
+          authorizationStepRevision,
+          revision: call + 1
+        };
+      }
+    }),
+    createRequestId: () => "versioned-authorization-request",
+    openAuthorizationUrl: async (url) => {
+      openedUrls.push(url);
+    },
+    waitForAuthorizationContinuation: async () => undefined
+  });
+  await service.ensureLoaded();
+
+  await service.beginAuthorization("generic-oauth");
+
+  assert.deepEqual(
+    requests.map(
+      ({ afterAuthorizationStepRevision }) => afterAuthorizationStepRevision
+    ),
+    [undefined, 1, 1, 2]
+  );
+  assert.deepEqual(openedUrls, [
+    "https://accounts.example.com/configure",
+    "https://accounts.example.com/device"
+  ]);
   service.dispose();
 });
 

--- a/packages/connector/renderer/src/application/services/connectorMarketService.ts
+++ b/packages/connector/renderer/src/application/services/connectorMarketService.ts
@@ -521,6 +521,7 @@ export class ConnectorMarketService implements IConnectorMarketService {
     };
     let expectedRevision = this.dataStore.revision;
     const seenAuthorizationViewIds = new Set<string>();
+    let afterAuthorizationStepRevision: number | undefined;
     let recoveredRevisionConflict = false;
     try {
       while (this.isCurrentMutation(connectorKey, token, generation)) {
@@ -536,6 +537,9 @@ export class ConnectorMarketService implements IConnectorMarketService {
           result = await this.dependencies.backend.beginAuthorization({
             ...request,
             expectedRevision,
+            ...(afterAuthorizationStepRevision === undefined
+              ? {}
+              : { afterAuthorizationStepRevision }),
             ...this.connectorRevisionFence(connectorKey)
           });
         } catch (error) {
@@ -598,6 +602,19 @@ export class ConnectorMarketService implements IConnectorMarketService {
         }
         const operationTrack = this.trackOperation(result.operation);
         const authorizationView = resolveAuthorizationView(result);
+        const authorizationStepRevision =
+          typeof result.authorizationStepRevision === "number" &&
+          Number.isSafeInteger(result.authorizationStepRevision) &&
+          result.authorizationStepRevision >= 0
+            ? result.authorizationStepRevision
+            : undefined;
+        if (
+          authorizationStepRevision !== undefined &&
+          (afterAuthorizationStepRevision === undefined ||
+            authorizationStepRevision > afterAuthorizationStepRevision)
+        ) {
+          afterAuthorizationStepRevision = authorizationStepRevision;
+        }
         const discoveredNextStep =
           authorizationView !== null &&
           !seenAuthorizationViewIds.has(authorizationView.viewId);
@@ -619,14 +636,16 @@ export class ConnectorMarketService implements IConnectorMarketService {
             result.connector.authorization.failureCode
           );
         }
-        if (!discoveredNextStep) {
-          await this.waitForAuthorizationTerminal(
+        if (Date.now() >= attempt.expiresAtMs) {
+          attempt.canceled = true;
+          await this.dependencies.backend.cancelAuthorization({ connectorKey });
+          throw new ConnectorAuthorizationTerminalError(
             connectorKey,
-            token,
-            generation,
-            attempt
+            "connector_authorization_timeout"
           );
-          return;
+        }
+        if (!discoveredNextStep) {
+          await this.waitForAuthorizationContinuation();
         }
       }
       if (attempt.canceled) {
@@ -1287,35 +1306,6 @@ export class ConnectorMarketService implements IConnectorMarketService {
       this.dependencies.waitForAuthorizationContinuation?.() ??
       waitForAuthorizationContinuation()
     );
-  }
-
-  private async waitForAuthorizationTerminal(
-    connectorKey: string,
-    token: symbol,
-    generation: number,
-    attempt: AuthorizationAttemptControl
-  ): Promise<void> {
-    while (this.isCurrentMutation(connectorKey, token, generation)) {
-      if (attempt.canceled) {
-        throw new ConnectorAuthorizationCanceledError(connectorKey);
-      }
-      if (this.authorizationState(connectorKey) === "connected") {
-        await this.waitForAuthorizationOperation(connectorKey);
-        return;
-      }
-      if (Date.now() >= attempt.expiresAtMs) {
-        attempt.canceled = true;
-        await this.dependencies.backend.cancelAuthorization({ connectorKey });
-        throw new ConnectorAuthorizationTerminalError(
-          connectorKey,
-          "connector_authorization_timeout"
-        );
-      }
-      await this.waitForAuthorizationContinuation();
-    }
-    if (attempt.canceled) {
-      throw new ConnectorAuthorizationCanceledError(connectorKey);
-    }
   }
 
   private acquireConnectorMutation(connectorKey: string): symbol {

--- a/packages/connector/runtime/implementationhost/credential_authorization.go
+++ b/packages/connector/runtime/implementationhost/credential_authorization.go
@@ -18,6 +18,7 @@ import (
 )
 
 const credentialBrokerInitialEventTimeout = 30 * time.Second
+const credentialBrokerContinuationWait = time.Second
 
 type managedCLILaunch struct {
 	arguments     []string
@@ -89,6 +90,7 @@ type credentialBrokerSession struct {
 	userCode string
 	err      error
 	version  uint64
+	hasEvent bool
 	changed  chan struct{}
 }
 
@@ -136,17 +138,17 @@ func (provider *managedCredentialAuthorizationProvider) Begin(
 	if err != nil {
 		return market.AuthorizationSession{}, err
 	}
-	session, err := provider.authorizationSessionOrStart(route, request.OperationID)
+	session, err := provider.authorizationSessionOrStart(route, request.OperationID, request.StepRevisionBase)
 	if err != nil {
 		return market.AuthorizationSession{}, err
 	}
-	if err := session.awaitInitialEvent(ctx); err != nil {
+	if err := session.awaitEventAfter(ctx, request.AfterStepRevision); err != nil {
 		cleanupContext, cancelCleanup := context.WithTimeout(context.Background(), 5*time.Second)
 		cleanupErr := provider.cancelAuthorizationSession(cleanupContext, session)
 		cancelCleanup()
 		return market.AuthorizationSession{}, errors.Join(err, cleanupErr)
 	}
-	state, authorizationURL, userCode, sessionErr := session.snapshot()
+	state, authorizationURL, userCode, stepRevision, sessionErr := session.snapshot()
 	if sessionErr != nil {
 		provider.clearAuthorizationSession(request.OperationID, session)
 		provider.host.releaseAuthorizationRoute(route)
@@ -159,6 +161,7 @@ func (provider *managedCredentialAuthorizationProvider) Begin(
 		SessionID:        request.OperationID + "/credential-broker",
 		AuthorizationURL: authorizationURL,
 		UserCode:         userCode,
+		StepRevision:     stepRevision,
 		State:            state,
 	}
 	if state == market.AuthorizationStateConnected {
@@ -266,11 +269,12 @@ func (provider *managedCredentialAuthorizationProvider) Inspect(
 func (provider *managedCredentialAuthorizationProvider) authorizationSessionOrStart(
 	route *connectorRoute,
 	operationID string,
+	stepRevisionBase uint64,
 ) (*credentialBrokerSession, error) {
 	operationID = strings.TrimSpace(operationID)
 	provider.mu.Lock()
 	if session := provider.sessions[operationID]; session != nil {
-		_, _, _, sessionErr := session.snapshot()
+		_, _, _, _, sessionErr := session.snapshot()
 		if sessionErr == nil {
 			provider.mu.Unlock()
 			return session, nil
@@ -286,7 +290,7 @@ func (provider *managedCredentialAuthorizationProvider) authorizationSessionOrSt
 	if activeOperationID := provider.activeByRoute[route.id]; activeOperationID != "" {
 		active := provider.sessions[activeOperationID]
 		if active != nil {
-			_, _, _, activeErr := active.snapshot()
+			_, _, _, _, activeErr := active.snapshot()
 			if activeErr != nil {
 				select {
 				case <-active.done:
@@ -315,7 +319,7 @@ func (provider *managedCredentialAuthorizationProvider) authorizationSessionOrSt
 	}
 	session := &credentialBrokerSession{
 		operationID: operationID, route: route, connection: connection, cancel: cancel,
-		done: make(chan struct{}), changed: make(chan struct{}),
+		done: make(chan struct{}), version: stepRevisionBase, changed: make(chan struct{}),
 	}
 	provider.sessions[operationID] = session
 	provider.activeByRoute[route.id] = operationID
@@ -600,10 +604,6 @@ func (host *Host) startCredentialBroker(
 	return connection, processID, nil
 }
 
-func receiveCredentialBrokerFrame(connection agentruntime.ProcessConnection) (agentruntime.ProcessFrame, error) {
-	return connection.Recv()
-}
-
 func receiveCredentialBrokerFrameContext(ctx context.Context, connection agentruntime.ProcessConnection) (agentruntime.ProcessFrame, error) {
 	if contextual, ok := connection.(agentruntime.ContextProcessConnection); ok {
 		return contextual.RecvContext(ctx)
@@ -733,23 +733,40 @@ func normalizeCredentialBrokerUserCode(value string) (string, error) {
 	return value, nil
 }
 
-func (session *credentialBrokerSession) awaitInitialEvent(ctx context.Context) error {
+func (session *credentialBrokerSession) awaitEventAfter(ctx context.Context, afterStepRevision uint64) error {
 	session.mu.Lock()
-	version := session.version
-	changed := session.changed
+	hasEvent := session.hasEvent
 	session.mu.Unlock()
-	if version != 0 {
-		return nil
+	wait := credentialBrokerContinuationWait
+	if !hasEvent {
+		wait = credentialBrokerInitialEventTimeout
 	}
-	timer := time.NewTimer(credentialBrokerInitialEventTimeout)
+	timer := time.NewTimer(wait)
 	defer timer.Stop()
-	select {
-	case <-changed:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-timer.C:
-		return errors.New("connector credential broker did not return an initial event")
+	for {
+		session.mu.Lock()
+		hasEvent = session.hasEvent
+		version := session.version
+		state := session.state
+		changed := session.changed
+		session.mu.Unlock()
+		if hasEvent && (version > afterStepRevision || state == market.AuthorizationStateConnected || state == market.AuthorizationStateFailed) {
+			return nil
+		}
+		select {
+		case <-changed:
+			continue
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+			session.mu.Lock()
+			hasEvent = session.hasEvent
+			session.mu.Unlock()
+			if !hasEvent {
+				return errors.New("connector credential broker did not return an initial event")
+			}
+			return nil
+		}
 	}
 }
 
@@ -760,6 +777,7 @@ func (session *credentialBrokerSession) update(state market.AuthorizationState, 
 	session.userCode = userCode
 	session.err = err
 	session.version++
+	session.hasEvent = true
 	close(session.changed)
 	session.changed = make(chan struct{})
 	session.mu.Unlock()
@@ -769,10 +787,10 @@ func (session *credentialBrokerSession) fail(err error) {
 	session.update(market.AuthorizationStateFailed, "", "", err)
 }
 
-func (session *credentialBrokerSession) snapshot() (market.AuthorizationState, string, string, error) {
+func (session *credentialBrokerSession) snapshot() (market.AuthorizationState, string, string, uint64, error) {
 	session.mu.Lock()
 	defer session.mu.Unlock()
-	return session.state, session.url, session.userCode, session.err
+	return session.state, session.url, session.userCode, session.version, session.err
 }
 
 func (session *credentialBrokerSession) terminal() bool {

--- a/packages/connector/runtime/implementationhost/credential_authorization.go
+++ b/packages/connector/runtime/implementationhost/credential_authorization.go
@@ -79,6 +79,7 @@ type credentialBrokerEvent struct {
 type credentialBrokerSession struct {
 	operationID string
 	route       *connectorRoute
+	connection  agentruntime.ProcessConnection
 	cancel      context.CancelFunc
 	done        chan struct{}
 
@@ -313,16 +314,18 @@ func (provider *managedCredentialAuthorizationProvider) authorizationSessionOrSt
 		return nil, fmt.Errorf("start connector credential broker: %w", err)
 	}
 	session := &credentialBrokerSession{
-		operationID: operationID, route: route, cancel: cancel, done: make(chan struct{}), changed: make(chan struct{}),
+		operationID: operationID, route: route, connection: connection, cancel: cancel,
+		done: make(chan struct{}), changed: make(chan struct{}),
 	}
 	provider.sessions[operationID] = session
 	provider.activeByRoute[route.id] = operationID
 	provider.mu.Unlock()
-	go consumeAuthorizationEvents(provider.host, route, connection, processID, session)
+	go consumeAuthorizationEvents(processContext, provider.host, route, connection, processID, session)
 	return session, nil
 }
 
 func consumeAuthorizationEvents(
+	ctx context.Context,
 	host managedCredentialAuthorizationHost,
 	route *connectorRoute,
 	connection agentruntime.ProcessConnection,
@@ -334,8 +337,14 @@ func consumeAuthorizationEvents(
 	defer func() { _ = route.releaseProcess(processID, connection) }()
 	var stdout, stderr strings.Builder
 	for {
-		frame, err := receiveCredentialBrokerFrame(connection)
+		frame, err := receiveCredentialBrokerFrameContext(ctx, connection)
 		if err != nil {
+			// Explicit cancellation owns the terminal state transition. Do not race
+			// the caller by projecting a transient broker failure while shutdown is
+			// already in progress.
+			if errors.Is(ctx.Err(), context.Canceled) {
+				return
+			}
 			if !errors.Is(err, io.EOF) {
 				failAuthorizationSession(host, route, session, fmt.Errorf("receive connector credential broker event: %w", err))
 			} else if !session.terminal() {
@@ -790,13 +799,17 @@ func (provider *managedCredentialAuthorizationProvider) cancelAuthorizationSessi
 		return nil
 	}
 	session.cancel()
+	var closeErr error
+	if session.connection != nil {
+		closeErr = session.connection.Close()
+	}
 	select {
 	case <-session.done:
 		provider.clearAuthorizationSession(session.operationID, session)
 		provider.host.releaseAuthorizationRoute(session.route)
-		return nil
+		return closeErr
 	case <-ctx.Done():
-		return fmt.Errorf("wait for connector credential broker termination: %w", ctx.Err())
+		return errors.Join(closeErr, fmt.Errorf("wait for connector credential broker termination: %w", ctx.Err()))
 	}
 }
 
@@ -806,6 +819,9 @@ func (provider *managedCredentialAuthorizationProvider) cancelAuthorizationSessi
 	}
 	if session := provider.takeAuthorizationSessionByRoute(routeID); session != nil {
 		session.cancel()
+		if session.connection != nil {
+			_ = session.connection.Close()
+		}
 	}
 }
 

--- a/packages/connector/runtime/implementationhost/credential_authorization_test.go
+++ b/packages/connector/runtime/implementationhost/credential_authorization_test.go
@@ -158,18 +158,46 @@ func TestManagedCredentialAuthorizationContinuesConnectorOwnedBroker(t *testing.
 	if first.State != market.AuthorizationStatePending || first.AuthorizationURL != "https://open.feishu.cn/page/cli?user_code=opaque" {
 		t.Fatalf("first session = %#v", first)
 	}
+	if first.StepRevision != 1 {
+		t.Fatalf("first step revision = %d, want 1", first.StepRevision)
+	}
 
+	secondResult := make(chan market.AuthorizationSession, 1)
+	secondError := make(chan error, 1)
+	go func() {
+		continuedRequest := request
+		continuedRequest.AfterStepRevision = first.StepRevision
+		session, err := provider.Begin(context.Background(), continuedRequest)
+		secondResult <- session
+		secondError <- err
+	}()
+	select {
+	case result := <-secondResult:
+		t.Fatalf("continuation returned the current step before a later event: %#v", result)
+	case <-time.After(20 * time.Millisecond):
+	}
 	connection.frames <- agentruntime.ProcessFrame{Stdout: []byte(`{"type":"authorization_url","url":"https://accounts.feishu.cn/device?user_code=user"}` + "\n")}
-	second := awaitAuthorizationSession(t, provider, request, "https://accounts.feishu.cn/device?user_code=user")
+	if err := <-secondError; err != nil {
+		t.Fatal(err)
+	}
+	second := <-secondResult
 	if second.State != market.AuthorizationStatePending {
 		t.Fatalf("second session = %#v", second)
+	}
+	if second.AuthorizationURL != "https://accounts.feishu.cn/device?user_code=user" || second.StepRevision != 2 {
+		t.Fatalf("second step = %#v", second)
 	}
 
 	exitCode := 0
 	connection.frames <- agentruntime.ProcessFrame{Stdout: []byte(`{"type":"connected"}` + "\n"), ExitCode: &exitCode}
-	connected := awaitAuthorizationSession(t, provider, request, "")
+	terminalRequest := request
+	terminalRequest.AfterStepRevision = second.StepRevision
+	connected := awaitAuthorizationSession(t, provider, terminalRequest, "")
 	if connected.State != market.AuthorizationStateConnected {
 		t.Fatalf("connected session = %#v", connected)
+	}
+	if connected.StepRevision != 3 {
+		t.Fatalf("connected step revision = %d, want 3", connected.StepRevision)
 	}
 	if !reflect.DeepEqual(host.requests, []credentialBrokerRequest{{Protocol: market.CredentialBrokerProtocolV1, Operation: "begin"}}) {
 		t.Fatalf("broker requests = %#v", host.requests)
@@ -194,6 +222,7 @@ func TestManagedCredentialAuthorizationReturnsDeviceCodeFromBroker(t *testing.T)
 	go func() {
 		session, err := provider.Begin(context.Background(), market.AuthorizationStartRequest{
 			OperationID: "authorize-github", Connector: market.Connector{Key: "github-cli"},
+			AfterStepRevision: 4, StepRevisionBase: 4,
 		})
 		result <- session
 		resultErr <- err
@@ -204,7 +233,7 @@ func TestManagedCredentialAuthorizationReturnsDeviceCodeFromBroker(t *testing.T)
 		t.Fatal(err)
 	}
 	session := <-result
-	if session.AuthorizationURL != "https://github.com/login/device" || session.UserCode != "ABCD-EFGH" {
+	if session.AuthorizationURL != "https://github.com/login/device" || session.UserCode != "ABCD-EFGH" || session.StepRevision != 5 {
 		t.Fatalf("authorization session = %#v", session)
 	}
 }
@@ -464,7 +493,7 @@ func awaitCachedAuthorizationFailure(t *testing.T, provider *managedCredentialAu
 		session := provider.sessions[operationID]
 		provider.mu.Unlock()
 		if session != nil {
-			_, _, _, err := session.snapshot()
+			_, _, _, _, err := session.snapshot()
 			if err != nil {
 				return
 			}

--- a/packages/connector/runtime/implementationhost/credential_authorization_test.go
+++ b/packages/connector/runtime/implementationhost/credential_authorization_test.go
@@ -86,18 +86,27 @@ func (stub *credentialAuthorizationHostStub) startCredentialBroker(
 }
 
 type credentialBrokerConnection struct {
-	frames chan agentruntime.ProcessFrame
+	frames    chan agentruntime.ProcessFrame
+	closed    chan struct{}
+	closeOnce sync.Once
 }
 
 func newCredentialBrokerConnection() *credentialBrokerConnection {
-	return &credentialBrokerConnection{frames: make(chan agentruntime.ProcessFrame, 8)}
+	return &credentialBrokerConnection{frames: make(chan agentruntime.ProcessFrame, 8), closed: make(chan struct{})}
 }
 
 func (*credentialBrokerConnection) Send([]byte) error { return nil }
-func (*credentialBrokerConnection) Close() error      { return nil }
 func (*credentialBrokerConnection) CloseInput() error { return nil }
 func (*credentialBrokerConnection) Terminate() error  { return nil }
 func (*credentialBrokerConnection) Kill() error       { return nil }
+
+func (connection *credentialBrokerConnection) Close() error {
+	connection.closeOnce.Do(func() {
+		close(connection.closed)
+		close(connection.frames)
+	})
+	return nil
+}
 
 func (connection *credentialBrokerConnection) Recv() (agentruntime.ProcessFrame, error) {
 	frame, ok := <-connection.frames
@@ -105,6 +114,18 @@ func (connection *credentialBrokerConnection) Recv() (agentruntime.ProcessFrame,
 		return agentruntime.ProcessFrame{}, io.EOF
 	}
 	return frame, nil
+}
+
+func (connection *credentialBrokerConnection) RecvContext(ctx context.Context) (agentruntime.ProcessFrame, error) {
+	select {
+	case <-ctx.Done():
+		return agentruntime.ProcessFrame{}, ctx.Err()
+	case frame, ok := <-connection.frames:
+		if !ok {
+			return agentruntime.ProcessFrame{}, io.EOF
+		}
+		return frame, nil
+	}
 }
 
 func TestManagedCredentialAuthorizationContinuesConnectorOwnedBroker(t *testing.T) {
@@ -390,7 +411,7 @@ func TestManagedCredentialAuthorizationRestartsFailedBrokerOnFirstRetry(t *testi
 	}
 }
 
-func TestManagedCredentialAuthorizationCancelWaitsForBrokerExit(t *testing.T) {
+func TestManagedCredentialAuthorizationCancelTerminatesAndWaitsForBrokerExit(t *testing.T) {
 	connection := newCredentialBrokerConnection()
 	route := &connectorRoute{id: "default\x00dingtalk-cli", credentialBrokerLaunch: &managedCredentialBrokerLaunch{
 		timeout: 5 * time.Minute, allowedHosts: map[string]struct{}{"login.dingtalk.com": {}},
@@ -408,33 +429,30 @@ func TestManagedCredentialAuthorizationCancelWaitsForBrokerExit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	provider.mu.Lock()
-	session := provider.sessions[request.OperationID]
-	originalCancel := session.cancel
-	cancelRequested := make(chan struct{})
-	session.cancel = func() {
-		close(cancelRequested)
-		originalCancel()
-	}
-	provider.mu.Unlock()
 	cancelDone := make(chan error, 1)
 	go func() {
 		cancelDone <- provider.Cancel(context.Background(), market.AuthorizationCancelRequest{OperationID: request.OperationID})
 	}()
-	<-cancelRequested
+	select {
+	case <-connection.closed:
+	case <-time.After(time.Second):
+		t.Fatal("cancel did not close the credential broker connection")
+	}
 	select {
 	case err := <-cancelDone:
-		t.Fatalf("cancel returned before broker exit: %v", err)
-	default:
-	}
-	close(connection.frames)
-	if err := <-cancelDone; err != nil {
-		t.Fatal(err)
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cancel did not wait for credential broker termination")
 	}
 	provider.mu.Lock()
-	defer provider.mu.Unlock()
 	if provider.sessions[request.OperationID] != nil || provider.activeByRoute[route.id] != "" {
 		t.Fatalf("canceled session remained active: sessions=%#v routes=%#v", provider.sessions, provider.activeByRoute)
+	}
+	provider.mu.Unlock()
+	if observed := host.authorizationObservations(); !reflect.DeepEqual(observed, []market.AuthorizationState{market.AuthorizationStatePending}) {
+		t.Fatalf("authorization observations after cancel = %#v", observed)
 	}
 }
 

--- a/services/tuttid/api/daemon_connector_market.go
+++ b/services/tuttid/api/daemon_connector_market.go
@@ -462,7 +462,8 @@ func connectorMarketAuthorizationMutation(
 	body *tuttigenerated.ConnectorMarketAuthorizationRequest,
 ) (market.ConnectorMutation, []byte, error) {
 	if body == nil || body.ExpectedRevision < 0 ||
-		(body.ExpectedConnectorRevision != nil && *body.ExpectedConnectorRevision < 0) {
+		(body.ExpectedConnectorRevision != nil && *body.ExpectedConnectorRevision < 0) ||
+		(body.AfterAuthorizationStepRevision != nil && *body.AfterAuthorizationStepRevision < 0) {
 		return market.ConnectorMutation{}, nil, invalidConnectorMarketRequest()
 	}
 	var secret []byte
@@ -483,6 +484,9 @@ func connectorMarketAuthorizationMutation(
 	if body.ExpectedConnectorRevision != nil {
 		revision := uint64(*body.ExpectedConnectorRevision)
 		result.ExpectedConnectorRevision = &revision
+	}
+	if body.AfterAuthorizationStepRevision != nil {
+		result.AfterAuthorizationStepRevision = uint64(*body.AfterAuthorizationStepRevision)
 	}
 	return result, secret, nil
 }

--- a/services/tuttid/api/daemon_connector_market_test.go
+++ b/services/tuttid/api/daemon_connector_market_test.go
@@ -193,9 +193,10 @@ func TestDaemonAPIForwardsReplaceActiveAuthorizationPolicy(t *testing.T) {
 				ConnectorKey: connector.Key, Kind: market.OperationKindStartAuthorization,
 				State: market.OperationStateCompleted, CreatedAt: time.Now(), UpdatedAt: time.Now(),
 			},
-			AuthorizationURL:       "https://accounts.example.com/oauth",
-			AuthorizationExpiresAt: time.Now().Add(time.Minute),
-			Revision:               2,
+			AuthorizationURL:          "https://accounts.example.com/oauth",
+			AuthorizationExpiresAt:    time.Now().Add(time.Minute),
+			AuthorizationStepRevision: 2,
+			Revision:                  2,
 		}, nil
 	}}
 	mux := http.NewServeMux()
@@ -207,12 +208,14 @@ func TestDaemonAPIForwardsReplaceActiveAuthorizationPolicy(t *testing.T) {
 	recorder := performGeneratedRouteRequest(t, mux, http.MethodPost,
 		"/v1/connector-market/connectors/notion/authorization:start", map[string]any{
 			"clientRequestId": "authorization-b", "expectedRevision": 1,
-			"replacementPolicy": "replace_active",
+			"afterAuthorizationStepRevision": 1,
+			"replacementPolicy":              "replace_active",
 		})
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d; body: %s", recorder.Code, http.StatusOK, recorder.Body.String())
 	}
 	if received.AccountID != "account-1" || received.ClientRequestID != "authorization-b" ||
+		received.AfterAuthorizationStepRevision != 1 ||
 		received.ReplacementPolicy != market.AuthorizationReplacementPolicyReplaceActive {
 		t.Fatalf("authorization mutation = %#v", received)
 	}

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -6618,9 +6618,11 @@ type ConnectorMarketAuthorizationReplacementPolicy string
 
 // ConnectorMarketAuthorizationRequest defines model for ConnectorMarketAuthorizationRequest.
 type ConnectorMarketAuthorizationRequest struct {
-	ClientRequestId           string `json:"clientRequestId"`
-	ExpectedConnectorRevision *int64 `json:"expectedConnectorRevision,omitempty"`
-	ExpectedRevision          int64  `json:"expectedRevision"`
+	// AfterAuthorizationStepRevision Cursor for a previously delivered authorization step. When provided, the Host resumes the same authorization attempt and waits briefly for a later step. A bounded poll may replay the current step. The cursor contains no authorization URL, user code, or credential material.
+	AfterAuthorizationStepRevision *int64 `json:"afterAuthorizationStepRevision,omitempty"`
+	ClientRequestId                string `json:"clientRequestId"`
+	ExpectedConnectorRevision      *int64 `json:"expectedConnectorRevision,omitempty"`
+	ExpectedRevision               int64  `json:"expectedRevision"`
 
 	// ReplacementPolicy When set to replace_active, the Host fences and terminates a different unresolved authorization attempt before starting this request. Omission preserves the legacy resume-or-conflict behavior.
 	ReplacementPolicy *ConnectorMarketAuthorizationReplacementPolicy `json:"replacementPolicy,omitempty"`
@@ -6630,7 +6632,10 @@ type ConnectorMarketAuthorizationRequest struct {
 // ConnectorMarketAuthorizationResponse defines model for ConnectorMarketAuthorizationResponse.
 type ConnectorMarketAuthorizationResponse struct {
 	AuthorizationExpiresAt time.Time `json:"authorizationExpiresAt"`
-	AuthorizationUrl       *string   `json:"authorizationUrl,omitempty"`
+
+	// AuthorizationStepRevision Monotonic, non-secret revision of the provider authorization event returned by this response. Clients pass it back as afterAuthorizationStepRevision when waiting for a later step.
+	AuthorizationStepRevision int64   `json:"authorizationStepRevision"`
+	AuthorizationUrl          *string `json:"authorizationUrl,omitempty"`
 
 	// AuthorizationView Opaque runtime Authorization View V1 envelope. Clients must validate it with the shared authorization protocol before rendering.
 	AuthorizationView *map[string]interface{}  `json:"authorizationView,omitempty"`


### PR DESCRIPTION
## Summary

Connector credential authorization could lose a later device-code presentation during an idempotent replay, and canceling a managed credential broker could remain in durable `canceling` forever. The broker reader blocked in `Recv()` while canceling only canceled a context that the running process transport no longer observed.

This change makes authorization steps explicitly monotonic and makes broker termination part of the session lifecycle:

- add `authorizationStepRevision` and `afterAuthorizationStepRevision` to the Connector Market contract, durable session projection, generated clients, and renderer polling flow
- resume an existing broker session after a caller-provided step cursor without persisting authorization URLs or device codes
- read broker output through `RecvContext` and close the owned process connection on cancellation, then wait for the consumer to finish before releasing the session and route
- avoid projecting a transient authorization failure when explicit cancellation owns the terminal transition
- document the step-ordering and process-termination contracts

## Verification

- `corepack pnpm@10.11.0 check:changed` — passed 24 selected lanes after the worktree dependencies were installed; one resource-contention run of the unrelated full `services/tuttid` suite was retried after the competing suite exited
- pre-push `corepack pnpm@10.11.0 check:changed -- --push-ready` — passed 26 lanes
- manual linked-host reproduction: a previously persisted `canceling` GitHub CLI attempt converged; a fresh cancel returned HTTP 204 in under one second and projected `disconnected` instead of timing out after 15 seconds
- manual linked-host authorization: the GitHub CLI flow produced a V1 `device_code` view with a non-empty user code, and the follow-up cancel completed immediately

## Fallback Three Questions

- Source: provider credential brokers can legitimately emit a later authorization presentation after the current HTTP response has already returned, while the API currently has no response stream.
- Why can it not be fixed at that source? Multi-step provider behavior is valid and provider-specific; the host owns idempotency, ordering, and replay across all providers and clients.
- Removal condition: remove the bounded continuation wait when the Connector Market authorization API provides a push/stream protocol with acknowledged step revisions and no polling fallback is supported.

## Checklist

- [x] N/A — this changes Connector authorization lifecycle, not Agent session/turn/goal/runtime-operation semantics.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] N/A — no README or CONTRIBUTING language source changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
