### PR TITLE
fix(connector): streamline CLI authorization flow

### DIFF
--- a/docs/architecture/connector.md
+++ b/docs/architecture/connector.md
@@ -628,10 +628,11 @@ synchronizing -> materializing -> ready`; failure is terminal and disposes
 - command admission and presentation share one renderer-local per-Connector
   mutation phase (`installing`, `updating`, `uninstalling`, `authorizing`,
   `disconnecting`, or `updating_runtime`) in the reactive Market store. Cards
-  and dialogs remain busy until that phase is released, even when a newer
-  daemon projection has already reached `connected`. A disconnect submitted
-  through stale UI or another caller while authorization is settling waits for
-  that authorization action, rereads the projected state, and runs at most once
+  remain busy and an open authorization dialog remains on its waiting view
+  until that phase is released, even when a newer daemon projection has already
+  reached `connected`. A disconnect submitted through stale UI or another
+  caller while authorization is settling waits for that authorization action,
+  rereads the projected state, and runs at most once
 - event refreshes are coalesced, daemon reconnect performs a full reload, and
   accepted commands are followed through the operation endpoint or events
 - the settings catalog toolbar Refresh control indicates an explicit
@@ -709,9 +710,9 @@ right-hand pane. An uninstalled connector opens an installation confirmation.
 An unconnected installed connector opens the authorization dialog. The token
 form keeps typed secrets after submit so a failed or in-flight attempt does
 not force the user to re-enter them. Completing authorization in that dialog
-keeps the modal open and advances it to the management dialog, where
-disconnect and try remain available. An already authorized connector opens
-the management dialog directly. Blocked releases
+closes the modal and reports success without exposing the settling management
+projection. Reopening an already authorized connector opens the management
+dialog directly, where disconnect and try remain available. Blocked releases
 open the blocked-state dialog. Only one dialog host is mounted at a time, so
 the catalog keeps the full settings content width and never leaves an empty
 right column.

--- a/packages/connector/renderer/src/application/services/connectorMarketService.test.ts
+++ b/packages/connector/renderer/src/application/services/connectorMarketService.test.ts
@@ -2208,7 +2208,7 @@ test("keeps QR authorization in app state without opening its payload", async ()
   service.dispose();
 });
 
-test("keeps device-code authorization in the existing dialog until the user activates it", async () => {
+test("opens device-code authorization once and keeps the view until completion", async () => {
   const continueAuthorization = deferred<void>();
   const openedUrls: string[] = [];
   let step = 0;
@@ -2260,7 +2260,7 @@ test("keeps device-code authorization in the existing dialog until the user acti
       service.dataStore.authorizationViewsByConnectorKey["github-cli"]?.view
         .type === "device_code"
   );
-  assert.deepEqual(openedUrls, []);
+  assert.deepEqual(openedUrls, ["https://github.com/login/device"]);
   assert.equal(
     service.dataStore.authorizationViewsByConnectorKey["github-cli"]?.view
       .type === "device_code"
@@ -2272,7 +2272,7 @@ test("keeps device-code authorization in the existing dialog until the user acti
 
   continueAuthorization.resolve();
   await authorization;
-  assert.deepEqual(openedUrls, []);
+  assert.deepEqual(openedUrls, ["https://github.com/login/device"]);
   service.dispose();
 });
 

--- a/packages/connector/renderer/src/application/services/connectorMarketService.ts
+++ b/packages/connector/renderer/src/application/services/connectorMarketService.ts
@@ -671,8 +671,14 @@ export class ConnectorMarketService implements IConnectorMarketService {
           seenAuthorizationViewIds.add(authorizationView.viewId);
           this.dataStore.authorizationViewsByConnectorKey[connectorKey] =
             authorizationView;
-          if (authorizationView.view.type === "external_link") {
-            await this.openAuthorizationUrl(authorizationView.view.url);
+          const authorizationUrl =
+            authorizationView.view.type === "external_link"
+              ? authorizationView.view.url
+              : authorizationView.view.type === "device_code"
+                ? authorizationView.view.verificationUrl
+                : null;
+          if (authorizationUrl) {
+            await this.openAuthorizationUrl(authorizationUrl);
           }
         }
         if (this.authorizationState(connectorKey) === "connected") {

--- a/packages/connector/renderer/src/application/services/view/connectorMarketViewBuilder.test.ts
+++ b/packages/connector/renderer/src/application/services/view/connectorMarketViewBuilder.test.ts
@@ -466,8 +466,8 @@ test("keeps an authorized connector busy until the renderer authorization mutati
   assert.equal(view.cardsByKey[connector.key]?.status, "connected");
   assert.equal(view.cardsByKey[connector.key]?.mutationPhase, "authorizing");
   assert.equal(
-    view.dialog?.kind === "management" && view.dialog.canAuthorize,
-    false
+    view.dialog?.kind === "authorization" && view.dialog.authorizing,
+    true
   );
 });
 

--- a/packages/connector/renderer/src/application/services/view/connectorMarketViewBuilder.ts
+++ b/packages/connector/renderer/src/application/services/view/connectorMarketViewBuilder.ts
@@ -240,7 +240,11 @@ function buildConnectorDialogView(
       updating: installed || mutationPhase === "updating"
     };
   }
-  if (!["connected", "not_required"].includes(connector.authorization.state)) {
+  if (
+    mutationPhase === "authorizing" ||
+    pendingAuthorization ||
+    !["connected", "not_required"].includes(connector.authorization.state)
+  ) {
     return {
       ...base,
       authorizationInteraction:

--- a/packages/connector/renderer/src/ui/authorization/AuthorizationViewRenderer.tsx
+++ b/packages/connector/renderer/src/ui/authorization/AuthorizationViewRenderer.tsx
@@ -311,6 +311,7 @@ function AuthorizationViewHeading({
 function AuthorizationActionFooter({
   actionLabel,
   actionType,
+  allowCancelWhileBusy = false,
   busy,
   cancelLabel,
   viewId,
@@ -318,6 +319,7 @@ function AuthorizationActionFooter({
 }: {
   actionLabel?: string;
   actionType?: AuthorizationActionEventType;
+  allowCancelWhileBusy?: boolean;
   busy: boolean;
   cancelLabel: string;
   viewId: string;
@@ -326,7 +328,7 @@ function AuthorizationActionFooter({
   return (
     <DialogFooter className="sm:justify-center">
       <Button
-        disabled={busy}
+        disabled={busy && !allowCancelWhileBusy}
         size="dialog"
         type="button"
         variant="secondary"
@@ -438,7 +440,10 @@ export function DefaultAuthorizationViewRenderer(
   const action =
     view.type === "external_link" || view.type === "device_code"
       ? {
-          label: view.actionLabel ?? props.labels.activate,
+          label:
+            view.type === "device_code" && props.busy
+              ? props.labels.activate
+              : (view.actionLabel ?? props.labels.activate),
           type: "activate" as const
         }
       : view.type === "result" &&
@@ -469,6 +474,7 @@ export function DefaultAuthorizationViewRenderer(
       <AuthorizationActionFooter
         actionLabel={action?.label}
         actionType={action?.type}
+        allowCancelWhileBusy={view.type === "device_code"}
         busy={props.busy}
         cancelLabel={props.labels.cancel}
         viewId={props.view.viewId}

--- a/packages/connector/renderer/src/ui/dialogs/ConnectorAuthorizationDialog.tsx
+++ b/packages/connector/renderer/src/ui/dialogs/ConnectorAuthorizationDialog.tsx
@@ -78,6 +78,8 @@ export function ConnectorAuthorizationDialog({
     authorizationView ?? (resolved.kind === "form" ? resolved.view : null);
   const showAuthorizationView =
     currentView !== null && currentView.view.type !== "external_link";
+  const waitingForDeviceCode =
+    currentView?.view.type === "device_code" && (authorizing || pending);
 
   const handleInteractionEvent = (event: AuthorizationEventEnvelopeV1) => {
     if (!currentView) return;
@@ -147,9 +149,16 @@ export function ConnectorAuthorizationDialog({
 
       {showAuthorizationView && currentView ? (
         <AuthorizationRenderer
-          busy={authorizationView ? false : authorizing || pending}
+          busy={
+            waitingForDeviceCode ||
+            (!authorizationView && (authorizing || pending))
+          }
           labels={{
-            activate: i18n.t("actionContinueAuthorization"),
+            activate: i18n.t(
+              waitingForDeviceCode
+                ? "actionWaitingAuthorization"
+                : "actionContinueAuthorization"
+            ),
             cancel: i18n.t("cancel"),
             copyDeviceCode: i18n.t("copyDeviceCode"),
             deviceCodeCopied: i18n.t("deviceCodeCopied"),

--- a/packages/connector/renderer/src/ui/dialogs/ConnectorMarketDialogs.spec.tsx
+++ b/packages/connector/renderer/src/ui/dialogs/ConnectorMarketDialogs.spec.tsx
@@ -66,9 +66,11 @@ function emptyView(
 }
 
 describe("ConnectorMarketDialogs", () => {
-  it("keeps the dialog open after authorization so disconnect and try stay available", async () => {
+  it("closes the authorization dialog and shows only the success toast", async () => {
     const viewState = proxy(emptyView(authorizationDialog));
-    const closeDialog = vi.fn();
+    const closeDialog = vi.fn(() => {
+      viewState.dialog = null;
+    });
     const onTryConnector = vi.fn();
     const root = {
       market: {
@@ -104,16 +106,16 @@ describe("ConnectorMarketDialogs", () => {
     fireEvent.click(screen.getByRole("button", { name: "actionAuthorize" }));
 
     expect(
-      await screen.findByRole("button", { name: "actionTry" })
+      await screen.findByText("actionAuthorizeSuccess")
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "actionDisconnect" })
-    ).toBeInTheDocument();
-    expect(closeDialog).not.toHaveBeenCalled();
-
-    fireEvent.click(screen.getByRole("button", { name: "actionTry" }));
     expect(closeDialog).toHaveBeenCalledTimes(1);
-    expect(onTryConnector).toHaveBeenCalledWith("gmail");
+    expect(
+      screen.queryByRole("button", { name: "actionTry" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "actionDisconnect" })
+    ).not.toBeInTheDocument();
+    expect(onTryConnector).not.toHaveBeenCalled();
   });
 
   it("copies a pending device code and shows the success state", async () => {
@@ -170,11 +172,12 @@ describe("ConnectorMarketDialogs", () => {
       ).toBeInTheDocument();
     });
     expect(
-      screen.getByRole("button", { name: "actionContinueAuthorization" })
-    ).toBeEnabled();
+      screen.getByRole("button", { name: "actionWaitingAuthorization" })
+    ).toBeDisabled();
     expect(
-      screen.queryByRole("button", { name: "actionWaitingAuthorization" })
+      screen.queryByRole("button", { name: "actionContinueAuthorization" })
     ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "cancel" })).toBeEnabled();
   });
 
   it("keeps the copy affordance when clipboard access fails", async () => {

--- a/packages/connector/renderer/src/ui/dialogs/ConnectorMarketDialogs.tsx
+++ b/packages/connector/renderer/src/ui/dialogs/ConnectorMarketDialogs.tsx
@@ -48,6 +48,7 @@ export function ConnectorMarketDialogs() {
         .beginAuthorization(connectorKey, secret)
         .then(() => {
           setShowSuccessToast("authorize");
+          uiState.closeDialog();
         })
         .catch((error: unknown) => {
           if (
@@ -70,7 +71,7 @@ export function ConnectorMarketDialogs() {
           }
         });
     },
-    [i18n, market, onError]
+    [i18n, market, onError, uiState]
   );
 
   useEffect(() => {
@@ -111,7 +112,7 @@ export function ConnectorMarketDialogs() {
   // Hide management dialog when showing success toast
   const shouldHideDialog =
     dialog?.kind === "management" &&
-    (showSuccessToast === "install" || Boolean(uninstallSuccess));
+    Boolean(showSuccessToast || uninstallSuccess);
 
   const cancelAuthorizationDialog = () => {
     if (dialog?.kind !== "authorization") {


### PR DESCRIPTION
## Summary

- automatically open device-code authorization pages and keep the authorization action in a disabled loading state
- keep the authorization dialog stable while daemon state settles, then close it directly on success
- update connector architecture documentation and renderer coverage

## Validation

- pnpm --filter @tutti-os/connector-renderer test
- pnpm --filter @tutti-os/connector-renderer typecheck
- pnpm check:changed
- push-ready checks: 11 lanes passed