### PR TITLE
docs(readme): add Windows desktop download

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Anyone interested is welcome to join our [Discord](https://discord.gg/UUemKEWtw6
 
 [Download Tutti · Local for macOS](https://tutti.sh/desktop/download?platform=macos&arch=universal&format=dmg)
 
-Windows support is coming soon.
+[Download Tutti · Local for Windows (x64)](https://tutti.sh/desktop/download?platform=windows&arch=x64&format=exe)
 
 <!-- TODO: waitlist link for Tutti · VM -->
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,7 +31,7 @@
 
 [下载 Tutti · Local macOS 版](https://tutti.sh/desktop/download?platform=macos&arch=universal&format=dmg)
 
-Windows 版本即将推出。
+[下载 Tutti · Local Windows x64 版](https://tutti.sh/desktop/download?platform=windows&arch=x64&format=exe)
 
 <!-- TODO: Tutti · VM waitlist 链接 -->
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -31,7 +31,7 @@
 
 [下載 Tutti · Local macOS 版](https://tutti.sh/desktop/download?platform=macos&arch=universal&format=dmg)
 
-Windows 版本即將推出。
+[下載 Tutti · Local Windows x64 版](https://tutti.sh/desktop/download?platform=windows&arch=x64&format=exe)
 
 <!-- TODO: Tutti · VM 等候名單連結 -->
 


### PR DESCRIPTION
## Summary

- replace the Windows coming-soon copy with the public Windows x64 EXE download
- keep English, Simplified Chinese, and Traditional Chinese READMEs aligned

## Validation

- pnpm check:changed
- download endpoint redirects to the v0.2.30 Windows x64 EXE and returns HTTP 200

## Windows impact

Documentation-only. This exposes the existing Windows x64 installer URL and does not change packaging or runtime behavior.