### PR TITLE
fix(release): publish app runtime before desktop builds

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -214,6 +214,10 @@ jobs:
           echo "dry_run=${dry_run}" >> "$GITHUB_OUTPUT"
           echo "strategy=${strategy}" >> "$GITHUB_OUTPUT"
 
+      - name: Verify managed app runtime is published before release build
+        if: steps.mode.outputs.dry_run != 'true'
+        run: node tools/scripts/verify-tutti-app-runtime-release.mjs
+
       - name: Resolve release tag
         id: release
         shell: bash

--- a/.github/workflows/publish-tutti-app-runtime.yml
+++ b/.github/workflows/publish-tutti-app-runtime.yml
@@ -1,6 +1,11 @@
 name: Publish Tutti App Runtime
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - config/tutti.app-runtime.lock.json
   workflow_dispatch:
     inputs:
       aws_region:
@@ -31,6 +36,10 @@ on:
 permissions:
   contents: read
   id-token: write
+
+concurrency:
+  group: tutti-app-runtime-production
+  cancel-in-progress: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -458,10 +458,11 @@ Promotion performs these checks before changing public state:
 - the reviewed bilingual notes still produce the approval digest captured before the Environment gate
 - the target version does not move the selected public channel backwards
 
-When `config/tutti.app-runtime.lock.json` changes, run `Publish Tutti App
-Runtime` and verify the production catalog before promoting the desktop release.
-The promotion gate reads the lock from the exact release target, so a later
-manual promotion cannot bypass this ordering.
+Merging a change to `config/tutti.app-runtime.lock.json` on `main` automatically
+runs `Publish Tutti App Runtime`; its manual trigger remains available for
+recovery. Desktop release resolution checks the catalog before reserving a tag
+or starting platform builds. The promotion gate repeats the check against the
+exact release target, so a later manual promotion cannot bypass this ordering.
 
 It then extracts the human-reviewed summary, copies stable candidate objects from `candidates/<candidate-id>/` to the immutable `<tag>/` path, creates the formal stable tag, updates release notes and assets, publishes the GitHub Release, writes the channel pointer and changelog, refreshes the stable alias, verifies the public pointer, and sends the published card. Promotion never rebuilds installers or calls the summary model. Editing notes or replacing assets after submission changes the approval digest and forces a new approval run. Promotion is serialized because channel pointers are shared mutable state.
 

--- a/docs/conventions/workspace-app-runtime.md
+++ b/docs/conventions/workspace-app-runtime.md
@@ -141,8 +141,11 @@ release is promoted. Runtime versions use an ordered `YYYY.MM.PATCH` format and
 newer runtime releases remain compatible with older desktop releases because
 tuttid always resolves the mutable catalog's current entry. The promotion
 workflow enforces this ordering with
-`tools/scripts/verify-tutti-app-runtime-release.mjs`; publish the managed runtime
-first when the lock version changes.
+`tools/scripts/verify-tutti-app-runtime-release.mjs`. Merging a change to
+`config/tutti.app-runtime.lock.json` on `main` automatically runs `Publish Tutti
+App Runtime`; the manual trigger remains available for recovery. Desktop
+releases check the production catalog before reserving a tag or starting builds,
+and promotion repeats the check as a final safety gate.
 
 ## Catalog Shape
 

--- a/tools/scripts/build-tutti-app-runtime-catalog.test.mjs
+++ b/tools/scripts/build-tutti-app-runtime-catalog.test.mjs
@@ -110,6 +110,13 @@ test("Tutti app runtime workflow publishes immutable artifacts and mutable catal
   const workflow = await readFile(runtimeWorkflowPath, "utf8");
 
   assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /push:\s*\n\s*branches:\s*\n\s*- main/);
+  assert.match(
+    workflow,
+    /paths:\s*\n\s*- config\/tutti\.app-runtime\.lock\.json/
+  );
+  assert.match(workflow, /group: tutti-app-runtime-production/);
+  assert.match(workflow, /cancel-in-progress: false/);
   assert.match(workflow, /config\/tutti\.app-runtime\.lock\.json/);
   assert.match(workflow, /platform === "windows-amd64"/);
   assert.match(workflow, /lock\.python\?\.windows\?\.version/);

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -456,6 +456,33 @@ test("desktop promotion requires the managed app runtime release first", async (
   );
 });
 
+test("desktop release checks the managed app runtime before reserving a tag or building", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+  const runtimeGateIndex = workflow.indexOf(
+    "name: Verify managed app runtime is published before release build"
+  );
+  const releaseTagIndex = workflow.indexOf("name: Resolve release tag");
+  const buildIndex = workflow.indexOf("build-macos:");
+
+  assert.ok(
+    runtimeGateIndex >= 0,
+    "release should include an early runtime gate"
+  );
+  assert.ok(
+    runtimeGateIndex < releaseTagIndex,
+    "runtime gate should pass before reserving a release tag"
+  );
+  assert.ok(
+    runtimeGateIndex < buildIndex,
+    "runtime gate should pass before desktop builds start"
+  );
+  assert.match(workflow, /if: steps\.mode\.outputs\.dry_run != 'true'/);
+  assert.match(
+    workflow,
+    /node tools\/scripts\/verify-tutti-app-runtime-release\.mjs/
+  );
+});
+
 test("desktop release workflow schedules a daily Beijing 4:16am rc release", async () => {
   const workflow = await readFile(workflowPath, "utf8");
 


### PR DESCRIPTION
Automatically publishes the managed app runtime when its lock changes on main, serializes production catalog writes, and moves the desktop runtime gate ahead of tag reservation and platform builds.\n\nValidation: 66 focused runtime and desktop release tests pass.