### PR TITLE
fix(browser-node): recover failed preview navigation

### DIFF
--- a/packages/browser/workbench-node/src/core/runtimeStore.test.ts
+++ b/packages/browser/workbench-node/src/core/runtimeStore.test.ts
@@ -192,6 +192,32 @@ test("keeps Browser Node load errors until a new load starts", () => {
   assert.equal(store.getNodeState("browser-1").error, null);
 });
 
+test("clears Browser Node load errors when the main document succeeds", () => {
+  const store = createBrowserNodeRuntimeStore();
+
+  store.applyEvent({
+    code: "navigation-failed",
+    diagnosticMessage: "Bad Gateway",
+    nodeId: "browser-1",
+    params: { statusCode: 502 },
+    type: "error"
+  });
+  store.applyEvent({
+    canGoBack: false,
+    canGoForward: false,
+    isLoading: false,
+    isOccluded: false,
+    lifecycle: "active",
+    navigationStatusCode: 200,
+    nodeId: "browser-1",
+    title: "Recovered",
+    type: "state",
+    url: "http://127.0.0.1:3000/"
+  });
+
+  assert.equal(store.getNodeState("browser-1").error, null);
+});
+
 test("keeps Browser Node load errors through Chromium error page loading", () => {
   const store = createBrowserNodeRuntimeStore();
 
@@ -218,6 +244,7 @@ test("keeps Browser Node load errors through Chromium error page loading", () =>
     isLoading: true,
     isOccluded: false,
     lifecycle: "active",
+    navigationStatusCode: 200,
     nodeId: "browser-1",
     title: null,
     type: "state",

--- a/packages/browser/workbench-node/src/core/runtimeStore.ts
+++ b/packages/browser/workbench-node/src/core/runtimeStore.ts
@@ -46,12 +46,19 @@ function normalizePublishedBrowserValue(
 
 function shouldClearLoadError({
   isLoading,
+  navigationStatusCode,
   url
 }: {
   isLoading: boolean;
+  navigationStatusCode?: number;
   url: string | null;
 }): boolean {
-  return isLoading && !isChromiumErrorPageUrl(url);
+  const mainDocumentSucceeded =
+    navigationStatusCode !== undefined &&
+    navigationStatusCode >= 200 &&
+    navigationStatusCode < 400 &&
+    !isChromiumErrorPageUrl(url);
+  return mainDocumentSucceeded || (isLoading && !isChromiumErrorPageUrl(url));
 }
 
 export function createBrowserNodeRuntimeStore(): BrowserNodeRuntimeStore {
@@ -187,6 +194,7 @@ function resolveNextState(
     canGoForward: event.canGoForward,
     error: shouldClearLoadError({
       isLoading: event.isLoading,
+      navigationStatusCode: event.navigationStatusCode,
       url: event.url
     })
       ? null

--- a/packages/browser/workbench-node/src/core/types.ts
+++ b/packages/browser/workbench-node/src/core/types.ts
@@ -50,6 +50,7 @@ export interface BrowserNodeStateEvent {
   url: string | null;
   title: string | null;
   isLoading: boolean;
+  navigationStatusCode?: number;
   canGoBack: boolean;
   canGoForward: boolean;
   zoomFactor?: number;

--- a/packages/browser/workbench-node/src/electron-main/electronMain.test.ts
+++ b/packages/browser/workbench-node/src/electron-main/electronMain.test.ts
@@ -1434,6 +1434,114 @@ test("reports Browser Node guest HTTP error navigations", async () => {
   );
 });
 
+test("reloads a failed Browser Node guest without cache until navigation recovers", async () => {
+  const events: BrowserNodeEvent[] = [];
+  const contents = new MockBrowserGuestWebContents(30);
+  const manager = createBrowserGuestManager({
+    emit: (event) => events.push(event),
+    openExternal: () => undefined,
+    resolveWebContents: (id) => (id === contents.id ? contents : null)
+  });
+
+  await manager.registerGuest({
+    nodeId: "browser-failed-reload",
+    profileId: null,
+    sessionMode: "shared",
+    webContentsId: 30
+  });
+
+  contents.emit(
+    "did-navigate",
+    {},
+    "http://127.0.0.1:3000/",
+    502,
+    "Bad Gateway"
+  );
+  await manager.reload({ nodeId: "browser-failed-reload" });
+
+  assert.equal(contents.reloadIgnoringCacheCalls, 1);
+  assert.equal(contents.reloadCalls, 0);
+
+  contents.emit("did-navigate", {}, "http://127.0.0.1:3000/", 200, "OK");
+  await manager.reload({ nodeId: "browser-failed-reload" });
+
+  assert.equal(contents.reloadIgnoringCacheCalls, 1);
+  assert.equal(contents.reloadCalls, 1);
+  assert.equal(
+    events.some(
+      (event) =>
+        event.type === "state" &&
+        event.navigationStatusCode === 200 &&
+        event.nodeId === "browser-failed-reload"
+    ),
+    true
+  );
+});
+
+test("keeps subframe failures out of main navigation recovery state", async () => {
+  const events: BrowserNodeEvent[] = [];
+  const contents = new MockBrowserGuestWebContents(31);
+  const manager = createBrowserGuestManager({
+    emit: (event) => events.push(event),
+    openExternal: () => undefined,
+    resolveWebContents: (id) => (id === contents.id ? contents : null)
+  });
+
+  await manager.registerGuest({
+    nodeId: "browser-subframe-failure",
+    profileId: null,
+    sessionMode: "shared",
+    webContentsId: 31
+  });
+  events.length = 0;
+
+  contents.emit(
+    "did-fail-load",
+    {},
+    -102,
+    "ERR_CONNECTION_REFUSED",
+    "https://example.com/frame",
+    false
+  );
+  await manager.reload({ nodeId: "browser-subframe-failure" });
+
+  assert.equal(
+    events.some((event) => event.type === "error"),
+    false
+  );
+  assert.equal(contents.reloadIgnoringCacheCalls, 0);
+  assert.equal(contents.reloadCalls, 1);
+});
+
+test("ends failed reload recovery after a successful non-HTTP navigation", async () => {
+  const contents = new MockBrowserGuestWebContents(32);
+  const manager = createBrowserGuestManager({
+    emit: () => undefined,
+    openExternal: () => undefined,
+    resolveWebContents: (id) => (id === contents.id ? contents : null)
+  });
+
+  await manager.registerGuest({
+    nodeId: "browser-non-http-recovery",
+    profileId: null,
+    sessionMode: "shared",
+    webContentsId: 32
+  });
+  contents.emit(
+    "did-navigate",
+    {},
+    "http://127.0.0.1:3000/",
+    502,
+    "Bad Gateway"
+  );
+  contents.emit("did-navigate", {}, "about:blank", -1, "");
+
+  await manager.reload({ nodeId: "browser-non-http-recovery" });
+
+  assert.equal(contents.reloadIgnoringCacheCalls, 0);
+  assert.equal(contents.reloadCalls, 1);
+});
+
 test("keeps Browser Node navigation failures as the final emitted event", async () => {
   const events: BrowserNodeEvent[] = [];
   const contents = new MockBrowserGuestWebContents(19);
@@ -1759,6 +1867,7 @@ class MockBrowserGuestWebContents
   loading = false;
   printCalls = 0;
   reloadCalls = 0;
+  reloadIgnoringCacheCalls = 0;
   findInPageCalls: Array<{
     options: Record<string, unknown> | undefined;
     text: string;
@@ -1856,6 +1965,10 @@ class MockBrowserGuestWebContents
 
   reload(): void {
     this.reloadCalls += 1;
+  }
+
+  reloadIgnoringCache(): void {
+    this.reloadIgnoringCacheCalls += 1;
   }
 
   setWindowOpenHandler(

--- a/packages/browser/workbench-node/src/electron-main/guestManager.ts
+++ b/packages/browser/workbench-node/src/electron-main/guestManager.ts
@@ -63,6 +63,7 @@ interface BrowserGuestSession {
     listener: (...args: unknown[]) => void;
   }>;
   navigationFailureSequence: number;
+  navigationFailed: boolean;
   navigationPolicy: BrowserNodeNavigationPolicy | null;
   nodeId: string;
   profileId: string | null;
@@ -177,6 +178,7 @@ export function createBrowserGuestManager({
       lifecycle: "cold",
       listeners: [],
       navigationFailureSequence: 0,
+      navigationFailed: false,
       navigationPolicy: input?.navigationPolicy ?? null,
       nodeId,
       profileId: input?.profileId ?? null,
@@ -188,7 +190,10 @@ export function createBrowserGuestManager({
     return session;
   };
 
-  const publishState = (session: BrowserGuestSession): void => {
+  const publishState = (
+    session: BrowserGuestSession,
+    navigationStatusCode?: number
+  ): void => {
     const contents =
       session.contents && !session.contents.isDestroyed()
         ? session.contents
@@ -200,6 +205,7 @@ export function createBrowserGuestManager({
       isLoading: contents ? contents.isLoading() : false,
       isOccluded: session.lifecycle === "cold",
       lifecycle: session.lifecycle,
+      ...(navigationStatusCode !== undefined ? { navigationStatusCode } : {}),
       nodeId: session.nodeId,
       title: contents ? session.committedTitle : null,
       type: "state",
@@ -270,8 +276,17 @@ export function createBrowserGuestManager({
       if (url !== undefined) {
         session.committedUrl = url || null;
       }
-      publishState(session);
-      if (!isHttpErrorStatusCode(statusCode)) {
+      const navigationFailed = isHttpErrorStatusCode(statusCode);
+      if (navigationFailed) {
+        session.navigationFailed = true;
+      } else if (
+        statusCode === -1 ||
+        (statusCode !== undefined && statusCode >= 200 && statusCode < 400)
+      ) {
+        session.navigationFailed = false;
+      }
+      publishState(session, statusCode);
+      if (!navigationFailed) {
         return;
       }
 
@@ -305,6 +320,18 @@ export function createBrowserGuestManager({
         publishState(session);
         return;
       }
+      if (isMainFrame === false) {
+        logger?.debug?.("Browser Node guest subframe navigation failed", {
+          errorCode,
+          errorDescription,
+          nodeId: session.nodeId,
+          validatedUrl,
+          webContentsId: session.webContentsId
+        });
+        publishState(session);
+        return;
+      }
+      session.navigationFailed = true;
       logger?.warn?.("Browser Node guest navigation failed", {
         currentUrl: contents.getURL(),
         desiredUrl: session.desiredUrl,
@@ -447,6 +474,7 @@ export function createBrowserGuestManager({
       if (session.navigationFailureSequence !== failureSequenceBeforeLoad) {
         return;
       }
+      session.navigationFailed = true;
       publishState(session);
       emitBrowserNavigationFailed({
         emit,
@@ -850,9 +878,14 @@ export function createBrowserGuestManager({
       await loadDesiredUrl(session);
     },
     reload(input) {
-      const contents = sessions.get(input.nodeId)?.contents;
+      const browserSession = sessions.get(input.nodeId);
+      const contents = browserSession?.contents;
       if (contents && !contents.isDestroyed()) {
-        contents.reload();
+        if (browserSession?.navigationFailed && contents.reloadIgnoringCache) {
+          contents.reloadIgnoringCache();
+        } else {
+          contents.reload();
+        }
       }
       return Promise.resolve();
     },

--- a/packages/browser/workbench-node/src/electron-main/types.ts
+++ b/packages/browser/workbench-node/src/electron-main/types.ts
@@ -176,6 +176,7 @@ export interface BrowserGuestWebContents {
     callback: (success: boolean, failureReason: string) => void
   ): void;
   reload(): void;
+  reloadIgnoringCache?(): void;
   setUserAgent?(userAgent: string): void;
   setWindowOpenHandler?(
     handler: (details: { url: string }) => BrowserGuestWindowOpenHandlerResponse


### PR DESCRIPTION
## Summary

- track main-document navigation failure state per Browser Node guest
- reload failed previews with reloadIgnoringCache until a successful navigation recovers
- clear stale navigation-failed UI state on successful main-document responses
- ignore subframe load failures when deciding main-navigation recovery state

## Verification

- Negative control: pnpm --filter @tutti-os/browser-node test failed the three new regression cases on origin/main for stale error state, cached failed reload, and subframe poisoning.
- pnpm --filter @tutti-os/browser-node test (173 passed)
- pnpm check:changed (9 lanes passed)
- pre-push pnpm check:changed -- --push-ready (10 lanes passed)

Test evidence

- Protected contract or prior failure: a Browser preview that receives a transient 502 must recover on user reload without retaining the prior navigation-failed overlay.
- Credible faulty implementation / negative control: ordinary reload after a failure can reuse the failed response; successful navigation can leave the prior error sticky; subframe failures can poison the top-level page. All three failed before the production change.
- Existing coverage gap: prior tests asserted failure publication but not recovery, cache bypass, or main-frame ownership.
- Owning seam and test level: Browser guest manager component tests plus the Browser runtime store state projection.
- Observable outcomes and important non-effects: failed reload bypasses cache, later success restores ordinary reload and clears the error, subframe failure emits no top-level navigation error.
- Blocking lane and native OS: Browser Node package tests and changed-aware Electron boundary/typecheck lanes on macOS; behavior uses platform-neutral Electron WebContents events/APIs.
- Residual risk: real proxy startup timing remains covered by downstream integration/manual qualification after package release.

## Fallback Three Questions

- Source: Electron reports failed top-level HTTP navigation through did-navigate/did-fail-load, while an ordinary Chromium reload may reuse the failed response.
- Why can it not be fixed at that source? A transient failure can come from the loopback preview proxy, server startup, or an external origin; Browser Node owns the user reload policy and UI error lifetime across all of them.
- Removal condition: remove the cache-bypass branch if Electron guarantees ordinary reload revalidates failed main-document responses, or if Browser Node stops persisting navigation failure state.

## Checklist

- [x] This change does not alter agent lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] No durable documentation change is required for this internal recovery fix.
- [x] No README/CONTRIBUTING source changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] The commit is signed off with DCO.