### PR TITLE
fix(agent): add event stream backpressure diagnostics

### DIFF
--- a/packages/agent/daemon/runtime/acp_client_read_loop.go
+++ b/packages/agent/daemon/runtime/acp_client_read_loop.go
@@ -51,7 +51,11 @@ func (c *acpClient) readLoop() {
 					}
 				}
 			}
-			slog.Warn("agent session ACP stderr",
+			// Provider stderr is already retained in the startup trace and the
+			// bounded diagnostics tail. It is normal for providers to emit many
+			// small stderr frames, so keep this duplicate diagnostic off the
+			// default warning log path.
+			slog.Debug("agent session ACP stderr",
 				"event", "agent_session.acp.stderr",
 				"message", truncateACPLogValue(string(frame.Stderr), 1200),
 			)

--- a/packages/agent/daemon/runtime/event_hub.go
+++ b/packages/agent/daemon/runtime/event_hub.go
@@ -1,8 +1,18 @@
 package agentruntime
 
 import (
+	"log/slog"
 	"strings"
 	"sync"
+	"time"
+)
+
+const (
+	eventHubSubscriberQueueLimit        = 512
+	eventHubQueuePressureThreshold      = 64
+	eventHubQueuePressureLogInterval    = time.Second
+	eventHubConsumerBlockedLogThreshold = 250 * time.Millisecond
+	eventHubConsumerBlockedLogInterval  = 5 * time.Second
 )
 
 type EventHub struct {
@@ -30,7 +40,7 @@ func (h *EventHub) SubscribeWithInitial(roomID, agentSessionID string, initial [
 		close(ch)
 		return ch, func() {}
 	}
-	subscriber := newEventSubscriber()
+	subscriber := newEventSubscriber(roomID, agentSessionID)
 	h.mu.Lock()
 	if h.subscribers[key] == nil {
 		h.subscribers[key] = make(map[*eventSubscriber]struct{})
@@ -76,20 +86,35 @@ func (h *EventHub) Publish(roomID, agentSessionID string, events []StreamEvent) 
 }
 
 type eventSubscriber struct {
-	ch     chan StreamEvent
-	done   chan struct{}
-	wake   chan struct{}
-	mu     sync.Mutex
-	queue  []StreamEvent
-	head   int
-	closed bool
+	ch                        chan StreamEvent
+	done                      chan struct{}
+	wake                      chan struct{}
+	mu                        sync.Mutex
+	queue                     []queuedStreamEvent
+	head                      int
+	roomID                    string
+	agentSessionID            string
+	closed                    bool
+	overflowed                bool
+	overflowCount             uint64
+	consumerBlockedCount      uint64
+	lastQueuePressureLogAt    time.Time
+	lastQueuePressureLogDepth int
+	lastConsumerBlockedLogAt  time.Time
 }
 
-func newEventSubscriber() *eventSubscriber {
+type queuedStreamEvent struct {
+	event      StreamEvent
+	enqueuedAt time.Time
+}
+
+func newEventSubscriber(roomID, agentSessionID string) *eventSubscriber {
 	subscriber := &eventSubscriber{
-		ch:   make(chan StreamEvent, 64),
-		done: make(chan struct{}),
-		wake: make(chan struct{}, 1),
+		ch:             make(chan StreamEvent, 64),
+		done:           make(chan struct{}),
+		wake:           make(chan struct{}, 1),
+		roomID:         roomID,
+		agentSessionID: agentSessionID,
 	}
 	go subscriber.run()
 	return subscriber
@@ -99,14 +124,59 @@ func (s *eventSubscriber) enqueue(event StreamEvent) {
 	if s == nil {
 		return
 	}
+	now := time.Now()
+	var pressureLog *eventHubQueueLog
+	var overflowLog *eventHubQueueLog
 	s.mu.Lock()
-	if s.closed {
+	if s.closed || s.overflowed {
 		s.mu.Unlock()
 		return
 	}
-	s.queue = append(s.queue, event)
+	s.queue = append(s.queue, queuedStreamEvent{event: event, enqueuedAt: now})
+	if len(s.queue)-s.head > eventHubSubscriberQueueLimit {
+		queuedEvents := len(s.queue) - s.head
+		oldestAge := now.Sub(s.queue[s.head].enqueuedAt)
+		s.overflowCount++
+		overflowLog = &eventHubQueueLog{
+			queueDepth:      queuedEvents,
+			oldestAge:       oldestAge,
+			overflowCount:   s.overflowCount,
+			consumerBlocked: 0,
+		}
+		s.queue = []queuedStreamEvent{{
+			event: StreamEvent{
+				EventType: StreamEventSessionReconcileRequired,
+				Data: map[string]any{
+					"agentSessionId": s.agentSessionID,
+					"eventType":      StreamEventSessionReconcileRequired,
+					"reason":         "event_hub_queue_overflow",
+				},
+			},
+			enqueuedAt: now,
+		}}
+		s.head = 0
+		s.overflowed = true
+	} else if queueDepth := len(s.queue) - s.head; queueDepth >= eventHubQueuePressureThreshold &&
+		(now.Sub(s.lastQueuePressureLogAt) >= eventHubQueuePressureLogInterval ||
+			queueDepth >= s.lastQueuePressureLogDepth+eventHubQueuePressureThreshold) {
+		oldestAge := now.Sub(s.queue[s.head].enqueuedAt)
+		s.lastQueuePressureLogAt = now
+		s.lastQueuePressureLogDepth = queueDepth
+		pressureLog = &eventHubQueueLog{
+			queueDepth:      queueDepth,
+			oldestAge:       oldestAge,
+			overflowCount:   s.overflowCount,
+			consumerBlocked: 0,
+		}
+	}
 	s.mu.Unlock()
 	s.notify()
+	if pressureLog != nil {
+		s.logQueuePressure(*pressureLog)
+	}
+	if overflowLog != nil {
+		s.logQueueOverflow(*overflowLog)
+	}
 }
 
 func (s *eventSubscriber) run() {
@@ -116,8 +186,12 @@ func (s *eventSubscriber) run() {
 		if !ok {
 			return
 		}
+		sendStartedAt := time.Now()
 		select {
 		case s.ch <- event:
+			if blockedFor := time.Since(sendStartedAt); blockedFor >= eventHubConsumerBlockedLogThreshold {
+				s.logConsumerBlocked(blockedFor)
+			}
 		case <-s.done:
 			return
 		}
@@ -128,14 +202,14 @@ func (s *eventSubscriber) next() (StreamEvent, bool) {
 	for {
 		s.mu.Lock()
 		if s.head < len(s.queue) {
-			event := s.queue[s.head]
-			s.queue[s.head] = StreamEvent{}
+			event := s.queue[s.head].event
+			s.queue[s.head] = queuedStreamEvent{}
 			s.head++
 			s.compactQueueLocked()
 			s.mu.Unlock()
 			return event, true
 		}
-		if s.closed {
+		if s.closed || s.overflowed {
 			s.mu.Unlock()
 			return StreamEvent{}, false
 		}
@@ -147,6 +221,73 @@ func (s *eventSubscriber) next() (StreamEvent, bool) {
 			return StreamEvent{}, false
 		}
 	}
+}
+
+type eventHubQueueLog struct {
+	queueDepth      int
+	oldestAge       time.Duration
+	overflowCount   uint64
+	consumerBlocked time.Duration
+}
+
+func (s *eventSubscriber) logQueuePressure(log eventHubQueueLog) {
+	slog.Warn("agent session event subscriber queue pressure",
+		"event", "agent_session.event_hub_queue_pressure",
+		"room_id", s.roomID,
+		"agent_session_id", s.agentSessionID,
+		"queue_depth", log.queueDepth,
+		"queue_limit", eventHubSubscriberQueueLimit,
+		"oldest_event_age_ms", log.oldestAge.Milliseconds(),
+		"overflow_count", log.overflowCount,
+	)
+}
+
+func (s *eventSubscriber) logQueueOverflow(log eventHubQueueLog) {
+	slog.Warn("agent session event subscriber queue overflowed",
+		"event", "agent_session.event_hub_queue_overflow",
+		"room_id", s.roomID,
+		"agent_session_id", s.agentSessionID,
+		"queue_depth", log.queueDepth,
+		"queue_limit", eventHubSubscriberQueueLimit,
+		"oldest_event_age_ms", log.oldestAge.Milliseconds(),
+		"overflow_count", log.overflowCount,
+	)
+}
+
+func (s *eventSubscriber) logConsumerBlocked(blockedFor time.Duration) {
+	now := time.Now()
+	s.mu.Lock()
+	s.consumerBlockedCount++
+	if now.Sub(s.lastConsumerBlockedLogAt) < eventHubConsumerBlockedLogInterval {
+		s.mu.Unlock()
+		return
+	}
+	s.lastConsumerBlockedLogAt = now
+	queueDepth := len(s.queue) - s.head
+	oldestAge := time.Duration(0)
+	if queueDepth > 0 {
+		oldestAge = now.Sub(s.queue[s.head].enqueuedAt)
+	}
+	log := eventHubQueueLog{
+		queueDepth:      queueDepth,
+		oldestAge:       oldestAge,
+		overflowCount:   s.overflowCount,
+		consumerBlocked: blockedFor,
+	}
+	blockedCount := s.consumerBlockedCount
+	s.mu.Unlock()
+
+	slog.Warn("agent session event subscriber consumer blocked",
+		"event", "agent_session.event_hub_consumer_blocked",
+		"room_id", s.roomID,
+		"agent_session_id", s.agentSessionID,
+		"queue_depth", log.queueDepth,
+		"queue_limit", eventHubSubscriberQueueLimit,
+		"oldest_event_age_ms", log.oldestAge.Milliseconds(),
+		"consumer_blocked_ms", log.consumerBlocked.Milliseconds(),
+		"consumer_blocked_count", blockedCount,
+		"overflow_count", log.overflowCount,
+	)
 }
 
 func (s *eventSubscriber) compactQueueLocked() {

--- a/packages/agent/daemon/runtime/event_hub_test.go
+++ b/packages/agent/daemon/runtime/event_hub_test.go
@@ -81,3 +81,52 @@ func TestEventHubQueuesSubscriberBackpressureWithoutDropping(t *testing.T) {
 		}
 	}
 }
+
+func TestEventHubReconcilesAndClosesOverflowedSubscriber(t *testing.T) {
+	t.Parallel()
+
+	hub := NewEventHub()
+	events, unsubscribe := hub.Subscribe("room-a", "session-1")
+	defer unsubscribe()
+
+	published := make([]StreamEvent, 0, eventHubSubscriberQueueLimit+128)
+	for i := 0; i < eventHubSubscriberQueueLimit+128; i++ {
+		published = append(published, StreamEvent{
+			EventType: StreamEventMessageDelta,
+			Data:      map[string]any{"index": i},
+		})
+	}
+	hub.Publish("room-a", "session-1", published)
+
+	for {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				t.Fatal("overflowed subscriber closed before reconcile event")
+			}
+			if event.EventType != StreamEventSessionReconcileRequired {
+				continue
+			}
+			data, ok := event.Data.(map[string]any)
+			if !ok || data["reason"] != "event_hub_queue_overflow" {
+				t.Fatalf("reconcile event data = %#v", event.Data)
+			}
+			if data["agentSessionId"] != "session-1" {
+				t.Fatalf("reconcile event session = %#v", data["agentSessionId"])
+			}
+			goto reconciled
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for reconcile event")
+		}
+	}
+
+reconciled:
+	select {
+	case _, ok := <-events:
+		if ok {
+			t.Fatal("overflowed subscriber emitted events after reconcile")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("overflowed subscriber did not close")
+	}
+}

--- a/packages/agent/daemon/runtime/types.go
+++ b/packages/agent/daemon/runtime/types.go
@@ -54,12 +54,13 @@ const (
 	messageStreamStateCompleted = "completed"
 	messageStreamStateFailed    = "failed"
 
-	StreamEventMessageUpdate     = "message_update"
-	StreamEventMessageDelta      = "message_delta"
-	StreamEventStatePatch        = "state_patch"
-	StreamEventAvailableCommands = "available_commands_update"
-	StreamEventConfigOptions     = "config_options_update"
-	StreamEventSessionAudit      = "session_audit"
+	StreamEventMessageUpdate            = "message_update"
+	StreamEventMessageDelta             = "message_delta"
+	StreamEventStatePatch               = "state_patch"
+	StreamEventAvailableCommands        = "available_commands_update"
+	StreamEventConfigOptions            = "config_options_update"
+	StreamEventSessionAudit             = "session_audit"
+	StreamEventSessionReconcileRequired = "session_reconcile_required"
 )
 
 type StartInput struct {


### PR DESCRIPTION
## Summary

- bound each Agent event subscriber queue at 512 events
- emit a scoped session_reconcile_required marker and close an overflowed subscriber so the client can replay authoritative state
- downgrade duplicated ACP provider stderr frames from warning to debug
- add sampled queue-pressure, consumer-blocked, and overflow diagnostics without logging payloads

## Why

The OOM diagnostics showed memory pressure during Agent activity but could not distinguish a blocked consumer from an unbounded live-event backlog. The runtime now bounds retention and records queue depth, oldest-event age, blocked-send duration, and overflow count.

## Verification

- go test ./packages/agent/daemon/runtime -run TestEventHub|TestACP -count=1 -race passed
- go test ./packages/agent/daemon/runtime -count=1 passed
- git diff --check passed

## Platform impact

The change is in the platform-neutral Agent runtime queue and logging path. No provider-specific or operating-system-specific behavior was added.

## Follow-up

TSH must consume a Tutti release containing this event type before the desktop recovery path is shipped.