### PR TITLE
fix(agent): fail closed when provider turn state is lost

### DIFF
--- a/packages/agent/claude-sdk-sidecar/README.md
+++ b/packages/agent/claude-sdk-sidecar/README.md
@@ -108,14 +108,19 @@ proceed. Checkpoint and terminal events use the same bound provider Turn ID and
 never fall back to the outbound correlation UUID.
 
 Exact cancellation returns a structured `pre_accept`, `provider_active`,
-`absent`, or `mismatch` disposition. An undispatched Turn or deferred Goal
-command can be removed locally. A dispatched Turn is fenced immediately, but
+`provider_state_lost`, `absent`, or `mismatch` disposition. An undispatched
+Turn or deferred Goal command can be removed locally. A dispatched Turn is
+fenced immediately, but
 its terminal event is emitted only after the Query reaches an authoritative
 shutdown boundary: either the SDK acknowledges the interrupt or the sidecar
 closes the owned Query transport and its consumer drains. `provider_active`
 includes the resolved provider Turn ID so the
 daemon can wait for that exact Turn's durable acceptance result before it
 confirms cancellation; failures and unknown dispositions remain fail-closed.
+If an accepted Turn still has live provider-acceptance evidence but its Query
+generation or provider mapping is gone, the sidecar returns
+`provider_state_lost`; it never downgrades that observation to ordinary
+`absent`.
 
 Interactive responses use `(turnId, requestId)` identity. The sidecar keeps a
 bounded terminal disposition registry so `submit_interactive` is idempotent:

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
@@ -74,6 +74,7 @@ type ClaudeQueryFactory = (input: {
 export type SessionCancelDisposition =
   | "pre_accept"
   | "provider_active"
+  | "provider_state_lost"
   | "absent"
   | "mismatch";
 
@@ -143,6 +144,7 @@ export class SessionRuntime {
   private readonly providerTurnAcceptance: ProviderTurnAcceptanceCoordinator;
   private readonly diagnostics: ClaudeSessionDiagnostics;
   private readonly emittedProviderCheckpoints = new Set<string>();
+  private readonly acceptedProviderTurnIds = new Set<string>();
 
   get query(): ClaudeQueryRuntime | undefined {
     return this.queryGeneration?.query;
@@ -174,8 +176,23 @@ export class SessionRuntime {
       onSyntheticActivate: (turnId) =>
         this.queryGeneration?.registerTurn(turnId),
       onSettled: (turnId) => {
+        this.acceptedProviderTurnIds.delete(turnId.trim());
         this.providerTurnAcceptance.terminal(turnId);
         this.emitSessionState();
+      },
+      onProviderTurnIdentityBound: (turnId) => {
+        const normalizedTurnId = turnId.trim();
+        if (!normalizedTurnId) {
+          return;
+        }
+        this.acceptedProviderTurnIds.add(normalizedTurnId);
+        while (this.acceptedProviderTurnIds.size > 64) {
+          const oldest = this.acceptedProviderTurnIds.values().next().value;
+          if (typeof oldest !== "string") {
+            break;
+          }
+          this.acceptedProviderTurnIds.delete(oldest);
+        }
       },
       continuationStartTimeoutMs,
       onContinuationStartTimeout: () => {
@@ -676,7 +693,27 @@ export class SessionRuntime {
     // Generation ownership is the narrow proof that permits retiring that
     // Query; it never retargets a stop request to an unrelated newer Query.
     const ownsExpectedTurn = generation?.ownsTurn(expectedTurnId) === true;
+    const phase =
+      this.providerTurnAcceptance.phase(expectedTurnId) ?? "unknown";
+    const providerStateWasAccepted =
+      preparation.providerTurnId.trim() !== "" ||
+      this.acceptedProviderTurnIds.has(expectedTurnId) ||
+      (phase !== "queued" &&
+        phase !== "dispatched" &&
+        phase !== "provider_observed" &&
+        phase !== "resolving_identity" &&
+        phase !== "terminal" &&
+        phase !== "unknown");
     if (preparation.disposition === "absent" && !ownsExpectedTurn) {
+      if (providerStateWasAccepted) {
+        return cancelResult(
+          false,
+          "provider_state_lost",
+          expectedTurnId,
+          preparation.providerTurnId,
+          phase
+        );
+      }
       return cancelResult(false, "absent", expectedTurnId);
     }
     if (preparation.disposition === "mismatch" && !ownsExpectedTurn) {
@@ -688,8 +725,6 @@ export class SessionRuntime {
       );
     }
 
-    const phase =
-      this.providerTurnAcceptance.phase(expectedTurnId) ?? "unknown";
     if (
       preparation.differentActiveTurn &&
       phase !== "queued" &&
@@ -709,6 +744,17 @@ export class SessionRuntime {
     }
 
     if (!generation) {
+      if (providerStateWasAccepted) {
+        this.turns.releaseExactCancellation(expectedTurnId);
+        this.turns.clearCancelled();
+        return cancelResult(
+          false,
+          "provider_state_lost",
+          expectedTurnId,
+          preparation.providerTurnId,
+          phase
+        );
+      }
       this.turns.discardExactAbsent(expectedTurnId);
       this.turns.clearCancelled();
       return cancelResult(false, "absent", expectedTurnId, "", phase);

--- a/packages/agent/claude-sdk-sidecar/src/turnLifecycle.ts
+++ b/packages/agent/claude-sdk-sidecar/src/turnLifecycle.ts
@@ -51,6 +51,7 @@ export class TurnLifecycle {
   private readonly emit: ClaudeSDKSidecarEventEmitter;
   private readonly onActivate: () => void;
   private readonly onSyntheticActivate: (turnId: string) => void;
+  private readonly onProviderTurnIdentityBound: (turnId: string) => void;
   private readonly onSettled: (turnId: string) => void;
   private readonly onContinuationStartTimeout: () => void;
   private readonly continuationStartTimeoutMs: number;
@@ -68,6 +69,7 @@ export class TurnLifecycle {
     emit: ClaudeSDKSidecarEventEmitter;
     onActivate: () => void;
     onSyntheticActivate?: (turnId: string) => void;
+    onProviderTurnIdentityBound?: (turnId: string) => void;
     onSettled: (turnId: string) => void;
     onContinuationStartTimeout?: () => void;
     continuationStartTimeoutMs?: number;
@@ -75,6 +77,8 @@ export class TurnLifecycle {
     this.emit = options.emit;
     this.onActivate = options.onActivate;
     this.onSyntheticActivate = options.onSyntheticActivate ?? (() => {});
+    this.onProviderTurnIdentityBound =
+      options.onProviderTurnIdentityBound ?? (() => {});
     this.onSettled = options.onSettled;
     this.onContinuationStartTimeout =
       options.onContinuationStartTimeout ?? (() => {});
@@ -657,6 +661,7 @@ export class TurnLifecycle {
     }
     turn.awaitingProviderTurnIdentity = false;
     turn.providerTurnStarted = true;
+    this.onProviderTurnIdentityBound(turn.turnId);
     this.emit({
       type: "provider_turn_identity_resolved",
       payload: {

--- a/packages/agent/daemon/hostadapter/runtime.go
+++ b/packages/agent/daemon/hostadapter/runtime.go
@@ -338,10 +338,11 @@ func (a *RuntimeController) Cancel(ctx context.Context, input host.RuntimeCancel
 		confirmed = append(confirmed, host.RuntimeCancelTarget{AgentSessionID: target.AgentSessionID, TurnID: target.TurnID})
 	}
 	hostResult := host.RuntimeCancelResult{
-		AgentSessionID:   result.AgentSessionID,
-		Canceled:         result.Canceled,
-		TargetAbsent:     result.TargetAbsent,
-		ConfirmedTargets: confirmed,
+		AgentSessionID:    result.AgentSessionID,
+		Canceled:          result.Canceled,
+		TargetAbsent:      result.TargetAbsent,
+		ProviderStateLost: result.ProviderStateLost,
+		ConfirmedTargets:  confirmed,
 	}
 	if errors.Is(err, agentruntime.ErrCancelTargetMismatch) {
 		return hostResult, host.ErrRuntimeCancelDeliveryUnconfirmed

--- a/packages/agent/daemon/runtime/claude_sdk_execution.go
+++ b/packages/agent/daemon/runtime/claude_sdk_execution.go
@@ -669,6 +669,11 @@ func (a *ClaudeCodeSDKAdapter) cancelClaudeSDKTurn(
 			return nil, errors.New("claude SDK returned inconsistent absent cancellation")
 		}
 		return nil, ErrSessionNoActiveTurn
+	case "provider_state_lost":
+		if canceled {
+			return nil, errors.New("claude SDK returned inconsistent provider state loss cancellation")
+		}
+		return nil, ErrProviderStateLost
 	case "mismatch":
 		if canceled || providerTurnID != "" {
 			return nil, errors.New("claude SDK returned inconsistent mismatched cancellation")

--- a/packages/agent/daemon/runtime/controller_cancel.go
+++ b/packages/agent/daemon/runtime/controller_cancel.go
@@ -73,6 +73,12 @@ func (c *Controller) Cancel(ctx context.Context, input CancelInput) (CancelResul
 		active.cancel()
 	}
 	if err != nil {
+		if errors.Is(err, ErrProviderStateLost) {
+			return CancelResult{
+				AgentSessionID:    session.AgentSessionID,
+				ProviderStateLost: true,
+			}, nil
+		}
 		if errors.Is(err, ErrSessionNoActiveTurn) {
 			if ok {
 				c.clearActiveTurnIfMatches(session.RoomID, session.AgentSessionID, active.turnID)

--- a/packages/agent/daemon/runtime/controller_cancel_test.go
+++ b/packages/agent/daemon/runtime/controller_cancel_test.go
@@ -142,9 +142,38 @@ func TestControllerExactCancelReportsTargetAbsentWithoutTurnRegistryRecord(t *te
 	}
 }
 
+func TestControllerCancelPreservesActiveTurnWhenProviderStateIsLost(t *testing.T) {
+	t.Parallel()
+
+	adapter := &cancelReconcileAdapter{err: ErrProviderStateLost}
+	controller := NewController([]Adapter{adapter}, nil)
+	started, err := controller.Start(context.Background(), StartInput{
+		RoomID: "room-1", AgentSessionID: "agent-session-1", Provider: ProviderCodex, Title: "Test",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	_, cancel := context.WithCancel(context.Background())
+	if _, err := controller.beginTurn(started.Session, "turn-1", cancel); err != nil {
+		t.Fatalf("beginTurn: %v", err)
+	}
+
+	result, err := controller.Cancel(context.Background(), rootCancelInput("room-1", started.Session.AgentSessionID, "turn-1", "user requested"))
+	if err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if !result.ProviderStateLost || result.Canceled || result.TargetAbsent {
+		t.Fatalf("result = %#v, want provider state loss without cancellation", result)
+	}
+	if _, ok := controller.activeTurn("room-1", started.Session.AgentSessionID); !ok {
+		t.Fatal("active turn was cleared after provider state loss")
+	}
+}
+
 type cancelReconcileAdapter struct {
 	cancelCalls atomic.Int64
 	empty       bool
+	err         error
 }
 
 func (*cancelReconcileAdapter) Provider() string { return ProviderCodex }
@@ -163,6 +192,9 @@ func (*cancelReconcileAdapter) Exec(context.Context, Session, []PromptContentBlo
 
 func (a *cancelReconcileAdapter) Cancel(_ context.Context, session Session, _ string) ([]activityshared.Event, error) {
 	a.cancelCalls.Add(1)
+	if a.err != nil {
+		return nil, a.err
+	}
 	if a.empty {
 		return nil, ErrSessionNoActiveTurn
 	}

--- a/packages/agent/daemon/runtime/errors.go
+++ b/packages/agent/daemon/runtime/errors.go
@@ -21,6 +21,7 @@ var (
 	ErrInteractiveAlreadyAnswered    = errors.New("interactive request has already been answered")
 	ErrInteractiveResponseInvalid    = errors.New("interactive response is invalid")
 	ErrSessionNoActiveTurn           = errors.New("agent session has no active turn")
+	ErrProviderStateLost             = errors.New("agent provider state was lost")
 	ErrCancelTargetMismatch          = errors.New("agent cancellation target is no longer active")
 	ErrActiveTurnTargetRequired      = errors.New("active-turn guidance requires an exact target turn")
 	ErrActiveTurnTargetMismatch      = errors.New("active-turn guidance target is no longer active")

--- a/packages/agent/daemon/runtime/types.go
+++ b/packages/agent/daemon/runtime/types.go
@@ -656,10 +656,11 @@ type TurnLifecycle struct {
 }
 
 type CancelResult struct {
-	AgentSessionID   string         `json:"agentSessionId"`
-	Canceled         bool           `json:"canceled"`
-	TargetAbsent     bool           `json:"targetAbsent,omitempty"`
-	ConfirmedTargets []CancelTarget `json:"confirmedTargets,omitempty"`
+	AgentSessionID    string         `json:"agentSessionId"`
+	Canceled          bool           `json:"canceled"`
+	TargetAbsent      bool           `json:"targetAbsent,omitempty"`
+	ProviderStateLost bool           `json:"providerStateLost,omitempty"`
+	ConfirmedTargets  []CancelTarget `json:"confirmedTargets,omitempty"`
 }
 
 type SubmitInteractiveResult struct {

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -196,6 +196,12 @@ does not infer either `canceled` or `failed` from the response. If the canonical
 Turn reaches a terminal state first, the operation completes as a no-op and
 preserves that existing outcome.
 
+If the runtime reports `provider_state_lost`, or reports an absent provider
+target while the canonical Turn is still unsettled, Host performs the same
+canonical-terminal check once. Without authoritative terminal evidence it
+settles the target as `failed` with `execution_status_unknown`; it never
+fabricates `completed`, `canceled`, or `interrupted` from provider absence.
+
 `AdoptProviderGoal` is the narrow
 reverse boundary for a Goal created by a provider tool during an already
 accepted Turn. It atomically records the active provider generation as a

--- a/packages/agent/host/errors.go
+++ b/packages/agent/host/errors.go
@@ -24,6 +24,7 @@ var (
 	// the one it stopped. Host keeps the durable cancel operation retryable and
 	// waits for canonical terminal evidence instead of fabricating a terminal.
 	ErrRuntimeCancelDeliveryUnconfirmed   = errors.New("agent runtime cancellation delivery is unconfirmed")
+	ErrRuntimeProviderStateLost           = errors.New("agent provider state was lost")
 	ErrRuntimeSessionActive               = errors.New("agent runtime session has an active turn")
 	ErrRuntimeSessionReprepareUnavailable = errors.New("agent runtime session reprepare is unavailable")
 	ErrRuntimeContextConflict             = errors.New("agent runtime context changed before rebind commit")

--- a/packages/agent/host/runtime_cancel_reconciliation_test.go
+++ b/packages/agent/host/runtime_cancel_reconciliation_test.go
@@ -179,3 +179,43 @@ func TestCancelDeliveryUnconfirmedDoesNotTreatLaterTargetAbsentAsCanceled(t *tes
 		t.Fatalf("runtime cancel calls=%d, want no third cancellation", runtime.cancelCalls())
 	}
 }
+
+func TestCancelProviderStateLostFailsClosedWithUnknownExecutionStatus(t *testing.T) {
+	store := openGoalFenceHostStore(t)
+	if _, accepted, err := store.RecordTurnTransition(t.Context(), storesqlite.TurnTransition{
+		WorkspaceID: "workspace", AgentSessionID: "session", TurnID: "turn-1",
+		Phase: storesqlite.TurnPhaseRunning, OccurredAtUnixMS: 2,
+	}); err != nil || !accepted {
+		t.Fatalf("seed running turn: accepted=%v err=%v", accepted, err)
+	}
+
+	runtime := &unconfirmedCancelRuntime{
+		session: storesqliteProviderRuntimeSession("workspace", "session"),
+		responses: []cancelRuntimeResponse{{result: agenthost.RuntimeCancelResult{
+			AgentSessionID: "session", ProviderStateLost: true,
+		}}},
+	}
+	host := agenthost.New(agenthost.Config{
+		CanonicalStore: sqliteCanonicalStore{Store: store}, Runtime: runtime,
+		RuntimeOperations: store, OperationOwner: "cancel-provider-state-lost-test",
+	})
+
+	result, err := host.CancelTurn(t.Context(), agenthost.CancelTurnInput{
+		WorkspaceID: "workspace", AgentSessionID: "session", TurnID: "turn-1", Reason: "user_requested",
+	})
+	if err != nil || !result.Settled || result.Outcome != storesqlite.TurnOutcomeFailed {
+		t.Fatalf("cancel result=%#v err=%v, want settled failed turn", result, err)
+	}
+	turn, found, err := store.GetTurn(t.Context(), "workspace", "session", "turn-1")
+	if err != nil || !found || turn.Phase != storesqlite.TurnPhaseSettled ||
+		turn.Outcome != storesqlite.TurnOutcomeFailed || turn.ErrorCode != "execution_status_unknown" {
+		t.Fatalf("canonical turn=%#v found=%v err=%v", turn, found, err)
+	}
+}
+
+func storesqliteProviderRuntimeSession(workspaceID, sessionID string) agenthost.ProviderRuntimeSession {
+	return agenthost.ProviderRuntimeSession{
+		ID: sessionID, WorkspaceID: workspaceID, Provider: "claude-code",
+		ProviderSessionID: "provider-session-1",
+	}
+}

--- a/packages/agent/host/runtime_cancel_targets.go
+++ b/packages/agent/host/runtime_cancel_targets.go
@@ -1,0 +1,68 @@
+package agenthost
+
+import (
+	"strings"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+func runtimeCancelTargetOutcomes(targets, confirmed []RuntimeCancelTarget) []storesqlite.CancelRuntimeOperationTargetOutcome {
+	confirmedSet := make(map[string]struct{}, len(confirmed))
+	for _, target := range confirmed {
+		confirmedSet[runtimeCancelTargetKey(target)] = struct{}{}
+	}
+	result := make([]storesqlite.CancelRuntimeOperationTargetOutcome, 0, len(targets))
+	for _, target := range targets {
+		outcome := storesqlite.TurnOutcomeInterrupted
+		if _, ok := confirmedSet[runtimeCancelTargetKey(target)]; ok {
+			outcome = storesqlite.TurnOutcomeCanceled
+		}
+		result = append(result, storesqlite.CancelRuntimeOperationTargetOutcome{
+			AgentSessionID: strings.TrimSpace(target.AgentSessionID),
+			TurnID:         strings.TrimSpace(target.TurnID),
+			Outcome:        outcome,
+		})
+	}
+	return result
+}
+
+func runtimeCancelTargetUnknownOutcomes(targets []RuntimeCancelTarget) []storesqlite.CancelRuntimeOperationTargetOutcome {
+	const errorCode = "execution_status_unknown"
+	const errorMessage = "provider final status was unavailable after the provider turn state was lost"
+	result := make([]storesqlite.CancelRuntimeOperationTargetOutcome, 0, len(targets))
+	for _, target := range targets {
+		result = append(result, storesqlite.CancelRuntimeOperationTargetOutcome{
+			AgentSessionID: strings.TrimSpace(target.AgentSessionID),
+			TurnID:         strings.TrimSpace(target.TurnID),
+			Outcome:        storesqlite.TurnOutcomeFailed,
+			ErrorCode:      errorCode,
+			ErrorMessage:   errorMessage,
+		})
+	}
+	return result
+}
+
+func runtimeCancelTargetKey(target RuntimeCancelTarget) string {
+	return strings.TrimSpace(target.AgentSessionID) + "\x00" + strings.TrimSpace(target.TurnID)
+}
+
+func runtimeCancelTargetsPayload(targets []RuntimeCancelTarget) []any {
+	result := make([]any, 0, len(targets))
+	for _, target := range targets {
+		result = append(result, map[string]any{"agentSessionId": strings.TrimSpace(target.AgentSessionID), "turnId": strings.TrimSpace(target.TurnID)})
+	}
+	return result
+}
+
+func runtimeCancelTargetsFromPayload(payload map[string]any) []RuntimeCancelTarget {
+	raw, _ := payload["targets"].([]any)
+	result := make([]RuntimeCancelTarget, 0, len(raw))
+	for _, item := range raw {
+		value, _ := item.(map[string]any)
+		target := RuntimeCancelTarget{AgentSessionID: runtimeOperationPayloadText(value, "agentSessionId"), TurnID: runtimeOperationPayloadText(value, "turnId")}
+		if target.AgentSessionID != "" && target.TurnID != "" {
+			result = append(result, target)
+		}
+	}
+	return result
+}

--- a/packages/agent/host/runtime_operations.go
+++ b/packages/agent/host/runtime_operations.go
@@ -636,63 +636,6 @@ func (h *Host) completeInterruptedCancelRuntimeOperation(
 	return completion.Operation, nil
 }
 
-func runtimeCancelTargetOutcomes(targets, confirmed []RuntimeCancelTarget) []storesqlite.CancelRuntimeOperationTargetOutcome {
-	confirmedSet := make(map[string]struct{}, len(confirmed))
-	for _, target := range confirmed {
-		confirmedSet[runtimeCancelTargetKey(target)] = struct{}{}
-	}
-	result := make([]storesqlite.CancelRuntimeOperationTargetOutcome, 0, len(targets))
-	for _, target := range targets {
-		outcome := storesqlite.TurnOutcomeInterrupted
-		if _, ok := confirmedSet[runtimeCancelTargetKey(target)]; ok {
-			outcome = storesqlite.TurnOutcomeCanceled
-		}
-		result = append(result, storesqlite.CancelRuntimeOperationTargetOutcome{AgentSessionID: strings.TrimSpace(target.AgentSessionID), TurnID: strings.TrimSpace(target.TurnID), Outcome: outcome})
-	}
-	return result
-}
-
-func runtimeCancelTargetUnknownOutcomes(targets []RuntimeCancelTarget) []storesqlite.CancelRuntimeOperationTargetOutcome {
-	const errorCode = "execution_status_unknown"
-	const errorMessage = "provider final status was unavailable after the provider turn state was lost"
-	result := make([]storesqlite.CancelRuntimeOperationTargetOutcome, 0, len(targets))
-	for _, target := range targets {
-		result = append(result, storesqlite.CancelRuntimeOperationTargetOutcome{
-			AgentSessionID: strings.TrimSpace(target.AgentSessionID),
-			TurnID:         strings.TrimSpace(target.TurnID),
-			Outcome:        storesqlite.TurnOutcomeFailed,
-			ErrorCode:      errorCode,
-			ErrorMessage:   errorMessage,
-		})
-	}
-	return result
-}
-
-func runtimeCancelTargetKey(target RuntimeCancelTarget) string {
-	return strings.TrimSpace(target.AgentSessionID) + "\x00" + strings.TrimSpace(target.TurnID)
-}
-
-func runtimeCancelTargetsPayload(targets []RuntimeCancelTarget) []any {
-	result := make([]any, 0, len(targets))
-	for _, target := range targets {
-		result = append(result, map[string]any{"agentSessionId": strings.TrimSpace(target.AgentSessionID), "turnId": strings.TrimSpace(target.TurnID)})
-	}
-	return result
-}
-
-func runtimeCancelTargetsFromPayload(payload map[string]any) []RuntimeCancelTarget {
-	raw, _ := payload["targets"].([]any)
-	result := make([]RuntimeCancelTarget, 0, len(raw))
-	for _, item := range raw {
-		value, _ := item.(map[string]any)
-		target := RuntimeCancelTarget{AgentSessionID: runtimeOperationPayloadText(value, "agentSessionId"), TurnID: runtimeOperationPayloadText(value, "turnId")}
-		if target.AgentSessionID != "" && target.TurnID != "" {
-			result = append(result, target)
-		}
-	}
-	return result
-}
-
 func (h *Host) releaseRuntimeOperation(ctx context.Context, operation storesqlite.RuntimeOperation, owner string, cause error, fail bool) (storesqlite.RuntimeOperation, error) {
 	released, _, releaseErr := h.operations.ReleaseOrFailRuntimeOperation(ctx, storesqlite.ReleaseOrFailRuntimeOperationInput{
 		WorkspaceID: operation.WorkspaceID, OperationID: operation.OperationID, LeaseOwner: owner,

--- a/packages/agent/host/runtime_operations.go
+++ b/packages/agent/host/runtime_operations.go
@@ -420,6 +420,9 @@ func (h *Host) executeCancelRuntimeOperation(
 		Targets: targets, Reason: runtimeOperationPayloadText(operation.Payload, "reason"),
 	})
 	if err != nil {
+		if errors.Is(err, ErrRuntimeProviderStateLost) {
+			return h.completeProviderStateLostCancelRuntimeOperation(ctx, operation, owner, targets)
+		}
 		if errors.Is(err, ErrRuntimeCancelDeliveryUnconfirmed) {
 			checkpointed, checkpointErr := h.checkpointCancelRuntimeOperationDeliveryUnconfirmed(ctx, operation, owner)
 			if checkpointErr != nil {
@@ -443,6 +446,9 @@ func (h *Host) executeCancelRuntimeOperation(
 		}
 		return h.releaseRuntimeOperation(ctx, operation, owner, err, !isRetryableRuntimeOperationError(err))
 	}
+	if result.ProviderStateLost {
+		return h.completeProviderStateLostCancelRuntimeOperation(ctx, operation, owner, targets)
+	}
 	if result.TargetAbsent && runtimeOperationPayloadBool(operation.Payload, storesqlite.CancelRuntimeOperationDeliveryUnconfirmedPayloadKey) {
 		settled, settledErr := h.cancelRuntimeOperationTargetsSettled(ctx, operation.WorkspaceID, targets)
 		if settledErr != nil {
@@ -460,7 +466,32 @@ func (h *Host) executeCancelRuntimeOperation(
 		)
 		return h.releaseRuntimeOperation(ctx, operation, owner, ErrRuntimeCancelDeliveryUnconfirmed, false)
 	}
+	if result.TargetAbsent {
+		return h.completeProviderStateLostCancelRuntimeOperation(ctx, operation, owner, targets)
+	}
 	return h.completeCancelRuntimeOperation(ctx, operation, owner, targets, result.ConfirmedTargets)
+}
+
+func (h *Host) completeProviderStateLostCancelRuntimeOperation(
+	ctx context.Context,
+	operation storesqlite.RuntimeOperation,
+	owner string,
+	targets []RuntimeCancelTarget,
+) (storesqlite.RuntimeOperation, error) {
+	settled, settledErr := h.cancelRuntimeOperationTargetsSettled(ctx, operation.WorkspaceID, targets)
+	if settledErr != nil {
+		return h.releaseRuntimeOperation(ctx, operation, owner, settledErr, !isRetryableRuntimeOperationError(settledErr))
+	}
+	if settled {
+		return h.completeCancelRuntimeOperation(ctx, operation, owner, targets, nil)
+	}
+	return h.completeCancelRuntimeOperationWithOutcomes(
+		ctx,
+		operation,
+		owner,
+		runtimeCancelTargetUnknownOutcomes(targets),
+		false,
+	)
 }
 
 func (h *Host) checkpointCancelRuntimeOperationDeliveryUnconfirmed(
@@ -487,16 +518,32 @@ func (h *Host) completeCancelRuntimeOperation(
 	targets []RuntimeCancelTarget,
 	confirmed []RuntimeCancelTarget,
 ) (storesqlite.RuntimeOperation, error) {
+	return h.completeCancelRuntimeOperationWithOutcomes(
+		ctx,
+		operation,
+		owner,
+		runtimeCancelTargetOutcomes(targets, confirmed),
+		len(confirmed) > 0,
+	)
+}
+
+func (h *Host) completeCancelRuntimeOperationWithOutcomes(
+	ctx context.Context,
+	operation storesqlite.RuntimeOperation,
+	owner string,
+	outcomes []storesqlite.CancelRuntimeOperationTargetOutcome,
+	providerConfirmed bool,
+) (storesqlite.RuntimeOperation, error) {
 	completion, _, err := h.operations.CompleteCancelRuntimeOperation(ctx, storesqlite.CompleteCancelRuntimeOperationInput{
 		WorkspaceID: operation.WorkspaceID, OperationID: operation.OperationID, LeaseOwner: owner,
-		TargetOutcomes: runtimeCancelTargetOutcomes(runtimeOperationPayloadText(operation.Payload, "rootAgentSessionId"), targets, confirmed),
+		TargetOutcomes: outcomes,
 		NowUnixMS:      h.now().UnixMilli(),
 	})
 	if err != nil {
 		return operation, err
 	}
 	completion.Operation.Payload = cloneMap(completion.Operation.Payload)
-	completion.Operation.Payload["providerConfirmed"] = len(confirmed) > 0
+	completion.Operation.Payload["providerConfirmed"] = providerConfirmed
 	if err := h.publishRuntimeOperationEvents(ctx, operation.WorkspaceID); err != nil {
 		logRuntimeOperationFailure(completion.Operation, fmt.Errorf("publish completed cancel runtime operation: %w", err))
 	}
@@ -589,21 +636,34 @@ func (h *Host) completeInterruptedCancelRuntimeOperation(
 	return completion.Operation, nil
 }
 
-func runtimeCancelTargetOutcomes(rootAgentSessionID string, targets, confirmed []RuntimeCancelTarget) []storesqlite.CancelRuntimeOperationTargetOutcome {
+func runtimeCancelTargetOutcomes(targets, confirmed []RuntimeCancelTarget) []storesqlite.CancelRuntimeOperationTargetOutcome {
 	confirmedSet := make(map[string]struct{}, len(confirmed))
 	for _, target := range confirmed {
 		confirmedSet[runtimeCancelTargetKey(target)] = struct{}{}
 	}
-	rootAgentSessionID = strings.TrimSpace(rootAgentSessionID)
 	result := make([]storesqlite.CancelRuntimeOperationTargetOutcome, 0, len(targets))
 	for _, target := range targets {
 		outcome := storesqlite.TurnOutcomeInterrupted
-		if strings.TrimSpace(target.AgentSessionID) == rootAgentSessionID {
-			outcome = storesqlite.TurnOutcomeCanceled
-		} else if _, ok := confirmedSet[runtimeCancelTargetKey(target)]; ok {
+		if _, ok := confirmedSet[runtimeCancelTargetKey(target)]; ok {
 			outcome = storesqlite.TurnOutcomeCanceled
 		}
 		result = append(result, storesqlite.CancelRuntimeOperationTargetOutcome{AgentSessionID: strings.TrimSpace(target.AgentSessionID), TurnID: strings.TrimSpace(target.TurnID), Outcome: outcome})
+	}
+	return result
+}
+
+func runtimeCancelTargetUnknownOutcomes(targets []RuntimeCancelTarget) []storesqlite.CancelRuntimeOperationTargetOutcome {
+	const errorCode = "execution_status_unknown"
+	const errorMessage = "provider final status was unavailable after the provider turn state was lost"
+	result := make([]storesqlite.CancelRuntimeOperationTargetOutcome, 0, len(targets))
+	for _, target := range targets {
+		result = append(result, storesqlite.CancelRuntimeOperationTargetOutcome{
+			AgentSessionID: strings.TrimSpace(target.AgentSessionID),
+			TurnID:         strings.TrimSpace(target.TurnID),
+			Outcome:        storesqlite.TurnOutcomeFailed,
+			ErrorCode:      errorCode,
+			ErrorMessage:   errorMessage,
+		})
 	}
 	return result
 }

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -549,10 +549,11 @@ type RuntimeCancelTarget struct {
 }
 
 type RuntimeCancelResult struct {
-	AgentSessionID   string
-	Canceled         bool
-	TargetAbsent     bool
-	ConfirmedTargets []RuntimeCancelTarget
+	AgentSessionID    string
+	Canceled          bool
+	TargetAbsent      bool
+	ProviderStateLost bool
+	ConfirmedTargets  []RuntimeCancelTarget
 }
 
 type RuntimeCloseInput struct {

--- a/packages/agent/store-sqlite/runtime_operation_completion.go
+++ b/packages/agent/store-sqlite/runtime_operation_completion.go
@@ -85,9 +85,14 @@ func (s *Store) CompleteCancelRuntimeOperation(ctx context.Context, input Comple
 					return "", "", nil, ErrRuntimeOperationSubjectState
 				}
 				outcome := turn.Outcome
+				errorMessage := turn.ErrorMessage
+				errorCode := turn.ErrorCode
 				settledByCompletion := turn.Phase != TurnPhaseSettled
 				if settledByCompletion {
-					outcome = requestedOutcomes[cancelTargetKey(target.AgentSessionID, target.TurnID)]
+					requested := requestedOutcomes[cancelTargetKey(target.AgentSessionID, target.TurnID)]
+					outcome = requested.Outcome
+					errorMessage = requested.ErrorMessage
+					errorCode = requested.ErrorCode
 					var activeTurnID sql.NullString
 					if err := tx.QueryRowContext(ctx, `
 SELECT active_turn_id FROM workspace_agent_sessions
@@ -100,9 +105,9 @@ WHERE workspace_id = ? AND agent_session_id = ?
 					}
 					if _, err := tx.ExecContext(ctx, `
 UPDATE workspace_agent_turns
-SET phase = ?, outcome = ?, settled_at_unix_ms = ?, updated_at_unix_ms = ?
+SET phase = ?, outcome = ?, error_json = ?, settled_at_unix_ms = ?, updated_at_unix_ms = ?
 WHERE workspace_id = ? AND agent_session_id = ? AND turn_id = ? AND phase != ?
-`, TurnPhaseSettled, outcome, input.NowUnixMS, input.NowUnixMS,
+	`, TurnPhaseSettled, outcome, encodeTurnErrorJSON(errorMessage, errorCode), input.NowUnixMS, input.NowUnixMS,
 						op.WorkspaceID, target.AgentSessionID, target.TurnID, TurnPhaseSettled); err != nil {
 						return "", "", nil, fmt.Errorf("settle cancel runtime operation target: %w", err)
 					}
@@ -114,6 +119,8 @@ WHERE workspace_id = ? AND agent_session_id = ? AND active_turn_id = ?
 					}
 					turn.Phase = TurnPhaseSettled
 					turn.Outcome = outcome
+					turn.ErrorMessage = errorMessage
+					turn.ErrorCode = errorCode
 					turn.SettledAtUnixMS = input.NowUnixMS
 					turn.UpdatedAtUnixMS = input.NowUnixMS
 					if !rootTargeted {
@@ -128,6 +135,9 @@ WHERE workspace_id = ? AND agent_session_id = ? AND active_turn_id = ?
 				}
 				if target.AgentSessionID == op.AgentSessionID && target.TurnID == op.TurnID && outcome == TurnOutcomeCanceled {
 					result = RuntimeOperationResultCanceled
+				}
+				if target.AgentSessionID == op.AgentSessionID && target.TurnID == op.TurnID && outcome == TurnOutcomeFailed {
+					result = RuntimeOperationResultFailed
 				}
 				if outcome == TurnOutcomeCanceled {
 					if _, err := tx.ExecContext(ctx, `
@@ -154,6 +164,12 @@ WHERE workspace_id = ? AND agent_session_id = ? AND turn_id = ? AND status = ?
 					"turnId":         target.TurnID,
 					"outcome":        outcome,
 				}
+				if errorCode != "" {
+					eventTarget["errorCode"] = errorCode
+				}
+				if errorMessage != "" {
+					eventTarget["errorMessage"] = errorMessage
+				}
 				eventTargets = append(eventTargets, eventTarget)
 				if settledByCompletion {
 					settledTargets = append(settledTargets, eventTarget)
@@ -177,7 +193,7 @@ WHERE workspace_id = ? AND agent_session_id = ? AND turn_id = ? AND status = ?
 func cancelTargetOutcomeMap(
 	targets []runtimeCancelTarget,
 	values []CancelRuntimeOperationTargetOutcome,
-) (map[string]string, error) {
+) (map[string]CancelRuntimeOperationTargetOutcome, error) {
 	if len(values) != len(targets) {
 		return nil, errors.New("cancel completion outcomes must cover every target")
 	}
@@ -185,11 +201,13 @@ func cancelTargetOutcomeMap(
 	for _, target := range targets {
 		allowed[cancelTargetKey(target.AgentSessionID, target.TurnID)] = struct{}{}
 	}
-	result := make(map[string]string, len(values))
+	result := make(map[string]CancelRuntimeOperationTargetOutcome, len(values))
 	for _, value := range values {
 		value.AgentSessionID = strings.TrimSpace(value.AgentSessionID)
 		value.TurnID = strings.TrimSpace(value.TurnID)
 		value.Outcome = strings.TrimSpace(value.Outcome)
+		value.ErrorMessage = strings.TrimSpace(value.ErrorMessage)
+		value.ErrorCode = strings.TrimSpace(value.ErrorCode)
 		key := cancelTargetKey(value.AgentSessionID, value.TurnID)
 		if _, ok := allowed[key]; !ok {
 			return nil, errors.New("cancel completion outcome does not match an operation target")
@@ -197,10 +215,10 @@ func cancelTargetOutcomeMap(
 		if _, duplicate := result[key]; duplicate {
 			return nil, errors.New("cancel completion outcomes must be unique")
 		}
-		if value.Outcome != TurnOutcomeCanceled && value.Outcome != TurnOutcomeInterrupted {
-			return nil, errors.New("cancel completion outcome must be canceled or interrupted")
+		if value.Outcome != TurnOutcomeCanceled && value.Outcome != TurnOutcomeInterrupted && value.Outcome != TurnOutcomeFailed {
+			return nil, errors.New("cancel completion outcome must be canceled, interrupted, or failed")
 		}
-		result[key] = value.Outcome
+		result[key] = value
 	}
 	return result, nil
 }

--- a/packages/agent/store-sqlite/runtime_operation_types.go
+++ b/packages/agent/store-sqlite/runtime_operation_types.go
@@ -138,6 +138,8 @@ type CancelRuntimeOperationTargetOutcome struct {
 	AgentSessionID string
 	TurnID         string
 	Outcome        string
+	ErrorMessage   string
+	ErrorCode      string
 }
 
 type CompletePlanDecisionRuntimeOperationInput struct {


### PR DESCRIPTION
## Summary

- Preserve typed `provider_state_lost` from the Claude sidecar through daemon and Host.
- Fail closed with `failed` / `execution_status_unknown` when canonical terminal evidence is unavailable.
- Persist structured cancellation failure details and add regression coverage.

## Tests

- `pnpm push:checked` — blocked by unrelated `services/tuttid` test timeouts.
- Agent-focused Go, Sidecar, boundary, formatting, and TSH dependency checks passed.

## Notes

- TSH was not changed because it consumes published Tutti modules; it should be upgraded after this Tutti change is released.
- No manual Activity Center UI reproduction was run.
