### PR TITLE
fix(agent): prepare Tutti Agent auth home before login

### DIFF
--- a/docs/architecture/tutti-agent-readiness-bootstrap.md
+++ b/docs/architecture/tutti-agent-readiness-bootstrap.md
@@ -98,6 +98,14 @@ Desktop account auth and provider auth are related but distinct:
 - the daemon exchanges that session for a `tutti_llm` token bundle;
 - `tutti-agent login --with-tutti-llm-tokens` writes the provider auth marker.
 
+Before launching the login command, the daemon creates the canonical provider
+auth home when it is missing, then sets `TUTTI_AGENT_HOME` to that existing
+directory and clears an inherited `CODEX_HOME`. This ordering is required
+because Tutti Agent accepts an absent default home but requires an explicitly
+configured home to exist before configuration loading. Auth-home creation logs
+only the structured action and reason; login failures may include bounded CLI
+diagnostics after access and refresh tokens are redacted.
+
 The daemon wires account lifecycle callbacks at startup:
 
 ```text
@@ -187,6 +195,8 @@ The durable test surface covers:
   reconciliation, shared refresh-lock serialization, and explicit logout
   cleanup and revocation;
 - desktop routing of Tutti Agent login actions to the account service.
+- canonical auth-home preparation before an explicitly scoped login command,
+  including Windows and POSIX path handling and token-redacted diagnostics.
 
 Related documents:
 

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -709,6 +709,37 @@ file or directory`. A failed `codex app-server` probe is diagnostic evidence,
   [service.go](../../../services/tuttid/service/tuttiagent/service.go)
   [tutti-agent-readiness-bootstrap.md](../../architecture/tutti-agent-readiness-bootstrap.md)
 
+### Tutti Agent stays on login while the desktop account is signed in
+
+- Symptom:
+  The desktop account avatar is present, but Tutti Agent remains
+  `auth_required`. Repeated bootstrap attempts log
+  `stage=login`, while the Account service successfully issues and then
+  compensates the short-lived LLM token.
+- Root cause:
+  Desktop Account auth and provider auth are separate. The daemon scopes the
+  provider login subprocess to the canonical user `TUTTI_AGENT_HOME`. Tutti
+  Agent requires an explicitly configured home to exist during configuration
+  loading, even though its later credential writer can create the default home.
+  Passing a missing explicit directory therefore used to fail before the
+  writer ran.
+- Fix:
+  Create the canonical provider auth home before launching
+  `tutti-agent login --with-tutti-llm-tokens`. Keep the explicit environment
+  override so session-scoped homes cannot capture durable user credentials.
+  Log auth-home creation without the local path, and include only bounded,
+  access-token- and refresh-token-redacted CLI diagnostics on login failure.
+- Validation:
+  Run the `service/tuttiagent` tests covering
+  `RunTuttiAgentTokenLoginPreparesCanonicalAuthHomeBeforeLaunch`,
+  `PrepareTuttiAgentAuthHomeRejectsFile`, and
+  `SanitizeTuttiAgentLoginOutputRedactsTokensAndTruncates`. Confirm a clean user
+  home gains `.tutti-agent/auth.json`, provider status changes from
+  `auth_required` to `ready`, and no token value appears in daemon logs.
+- References:
+  [service.go](../../../services/tuttid/service/tuttiagent/service.go)
+  [tutti-agent-readiness-bootstrap.md](../../architecture/tutti-agent-readiness-bootstrap.md)
+
 ### Agent sandbox cannot reach local daemon
 
 - Symptom:

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -19,6 +19,7 @@ Provider discovery, installation, authentication, models, configuration, and run
 - [Tutti Agent npm install misses the platform package](./agent-provider-setup.md#tutti-agent-npm-install-misses-the-platform-package)
 - [Managed npm install fails before reaching every registry](./agent-provider-setup.md#managed-npm-install-fails-before-reaching-every-registry)
 - [Tutti Agent unexpectedly loses login after a host auth read failure](./agent-provider-setup.md#tutti-agent-unexpectedly-loses-login-after-a-host-auth-read-failure)
+- [Tutti Agent stays on login while the desktop account is signed in](./agent-provider-setup.md#tutti-agent-stays-on-login-while-the-desktop-account-is-signed-in)
 - [Agent sandbox cannot reach local daemon](./agent-provider-setup.md#agent-sandbox-cannot-reach-local-daemon)
 - [Codex provider install fails with missing npm](./agent-provider-setup.md#codex-provider-install-fails-with-missing-npm)
 - [Codex ACP warns about user-level config as project-local config](./agent-provider-setup.md#codex-acp-warns-about-user-level-config-as-project-local-config)

--- a/services/tuttid/service/tuttiagent/service.go
+++ b/services/tuttid/service/tuttiagent/service.go
@@ -181,6 +181,9 @@ func bootstrapTuttiAgentUserAuth(ctx context.Context, input runtimeprep.PrepareI
 		if stage := tuttiAgentAuthFailureStage(err); stage != "" {
 			logArgs = append(logArgs, "stage", stage)
 		}
+		if detail := tuttiAgentAuthFailureDetail(err); detail != "" {
+			logArgs = append(logArgs, "detail", detail)
+		}
 		slog.Warn("tutti-agent auth reconcile failed", logArgs...)
 		if tuttiAgentLLMTokenIssueRejectedWithCode(err, http.StatusUnauthorized) {
 			slog.Info("tutti-agent auth retained after token issue rejection",
@@ -395,6 +398,14 @@ func tuttiAgentAuthFailureStage(err error) string {
 	return strings.TrimSpace(stageErr.Stage)
 }
 
+func tuttiAgentAuthFailureDetail(err error) string {
+	var stageErr tuttiagentauth.StageError
+	if !errors.As(err, &stageErr) || strings.TrimSpace(stageErr.Stage) != "login" || stageErr.Err == nil {
+		return ""
+	}
+	return truncateTuttiAgentDiagnostic(strings.TrimSpace(stageErr.Err.Error()), 2048)
+}
+
 func issueTuttiAgentLLMToken(ctx context.Context, cookie string) (tuttiAgentLLMTokenBundle, error) {
 	requestBody, err := json.Marshal(map[string]any{
 		"requested_app_id": tuttiAgentLLMAppID(),
@@ -526,14 +537,68 @@ func runTuttiAgentTokenLogin(ctx context.Context, binaryPath string, bundle tutt
 		// the same canonical user auth file inspected by the reconciler; leaving
 		// either override in place can make a successful login invisible to the
 		// verifier (or write the bundle into another session home).
+		created, prepareErr := prepareTuttiAgentAuthHome(authPath)
+		if prepareErr != nil {
+			return prepareErr
+		}
+		if created {
+			slog.Info("tutti-agent auth home prepared",
+				"event", "tutti_agent.auth_home.prepared",
+				"action", "create",
+				"reason", "missing_directory",
+			)
+		}
 		cmd.Env = tuttiAgentLoginEnvironment(os.Environ(), authPath)
 	}
 	cmd.Stdin = bytes.NewReader(stdin)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("tutti-agent login failed: %w: %s", err, strings.TrimSpace(string(output)))
+		detail := sanitizeTuttiAgentLoginOutput(string(output), bundle)
+		if detail == "" {
+			return fmt.Errorf("tutti-agent login failed: %w", err)
+		}
+		return fmt.Errorf("tutti-agent login failed: %w: %s", err, detail)
 	}
 	return nil
+}
+
+func prepareTuttiAgentAuthHome(authPath string) (bool, error) {
+	authHome := filepath.Dir(filepath.Clean(authPath))
+	info, err := os.Stat(authHome)
+	if err == nil {
+		if !info.IsDir() {
+			return false, fmt.Errorf("prepare tutti-agent auth home: %s is not a directory", authHome)
+		}
+		return false, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return false, fmt.Errorf("inspect tutti-agent auth home: %w", err)
+	}
+	if err := os.MkdirAll(authHome, 0o700); err != nil {
+		return false, fmt.Errorf("prepare tutti-agent auth home: %w", err)
+	}
+	return true, nil
+}
+
+func sanitizeTuttiAgentLoginOutput(output string, bundle tuttiAgentLLMTokenBundle) string {
+	detail := strings.TrimSpace(output)
+	for _, secret := range []string{bundle.AccessToken, bundle.RefreshToken} {
+		if secret = strings.TrimSpace(secret); secret != "" {
+			detail = strings.ReplaceAll(detail, secret, "[REDACTED]")
+		}
+	}
+	return truncateTuttiAgentDiagnostic(detail, 2048)
+}
+
+func truncateTuttiAgentDiagnostic(value string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	runes := []rune(value)
+	if len(runes) <= limit {
+		return value
+	}
+	return string(runes[:limit]) + "…"
 }
 
 func tuttiAgentLoginEnvironment(base []string, authPath string) []string {

--- a/services/tuttid/service/tuttiagent/service_test.go
+++ b/services/tuttid/service/tuttiagent/service_test.go
@@ -111,6 +111,61 @@ func TestTuttiAgentLoginEnvironmentUsesCanonicalAuthHome(t *testing.T) {
 	}
 }
 
+func TestRunTuttiAgentTokenLoginPreparesCanonicalAuthHomeBeforeLaunch(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	authHome := filepath.Join(home, ".tutti-agent")
+
+	err := runTuttiAgentTokenLogin(
+		t.Context(),
+		filepath.Join(t.TempDir(), "missing-tutti-agent"),
+		tuttiAgentLLMTokenBundle{},
+	)
+	if err == nil {
+		t.Fatal("runTuttiAgentTokenLogin() succeeded with a missing binary")
+	}
+	info, statErr := os.Stat(authHome)
+	if statErr != nil {
+		t.Fatalf("stat prepared auth home: %v", statErr)
+	}
+	if !info.IsDir() {
+		t.Fatalf("prepared auth home mode = %v, want directory", info.Mode())
+	}
+}
+
+func TestPrepareTuttiAgentAuthHomeRejectsFile(t *testing.T) {
+	authHome := filepath.Join(t.TempDir(), ".tutti-agent")
+	if err := os.WriteFile(authHome, []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := prepareTuttiAgentAuthHome(filepath.Join(authHome, "auth.json"))
+	if err == nil || !strings.Contains(err.Error(), "is not a directory") {
+		t.Fatalf("prepareTuttiAgentAuthHome() error = %v, want not-a-directory detail", err)
+	}
+}
+
+func TestSanitizeTuttiAgentLoginOutputRedactsTokensAndTruncates(t *testing.T) {
+	bundle := tuttiAgentLLMTokenBundle{
+		AccessToken:  "access-secret",
+		RefreshToken: "refresh-secret",
+	}
+	detail := sanitizeTuttiAgentLoginOutput(
+		"login failed access-secret refresh-secret "+strings.Repeat("x", 2100),
+		bundle,
+	)
+	if strings.Contains(detail, "access-secret") || strings.Contains(detail, "refresh-secret") {
+		t.Fatalf("sanitizeTuttiAgentLoginOutput() leaked a token: %q", detail)
+	}
+	if !strings.Contains(detail, "[REDACTED]") {
+		t.Fatalf("sanitizeTuttiAgentLoginOutput() = %q, want redaction marker", detail)
+	}
+	if !strings.HasSuffix(detail, "…") {
+		t.Fatalf("sanitizeTuttiAgentLoginOutput() was not truncated: %q", detail)
+	}
+}
+
 func TestTuttiAgentUserAuthReadyRejectsExpiredAccessToken(t *testing.T) {
 	expiresAt := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
 	writeTuttiAgentUserAuth(t, t.TempDir(), `{"tutti_llm":{"access_token":"lat_test","access_token_expires_at":`+strconv.Quote(expiresAt)+`,"refresh_token":"lrt_test"}}`)


### PR DESCRIPTION
## Summary
- create the canonical Tutti Agent auth home before setting the explicit login environment
- add bounded token-redacted login failure diagnostics and structured auth-home creation logs
- add cross-platform regression coverage and durable troubleshooting documentation

## Validation
- go test ./services/tuttid/service/tuttiagent
- go test ./packages/agent/daemon/tuttiagentauth ./services/tuttid/service/tuttiagent
- Windows amd64 test binary cross-compile
- pnpm check:changed
- pnpm lint:go
- pnpm build:go

## Windows impact
The change uses filepath, os.Stat, and os.MkdirAll without OS-specific literals. The focused tests compile into the Windows amd64 test binary; POSIX tests executed locally.