### PR TITLE
fix(agent): restore Claude remote auth probe

### DIFF
--- a/packages/agent/daemon/providerregistry/claude_code.go
+++ b/packages/agent/daemon/providerregistry/claude_code.go
@@ -33,10 +33,18 @@ func claudeCodeDescriptor() ProviderDescriptor {
 			BinaryNames:                     []string{"claude"},
 			AuthStatusCommand:               []string{"auth", "status"},
 			AuthStatusCommandTimeoutSeconds: 600,
-			// Claude authentication is owned by the SDK/CLI auth-status and real
-			// runtime outcomes. Account usage is an optional presentation
-			// capability and must never be used as remote auth evidence.
-			RemoteAuthProbe: RemoteAuthProbeDescriptor{},
+			RemoteAuthProbe: RemoteAuthProbeDescriptor{
+				Kind:           RemoteAuthProbeKindHTTPBearer,
+				CredentialKind: RemoteAuthCredentialKindClaudeOAuth,
+				Endpoint:       "https://api.anthropic.com/api/oauth/usage",
+				Method:         "GET",
+				Headers: map[string]string{
+					"Accept":         "application/json",
+					"anthropic-beta": "oauth-2025-04-20",
+					"User-Agent":     "claude-code/2.1.0",
+				},
+				TimeoutSeconds: 10,
+			},
 			AuthMarkerPaths: []string{"~/.claude.json", "~/.claude/auth.json"},
 			APIEndpoints:    []string{"https://api.anthropic.com/v1/messages"},
 			CustomConfigEnvVars: []string{

--- a/packages/agent/daemon/providerregistry/registry_test.go
+++ b/packages/agent/daemon/providerregistry/registry_test.go
@@ -463,13 +463,19 @@ func TestMigratedClaudeCodeDescriptorIsComplete(t *testing.T) {
 		descriptor.Status.AuthStatusCommandTimeoutSeconds != 600 {
 		t.Fatalf("target/status = %#v / %#v", descriptor.Target, descriptor.Status)
 	}
-	if descriptor.Status.RemoteAuthProbe.Kind != "" ||
-		descriptor.Status.RemoteAuthProbe.CredentialKind != "" ||
-		descriptor.Status.RemoteAuthProbe.Endpoint != "" ||
-		descriptor.Status.RemoteAuthProbe.Method != "" ||
-		len(descriptor.Status.RemoteAuthProbe.Headers) != 0 ||
-		descriptor.Status.RemoteAuthProbe.TimeoutSeconds != 0 {
-		t.Fatalf("remote auth probe = %#v", descriptor.Status.RemoteAuthProbe)
+	probe := descriptor.Status.RemoteAuthProbe
+	if probe.Kind != RemoteAuthProbeKindHTTPBearer ||
+		probe.CredentialKind != RemoteAuthCredentialKindClaudeOAuth ||
+		probe.Endpoint != "https://api.anthropic.com/api/oauth/usage" ||
+		probe.Method != "GET" ||
+		probe.TimeoutSeconds != 10 ||
+		probe.Headers["Accept"] != "application/json" ||
+		probe.Headers["anthropic-beta"] != "oauth-2025-04-20" ||
+		probe.Headers["User-Agent"] != "claude-code/2.1.0" {
+		t.Fatalf("remote auth probe = %#v", probe)
+	}
+	if !descriptor.Desktop.AuthProbeAfterCredentialSync {
+		t.Fatal("Claude auth probe must run after credential synchronization")
 	}
 	if !descriptor.ComposerProfile.Behavior.ModelOptionsAuthoritative ||
 		!descriptor.ComposerProfile.Behavior.RefreshModelOptionsAfterSettings ||


### PR DESCRIPTION
## Summary
- Restore Claude OAuth remote authentication probing against the provider usage endpoint.
- Keep the existing post-credential-sync barrier so refreshed credentials trigger a fresh remote verification.

## Tests
- `pnpm check:changed -- --push-ready`
- `go test ./packages/agent/daemon/providerregistry/...`
- `go test ./services/tuttid/service/agentstatus -count=1`
- `pnpm push:checked` was attempted; its full validation hit unrelated workspace/Codex/AppRunner environment failures.

## Notes
- No TSH dependency update is included; TSH will consume this after the Tutti release and cohort upgrade.