### PR TITLE
fix(agent): backport managed auth runtime to release/0818

### DIFF
--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -24,7 +24,8 @@ Use the focused runtime index or open one area directly:
   failures behind an empty `end_turn`.
   Also covers focus-driven provider CLI scans, repeated Extension Target version
   probes, optional Provider absence misclassified as an environment failure,
-  extension release refresh delaying daemon startup, and CPU spikes.
+  extension release refresh delaying daemon startup, Tutti Agent browser login
+  that loses the managed Node environment, and CPU spikes.
 - [Agent Sessions And Lifecycle](./agent-session-lifecycle.md): Turn state, activation, planning-mode classification, capability snapshots, Tutti workflow response contracts, loading, cancel, goal controls, restore, file-change undo, rail projection, realtime completion provenance, event updates, imports, and performance.
   Includes shared-device recovery that looks terminal while the host is still retrying.
   Also covers new or derived conversations that silently fail or lose

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -4,6 +4,47 @@
 
 Provider discovery, installation, authentication, models, configuration, and runtime reachability.
 
+### Tutti Agent browser login succeeds but the desktop remains on the login screen
+
+- Symptom:
+  Tutti account state is already visible in the desktop header and the browser
+  login flow returns successfully, but the Tutti Agent surface does not react.
+  Daemon logs show the token issue request succeeding, followed by
+  `tutti-agent login --with-tutti-llm-tokens` failing because `node` cannot be
+  found.
+- Quick checks:
+  Compare the auth subprocess logs with the provider command resolution. A
+  packaged npm launcher commonly starts with `#!/usr/bin/env node`; therefore
+  finding the launcher binary is not enough. Check the resolved auth-command
+  event for `managed_node_configured=true` and `managed_node_on_path=true`, then
+  correlate it with the login process start and completion events. Never print
+  token payloads while diagnosing this path.
+- Root cause:
+  Tutti Agent sessions, status probes, and model discovery resolve the provider
+  command through Tutti's managed-runtime resolver, which adds the bundled Node
+  directory to the child environment. The dedicated auth bootstrap previously
+  reused only a binary path and launched it with the daemon's ambient
+  environment. On machines without a compatible system Node, `/usr/bin/env`
+  could not execute the npm launcher even though the Rust program behind that
+  launcher and the browser login itself were healthy.
+- Fix:
+  Resolve the provider command and full managed-runtime environment at each
+  auth entrypoint, then pass that same environment to the login subprocess.
+  Keep the canonical Tutti Agent auth-home overrides authoritative. Do not
+  special-case a guessed Node path or copy only `TUTTI_APP_NODE`: npm launchers
+  consume `PATH`, and the shared resolver owns its construction.
+- Validation:
+  Remove system Node from `PATH`, retain only Tutti's managed Node in the
+  provider resolution, and execute an npm-style `/usr/bin/env node` launcher.
+  Verify browser callback, model discovery, and session preparation all create
+  ready auth material and leave the UI. Repeat provider command/environment
+  resolution tests on Windows; on macOS/Linux retain an executable shebang
+  integration test.
+- References:
+  [auth_bootstrapper.go](../../../services/tuttid/service/tuttiagent/auth_bootstrapper.go)
+  [service.go](../../../services/tuttid/service/tuttiagent/service.go)
+  [wiring_daemon_api.go](../../../services/tuttid/wiring_daemon_api.go)
+
 ### Hermes is ready but a new Windows session reports Agent failed to start
 
 - Symptom:

--- a/services/tuttid/agent_replay_composition.go
+++ b/services/tuttid/agent_replay_composition.go
@@ -257,8 +257,9 @@ func configureReplayAwareTuttiAgentReadiness(
 	account *accountservice.Service,
 	status *agentstatusservice.Service,
 	targets agenttargetservice.Service,
+	bootstrapAuth func(context.Context),
 ) *tuttiagentservice.ReadinessCoordinator {
-	readiness := tuttiagentservice.NewReadinessCoordinator(status, targets)
+	readiness := tuttiagentservice.NewReadinessCoordinator(status, targets, bootstrapAuth)
 	if replay {
 		return readiness
 	}

--- a/services/tuttid/service/agent/model_catalog.go
+++ b/services/tuttid/service/agent/model_catalog.go
@@ -169,7 +169,11 @@ func agentModelCatalogSpecFromDescriptor(descriptor providerregistry.ProviderDes
 				if c.TuttiAgent != nil {
 					return c.TuttiAgent
 				}
-				lister := defaultTuttiAgentModelLister(descriptor.Identity.ID, c.ProviderCommands)
+				lister := defaultTuttiAgentModelLister(
+					descriptor.Identity.ID,
+					c.ProviderCommands,
+					c.TuttiAgentAuthBootstrap,
+				)
 				lister.Session = c.codexSession(descriptor.Identity.ID, lister)
 				return lister
 			},
@@ -185,12 +189,13 @@ func agentModelCatalogSpecFromDescriptor(descriptor providerregistry.ProviderDes
 }
 
 type CachedAgentModelCatalog struct {
-	Codex             AgentModelLister
-	TuttiAgent        AgentModelLister
-	OpenCode          AgentModelLister
-	ModelCapabilities ModelCapabilitiesResolver
-	ProviderCommands  ProviderCommandResolver
-	Now               func() time.Time
+	Codex                   AgentModelLister
+	TuttiAgent              AgentModelLister
+	OpenCode                AgentModelLister
+	ModelCapabilities       ModelCapabilitiesResolver
+	ProviderCommands        ProviderCommandResolver
+	TuttiAgentAuthBootstrap func(context.Context)
+	Now                     func() time.Time
 	// PersistentPath is configured by the daemon composition root. Keeping the
 	// path injectable leaves unit tests in-memory and avoids coupling them to a
 	// developer's real provider cache.
@@ -509,21 +514,33 @@ func specCachesModelCatalog(spec agentModelCatalogSpec) bool {
 	return spec.ttl > 0 || spec.errTTL > 0 || spec.fallbackTTL > 0
 }
 
-func defaultTuttiAgentModelLister(provider string, providerCommands ProviderCommandResolver) CodexCLIModelLister {
+func defaultTuttiAgentModelLister(
+	provider string,
+	providerCommands ProviderCommandResolver,
+	bootstrapAuth func(context.Context),
+) CodexCLIModelLister {
 	return CodexCLIModelLister{
 		Command:          "tutti-agent",
 		ClientName:       "tutti_agent",
 		Provider:         provider,
 		ProviderCommands: providerCommands,
-		PrepareEnv:       prepareTuttiAgentModelListEnv,
+		PrepareEnv: func(ctx context.Context, env []string) ([]string, error) {
+			return prepareTuttiAgentModelListEnv(ctx, env, bootstrapAuth)
+		},
 	}
 }
 
-func prepareTuttiAgentModelListEnv(ctx context.Context, env []string) ([]string, error) {
+func prepareTuttiAgentModelListEnv(
+	ctx context.Context,
+	env []string,
+	bootstrapAuth func(context.Context),
+) ([]string, error) {
 	env = append([]string(nil), env...)
 	env = withoutEnvKeys(env, "TUTTI_AGENT_HOME", "CODEX_HOME")
 	tuttiAgentHome := filepath.Join(tuttitypes.DefaultStateDir(), "agent-model-catalog", "tutti-agent-home")
-	tuttiagentservice.BootstrapTuttiAgentUserAuth(ctx)
+	if bootstrapAuth != nil {
+		bootstrapAuth(ctx)
+	}
 	if err := refreshTuttiAgentModelCatalogAuth(tuttiAgentHome); err != nil {
 		return nil, err
 	}

--- a/services/tuttid/service/agent/model_catalog_test.go
+++ b/services/tuttid/service/agent/model_catalog_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gofrs/flock"
 	agentstatusservice "github.com/tutti-os/tutti/services/tuttid/service/agentstatus"
+	tuttiagentservice "github.com/tutti-os/tutti/services/tuttid/service/tuttiagent"
 )
 
 func writeCodexModelCatalogConfig(t *testing.T, contents string) {
@@ -445,7 +446,11 @@ func TestDefaultTuttiAgentModelListerUsesTuttiHomeAndClearsCodexHome(t *testing.
 		t.Fatal(err)
 	}
 
-	lister := defaultTuttiAgentModelLister("tutti-agent", nil)
+	lister := defaultTuttiAgentModelLister(
+		"tutti-agent",
+		nil,
+		nil,
+	)
 	env, err := lister.PrepareEnv(t.Context(), []string{
 		"TUTTI_AGENT_HOME=" + filepath.Join(home, "ignored-agent-home"),
 		"CODEX_HOME=" + filepath.Join(home, "codex-home"),
@@ -549,7 +554,11 @@ func TestDefaultTuttiAgentModelListerBootstrapsExpiredTuttiAgentAuth(t *testing.
 	t.Setenv("TUTTI_AGENT_LOGIN_CAPTURE", capturePath)
 	installFakeTuttiAgentModelListBinary(t)
 
-	lister := defaultTuttiAgentModelLister("tutti-agent", nil)
+	lister := defaultTuttiAgentModelLister(
+		"tutti-agent",
+		nil,
+		tuttiagentservice.BootstrapTuttiAgentUserAuth,
+	)
 	if _, err := lister.PrepareEnv(t.Context(), nil); err != nil {
 		t.Fatalf("PrepareEnv() error = %v", err)
 	}
@@ -593,7 +602,7 @@ func TestPrepareTuttiAgentModelListEnvRefreshesStaleCatalogAuth(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := prepareTuttiAgentModelListEnv(t.Context(), nil); err != nil {
+	if _, err := prepareTuttiAgentModelListEnv(t.Context(), nil, nil); err != nil {
 		t.Fatalf("prepareTuttiAgentModelListEnv() error = %v", err)
 	}
 	got, err := os.ReadFile(filepath.Join(catalogHome, "auth.json"))
@@ -657,7 +666,7 @@ done
 			Env:     []string{"PATH=" + nodeBinDir + string(os.PathListSeparator) + binDir},
 		},
 	}
-	lister := defaultTuttiAgentModelLister("tutti-agent", resolver)
+	lister := defaultTuttiAgentModelLister("tutti-agent", resolver, nil)
 	lister.Environ = func() []string {
 		// The daemon environment deliberately finds the npm launcher but not
 		// Node. The provider resolver must inject Tutti's managed Node runtime.
@@ -711,7 +720,11 @@ func TestPrepareTuttiAgentModelListEnvHonorsCancellationWhileAuthLocked(t *testi
 	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer cancel()
 	startedAt := time.Now()
-	if _, err := prepareTuttiAgentModelListEnv(ctx, nil); err != nil {
+	if _, err := prepareTuttiAgentModelListEnv(
+		ctx,
+		nil,
+		tuttiagentservice.BootstrapTuttiAgentUserAuth,
+	); err != nil {
 		t.Fatalf("prepareTuttiAgentModelListEnv() error = %v", err)
 	}
 	if !errors.Is(ctx.Err(), context.DeadlineExceeded) {

--- a/services/tuttid/service/tuttiagent/auth_bootstrapper.go
+++ b/services/tuttid/service/tuttiagent/auth_bootstrapper.go
@@ -1,0 +1,84 @@
+package tuttiagent
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+
+	"github.com/tutti-os/tutti/packages/agent/daemon/runtimecmd"
+	runtimeprep "github.com/tutti-os/tutti/packages/agent/runtimeprep"
+	agentstatusservice "github.com/tutti-os/tutti/services/tuttid/service/agentstatus"
+)
+
+type ProviderCommandResolver interface {
+	ResolveProviderCommand(context.Context, string) (agentstatusservice.ProviderCommandResolution, error)
+}
+
+// AuthBootstrapper keeps every Tutti Agent auth entrypoint on the same
+// provider command and managed-runtime environment used by sessions, status
+// probes, and model discovery.
+type AuthBootstrapper struct {
+	ProviderCommands ProviderCommandResolver
+	ResolveEnv       func([]string) []string
+	ResolveCommand   func(string, []string) string
+}
+
+func NewAuthBootstrapper(providerCommands ProviderCommandResolver) *AuthBootstrapper {
+	resolver := runtimecmd.Resolver{}
+	return &AuthBootstrapper{
+		ProviderCommands: providerCommands,
+		ResolveEnv:       resolver.Env,
+		ResolveCommand:   resolver.Resolve,
+	}
+}
+
+func (b *AuthBootstrapper) Bootstrap(ctx context.Context, input runtimeprep.PrepareInput) {
+	command, err := b.resolveLoginCommand(ctx)
+	if err != nil {
+		slog.Warn("tutti-agent auth command resolution failed",
+			"event", "tutti_agent.auth_command.resolve_failed",
+			"error", err,
+		)
+		return
+	}
+	slog.Info("tutti-agent auth command resolved",
+		"event", "tutti_agent.auth_command.resolved",
+		"binary", command.BinaryPath,
+		"managed_node_configured", tuttiAgentEnvironmentValue(command.Env, "TUTTI_APP_NODE") != "",
+		"managed_node_on_path", environmentPathContainsFileDir(command.Env, tuttiAgentEnvironmentValue(command.Env, "TUTTI_APP_NODE")),
+	)
+	bootstrapTuttiAgentUserAuth(ctx, input, command)
+}
+
+func (b *AuthBootstrapper) resolveLoginCommand(ctx context.Context) (tuttiAgentLoginCommand, error) {
+	if b == nil || b.ProviderCommands == nil {
+		return tuttiAgentLoginCommand{}, errors.New("provider command resolver is unavailable")
+	}
+	resolution, err := b.ProviderCommands.ResolveProviderCommand(ctx, tuttiAgentProvider)
+	if err != nil {
+		return tuttiAgentLoginCommand{}, err
+	}
+	if len(resolution.Command) == 0 || strings.TrimSpace(resolution.Command[0]) == "" {
+		return tuttiAgentLoginCommand{}, errors.New("resolved provider command is empty")
+	}
+	resolveEnv := b.ResolveEnv
+	if resolveEnv == nil {
+		resolver := runtimecmd.Resolver{}
+		resolveEnv = resolver.Env
+	}
+	env := resolveEnv(resolution.Env)
+	resolveCommand := b.ResolveCommand
+	if resolveCommand == nil {
+		resolver := runtimecmd.Resolver{}
+		resolveCommand = resolver.Resolve
+	}
+	return tuttiAgentLoginCommand{
+		BinaryPath: resolveCommand(resolution.Command[0], env),
+		Env:        env,
+	}, nil
+}
+
+func (b *AuthBootstrapper) BootstrapUserAuth(ctx context.Context) {
+	b.Bootstrap(ctx, runtimeprep.PrepareInput{})
+}

--- a/services/tuttid/service/tuttiagent/auth_bootstrapper_posix_test.go
+++ b/services/tuttid/service/tuttiagent/auth_bootstrapper_posix_test.go
@@ -1,0 +1,91 @@
+//go:build !windows
+
+package tuttiagent
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tutti-os/tutti/packages/agent/daemon/runtimecmd"
+	runtimeprep "github.com/tutti-os/tutti/packages/agent/runtimeprep"
+	agentstatusservice "github.com/tutti-os/tutti/services/tuttid/service/agentstatus"
+)
+
+type authProviderCommandResolverStub struct {
+	resolution agentstatusservice.ProviderCommandResolution
+	provider   string
+}
+
+func (s *authProviderCommandResolverStub) ResolveProviderCommand(
+	_ context.Context,
+	provider string,
+) (agentstatusservice.ProviderCommandResolution, error) {
+	s.provider = provider
+	return s.resolution, nil
+}
+
+func TestAuthBootstrapperUsesManagedNodeEnvironmentForNPMLauncher(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("PATH", filepath.Join(t.TempDir(), "path-without-node"))
+	writeHostAccountAuth(t, "session_id=session_test")
+
+	account := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != tuttiAgentLLMTokenIssueRoute {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(validTuttiAgentTokenPayload(t, []string{"llm:models", "llm:chat"})))
+	}))
+	defer account.Close()
+	t.Setenv("TUTTI_ACCOUNT_BASE_URL", account.URL)
+
+	nodeBinDir := filepath.Join(t.TempDir(), "managed-node", "bin")
+	if err := os.MkdirAll(nodeBinDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nodePath := filepath.Join(nodeBinDir, "node")
+	nodeScript := "#!/bin/sh\n" +
+		"shift\n" +
+		"if [ \"$1\" != \"login\" ] || [ \"$2\" != \"--with-tutti-llm-tokens\" ]; then exit 2; fi\n" +
+		"/bin/cat >/dev/null\n" +
+		"/bin/mkdir -p \"$TUTTI_AGENT_HOME\"\n" +
+		"printf '%s' '{\"tutti_llm\":{\"access_token\":\"lat_new\",\"access_token_expires_at\":4102444800,\"refresh_token\":\"lrt_new\"}}' > \"$TUTTI_AGENT_HOME/auth.json\"\n"
+	if err := os.WriteFile(nodePath, []byte(nodeScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	launcher := filepath.Join(nodeBinDir, "tutti-agent")
+	if err := os.WriteFile(launcher, []byte("#!/usr/bin/env node\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	providerCommands := &authProviderCommandResolverStub{
+		resolution: agentstatusservice.ProviderCommandResolution{
+			Command: []string{"tutti-agent", "app-server"},
+			Env: []string{
+				"PATH=" + nodeBinDir,
+				"TUTTI_APP_NODE=" + nodePath,
+			},
+		},
+	}
+	resolver := runtimecmd.Resolver{}
+	bootstrapper := &AuthBootstrapper{
+		ProviderCommands: providerCommands,
+		ResolveEnv:       resolver.Env,
+	}
+
+	bootstrapper.Bootstrap(t.Context(), runtimeprep.PrepareInput{})
+
+	if providerCommands.provider != tuttiAgentProvider {
+		t.Fatalf("resolved provider = %q, want %q", providerCommands.provider, tuttiAgentProvider)
+	}
+	if !tuttiAgentUserAuthMaterialReady() {
+		t.Fatal("managed Node launcher did not materialize ready Tutti Agent auth")
+	}
+}

--- a/services/tuttid/service/tuttiagent/auth_bootstrapper_test.go
+++ b/services/tuttid/service/tuttiagent/auth_bootstrapper_test.go
@@ -1,0 +1,61 @@
+package tuttiagent
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	agentstatusservice "github.com/tutti-os/tutti/services/tuttid/service/agentstatus"
+)
+
+type authCommandResolverStub struct {
+	resolution agentstatusservice.ProviderCommandResolution
+}
+
+func (s authCommandResolverStub) ResolveProviderCommand(
+	context.Context,
+	string,
+) (agentstatusservice.ProviderCommandResolution, error) {
+	return s.resolution, nil
+}
+
+func TestAuthBootstrapperResolvesProviderCommandEnvironment(t *testing.T) {
+	providerEnv := []string{"PATH=provider-path", "TUTTI_APP_NODE=managed-node"}
+	wantEnv := []string{"PATH=resolved-path", "TUTTI_APP_NODE=managed-node", "BASE=value"}
+	var receivedOverrides []string
+	bootstrapper := &AuthBootstrapper{
+		ProviderCommands: authCommandResolverStub{
+			resolution: agentstatusservice.ProviderCommandResolution{
+				Command: []string{"provider-launcher", "app-server"},
+				Env:     providerEnv,
+			},
+		},
+		ResolveEnv: func(overrides []string) []string {
+			receivedOverrides = append([]string(nil), overrides...)
+			return append([]string(nil), wantEnv...)
+		},
+		ResolveCommand: func(command string, env []string) string {
+			if command != "provider-launcher" {
+				t.Fatalf("command to resolve = %q, want provider-launcher", command)
+			}
+			if !reflect.DeepEqual(env, wantEnv) {
+				t.Fatalf("command resolution environment = %v, want %v", env, wantEnv)
+			}
+			return "resolved-provider-launcher"
+		},
+	}
+
+	command, err := bootstrapper.resolveLoginCommand(t.Context())
+	if err != nil {
+		t.Fatalf("resolveLoginCommand() error = %v", err)
+	}
+	if command.BinaryPath != "resolved-provider-launcher" {
+		t.Fatalf("binary = %q, want resolved-provider-launcher", command.BinaryPath)
+	}
+	if !reflect.DeepEqual(receivedOverrides, providerEnv) {
+		t.Fatalf("environment overrides = %v, want %v", receivedOverrides, providerEnv)
+	}
+	if !reflect.DeepEqual(command.Env, wantEnv) {
+		t.Fatalf("resolved environment = %v, want %v", command.Env, wantEnv)
+	}
+}

--- a/services/tuttid/service/tuttiagent/auth_file_symlink_test.go
+++ b/services/tuttid/service/tuttiagent/auth_file_symlink_test.go
@@ -121,7 +121,10 @@ func TestBootstrapRestoresRemovedAuthSymlinkAfterLoginFailure(t *testing.T) {
 	writeHostAccountAuth(t, "session_id=session_test")
 	binaryPath := writeTuttiAgentTestBinary(t, "exit 9\n")
 
-	bootstrapTuttiAgentUserAuth(t.Context(), runtimeprep.PrepareInput{}, binaryPath)
+	bootstrapTuttiAgentUserAuth(t.Context(), runtimeprep.PrepareInput{}, tuttiAgentLoginCommand{
+		BinaryPath: binaryPath,
+		Env:        os.Environ(),
+	})
 
 	info, err := os.Lstat(link)
 	if err != nil || info.Mode()&os.ModeSymlink == 0 {

--- a/services/tuttid/service/tuttiagent/readiness.go
+++ b/services/tuttid/service/tuttiagent/readiness.go
@@ -28,16 +28,20 @@ type TargetService interface {
 type ReadinessCoordinator struct {
 	Runtime       RuntimeService
 	Targets       TargetService
-	BootstrapAuth func(context.Context, string)
+	BootstrapAuth func(context.Context)
 
 	mu sync.Mutex
 }
 
-func NewReadinessCoordinator(runtime RuntimeService, targets TargetService) *ReadinessCoordinator {
+func NewReadinessCoordinator(
+	runtime RuntimeService,
+	targets TargetService,
+	bootstrapAuth func(context.Context),
+) *ReadinessCoordinator {
 	return &ReadinessCoordinator{
 		Runtime:       runtime,
 		Targets:       targets,
-		BootstrapAuth: BootstrapTuttiAgentUserAuthWithBinary,
+		BootstrapAuth: bootstrapAuth,
 	}
 }
 
@@ -90,7 +94,6 @@ func (c *ReadinessCoordinator) Reconcile(ctx context.Context) error {
 	if !ok {
 		return errors.New("tutti-agent provider status is missing")
 	}
-	binaryPath := status.CLI.BinaryPath
 	if !tuttiAgentRuntimeReady(status.Availability.Status) {
 		if status.ActiveAction != nil &&
 			status.ActiveAction.ID == agentstatusservice.ActionInstall &&
@@ -121,7 +124,6 @@ func (c *ReadinessCoordinator) Reconcile(ctx context.Context) error {
 				result.Message,
 			)
 		}
-		binaryPath = result.Probe.BinaryPath
 	}
 
 	enabled, err := c.targetEnabled(ctx)
@@ -131,7 +133,7 @@ func (c *ReadinessCoordinator) Reconcile(ctx context.Context) error {
 	if !enabled || c.BootstrapAuth == nil {
 		return nil
 	}
-	c.BootstrapAuth(ctx, binaryPath)
+	c.BootstrapAuth(ctx)
 	return nil
 }
 

--- a/services/tuttid/service/tuttiagent/readiness_test.go
+++ b/services/tuttid/service/tuttiagent/readiness_test.go
@@ -43,7 +43,7 @@ func TestReadinessCoordinatorInstallsRuntimeWhenTargetDisabled(t *testing.T) {
 	coordinator := ReadinessCoordinator{
 		Runtime: runtime,
 		Targets: readinessTargetsStub{enabled: false},
-		BootstrapAuth: func(context.Context, string) {
+		BootstrapAuth: func(context.Context) {
 			authCalls.Add(1)
 		},
 	}
@@ -65,10 +65,7 @@ func TestReadinessCoordinatorAuthenticatesAfterRuntimeInstallWhenTargetEnabled(t
 	coordinator := ReadinessCoordinator{
 		Runtime: runtime,
 		Targets: readinessTargetsStub{enabled: true},
-		BootstrapAuth: func(_ context.Context, binaryPath string) {
-			if binaryPath != "/managed/bin/tutti-agent" {
-				t.Errorf("binary path = %q, want managed probe path", binaryPath)
-			}
+		BootstrapAuth: func(context.Context) {
 			authCalls.Add(1)
 		},
 	}
@@ -94,7 +91,7 @@ func TestReadinessCoordinatorSkipsInstallForReadyRuntimeButStillAuthenticates(t 
 	coordinator := ReadinessCoordinator{
 		Runtime: runtime,
 		Targets: readinessTargetsStub{enabled: true},
-		BootstrapAuth: func(context.Context, string) {
+		BootstrapAuth: func(context.Context) {
 			authCalls.Add(1)
 		},
 	}
@@ -121,10 +118,7 @@ func TestReadinessCoordinatorTreatsAuthRequiredAsInstalledRuntime(t *testing.T) 
 	coordinator := ReadinessCoordinator{
 		Runtime: runtime,
 		Targets: readinessTargetsStub{enabled: true},
-		BootstrapAuth: func(_ context.Context, binaryPath string) {
-			if binaryPath != "/managed/bin/tutti-agent" {
-				t.Errorf("binary path = %q, want managed status path", binaryPath)
-			}
+		BootstrapAuth: func(context.Context) {
 			authCalls.Add(1)
 		},
 	}
@@ -147,7 +141,7 @@ func TestReadinessCoordinatorWaitsForExistingInstallAction(t *testing.T) {
 	coordinator := ReadinessCoordinator{
 		Runtime: runtime,
 		Targets: readinessTargetsStub{enabled: true},
-		BootstrapAuth: func(context.Context, string) {
+		BootstrapAuth: func(context.Context) {
 			authCalls.Add(1)
 		},
 	}

--- a/services/tuttid/service/tuttiagent/service.go
+++ b/services/tuttid/service/tuttiagent/service.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -42,13 +43,16 @@ const (
 
 // NewPreparer returns the shared runtime preparer with Tutti account bootstrap
 // and the daemon-owned stable Skill bundle store injected at the product boundary.
-func NewPreparer(stateDir string) runtimeprep.TuttiAgentPreparer {
+func NewPreparer(
+	stateDir string,
+	bootstrap func(context.Context, runtimeprep.PrepareInput),
+) runtimeprep.TuttiAgentPreparer {
 	stableRoot := filepath.Join(
 		filepath.Clean(strings.TrimSpace(stateDir)),
 		"agent",
 	)
 	return runtimeprep.TuttiAgentPreparer{
-		BeforePrepare: bootstrapTuttiAgentUserAuthForPrepare,
+		BeforePrepare: bootstrap,
 		AuthProjector: runtimeprep.MutagenAuthFileProjector{StateDir: stateDir},
 		StableSkillBundleRoot: filepath.Join(
 			stableRoot,
@@ -82,13 +86,16 @@ func tuttiAgentAccountBase() string {
 // failures leave the session in the auth-required state that the provider
 // status service already reports.
 func BootstrapTuttiAgentUserAuth(ctx context.Context) {
-	bootstrapTuttiAgentUserAuth(ctx, runtimeprep.PrepareInput{}, "")
+	bootstrapTuttiAgentUserAuth(ctx, runtimeprep.PrepareInput{}, tuttiAgentLoginCommand{})
 }
 
 // BootstrapTuttiAgentUserAuthWithBinary reconciles auth with the exact managed
 // runtime that passed provider readiness probing.
 func BootstrapTuttiAgentUserAuthWithBinary(ctx context.Context, binaryPath string) {
-	bootstrapTuttiAgentUserAuth(ctx, runtimeprep.PrepareInput{}, binaryPath)
+	bootstrapTuttiAgentUserAuth(ctx, runtimeprep.PrepareInput{}, tuttiAgentLoginCommand{
+		BinaryPath: binaryPath,
+		Env:        os.Environ(),
+	})
 }
 
 // LogoutTuttiAgentUserAuth removes the local auth marker synchronously so
@@ -132,13 +139,11 @@ func logoutTuttiAgentUserAuth(ctx context.Context) error {
 	return unlockErr
 }
 
-// bootstrapTuttiAgentUserAuth is the provider-prepare variant that preserves
-// runtime prepare trace context when a real Tutti Agent session is starting.
-func bootstrapTuttiAgentUserAuthForPrepare(ctx context.Context, input runtimeprep.PrepareInput) {
-	bootstrapTuttiAgentUserAuth(ctx, input, "")
-}
-
-func bootstrapTuttiAgentUserAuth(ctx context.Context, input runtimeprep.PrepareInput, binaryPath string) {
+func bootstrapTuttiAgentUserAuth(
+	ctx context.Context,
+	input runtimeprep.PrepareInput,
+	command tuttiAgentLoginCommand,
+) {
 	cookie, state := tuttiAgentAccountSessionCookie()
 	if state != tuttiAgentAccountSessionPresent {
 		reason := "host_auth_absent"
@@ -170,7 +175,7 @@ func bootstrapTuttiAgentUserAuth(ctx context.Context, input runtimeprep.PrepareI
 		ctx,
 		tuttiAgentSessionAuthorizer{cookie: cookie},
 		tuttiAgentUserCredentialStore{},
-		tuttiAgentLoginRunner{BinaryPath: binaryPath},
+		tuttiAgentLoginRunner{Command: command},
 		time.Now().UTC(),
 	)
 	if err != nil {
@@ -369,11 +374,11 @@ func (tuttiAgentUserCredentialStore) Remove(context.Context) error {
 }
 
 type tuttiAgentLoginRunner struct {
-	BinaryPath string
+	Command tuttiAgentLoginCommand
 }
 
 func (r tuttiAgentLoginRunner) Login(ctx context.Context, bundle tuttiagentauth.TokenBundle) error {
-	return runTuttiAgentTokenLogin(ctx, r.BinaryPath, bundle)
+	return runTuttiAgentTokenLogin(ctx, r.Command, bundle)
 }
 
 type tuttiAgentLLMTokenIssueRejectedError struct {
@@ -515,8 +520,13 @@ func revokeTuttiAgentLLMToken(ctx context.Context, accountBaseURL string, refres
 	return nil
 }
 
-func runTuttiAgentTokenLogin(ctx context.Context, binaryPath string, bundle tuttiAgentLLMTokenBundle) error {
-	binary := strings.TrimSpace(binaryPath)
+type tuttiAgentLoginCommand struct {
+	BinaryPath string
+	Env        []string
+}
+
+func runTuttiAgentTokenLogin(ctx context.Context, command tuttiAgentLoginCommand, bundle tuttiAgentLLMTokenBundle) error {
+	binary := strings.TrimSpace(command.BinaryPath)
 	if binary == "" {
 		var err error
 		binary, err = resolveTuttiAgentBinary()
@@ -531,6 +541,10 @@ func runTuttiAgentTokenLogin(ctx context.Context, binaryPath string, bundle tutt
 	loginCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(loginCtx, binary, "login", "--with-tutti-llm-tokens")
+	baseEnv := command.Env
+	if len(baseEnv) == 0 {
+		baseEnv = os.Environ()
+	}
 	if authPath, ok := userTuttiAgentAuthPath(); ok {
 		// The daemon may inherit TUTTI_AGENT_HOME/CODEX_HOME from a parent
 		// process or an earlier provider session.  The login command must write
@@ -548,17 +562,36 @@ func runTuttiAgentTokenLogin(ctx context.Context, binaryPath string, bundle tutt
 				"reason", "missing_directory",
 			)
 		}
-		cmd.Env = tuttiAgentLoginEnvironment(os.Environ(), authPath)
+		cmd.Env = tuttiAgentLoginEnvironment(baseEnv, authPath)
 	}
+	startedAt := time.Now()
+	slog.Info("tutti-agent auth login process started",
+		"event", "tutti_agent.auth_login.process_started",
+		"binary", binary,
+		"managed_node_configured", tuttiAgentEnvironmentValue(cmd.Env, "TUTTI_APP_NODE") != "",
+		"managed_node_on_path", environmentPathContainsFileDir(cmd.Env, tuttiAgentEnvironmentValue(cmd.Env, "TUTTI_APP_NODE")),
+	)
 	cmd.Stdin = bytes.NewReader(stdin)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		detail := sanitizeTuttiAgentLoginOutput(string(output), bundle)
+		slog.Warn("tutti-agent auth login process failed",
+			"event", "tutti_agent.auth_login.process_failed",
+			"binary", binary,
+			"duration_ms", time.Since(startedAt).Milliseconds(),
+			"error", err,
+			"detail", detail,
+		)
 		if detail == "" {
 			return fmt.Errorf("tutti-agent login failed: %w", err)
 		}
 		return fmt.Errorf("tutti-agent login failed: %w: %s", err, detail)
 	}
+	slog.Info("tutti-agent auth login process completed",
+		"event", "tutti_agent.auth_login.process_completed",
+		"binary", binary,
+		"duration_ms", time.Since(startedAt).Milliseconds(),
+	)
 	return nil
 }
 
@@ -626,6 +659,38 @@ func replaceEnvironmentValue(env []string, key, value string) []string {
 		result = append(result, prefix+value)
 	}
 	return result
+}
+
+func environmentPathContainsFileDir(env []string, filePath string) bool {
+	dir := filepath.Dir(strings.TrimSpace(filePath))
+	if filePath == "" || dir == "." {
+		return false
+	}
+	for _, candidate := range filepath.SplitList(tuttiAgentEnvironmentValue(env, "PATH")) {
+		if samePath(candidate, dir) {
+			return true
+		}
+	}
+	return false
+}
+
+func tuttiAgentEnvironmentValue(env []string, key string) string {
+	for index := len(env) - 1; index >= 0; index-- {
+		candidateKey, value, ok := strings.Cut(env[index], "=")
+		if ok && strings.EqualFold(candidateKey, key) {
+			return value
+		}
+	}
+	return ""
+}
+
+func samePath(left, right string) bool {
+	left = filepath.Clean(strings.TrimSpace(left))
+	right = filepath.Clean(strings.TrimSpace(right))
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(left, right)
+	}
+	return left == right
 }
 
 func resolveTuttiAgentBinary() (string, error) {

--- a/services/tuttid/service/tuttiagent/service_test.go
+++ b/services/tuttid/service/tuttiagent/service_test.go
@@ -119,7 +119,7 @@ func TestRunTuttiAgentTokenLoginPreparesCanonicalAuthHomeBeforeLaunch(t *testing
 
 	err := runTuttiAgentTokenLogin(
 		t.Context(),
-		filepath.Join(t.TempDir(), "missing-tutti-agent"),
+		tuttiAgentLoginCommand{BinaryPath: filepath.Join(t.TempDir(), "missing-tutti-agent")},
 		tuttiAgentLLMTokenBundle{},
 	)
 	if err == nil {
@@ -238,7 +238,7 @@ func TestBootstrapTuttiAgentUserAuthIssuesTokenWhenExistingAccessTokenExpired(t 
 	t.Setenv("TUTTI_AGENT_LOGIN_CAPTURE", capturePath)
 	installFakeTuttiAgentBinary(t)
 
-	bootstrapTuttiAgentUserAuth(t.Context(), runtimeprep.PrepareInput{}, "")
+	bootstrapTuttiAgentUserAuth(t.Context(), runtimeprep.PrepareInput{}, tuttiAgentLoginCommand{})
 
 	select {
 	case <-issueRequests:
@@ -279,7 +279,7 @@ func TestBootstrapTuttiAgentUserAuthRetainsAuthWithoutHostSession(t *testing.T) 
 	)
 	t.Setenv("TUTTI_STATE_DIR", t.TempDir())
 
-	bootstrapTuttiAgentUserAuth(t.Context(), runtimeprep.PrepareInput{}, "")
+	bootstrapTuttiAgentUserAuth(t.Context(), runtimeprep.PrepareInput{}, tuttiAgentLoginCommand{})
 
 	authPath := filepath.Join(home, ".tutti-agent", "auth.json")
 	assertTuttiAgentAuthUnchanged(t, authPath, []byte(`{"tutti_llm":{"account_base_url":`+strconv.Quote(account.URL)+`,"access_token":"lat_old","access_token_expires_at":`+strconv.Quote(expiresAt)+`,"refresh_token":"lrt_old"}}`))
@@ -312,7 +312,7 @@ func TestBootstrapTuttiAgentUserAuthRetainsAuthWhenHostAuthIsInvalidJSON(t *test
 	}
 	t.Setenv("TUTTI_STATE_DIR", stateDir)
 
-	bootstrapTuttiAgentUserAuth(t.Context(), runtimeprep.PrepareInput{}, "")
+	bootstrapTuttiAgentUserAuth(t.Context(), runtimeprep.PrepareInput{}, tuttiAgentLoginCommand{})
 
 	authPath := filepath.Join(home, ".tutti-agent", "auth.json")
 	assertTuttiAgentAuthUnchanged(t, authPath, []byte(authJSON))
@@ -345,7 +345,7 @@ func TestBootstrapTuttiAgentUserAuthRetainsAuthWhenHostAuthIsUnreadable(t *testi
 	}
 	t.Setenv("TUTTI_STATE_DIR", stateDir)
 
-	bootstrapTuttiAgentUserAuth(t.Context(), runtimeprep.PrepareInput{}, "")
+	bootstrapTuttiAgentUserAuth(t.Context(), runtimeprep.PrepareInput{}, tuttiAgentLoginCommand{})
 
 	authPath := filepath.Join(home, ".tutti-agent", "auth.json")
 	assertTuttiAgentAuthUnchanged(t, authPath, []byte(authJSON))
@@ -387,7 +387,7 @@ func TestBootstrapTuttiAgentUserAuthRetainsAuthAfterUnauthorizedTokenIssue(t *te
 	authJSON := `{"tutti_llm":{"account_base_url":` + strconv.Quote(account.URL) + `,"access_token":"lat_old","access_token_expires_at":` + strconv.Quote(expiredAt) + `,"refresh_token":"lrt_old"}}`
 	writeTuttiAgentUserAuth(t, home, authJSON)
 
-	bootstrapTuttiAgentUserAuth(t.Context(), runtimeprep.PrepareInput{}, "")
+	bootstrapTuttiAgentUserAuth(t.Context(), runtimeprep.PrepareInput{}, tuttiAgentLoginCommand{})
 
 	authPath := filepath.Join(home, ".tutti-agent", "auth.json")
 	assertTuttiAgentAuthUnchanged(t, authPath, []byte(authJSON))
@@ -443,7 +443,10 @@ func TestBootstrapTuttiAgentUserAuthRestoresPreviousAuthAfterReconcileFailures(t
 			writeHostAccountAuth(t, "session_id=session_test")
 			binaryPath := writeTuttiAgentTestBinary(t, test.loginScript)
 
-			bootstrapTuttiAgentUserAuth(t.Context(), runtimeprep.PrepareInput{}, binaryPath)
+			bootstrapTuttiAgentUserAuth(t.Context(), runtimeprep.PrepareInput{}, tuttiAgentLoginCommand{
+				BinaryPath: binaryPath,
+				Env:        os.Environ(),
+			})
 
 			assertTuttiAgentAuthUnchanged(t, filepath.Join(home, ".tutti-agent", "auth.json"), oldAuth)
 		})
@@ -479,7 +482,7 @@ func TestBootstrapTuttiAgentUserAuthWaitsForAgentRefreshLock(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		bootstrapTuttiAgentUserAuth(ctx, runtimeprep.PrepareInput{}, "")
+		bootstrapTuttiAgentUserAuth(ctx, runtimeprep.PrepareInput{}, tuttiAgentLoginCommand{})
 	}()
 	select {
 	case <-done:

--- a/services/tuttid/wiring_daemon_api.go
+++ b/services/tuttid/wiring_daemon_api.go
@@ -216,6 +216,7 @@ func buildDaemonAPI(
 		CodexRuntimeSelectionStore: agentProviderRuntimeSelectionStore,
 		UserPathAdapter:            agentstatusservice.NewUserPathAdapter(),
 	})
+	tuttiAgentAuth := tuttiagentservice.NewAuthBootstrapper(&agentStatusService)
 	// Shared so a runtime auth failure (reporter side) surfaces in the status
 	// probe (List side) — see agentRunOutcomeReporter.
 	runOutcomes := agentStatusService.RunOutcomes
@@ -266,7 +267,10 @@ func buildDaemonAPI(
 	}
 	agentRuntimePreparer := runtimeprep.NewDefaultPreparer(tuttitypes.DefaultStateDir())
 	agentRuntimePreparer.RegisterProvider(runtimeprep.CodexPreparer{AuthProjector: runtimeprep.MutagenAuthFileProjector{StateDir: tuttitypes.DefaultStateDir()}})
-	agentRuntimePreparer.RegisterProvider(tuttiagentservice.NewPreparer(tuttitypes.DefaultStateDir()))
+	agentRuntimePreparer.RegisterProvider(tuttiagentservice.NewPreparer(
+		tuttitypes.DefaultStateDir(),
+		tuttiAgentAuth.Bootstrap,
+	))
 	configureAgentRuntimeAvailability(agentRuntimePreparer, browserService, computerService)
 	userProjectService := userprojectservice.Service{
 		Store:     userProjectStore,
@@ -287,6 +291,7 @@ func buildDaemonAPI(
 	)
 	agentModelCatalog.ModelCapabilities = agentModelCapabilities
 	agentModelCatalog.ProviderCommands = &agentStatusService
+	agentModelCatalog.TuttiAgentAuthBootstrap = tuttiAgentAuth.BootstrapUserAuth
 	agentSessionPurgeStore, ok := agentActivityRepo.(agenthost.SessionPurgeStore)
 	if !ok {
 		return tuttiapi.DaemonAPI{}, nil, nil, nil, fmt.Errorf("agent session purge store is unavailable")
@@ -778,6 +783,7 @@ func buildDaemonAPI(
 	terminalService := workspaceservice.NewTerminalService(workspaceservice.NewPlatformTerminalProcessFactory())
 	tuttiAgentReadiness := configureReplayAwareTuttiAgentReadiness(
 		replayComposition, accountService, &agentStatusService, agentTargets,
+		tuttiAgentAuth.BootstrapUserAuth,
 	)
 
 	providerAuthWatcher := startAgentModelInvalidationAuthWatcher(


### PR DESCRIPTION
Backports #2624 to `release/0818`.

This preserves the provider command environment, including Tutti-managed Node, across Tutti Agent auth bootstrap, readiness, model discovery, and session preparation. The backport adapts the model-catalog wiring to the older release branch layout without carrying unrelated main-branch refactors.

Validation:
- `go test ./services/tuttid/service/tuttiagent ./services/tuttid/service/agent`: passed as part of the focused run.
- Focused run total: 1196 passed, 1 failed, 2 skipped.
- The single failing top-level test, `TestAgentRuntimeAdapterReturnsClaudeSDKModelConfigOptions`, fails identically on the untouched `origin/release/0818` baseline and is unrelated to this backport.
- PR #2624 macOS fresh-install E2E: https://github.com/tutti-os/tutti/actions/runs/33052252958

Signed-off-by: jomeswang <1551403343@qq.com>