### PR TITLE
fix(agent): bound Codex app-server diagnostic output

### DIFF
--- a/packages/agent/daemon/runtime/acp_client_read_loop.go
+++ b/packages/agent/daemon/runtime/acp_client_read_loop.go
@@ -51,7 +51,11 @@ func (c *acpClient) readLoop() {
 					}
 				}
 			}
-			slog.Warn("agent session ACP stderr",
+			// Provider stderr is already retained in the startup trace and the
+			// bounded diagnostics tail. It is normal for providers to emit many
+			// small stderr frames, so keep this duplicate diagnostic off the
+			// default warning log path.
+			slog.Debug("agent session ACP stderr",
 				"event", "agent_session.acp.stderr",
 				"message", truncateACPLogValue(string(frame.Stderr), 1200),
 			)

--- a/packages/agent/daemon/runtime/codex_appserver_startup_trace.go
+++ b/packages/agent/daemon/runtime/codex_appserver_startup_trace.go
@@ -16,6 +16,7 @@ import (
 
 const codexAppServerStartupTraceFileName = "tutti-codex-appserver-startup.jsonl"
 const codexAppServerStartupTraceMaxBytes = 64 * 1024 * 1024
+const codexAppServerStderrTailLimit = 8 * 1024
 
 var codexAppServerStartupTraceMu sync.Mutex
 
@@ -49,6 +50,9 @@ type codexAppServerStartupTrace struct {
 	startupObserver    CodexAppServerStartupObserver
 	stderrMu           sync.Mutex
 	stderrLine         []byte
+	stderrTail         []byte
+	stderrBytes        atomic.Int64
+	stderrChunks       atomic.Int64
 	openSpans          map[string][]codexAppServerOpenSpan
 	spanSequence       atomic.Uint64
 	completedSpanCount atomic.Int64
@@ -169,10 +173,17 @@ func (t *codexAppServerStartupTrace) Finish(err error) {
 		return
 	}
 	outcome := "succeeded"
-	fields := map[string]any{}
+	stderrChunks, stderrBytes, stderrTail := t.stderrDiagnostics()
+	fields := map[string]any{
+		"stderr_chunks": stderrChunks,
+		"stderr_bytes":  stderrBytes,
+	}
 	if err != nil {
 		outcome = "failed"
 		fields["error"] = err.Error()
+		if stderrTail != "" {
+			fields["stderr_tail"] = truncateACPLogValue(stderrTail, codexAppServerStderrTailLimit)
+		}
 		t.Log("start.failed", fields)
 	} else {
 		t.Log("start.succeeded", fields)
@@ -198,16 +209,14 @@ func (t *codexAppServerStartupTrace) LogMessage(method string, hasID bool, param
 }
 
 func (t *codexAppServerStartupTrace) LogStderr(chunk []byte) {
-	text := strings.TrimSpace(string(chunk))
-	if text == "" {
+	if len(chunk) == 0 {
 		return
 	}
-	t.Log("process.stderr", map[string]any{
-		"message": truncateACPLogValue(text, 2000),
-		"size":    len(chunk),
-	})
+	t.stderrChunks.Add(1)
+	t.stderrBytes.Add(int64(len(chunk)))
 
 	t.stderrMu.Lock()
+	t.stderrTail = appendCodexAppServerStderrTail(t.stderrTail, chunk, codexAppServerStderrTailLimit)
 	observations := make([]CodexAppServerSpanObservation, 0)
 	t.stderrLine = append(t.stderrLine, chunk...)
 	for {
@@ -227,6 +236,28 @@ func (t *codexAppServerStartupTrace) LogStderr(chunk []byte) {
 	for _, observation := range observations {
 		t.notifySpanObserver(observation)
 	}
+}
+
+func appendCodexAppServerStderrTail(tail, chunk []byte, limit int) []byte {
+	if limit <= 0 {
+		return nil
+	}
+	if len(chunk) >= limit {
+		return append([]byte(nil), chunk[len(chunk)-limit:]...)
+	}
+	if keep := limit - len(chunk); len(tail) > keep {
+		tail = tail[len(tail)-keep:]
+	}
+	return append(tail, chunk...)
+}
+
+func (t *codexAppServerStartupTrace) stderrDiagnostics() (chunks, bytes int64, tail string) {
+	chunks = t.stderrChunks.Load()
+	bytes = t.stderrBytes.Load()
+	t.stderrMu.Lock()
+	tail = strings.TrimSpace(string(t.stderrTail))
+	t.stderrMu.Unlock()
+	return chunks, bytes, tail
 }
 
 func withCodexAppServerLogging(env []string) []string {

--- a/packages/agent/daemon/runtime/codex_appserver_startup_trace_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_startup_trace_test.go
@@ -1,7 +1,9 @@
 package agentruntime
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,6 +30,12 @@ func TestCodexAppServerStartupTraceRecordsStructuredSpanClose(t *testing.T) {
 
 	trace.LogStderr(firstChunk)
 	trace.LogStderr(secondChunk)
+	if got, want := trace.stderrChunks.Load(), int64(2); got != want {
+		t.Fatalf("stderr chunks = %d, want %d", got, want)
+	}
+	if got, want := trace.stderrBytes.Load(), int64(len(firstChunk)+len(secondChunk)); got != want {
+		t.Fatalf("stderr bytes = %d, want %d", got, want)
+	}
 
 	data, err := os.ReadFile(trace.path)
 	if err != nil {
@@ -87,6 +95,54 @@ func TestCodexAppServerStartupTraceRecordsStructuredSpanClose(t *testing.T) {
 	}
 	if closeObservation.SpanBusy != "120ms" || closeObservation.SpanIdle != "5ms" {
 		t.Fatalf("close observation timing = %#v, want busy/idle values", closeObservation)
+	}
+}
+
+func TestCodexAppServerStartupTraceBoundsStderrDiagnostics(t *testing.T) {
+	trace := &codexAppServerStartupTrace{
+		startedAt: time.Now(),
+		session:   Session{Provider: ProviderCodex, RoomID: "room-1", AgentSessionID: "session-1"},
+		path:      filepath.Join(t.TempDir(), "trace.jsonl"),
+		openSpans: make(map[string][]codexAppServerOpenSpan),
+	}
+	firstChunk := bytes.Repeat([]byte("x"), codexAppServerStderrTailLimit+100)
+	secondChunk := []byte("\nstartup timeout details")
+	trace.LogStderr(firstChunk)
+	trace.LogStderr(secondChunk)
+	trace.Finish(errors.New("startup timeout"))
+
+	data, err := os.ReadFile(trace.path)
+	if err != nil {
+		t.Fatalf("read trace: %v", err)
+	}
+	var failedRecord map[string]any
+	for _, line := range splitJSONLines(data) {
+		var record map[string]any
+		if err := json.Unmarshal(line, &record); err != nil {
+			t.Fatalf("decode trace line %q: %v", line, err)
+		}
+		if record["event"] == "process.stderr" {
+			t.Fatal("trace contains per-chunk process.stderr record")
+		}
+		if record["event"] == "start.failed" {
+			failedRecord = record
+		}
+	}
+	if failedRecord == nil {
+		t.Fatal("missing start.failed record")
+	}
+	if failedRecord["stderr_chunks"] != float64(2) {
+		t.Fatalf("stderr_chunks = %#v, want 2", failedRecord["stderr_chunks"])
+	}
+	if failedRecord["stderr_bytes"] != float64(len(firstChunk)+len(secondChunk)) {
+		t.Fatalf("stderr_bytes = %#v, want %d", failedRecord["stderr_bytes"], len(firstChunk)+len(secondChunk))
+	}
+	tail, ok := failedRecord["stderr_tail"].(string)
+	if !ok || !strings.Contains(tail, "startup timeout details") {
+		t.Fatalf("stderr_tail = %#v, want bounded failure tail", failedRecord["stderr_tail"])
+	}
+	if len(tail) > codexAppServerStderrTailLimit {
+		t.Fatalf("stderr_tail length = %d, want <= %d", len(tail), codexAppServerStderrTailLimit)
 	}
 }
 

--- a/packages/agent/daemon/runtime/event_hub.go
+++ b/packages/agent/daemon/runtime/event_hub.go
@@ -1,8 +1,18 @@
 package agentruntime
 
 import (
+	"log/slog"
 	"strings"
 	"sync"
+	"time"
+)
+
+const (
+	eventHubSubscriberQueueLimit        = 512
+	eventHubQueuePressureThreshold      = 64
+	eventHubQueuePressureLogInterval    = time.Second
+	eventHubConsumerBlockedLogThreshold = 250 * time.Millisecond
+	eventHubConsumerBlockedLogInterval  = 5 * time.Second
 )
 
 type EventHub struct {
@@ -30,7 +40,7 @@ func (h *EventHub) SubscribeWithInitial(roomID, agentSessionID string, initial [
 		close(ch)
 		return ch, func() {}
 	}
-	subscriber := newEventSubscriber()
+	subscriber := newEventSubscriber(roomID, agentSessionID)
 	h.mu.Lock()
 	if h.subscribers[key] == nil {
 		h.subscribers[key] = make(map[*eventSubscriber]struct{})
@@ -76,20 +86,35 @@ func (h *EventHub) Publish(roomID, agentSessionID string, events []StreamEvent) 
 }
 
 type eventSubscriber struct {
-	ch     chan StreamEvent
-	done   chan struct{}
-	wake   chan struct{}
-	mu     sync.Mutex
-	queue  []StreamEvent
-	head   int
-	closed bool
+	ch                        chan StreamEvent
+	done                      chan struct{}
+	wake                      chan struct{}
+	mu                        sync.Mutex
+	queue                     []queuedStreamEvent
+	head                      int
+	roomID                    string
+	agentSessionID            string
+	closed                    bool
+	overflowed                bool
+	overflowCount             uint64
+	consumerBlockedCount      uint64
+	lastQueuePressureLogAt    time.Time
+	lastQueuePressureLogDepth int
+	lastConsumerBlockedLogAt  time.Time
 }
 
-func newEventSubscriber() *eventSubscriber {
+type queuedStreamEvent struct {
+	event      StreamEvent
+	enqueuedAt time.Time
+}
+
+func newEventSubscriber(roomID, agentSessionID string) *eventSubscriber {
 	subscriber := &eventSubscriber{
-		ch:   make(chan StreamEvent, 64),
-		done: make(chan struct{}),
-		wake: make(chan struct{}, 1),
+		ch:             make(chan StreamEvent, 64),
+		done:           make(chan struct{}),
+		wake:           make(chan struct{}, 1),
+		roomID:         roomID,
+		agentSessionID: agentSessionID,
 	}
 	go subscriber.run()
 	return subscriber
@@ -99,14 +124,59 @@ func (s *eventSubscriber) enqueue(event StreamEvent) {
 	if s == nil {
 		return
 	}
+	now := time.Now()
+	var pressureLog *eventHubQueueLog
+	var overflowLog *eventHubQueueLog
 	s.mu.Lock()
-	if s.closed {
+	if s.closed || s.overflowed {
 		s.mu.Unlock()
 		return
 	}
-	s.queue = append(s.queue, event)
+	s.queue = append(s.queue, queuedStreamEvent{event: event, enqueuedAt: now})
+	if len(s.queue)-s.head > eventHubSubscriberQueueLimit {
+		queuedEvents := len(s.queue) - s.head
+		oldestAge := now.Sub(s.queue[s.head].enqueuedAt)
+		s.overflowCount++
+		overflowLog = &eventHubQueueLog{
+			queueDepth:      queuedEvents,
+			oldestAge:       oldestAge,
+			overflowCount:   s.overflowCount,
+			consumerBlocked: 0,
+		}
+		s.queue = []queuedStreamEvent{{
+			event: StreamEvent{
+				EventType: StreamEventSessionReconcileRequired,
+				Data: map[string]any{
+					"agentSessionId": s.agentSessionID,
+					"eventType":      StreamEventSessionReconcileRequired,
+					"reason":         "event_hub_queue_overflow",
+				},
+			},
+			enqueuedAt: now,
+		}}
+		s.head = 0
+		s.overflowed = true
+	} else if queueDepth := len(s.queue) - s.head; queueDepth >= eventHubQueuePressureThreshold &&
+		(now.Sub(s.lastQueuePressureLogAt) >= eventHubQueuePressureLogInterval ||
+			queueDepth >= s.lastQueuePressureLogDepth+eventHubQueuePressureThreshold) {
+		oldestAge := now.Sub(s.queue[s.head].enqueuedAt)
+		s.lastQueuePressureLogAt = now
+		s.lastQueuePressureLogDepth = queueDepth
+		pressureLog = &eventHubQueueLog{
+			queueDepth:      queueDepth,
+			oldestAge:       oldestAge,
+			overflowCount:   s.overflowCount,
+			consumerBlocked: 0,
+		}
+	}
 	s.mu.Unlock()
 	s.notify()
+	if pressureLog != nil {
+		s.logQueuePressure(*pressureLog)
+	}
+	if overflowLog != nil {
+		s.logQueueOverflow(*overflowLog)
+	}
 }
 
 func (s *eventSubscriber) run() {
@@ -116,8 +186,12 @@ func (s *eventSubscriber) run() {
 		if !ok {
 			return
 		}
+		sendStartedAt := time.Now()
 		select {
 		case s.ch <- event:
+			if blockedFor := time.Since(sendStartedAt); blockedFor >= eventHubConsumerBlockedLogThreshold {
+				s.logConsumerBlocked(blockedFor)
+			}
 		case <-s.done:
 			return
 		}
@@ -128,14 +202,14 @@ func (s *eventSubscriber) next() (StreamEvent, bool) {
 	for {
 		s.mu.Lock()
 		if s.head < len(s.queue) {
-			event := s.queue[s.head]
-			s.queue[s.head] = StreamEvent{}
+			event := s.queue[s.head].event
+			s.queue[s.head] = queuedStreamEvent{}
 			s.head++
 			s.compactQueueLocked()
 			s.mu.Unlock()
 			return event, true
 		}
-		if s.closed {
+		if s.closed || s.overflowed {
 			s.mu.Unlock()
 			return StreamEvent{}, false
 		}
@@ -147,6 +221,73 @@ func (s *eventSubscriber) next() (StreamEvent, bool) {
 			return StreamEvent{}, false
 		}
 	}
+}
+
+type eventHubQueueLog struct {
+	queueDepth      int
+	oldestAge       time.Duration
+	overflowCount   uint64
+	consumerBlocked time.Duration
+}
+
+func (s *eventSubscriber) logQueuePressure(log eventHubQueueLog) {
+	slog.Warn("agent session event subscriber queue pressure",
+		"event", "agent_session.event_hub_queue_pressure",
+		"room_id", s.roomID,
+		"agent_session_id", s.agentSessionID,
+		"queue_depth", log.queueDepth,
+		"queue_limit", eventHubSubscriberQueueLimit,
+		"oldest_event_age_ms", log.oldestAge.Milliseconds(),
+		"overflow_count", log.overflowCount,
+	)
+}
+
+func (s *eventSubscriber) logQueueOverflow(log eventHubQueueLog) {
+	slog.Warn("agent session event subscriber queue overflowed",
+		"event", "agent_session.event_hub_queue_overflow",
+		"room_id", s.roomID,
+		"agent_session_id", s.agentSessionID,
+		"queue_depth", log.queueDepth,
+		"queue_limit", eventHubSubscriberQueueLimit,
+		"oldest_event_age_ms", log.oldestAge.Milliseconds(),
+		"overflow_count", log.overflowCount,
+	)
+}
+
+func (s *eventSubscriber) logConsumerBlocked(blockedFor time.Duration) {
+	now := time.Now()
+	s.mu.Lock()
+	s.consumerBlockedCount++
+	if now.Sub(s.lastConsumerBlockedLogAt) < eventHubConsumerBlockedLogInterval {
+		s.mu.Unlock()
+		return
+	}
+	s.lastConsumerBlockedLogAt = now
+	queueDepth := len(s.queue) - s.head
+	oldestAge := time.Duration(0)
+	if queueDepth > 0 {
+		oldestAge = now.Sub(s.queue[s.head].enqueuedAt)
+	}
+	log := eventHubQueueLog{
+		queueDepth:      queueDepth,
+		oldestAge:       oldestAge,
+		overflowCount:   s.overflowCount,
+		consumerBlocked: blockedFor,
+	}
+	blockedCount := s.consumerBlockedCount
+	s.mu.Unlock()
+
+	slog.Warn("agent session event subscriber consumer blocked",
+		"event", "agent_session.event_hub_consumer_blocked",
+		"room_id", s.roomID,
+		"agent_session_id", s.agentSessionID,
+		"queue_depth", log.queueDepth,
+		"queue_limit", eventHubSubscriberQueueLimit,
+		"oldest_event_age_ms", log.oldestAge.Milliseconds(),
+		"consumer_blocked_ms", log.consumerBlocked.Milliseconds(),
+		"consumer_blocked_count", blockedCount,
+		"overflow_count", log.overflowCount,
+	)
 }
 
 func (s *eventSubscriber) compactQueueLocked() {

--- a/packages/agent/daemon/runtime/event_hub_test.go
+++ b/packages/agent/daemon/runtime/event_hub_test.go
@@ -81,3 +81,52 @@ func TestEventHubQueuesSubscriberBackpressureWithoutDropping(t *testing.T) {
 		}
 	}
 }
+
+func TestEventHubReconcilesAndClosesOverflowedSubscriber(t *testing.T) {
+	t.Parallel()
+
+	hub := NewEventHub()
+	events, unsubscribe := hub.Subscribe("room-a", "session-1")
+	defer unsubscribe()
+
+	published := make([]StreamEvent, 0, eventHubSubscriberQueueLimit+128)
+	for i := 0; i < eventHubSubscriberQueueLimit+128; i++ {
+		published = append(published, StreamEvent{
+			EventType: StreamEventMessageDelta,
+			Data:      map[string]any{"index": i},
+		})
+	}
+	hub.Publish("room-a", "session-1", published)
+
+	for {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				t.Fatal("overflowed subscriber closed before reconcile event")
+			}
+			if event.EventType != StreamEventSessionReconcileRequired {
+				continue
+			}
+			data, ok := event.Data.(map[string]any)
+			if !ok || data["reason"] != "event_hub_queue_overflow" {
+				t.Fatalf("reconcile event data = %#v", event.Data)
+			}
+			if data["agentSessionId"] != "session-1" {
+				t.Fatalf("reconcile event session = %#v", data["agentSessionId"])
+			}
+			goto reconciled
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for reconcile event")
+		}
+	}
+
+reconciled:
+	select {
+	case _, ok := <-events:
+		if ok {
+			t.Fatal("overflowed subscriber emitted events after reconcile")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("overflowed subscriber did not close")
+	}
+}

--- a/packages/agent/daemon/runtime/types.go
+++ b/packages/agent/daemon/runtime/types.go
@@ -54,12 +54,13 @@ const (
 	messageStreamStateCompleted = "completed"
 	messageStreamStateFailed    = "failed"
 
-	StreamEventMessageUpdate     = "message_update"
-	StreamEventMessageDelta      = "message_delta"
-	StreamEventStatePatch        = "state_patch"
-	StreamEventAvailableCommands = "available_commands_update"
-	StreamEventConfigOptions     = "config_options_update"
-	StreamEventSessionAudit      = "session_audit"
+	StreamEventMessageUpdate            = "message_update"
+	StreamEventMessageDelta             = "message_delta"
+	StreamEventStatePatch               = "state_patch"
+	StreamEventAvailableCommands        = "available_commands_update"
+	StreamEventConfigOptions            = "config_options_update"
+	StreamEventSessionAudit             = "session_audit"
+	StreamEventSessionReconcileRequired = "session_reconcile_required"
 )
 
 type StartInput struct {


### PR DESCRIPTION
## Summary

- Add bounded Agent event-stream backpressure diagnostics.
- Stop persisting every Codex app-server stderr chunk as a trace record.
- Preserve allowlisted startup spans, stderr byte/chunk counts, and a bounded failure tail.

## Tests

- `pnpm check:changed -- --base upstream/main --push-ready`

## Notes

- No Codex source changes.
- Normal ACP events and startup span observations are unchanged.
- Raw per-chunk `process.stderr` trace records are intentionally removed to avoid diagnostic write amplification.
