### PR TITLE
fix(agent): preserve provider state after failed resume

### DIFF
--- a/packages/agent/host/conformance/conformance.go
+++ b/packages/agent/host/conformance/conformance.go
@@ -79,6 +79,7 @@ type Fixture struct {
 	// first fence delivery, modeling a Host restart with accepted durable intent
 	// but no in-memory provider Session.
 	DisconnectGoalFenceDelivery bool
+	ResumeErr                   error
 	FailCommitObserver          bool
 	RejectInitialExec           bool
 	RailProjectPaths            []string
@@ -157,32 +158,34 @@ type Metrics struct {
 	LastResumeEnv []string
 	// GuidanceProviderCalls counts guidance dispatches that passed the
 	// runtime's exact-target gate. ExecCalls includes the rejected gate check.
-	GuidanceProviderCalls              int
-	CancelCalls                        int
-	InteractiveCalls                   int
-	UpdateSettingsCalls                int
-	CloseCalls                         int
-	GoalControlCalls                   int
-	GoalReconcileCalls                 int
-	RuntimeSessionPublishCalls         int
-	RuntimeStartReportWrites           int
-	RuntimeOperationCommits            int
-	GoalOperationCommits               int
-	RootTurnSettlements                int
-	LastCancelTargets                  []agenthost.RuntimeCancelTarget
-	LastInteractiveTurnID              string
-	LastInteractiveRequestID           string
-	LastExecClientSubmitID             string
-	LastInitialTitle                   string
-	LastExecRequiresProviderAcceptance bool
-	LastClosePreservedCanonicalState   bool
-	LastResumeRecreate                 bool
-	LastResumeGoalGenerationFences     []agenthost.RuntimeGoalGenerationFenceInput
-	RecoverySteps                      []string
-	DeleteAdmissionPlans               []agenthost.DeleteSessionsPlan
-	DeleteReports                      []agenthost.DeleteSessionsReport
-	CanonicalDeleteCalls               int
-	DeletionEvents                     []string
+	GuidanceProviderCalls                int
+	CancelCalls                          int
+	InteractiveCalls                     int
+	UpdateSettingsCalls                  int
+	CloseCalls                           int
+	GoalControlCalls                     int
+	GoalReconcileCalls                   int
+	RuntimeSessionPublishCalls           int
+	RuntimeStartReportWrites             int
+	RuntimeOperationCommits              int
+	GoalOperationCommits                 int
+	RootTurnSettlements                  int
+	LastCancelTargets                    []agenthost.RuntimeCancelTarget
+	LastInteractiveTurnID                string
+	LastInteractiveRequestID             string
+	LastExecClientSubmitID               string
+	LastInitialTitle                     string
+	LastExecRequiresProviderAcceptance   bool
+	LastClosePreservedCanonicalState     bool
+	RuntimePreparationCleanupCalls       int
+	LastCleanupPreservedRecoverableState bool
+	LastResumeRecreate                   bool
+	LastResumeGoalGenerationFences       []agenthost.RuntimeGoalGenerationFenceInput
+	RecoverySteps                        []string
+	DeleteAdmissionPlans                 []agenthost.DeleteSessionsPlan
+	DeleteReports                        []agenthost.DeleteSessionsReport
+	CanonicalDeleteCalls                 int
+	DeletionEvents                       []string
 }
 
 // Driver adapts one host implementation to the shared lifecycle scenarios.

--- a/packages/agent/host/conformance/conformance_test.go
+++ b/packages/agent/host/conformance/conformance_test.go
@@ -12,8 +12,8 @@ func TestPublishedScenarioCatalogsHaveUniqueNames(t *testing.T) {
 		scenarios []Scenario
 		wantCount int
 	}{
-		{name: "adapter lifecycle", scenarios: Scenarios(), wantCount: 34},
-		{name: "application core", scenarios: ApplicationCoreScenarios(), wantCount: 29},
+		{name: "adapter lifecycle", scenarios: Scenarios(), wantCount: 35},
+		{name: "application core", scenarios: ApplicationCoreScenarios(), wantCount: 30},
 		{name: "guidance", scenarios: GuidanceScenarios(), wantCount: 3},
 		{name: "resume policy", scenarios: ResumePolicyScenarios(), wantCount: 5},
 		{name: "submission fence", scenarios: SubmissionFenceScenarios(), wantCount: 1},
@@ -120,6 +120,7 @@ func TestScenarioOwnershipIsExplicit(t *testing.T) {
 		"create with explicit rail placement",
 		"create with authoritative rail placement outside local project registry",
 		"resume persisted session",
+		"failed resume preserves recoverable provider state",
 		"send input",
 		"send connector-only input",
 		"guidance requires exact target before dispatch",
@@ -156,6 +157,7 @@ func TestScenarioOwnershipIsExplicit(t *testing.T) {
 		"create with explicit rail placement",
 		"create with authoritative rail placement outside local project registry",
 		"resume persisted session",
+		"failed resume preserves recoverable provider state",
 		"send input",
 		"send connector-only input",
 		"guidance requires exact target before dispatch",

--- a/packages/agent/host/conformance/resume_failure_scenario.go
+++ b/packages/agent/host/conformance/resume_failure_scenario.go
@@ -1,0 +1,37 @@
+package conformance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
+)
+
+func runFailedResumePreservesRecoverableState(ctx context.Context, driver Driver) error {
+	resumeErr := errors.New("provider resume failed")
+	fixture := Fixture{Session: &SessionSeed{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-resume-failure", Provider: "codex",
+		ProviderSessionID: "provider-session-1", Cwd: "/workspace", Title: "Persisted", InitialTitleEstablished: true,
+	}, Turn: &TurnSeed{
+		TurnID: "turn-established", Phase: canonical.TurnPhaseSettled,
+		Outcome: canonical.TurnOutcomeCompleted, RootProviderTurnID: "provider-turn-1",
+	}, ResumeErr: resumeErr}
+	if err := driver.Reset(ctx, fixture); err != nil {
+		return err
+	}
+	if _, err := driver.EnsureSession(ctx, agenthost.SessionRef{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-resume-failure",
+	}); !errors.Is(err, resumeErr) {
+		return fmt.Errorf("failed resume error=%v, want %v", err, resumeErr)
+	}
+	metrics := driver.Metrics()
+	if metrics.ResumeCalls != 1 || metrics.CloseCalls != 1 || !metrics.LastClosePreservedCanonicalState {
+		return fmt.Errorf("failed resume runtime cleanup metrics=%#v", metrics)
+	}
+	if metrics.RuntimePreparationCleanupCalls != 1 || !metrics.LastCleanupPreservedRecoverableState {
+		return fmt.Errorf("failed resume preparation cleanup metrics=%#v", metrics)
+	}
+	return nil
+}

--- a/packages/agent/host/conformance/scenarios.go
+++ b/packages/agent/host/conformance/scenarios.go
@@ -18,7 +18,11 @@ var (
 		Name: "create with authoritative rail placement outside local project registry",
 		run:  runCreateWithAuthoritativeRailPlacement,
 	}
-	resumePersistedSessionScenario = Scenario{Name: "resume persisted session", run: runResumePersistedSession}
+	resumePersistedSessionScenario                = Scenario{Name: "resume persisted session", run: runResumePersistedSession}
+	failedResumePreservesRecoverableStateScenario = Scenario{
+		Name: "failed resume preserves recoverable provider state",
+		run:  runFailedResumePreservesRecoverableState,
+	}
 	sendInputScenario              = Scenario{Name: "send input", run: runSendInput}
 	sendConnectorOnlyInputScenario = Scenario{Name: "send connector-only input", run: runSendConnectorOnlyInput}
 	providerAcceptanceScenario     = Scenario{
@@ -81,6 +85,7 @@ func Scenarios() []Scenario {
 		createWithRailPlacementScenario,
 		createWithAuthoritativeRailPlacementScenario,
 		resumePersistedSessionScenario,
+		failedResumePreservesRecoverableStateScenario,
 		sendInputScenario,
 		sendConnectorOnlyInputScenario,
 		guidanceTargetRequiredScenario,
@@ -245,6 +250,7 @@ func ApplicationCoreScenarios() []Scenario {
 		createWithRailPlacementScenario,
 		createWithAuthoritativeRailPlacementScenario,
 		resumePersistedSessionScenario,
+		failedResumePreservesRecoverableStateScenario,
 		sendInputScenario,
 		sendConnectorOnlyInputScenario,
 		guidanceTargetRequiredScenario,

--- a/packages/agent/host/lifecycle.go
+++ b/packages/agent/host/lifecycle.go
@@ -458,12 +458,12 @@ func (h *Host) ensureRuntimeSessionLocked(ctx context.Context, ref SessionRef) (
 	}
 	release, err := h.acquireStartup(ctx, canonicalSession.Provider)
 	if err != nil {
-		return ProviderRuntimeSession{}, h.cleanupRejectedPreparedRuntime(ctx, ref, canonicalSession.Provider, err)
+		return ProviderRuntimeSession{}, h.cleanupFailedRuntimeResume(ctx, ref, canonicalSession.Provider, err)
 	}
 	defer release()
 	goalGenerationFences, err := h.listRuntimeGoalGenerationFences(ctx, ref)
 	if err != nil {
-		return ProviderRuntimeSession{}, h.cleanupRejectedPreparedRuntime(ctx, ref, canonicalSession.Provider, err)
+		return ProviderRuntimeSession{}, h.cleanupFailedRuntimeResume(ctx, ref, canonicalSession.Provider, err)
 	}
 	result, err := h.runtime.Resume(ctx, RuntimeResumeInput{
 		WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
@@ -479,10 +479,10 @@ func (h *Host) ensureRuntimeSessionLocked(ctx context.Context, ref SessionRef) (
 		RecreateIfMissing:      policy.Mode == ResumeModeRecreate,
 	})
 	if err != nil {
-		return ProviderRuntimeSession{}, h.cleanupRejectedPreparedRuntime(ctx, ref, canonicalSession.Provider, err)
+		return ProviderRuntimeSession{}, h.cleanupFailedRuntimeResume(ctx, ref, canonicalSession.Provider, err)
 	}
 	if err := h.restoreGoalGenerationFences(ctx, ref); err != nil {
-		return ProviderRuntimeSession{}, h.cleanupRejectedPreparedRuntime(ctx, ref, canonicalSession.Provider, err)
+		return ProviderRuntimeSession{}, h.cleanupFailedRuntimeResume(ctx, ref, canonicalSession.Provider, err)
 	}
 	h.goalFencesRestored.Store(ref.WorkspaceID+"\x00"+ref.AgentSessionID, struct{}{})
 	return result, nil

--- a/packages/agent/host/lifecycle_resume_test.go
+++ b/packages/agent/host/lifecycle_resume_test.go
@@ -177,7 +177,7 @@ func TestEnsureRuntimeSessionPreservesLiveResumableObservation(t *testing.T) {
 	}
 }
 
-func TestEnsureRuntimeSessionCleansPreparedResourcesWhenResumeFails(t *testing.T) {
+func TestEnsureRuntimeSessionCleansPreparedResourcesAndPreservesRecoverableStateWhenResumeFails(t *testing.T) {
 	resumeErr := errors.New("resume failed")
 	store := liveResumeCanonicalStore{
 		session: storesqlite.Session{
@@ -204,7 +204,8 @@ func TestEnsureRuntimeSessionCleansPreparedResourcesWhenResumeFails(t *testing.T
 	}
 	if preparation.cleanupInput.WorkspaceID != "workspace-1" ||
 		preparation.cleanupInput.AgentSessionID != "session-1" ||
-		preparation.cleanupInput.Provider != "codex" {
+		preparation.cleanupInput.Provider != "codex" ||
+		!preparation.cleanupInput.PreserveRecoverableState {
 		t.Fatalf("cleanup input = %#v", preparation.cleanupInput)
 	}
 }

--- a/packages/agent/host/submit_provenance_recovery.go
+++ b/packages/agent/host/submit_provenance_recovery.go
@@ -7,7 +7,9 @@ import (
 	"time"
 )
 
-func (h *Host) cleanupRejectedPreparedRuntime(
+// cleanupFailedRuntimeResume releases live resources created by a failed
+// resume attempt without deleting the provider state needed by a later retry.
+func (h *Host) cleanupFailedRuntimeResume(
 	ctx context.Context,
 	ref SessionRef,
 	provider string,
@@ -16,7 +18,14 @@ func (h *Host) cleanupRejectedPreparedRuntime(
 	if h.preparation == nil {
 		return cause
 	}
-	return h.discardRejectedPreparedRuntime(ctx, cause, ref.WorkspaceID, ref.AgentSessionID, provider)
+	return h.cleanupPreparedRuntime(
+		ctx,
+		cause,
+		ref.WorkspaceID,
+		ref.AgentSessionID,
+		provider,
+		true,
+	)
 }
 
 func (h *Host) discardRejectedPreparedRuntime(
@@ -25,6 +34,17 @@ func (h *Host) discardRejectedPreparedRuntime(
 	workspaceID string,
 	agentSessionID string,
 	provider string,
+) error {
+	return h.cleanupPreparedRuntime(ctx, cause, workspaceID, agentSessionID, provider, false)
+}
+
+func (h *Host) cleanupPreparedRuntime(
+	ctx context.Context,
+	cause error,
+	workspaceID string,
+	agentSessionID string,
+	provider string,
+	preserveRecoverableState bool,
 ) error {
 	cleanupBaseCtx := context.WithoutCancel(ctx)
 	cleanupErrs := []error{cause}
@@ -41,6 +61,7 @@ func (h *Host) discardRejectedPreparedRuntime(
 		preparationCtx, cancelPreparation := context.WithTimeout(cleanupBaseCtx, 10*time.Second)
 		cleanupErrs = append(cleanupErrs, h.preparation.Cleanup(preparationCtx, RuntimeCleanupInput{
 			WorkspaceID: workspaceID, AgentSessionID: agentSessionID, Provider: provider,
+			PreserveRecoverableState: preserveRecoverableState,
 		}))
 		cancelPreparation()
 	}

--- a/services/tuttid/service/agent/host_conformance_test.go
+++ b/services/tuttid/service/agent/host_conformance_test.go
@@ -14,6 +14,7 @@ import (
 
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	hostconformance "github.com/tutti-os/tutti/packages/agent/host/conformance"
+	runtimeprep "github.com/tutti-os/tutti/packages/agent/runtimeprep"
 	agentactivitybiz "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
 	market "github.com/tutti-os/tutti/packages/connector/daemon/core"
@@ -317,11 +318,29 @@ type legacyHostConformanceDriver struct {
 	deletionEvents           *[]string
 	historicalState          *conformanceHistoricalStateStore
 	runtimeStartReportWrites int
+	runtimeCleanupInputs     []runtimeprep.CleanupInput
+}
+
+type conformanceRuntimePreparer struct {
+	cleanupInputs *[]runtimeprep.CleanupInput
+}
+
+func (conformanceRuntimePreparer) Prepare(
+	_ context.Context,
+	input runtimeprep.PrepareInput,
+) (runtimeprep.PreparedRuntime, error) {
+	return runtimeprep.PreparedRuntime{Cwd: input.Cwd}, nil
+}
+
+func (p conformanceRuntimePreparer) Cleanup(_ context.Context, input runtimeprep.CleanupInput) error {
+	*p.cleanupInputs = append(*p.cleanupInputs, input)
+	return nil
 }
 
 func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconformance.Fixture) error {
 	d.runtime = newFakeRuntime()
 	d.runtime.guidanceTargetMismatch = fixture.GuidanceTargetMismatch
+	d.runtime.resumeErr = fixture.ResumeErr
 	if fixture.CancelDeliveryUnconfirmed {
 		d.runtime.cancelErr = agenthost.ErrRuntimeCancelDeliveryUnconfirmed
 	}
@@ -380,6 +399,8 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 	d.recoverySteps = &steps
 	d.operationPort = &conformanceRuntimeOperationStore{runtimeOperationMemoryStore: d.operations, steps: &steps}
 	d.service = newUnconfiguredIsolatedAgentService(d.runtime)
+	d.runtimeCleanupInputs = nil
+	d.service.RuntimePreparer = conformanceRuntimePreparer{cleanupInputs: &d.runtimeCleanupInputs}
 	d.service.AgentTargetStore = fakeAgentTargetStore{targets: defaultTestAgentTargets()}
 	d.service.ConnectorMarketSnapshots = connectorMarketSnapshotStub{snapshot: market.Snapshot{
 		Connectors: []market.Connector{
@@ -1439,6 +1460,10 @@ func (d *legacyHostConformanceDriver) Metrics() hostconformance.Metrics {
 	}
 	if closeCallCount := len(d.runtime.closeCalls); closeCallCount > 0 {
 		metrics.LastClosePreservedCanonicalState = d.runtime.closeCalls[closeCallCount-1].PreserveCanonicalState
+	}
+	metrics.RuntimePreparationCleanupCalls = len(d.runtimeCleanupInputs)
+	if cleanupCallCount := len(d.runtimeCleanupInputs); cleanupCallCount > 0 {
+		metrics.LastCleanupPreservedRecoverableState = d.runtimeCleanupInputs[cleanupCallCount-1].PreserveRuntimeRoot
 	}
 	if d.deletionGuard != nil {
 		metrics.DeleteAdmissionPlans = append([]agenthost.DeleteSessionsPlan(nil), d.deletionGuard.plans...)

--- a/services/tuttid/service/agent/service_test_runtime_test.go
+++ b/services/tuttid/service/agent/service_test_runtime_test.go
@@ -51,6 +51,7 @@ type fakeRuntime struct {
 	goalRecoveryPolicyHook  func(context.Context, RuntimeGoalControlInput) (RuntimeGoalRecoveryPolicy, error)
 	goalGenerationFences    []RuntimeGoalGenerationFenceInput
 	goalGenerationFenceHook func(context.Context, RuntimeGoalGenerationFenceInput) error
+	resumeErr               error
 	resumeCalls             []RuntimeResumeInput
 	sessions                map[string]ProviderRuntimeSession
 	disconnectedSessions    map[string]bool
@@ -749,6 +750,9 @@ func (f *fakeRuntime) UpdateSettings(_ context.Context, input RuntimeUpdateSetti
 
 func (f *fakeRuntime) Resume(_ context.Context, input RuntimeResumeInput) (ProviderRuntimeSession, error) {
 	f.resumeCalls = append(f.resumeCalls, input)
+	if f.resumeErr != nil {
+		return ProviderRuntimeSession{}, f.resumeErr
+	}
 	session := ProviderRuntimeSession{
 		ID:                input.AgentSessionID,
 		AgentTargetID:     input.AgentTargetID,


### PR DESCRIPTION
## Summary

- preserve session-owned provider state when EnsureRuntimeSession fails after runtime preparation
- continue closing partial runtime connections and releasing transient preparation resources
- keep rejected new-session startup cleanup destructive
- add Host unit coverage and an adapter/direct-Host conformance scenario

## Verification

- rtk go test ./packages/agent/host/... ./packages/agent/runtimeprep -count=1
- rtk go test ./services/tuttid/service/agent -count=1
- rtk git diff --check

## Checklist

- [x] Agent lifecycle semantics remain in packages/agent/host and include a packages/agent/host/conformance scenario.
- [x] I kept the change focused on one concern.
- [x] Documentation is not required because this restores the documented PreserveRecoverableState contract.
- [x] No README or CONTRIBUTING language changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] The commit is signed off with DCO.