### PR TITLE
fix(desktop): confirm before closing active agent window

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebar.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -44,7 +45,10 @@ import {
   type StandaloneAgentFileOpenRequest
 } from "./StandaloneAgentToolSidebarPanel.tsx";
 import { StandaloneAgentToolLoadingState } from "./StandaloneAgentToolLoadingState.tsx";
-import { createStandaloneAgentToolHostGroup } from "./standaloneAgentToolWorkbench.ts";
+import {
+  attachStandaloneAgentWindowCloseGuard,
+  createStandaloneAgentToolHostGroup
+} from "./standaloneAgentToolWorkbench.ts";
 import { createStandaloneAgentTerminalLoginPresenter } from "../services/standaloneAgentTerminalLoginPresenter.ts";
 import { registerWorkspaceBrowserLaunchHandler } from "../services/workspaceBrowserLaunchCoordinator.ts";
 import { useExternalStoreValue } from "./useExternalStoreValue.ts";
@@ -60,6 +64,7 @@ export type { StandaloneAgentFileOpenRequest } from "./StandaloneAgentToolSideba
 const browserControllerReadyTimeoutMs = 8_000;
 
 interface StandaloneAgentToolSidebarProps {
+  activeAgentSessionId: string | null;
   activityService: WorkspaceAgentActivityService;
   agentSideConversationPresentation: AgentGUISideConversationPresentation;
   appOpenId?: string | null;
@@ -89,6 +94,7 @@ interface StandaloneAgentToolSidebarProps {
 }
 
 export function StandaloneAgentToolSidebar({
+  activeAgentSessionId,
   activityService,
   agentSideConversationPresentation,
   appOpenId = null,
@@ -152,6 +158,17 @@ export function StandaloneAgentToolSidebar({
   const sessionEngine = useMemo(
     () => activityService.getSessionEngine(workspaceId),
     [activityService, workspaceId]
+  );
+  useLayoutEffect(
+    () =>
+      attachStandaloneAgentWindowCloseGuard({
+        contributions,
+        getActiveAgentSessionId: () => activeAgentSessionId,
+        hostGroup: toolHostGroup,
+        title: i18n.t("workspace.agentGui.fallbackAgentLabel"),
+        workspaceId
+      }),
+    [activeAgentSessionId, contributions, i18n, toolHostGroup, workspaceId]
   );
   const messageCenterWorkingCount = useExternalStoreValue(
     sessionEngine.subscribe,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
@@ -814,6 +814,7 @@ export function StandaloneAgentWindow({
         }}
       >
         <StandaloneAgentToolSidebar
+          activeAgentSessionId={nodeState.lastActiveAgentSessionId}
           activityService={workspaceAgentActivityService}
           agentSideConversationPresentation={agentSideConversationPresentation}
           appOpenId={openAppId}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWorkbench.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWorkbench.tsx
@@ -133,7 +133,8 @@ function StandaloneAgentWindowWithToolRuntime({
       appI18n: runtime.appI18n,
       contributions: runtime.hostInput.contributions,
       onHostReady: runtime.onWorkbenchCloseGuardHostReady,
-      requestWindowClose: runtime.requestWindowClose
+      requestWindowClose: () =>
+        runtime.requestWindowClose({ reason: "native-window-close" })
     }),
     [
       runtime.appI18n,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentToolWorkbench.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentToolWorkbench.test.ts
@@ -7,6 +7,7 @@ import type {
   WorkbenchHostLaunchRequest
 } from "@tutti-os/workbench-surface";
 import {
+  attachStandaloneAgentWindowCloseGuard,
   createStandaloneAgentDirectToolHost,
   createStandaloneAgentToolHostGroup,
   createStandaloneAgentToolSnapshotRepository,
@@ -148,6 +149,53 @@ test("standalone Agent tool host group aggregates terminal close effects and rou
   group.host.closeNode("terminal-node");
   assert.deepEqual(closedNodeIds, ["terminal-node"]);
   assert.equal(group.host.getSnapshot().nodes.length, 1);
+});
+
+test("standalone Agent window close guard forwards the active session through the Agent contribution", async () => {
+  let activeAgentSessionId: string | null = "session-running";
+  const group = createStandaloneAgentToolHostGroup();
+  const contribution: WorkbenchContribution = {
+    id: "workspace-agent-gui",
+    nodes: [
+      {
+        frame: { height: 500, width: 800, x: 0, y: 0 },
+        getWindowCloseEffect: ({ externalNodeState, node }) =>
+          (externalNodeState as { lastActiveAgentSessionId?: string | null })
+            .lastActiveAgentSessionId === "session-running"
+            ? {
+                nodeId: node.id,
+                title: node.title,
+                typeId: node.data.typeId
+              }
+            : null,
+        renderBody: () => null,
+        title: "Agent",
+        typeId: "agent-gui"
+      }
+    ]
+  };
+
+  const dispose = attachStandaloneAgentWindowCloseGuard({
+    contributions: [contribution],
+    getActiveAgentSessionId: () => activeAgentSessionId,
+    hostGroup: group,
+    title: "Agent",
+    workspaceId: "workspace-1"
+  });
+
+  assert.deepEqual(await group.host.collectWindowCloseEffects(), [
+    {
+      nodeId: "standalone-agent-window-node",
+      title: "Agent",
+      typeId: "agent-gui"
+    }
+  ]);
+
+  activeAgentSessionId = null;
+  assert.deepEqual(await group.host.collectWindowCloseEffects(), []);
+
+  dispose();
+  assert.deepEqual(await group.host.collectWindowCloseEffects(), []);
 });
 
 test("standalone Agent direct terminal host exposes the mounted session to close guards", async () => {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentToolWorkbench.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentToolWorkbench.ts
@@ -1,4 +1,5 @@
 import type { AgentToolPanelId } from "@tutti-os/agent-gui/workbench/tool-sidebar";
+import { agentGuiWorkbenchTypeId } from "@tutti-os/agent-gui/workbench/launch";
 import type {
   WorkbenchContribution,
   WorkbenchHostHandle,
@@ -64,6 +65,59 @@ export function createStandaloneAgentToolSnapshotRepository(): WorkbenchHostSnap
 export interface StandaloneAgentToolHostGroup {
   readonly host: WorkbenchHostHandle;
   setHost(instanceId: string, host: WorkbenchHostHandle | null): void;
+}
+
+const standaloneAgentWindowCloseGuardHostId = "standalone-agent-window";
+const standaloneAgentWindowNodeId = "standalone-agent-window-node";
+
+export function attachStandaloneAgentWindowCloseGuard(input: {
+  contributions: readonly WorkbenchContribution[] | undefined;
+  getActiveAgentSessionId(): string | null | undefined;
+  hostGroup: StandaloneAgentToolHostGroup;
+  title: string;
+  workspaceId: string;
+}): () => void {
+  const nodeDefinition = input.contributions
+    ?.flatMap((contribution) => contribution.nodes ?? [])
+    .find((node) => node.typeId === agentGuiWorkbenchTypeId);
+  if (!nodeDefinition?.getWindowCloseEffect) {
+    return () => undefined;
+  }
+
+  const directHost = createStandaloneAgentDirectToolHost();
+  directHost.setNode({
+    instanceId: standaloneAgentWindowNodeId,
+    nodeId: standaloneAgentWindowNodeId,
+    resolveCloseEffect: async () => {
+      const node = directHost.host.getSnapshot().nodes[0];
+      if (!node) {
+        return null;
+      }
+      return (
+        (await nodeDefinition.getWindowCloseEffect?.({
+          externalNodeState: {
+            lastActiveAgentSessionId: input.getActiveAgentSessionId()
+          },
+          externalWorkspaceState: null,
+          instanceId: standaloneAgentWindowNodeId,
+          instanceKey: standaloneAgentWindowNodeId,
+          node,
+          workspaceId: input.workspaceId
+        })) ?? null
+      );
+    },
+    title: input.title,
+    typeId: agentGuiWorkbenchTypeId
+  });
+  input.hostGroup.setHost(
+    standaloneAgentWindowCloseGuardHostId,
+    directHost.host
+  );
+
+  return () => {
+    input.hostGroup.setHost(standaloneAgentWindowCloseGuardHostId, null);
+    directHost.host.dispose();
+  };
 }
 
 export interface StandaloneAgentDirectToolHost {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceWorkbenchShellRuntime.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceWorkbenchShellRuntime.tsx
@@ -121,7 +121,9 @@ export interface WorkspaceWorkbenchShellRuntime {
   ) => void;
   onWorkbenchHostHandleReady: (host: WorkbenchHostHandle | null) => void;
   onWorkbenchCloseGuardHostReady: (host: WorkbenchHostHandle | null) => void;
-  requestWindowClose: () => Promise<"approved" | "blocked">;
+  requestWindowClose: (input?: {
+    reason: "native-window-close" | "quit" | "window-close";
+  }) => Promise<"approved" | "blocked">;
   setDockEntryRetained: (entryId: string, retained: boolean) => Promise<void>;
   selectWallpaper: (wallpaperId: WorkspaceWallpaperId) => void;
   selectWallpaperDisplayMode: (
@@ -555,7 +557,8 @@ export function useWorkspaceWorkbenchShellRuntime({
       shellRuntimeController.missionControl.setAdapter,
     onWorkbenchHostHandleReady: handleWorkbenchHostReady,
     onWorkbenchCloseGuardHostReady: handleWorkbenchCloseGuardHostReady,
-    requestWindowClose: () => shellRuntimeController.requestWindowClose(),
+    requestWindowClose: (input) =>
+      shellRuntimeController.requestWindowClose(input),
     setDockEntryRetained,
     selectWallpaper: shellRuntimeController.wallpaperSelection.selectWallpaper,
     selectWallpaperDisplayMode:

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2919,6 +2919,13 @@ AgentGUI, Message Center, dock/header, workspace window, and standalone Agent wi
 
 Opening a panel/window creates presentation state only. It does not clone a Session, copy engine entities, or start another event stream. Standalone tools are Desktop chrome, not AgentGUI lifecycle.
 
+Closing a standalone Agent window must participate in the same Workbench close
+effect contract as an embedded Agent node. The standalone Desktop adapter
+projects the selected Agent session into the canonical Agent contribution's
+`getWindowCloseEffect` resolver and aggregates that effect with its tool hosts;
+it must not implement a second status check or bypass the close guard through a
+generic node-close request.
+
 Workbench previews must not mount a second AgentGUI tree. Genie capture prefers
 the host-provided native image and clones the visible node DOM into a texture
 only after native capture fails or exceeds its bounded wait. Electron hosts


### PR DESCRIPTION
## 修复内容

- 修复 Agent 运行期间点击独立 Agent 窗口右上角关闭按钮时不显示二次确认的问题
- 让独立 Agent 窗口复用现有 Workbench 关闭拦截契约，正确识别当前活跃会话
- 补充关闭行为回归测试及架构说明

## 验证

- 已完成独立窗口运行中关闭场景的实机验证
- pnpm check:changed -- --push-ready 通过（12 个检查）

## 范围

本 PR 仅包含上述关闭确认修复，不包含开发启动生成文件或其他未请求改动
