### PR TITLE
fix(connector): converge authorization after response loss

### DIFF
--- a/docs/architecture/connector.md
+++ b/docs/architecture/connector.md
@@ -69,7 +69,11 @@ filter so installed connectors remain in their server-owned sections.
 Installation is a device fact. Authorization is an account projection. A
 Connector may therefore be installed while inactive for the current account;
 authorization completion or expiry schedules a normal durable runtime
-reconcile without changing installed truth. Remote MCP HTTP 428 and JSON-RPC
+reconcile without changing installed truth. Provider authorization completion
+returns after that runtime Desired is durable; it does not wait for the runtime
+Observed receipt. The background convergence worker owns retries, so a runtime
+revision race cannot turn an already-committed authorization into a failed
+authorization response. Remote MCP HTTP 428 and JSON-RPC
 `-33001`/`-33002` during an enabled reconcile are authorization-required
 observations, not retryable install failures. Core persists an expired account
 projection, replans `RuntimeDesired` as disabled, and lets

--- a/docs/conventions/troubleshooting/connector-market.md
+++ b/docs/conventions/troubleshooting/connector-market.md
@@ -1,5 +1,35 @@
 # Connector Market Troubleshooting
 
+### Authorization reports failure after the provider connected
+
+**Symptoms**
+
+- the provider login or CLI device flow completes successfully
+- the Connector projection and matching `start_authorization` operation are
+  already `connected` and `completed`
+- the renderer still shows an authorization-start failure because a later
+  continuation request returned a retryable error
+
+**Check**
+
+Separate the durable authorization receipt from runtime convergence. Match the
+snapshot operation by `clientRequestId`, Connector key, and operation kind. If
+that operation completed and the same snapshot projects the Connector as
+connected, the first bad state is the rejected continuation response, not the
+provider login. Inspect whether runtime convergence returned a revision or
+transport error after authorization state was committed.
+
+**Rule**
+
+Provider authorization completion persists its projection and durable runtime
+Desired, then returns without waiting for the runtime Observed receipt. The
+background convergence worker owns runtime retries. A renderer that loses a
+continuation response reconciles the authoritative snapshot and accepts success
+only when the matching authorization receipt and connected projection agree;
+it must not treat an unrelated connected operation as success. Keep the same
+`clientRequestId` for every continuation and retain the overall authorization
+deadline.
+
 ### Disconnect fails immediately after authorization succeeds
 
 **Symptoms**

--- a/packages/connector/daemon/core/application_execution.go
+++ b/packages/connector/daemon/core/application_execution.go
@@ -423,7 +423,7 @@ func (application *Application) beginAuthorizationSession(
 		return AuthorizationSession{}, err
 	}
 	if session.State == AuthorizationStateConnected || (!remote && accountScoped) {
-		if err := application.projectAuthorizationAndScheduleRuntime(ctx, operation.Scope, operation.ConnectorKey, session.ConnectionID, session.State, ""); err != nil {
+		if err := application.projectAuthorizationAndPlanRuntime(ctx, operation.Scope, operation.ConnectorKey, session.ConnectionID, session.State, ""); err != nil {
 			return AuthorizationSession{}, err
 		}
 	}

--- a/packages/connector/daemon/core/application_scoped_runtime.go
+++ b/packages/connector/daemon/core/application_scoped_runtime.go
@@ -205,6 +205,28 @@ func (application *Application) projectAuthorizationAndScheduleRuntime(
 	return application.ReconcileRuntimeDesired(ctx, scope, connectorKey)
 }
 
+// projectAuthorizationAndPlanRuntime keeps provider authorization completion
+// independent from slow runtime convergence. The durable Desired record is the
+// handoff to the daemon convergence worker; the authorization response does
+// not wait for a process receipt that can be retried independently.
+func (application *Application) projectAuthorizationAndPlanRuntime(
+	ctx context.Context,
+	scope OperationScope,
+	connectorKey, connectionID string,
+	state AuthorizationState,
+	failureCode string,
+) error {
+	_, err := application.projectAuthorization(ctx, scope, connectorKey, connectionID, state, failureCode)
+	if err != nil || application.config.AuthorizationProjections == nil || strings.TrimSpace(scope.AccountID) == "" {
+		return err
+	}
+	if state == AuthorizationStatePending {
+		return nil
+	}
+	_, err = application.EnsureRuntimeDesired(ctx, scope, connectorKey)
+	return err
+}
+
 // projectAuthorization persists authorization truth without creating runtime
 // work. Recovery callers use it before the daemon creates and awaits exactly
 // one reconcile under the account lifecycle fence.

--- a/packages/connector/daemon/core/application_test.go
+++ b/packages/connector/daemon/core/application_test.go
@@ -1497,6 +1497,46 @@ func TestApplicationManagedAuthorizationContinuationReplaysBeforeProjectionTrans
 	}
 }
 
+func TestApplicationConnectedAuthorizationPlansRuntimeWithoutWaitingForHostConvergence(t *testing.T) {
+	connector := testManagedAuthorizedConnector("github-cli")
+	connector.Authorization = Authorization{State: AuthorizationStateDisconnected}
+	repository := newMemoryRepository(connector)
+	projections := &recordingAuthorizationProjectionStore{}
+	runtime := &memoryInstallRuntime{reconcileErrors: map[string]error{
+		connector.Key: NewDomainError(ErrorCodeRevisionConflict, "runtime changed during convergence", true, nil),
+	}}
+	application := newTestApplication(t, repository, &memoryScheduler{}, runtime, CatalogSnapshot{})
+	application.config.Authorization = connectedAuthorizationProviderStub{}
+	application.config.AuthorizationProjections = projections
+	application.config.RuntimeBindings = AccountRuntimeBindingResolver{Projections: projections}
+
+	result, err := application.BeginAuthorization(context.Background(), ConnectorMutation{
+		Mutation:     Mutation{ClientRequestID: "connected-authorization"},
+		ConnectorKey: connector.Key,
+		AccountID:    "account-1",
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginAuthorization returned a post-commit runtime error: %v", err)
+	}
+	convergence, err := repository.RuntimeConvergence(
+		context.Background(), OperationScope{AccountID: "account-1"}, connector.Key,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Connector.Authorization.State != AuthorizationStateConnected ||
+		result.Operation.State != OperationStateCompleted ||
+		projections.projection.State != AuthorizationStateConnected {
+		t.Fatalf("authorization did not commit: result=%#v projection=%#v", result, projections.projection)
+	}
+	if convergence.Desired.AuthorizationState != AuthorizationStateConnected || !convergence.Desired.Enabled {
+		t.Fatalf("runtime desired = %#v", convergence.Desired)
+	}
+	if runtime.reconciles != 0 {
+		t.Fatalf("authorization waited for runtime host convergence %d times", runtime.reconciles)
+	}
+}
+
 func TestApplicationResolvedAuthorizationReplayDoesNotRestartProvider(t *testing.T) {
 	connector := testManagedAuthorizedConnector("lark-cli")
 	connector.Authorization = Authorization{State: AuthorizationStateDisconnected}

--- a/packages/connector/renderer/src/application/services/connectorMarketService.test.ts
+++ b/packages/connector/renderer/src/application/services/connectorMarketService.test.ts
@@ -1547,9 +1547,20 @@ test("converges a busy authorization continuation from a connected snapshot", as
     backend: backendWith({
       getSnapshot: async () => {
         snapshotReads += 1;
-        return snapshotReads === 1
-          ? snapshot(1, [disconnected])
-          : snapshot(4, [connected]);
+        if (snapshotReads === 1) {
+          return snapshot(1, [disconnected]);
+        }
+        return {
+          ...snapshot(4, [connected]),
+          operations: [
+            {
+              ...operation("start_authorization", 4),
+              clientRequestId: "one-notion-authorization",
+              connectorKey: "notion",
+              state: "completed" as const
+            }
+          ]
+        };
       },
       beginAuthorization: async (request) => {
         requests.push(request);
@@ -1606,6 +1617,155 @@ test("converges a busy authorization continuation from a connected snapshot", as
     "connected"
   );
   assert.equal(service.dataStore.lastError, null);
+  service.dispose();
+});
+
+test("converges a retryable authorization continuation failure from its durable receipt", async () => {
+  const requests: ConnectorAuthorizationInput[] = [];
+  const diagnostics: unknown[] = [];
+  let snapshotReads = 0;
+  const disconnected = connector("github-cli", 1);
+  disconnected.authorization = { state: "disconnected" };
+  const connected = connector("github-cli", 4);
+  connected.authorization = { state: "connected" };
+  const service = new ConnectorMarketService({
+    backend: backendWith({
+      getSnapshot: async () => {
+        snapshotReads += 1;
+        if (snapshotReads === 1) {
+          return snapshot(1, [disconnected]);
+        }
+        return {
+          ...snapshot(4, [connected]),
+          operations: [
+            {
+              ...operation("start_authorization", 4),
+              clientRequestId: "one-github-cli-authorization",
+              connectorKey: "github-cli",
+              operationId: "github-cli-authorization",
+              state: "completed" as const
+            }
+          ]
+        };
+      },
+      beginAuthorization: async (request) => {
+        requests.push(request);
+        if (requests.length > 1) {
+          throw Object.assign(new Error("authorization response was lost"), {
+            code: "connector_market_unavailable",
+            retryable: true
+          });
+        }
+        const pending = connector("github-cli", 2);
+        pending.authorization = { state: "pending" };
+        return {
+          connector: pending,
+          operation: {
+            ...operation("start_authorization", 2),
+            clientRequestId: "one-github-cli-authorization",
+            connectorKey: "github-cli",
+            operationId: "github-cli-authorization",
+            state: "completed" as const
+          },
+          authorizationView: {
+            protocol: "tutti.connector.authorization.view.v1",
+            viewId: "github-cli-device-code",
+            view: {
+              type: "device_code",
+              verificationUrl: "https://github.com/login/device",
+              userCode: "ABCD-EFGH"
+            }
+          },
+          revision: 2
+        };
+      }
+    }),
+    createRequestId: () => "one-github-cli-authorization",
+    reportDiagnostic: (error) => diagnostics.push(error),
+    waitForAuthorizationContinuation: async () => undefined
+  });
+  await service.ensureLoaded();
+
+  await service.beginAuthorization("github-cli");
+
+  assert.equal(snapshotReads, 2);
+  assert.equal(requests.length, 2);
+  assert.deepEqual(
+    requests.map(({ clientRequestId }) => clientRequestId),
+    ["one-github-cli-authorization", "one-github-cli-authorization"]
+  );
+  assert.equal(
+    service.dataStore.connectorsByKey["github-cli"]?.authorization.state,
+    "connected"
+  );
+  assert.equal(service.dataStore.lastError, null);
+  assert.equal(diagnostics.length, 1);
+  service.dispose();
+});
+
+test("does not accept an unrelated connected receipt after a continuation failure", async () => {
+  const disconnected = connector("github-cli", 1);
+  disconnected.authorization = { state: "disconnected" };
+  const connected = connector("github-cli", 4);
+  connected.authorization = { state: "connected" };
+  const responseLoss = Object.assign(
+    new Error("authorization response was lost"),
+    {
+      code: "connector_market_unavailable",
+      retryable: true
+    }
+  );
+  let snapshotReads = 0;
+  let authorizationCalls = 0;
+  const service = new ConnectorMarketService({
+    backend: backendWith({
+      getSnapshot: async () => {
+        snapshotReads += 1;
+        if (snapshotReads === 1) {
+          return snapshot(1, [disconnected]);
+        }
+        return {
+          ...snapshot(4, [connected]),
+          operations: [
+            {
+              ...operation("start_authorization", 4),
+              clientRequestId: "another-authorization",
+              connectorKey: "github-cli",
+              state: "completed" as const
+            }
+          ]
+        };
+      },
+      beginAuthorization: async () => {
+        authorizationCalls += 1;
+        if (authorizationCalls > 1) {
+          throw responseLoss;
+        }
+        const pending = connector("github-cli", 2);
+        pending.authorization = { state: "pending" };
+        return {
+          connector: pending,
+          operation: {
+            ...operation("start_authorization", 2),
+            clientRequestId: "one-github-cli-authorization",
+            connectorKey: "github-cli",
+            state: "completed" as const
+          },
+          authorizationUrl: "https://github.com/login/device",
+          revision: 2
+        };
+      }
+    }),
+    createRequestId: () => "one-github-cli-authorization",
+    openAuthorizationUrl: async () => undefined,
+    waitForAuthorizationContinuation: async () => undefined
+  });
+  await service.ensureLoaded();
+
+  await assert.rejects(service.beginAuthorization("github-cli"), responseLoss);
+
+  assert.equal(snapshotReads, 2);
+  assert.equal(authorizationCalls, 2);
   service.dispose();
 });
 

--- a/packages/connector/renderer/src/application/services/connectorMarketService.ts
+++ b/packages/connector/renderer/src/application/services/connectorMarketService.ts
@@ -550,19 +550,22 @@ export class ConnectorMarketService implements IConnectorMarketService {
             ...this.connectorRevisionFence(connectorKey)
           });
         } catch (error) {
-          const code = normalizeConnectorMarketError(error).code;
+          const normalizedError = normalizeConnectorMarketError(error);
+          const code = normalizedError.code;
           const canRecoverRevision: boolean =
             !recoveredRevisionConflict &&
             code === "connector_market_revision_conflict";
-          const canRecoverBusyContinuation: boolean =
+          const canRecoverContinuation: boolean =
             seenAuthorizationViewIds.size > 0 &&
-            code === "connector_operation_in_progress";
+            (normalizedError.retryable ||
+              code === "connector_operation_in_progress");
           if (
-            (!canRecoverRevision && !canRecoverBusyContinuation) ||
+            (!canRecoverRevision && !canRecoverContinuation) ||
             !this.isCurrentMutation(connectorKey, token, generation)
           ) {
             throw error;
           }
+          this.reportDiagnostic(error);
           recoveredRevisionConflict =
             recoveredRevisionConflict || canRecoverRevision;
           const next = await this.dependencies.backend.getSnapshot();
@@ -575,11 +578,50 @@ export class ConnectorMarketService implements IConnectorMarketService {
           applyConnectorMarketSnapshot(this.dataStore, next);
           this.reconcileUninstallNotificationStates(next.operations);
           expectedRevision = this.dataStore.revision;
-          if (this.authorizationState(connectorKey) === "connected") {
-            await this.waitForAuthorizationOperation(connectorKey);
+          const operation = next.operations.find(
+            (candidate) =>
+              candidate.clientRequestId === attempt.requestId &&
+              candidate.connectorKey === connectorKey &&
+              candidate.kind === "start_authorization"
+          );
+          if (
+            operation?.state === "completed" &&
+            this.authorizationState(connectorKey) === "connected"
+          ) {
             return;
           }
-          if (canRecoverBusyContinuation) {
+          if (operation?.state === "failed") {
+            throw new ConnectorAuthorizationTerminalError(
+              connectorKey,
+              operation.failureCode
+            );
+          }
+          const authorizationState = this.authorizationState(connectorKey);
+          if (
+            operation &&
+            (authorizationState === "failed" ||
+              authorizationState === "expired")
+          ) {
+            throw new ConnectorAuthorizationTerminalError(
+              connectorKey,
+              this.dataStore.connectorsByKey[connectorKey]?.authorization
+                .failureCode
+            );
+          }
+          if (canRecoverContinuation && !operation) {
+            throw error;
+          }
+          if (Date.now() >= attempt.expiresAtMs) {
+            attempt.canceled = true;
+            await this.dependencies.backend.cancelAuthorization({
+              connectorKey
+            });
+            throw new ConnectorAuthorizationTerminalError(
+              connectorKey,
+              "connector_authorization_timeout"
+            );
+          }
+          if (canRecoverContinuation) {
             await this.waitForAuthorizationContinuation();
           }
           continue;


### PR DESCRIPTION
## Summary

Fix Connector authorization flows that report failure after the provider has already connected.

The daemon now commits the authorization projection and durable runtime Desired without waiting for the runtime Observed receipt. Runtime convergence remains owned by the background worker, so a retryable runtime revision race cannot turn committed authorization into a failed `authorization:start` response.

For compatibility with older daemons and transport response loss, the Renderer reconciles retryable continuation failures against the authoritative snapshot. It accepts success only when `clientRequestId`, Connector key, operation kind, terminal operation state, and connected projection all match the active attempt. Unrelated connected receipts fail closed, and retries retain the original authorization deadline.

The Connector architecture and troubleshooting guidance now document this ownership and recovery path.

## Verification

- Negative control: the new Core regression test failed before the fix with `BeginAuthorization returned a post-commit runtime error`.
- `GOWORK=off go test ./...` in `packages/connector/daemon/core` passed.
- `pnpm --filter @tutti-os/connector-renderer test` passed: 93 Node tests and 29 Vitest tests.
- `pnpm check:changed` passed 12 selected lanes.
- Pre-push `pnpm check:changed -- --push-ready` passed 14 selected lanes.

## Fallback Three Questions

- Source: a retryable continuation response can be lost or rejected after the same idempotent authorization attempt has already persisted a durable receipt.
- Why can it not be fixed at that source? The Core post-commit runtime coupling is fixed here, but transport response loss and already-released daemon behavior remain cross-version boundaries that the Renderer must reconcile safely.
- Removal condition: replace this compatibility path only when authorization observation has a loss-independent protocol that directly returns the correlated durable receipt and supported consumers no longer call the continuation mutation for observation.

## Checklist

- [x] This change does not alter Agent session/turn/goal/runtime-operation lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] I updated documentation for the changed authorization/runtime data flow and troubleshooting path.
- [x] No README or CONTRIBUTING source changed, so translation updates are not applicable.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] The commit is signed off with DCO.
