### PR TITLE
fix(agent): classify Claude account balance failures

### DIFF
--- a/packages/agent/daemon/runtime/provider_failure.go
+++ b/packages/agent/daemon/runtime/provider_failure.go
@@ -78,7 +78,13 @@ func claudeProviderFailure(payload map[string]any) ProviderFailure {
 	}
 	switch providerCode {
 	case "authentication_failed":
-		failure.Code, failure.AuthImpact, failure.AuthReason = "auth_required", providerFailureAuthRequired, "authentication_failed"
+		// Claude's SDK also uses this code for some HTTP 403 account failures;
+		// only a real 401 (or a missing status) is an authentication gate.
+		if claudeProviderInsufficientAccountBalance(message) {
+			failure.Code = FailureCodeInsufficientCredits
+		} else if status == nil || *status == 401 {
+			failure.Code, failure.AuthImpact, failure.AuthReason = "auth_required", providerFailureAuthRequired, "authentication_failed"
+		}
 	case "oauth_org_not_allowed":
 		failure.Code = "account_not_allowed"
 	case "billing_error":
@@ -114,6 +120,10 @@ func claudeProviderFailure(payload map[string]any) ProviderFailure {
 		}
 	}
 	return failure
+}
+
+func claudeProviderInsufficientAccountBalance(message string) bool {
+	return strings.Contains(strings.ToLower(message), "insufficient account balance")
 }
 
 func failureFromACPCall(err *acpCallError) ProviderFailure {

--- a/packages/agent/daemon/runtime/provider_failure_test.go
+++ b/packages/agent/daemon/runtime/provider_failure_test.go
@@ -28,10 +28,13 @@ func TestClaudeProviderFailureClassification(t *testing.T) {
 		name       string
 		code       string
 		status     int64
+		message    string
 		wantCode   string
 		wantImpact string
 	}{
 		{name: "auth", code: "authentication_failed", status: 401, wantCode: "auth_required", wantImpact: providerFailureAuthRequired},
+		{name: "insufficient account balance", code: "authentication_failed", status: 403, message: "Failed to authenticate. API Error: 403 Insufficient account balance", wantCode: FailureCodeInsufficientCredits, wantImpact: providerFailureAuthNone},
+		{name: "forbidden authentication error", code: "authentication_failed", status: 403, message: "Failed to authenticate. API Error: 403 Forbidden", wantCode: "provider_error", wantImpact: providerFailureAuthNone},
 		{name: "org", code: "oauth_org_not_allowed", status: 403, wantCode: "account_not_allowed", wantImpact: providerFailureAuthNone},
 		{name: "specific org beats status", code: "oauth_org_not_allowed", status: 401, wantCode: "account_not_allowed", wantImpact: providerFailureAuthNone},
 		{name: "billing", code: "billing_error", status: 402, wantCode: "billing_error", wantImpact: providerFailureAuthNone},
@@ -43,7 +46,7 @@ func TestClaudeProviderFailureClassification(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			payload := map[string]any{"code": test.code, "error": "upstream detail"}
+			payload := map[string]any{"code": test.code, "error": firstNonEmptyString(test.message, "upstream detail")}
 			if test.status != 0 {
 				payload["apiErrorStatus"] = test.status
 			}


### PR DESCRIPTION
## Summary

- Classify Claude's `403 Insufficient account balance` response as `billing_error` without an authentication impact.
- Preserve `auth_required` for genuine HTTP 401 authentication failures.
- Treat other HTTP 403 responses carrying Claude's `authentication_failed` code as provider errors instead of authentication gates.
- Add regression coverage for the balance and generic forbidden cases.

## Tests

- `pre-push: pnpm check:changed -- --push-ready` (8 lanes passed)

## Notes

- The root cause is Claude's SDK using `authentication_failed` for an account-balance HTTP 403, which previously triggered the auth-required path before the status could correct it.
- The original Tutti worktree contained unrelated uncommitted changes; this PR is based on `origin/main` and excludes them.
- The TSH dependency upgrade will follow the normal Tutti release flow and is not included in this PR.
