### PR TITLE
fix(i18n): check every locale module, not the three named ones

### DIFF
--- a/tools/scripts/check-i18n.mjs
+++ b/tools/scripts/check-i18n.mjs
@@ -19,11 +19,15 @@ const ignoredDirectories = new Set([
   "node_modules",
   "out"
 ]);
-const i18nModuleManifestExportNames = [
-  "tuttiI18nModule",
-  "agentGuiI18nModule",
-  "browserNodeI18nModule"
-];
+// Manifest exports are discovered by shape, not by a script-side name registry:
+// desktop-owned resources export `tuttiI18nModule`, and a reusable package may
+// pick a package-specific name when that keeps its vocabulary product-neutral
+// (docs/conventions/static-analysis.md, "such as browserNodeI18nModule"). A
+// fixed list silently drops every package that chooses a name not on it, so any
+// `export const <name>I18nModule` counts. Non-manifest matches are discarded by
+// parseExportedObjectLiteral returning null.
+const i18nModuleManifestExportPattern =
+  /^[ \t]*export const ([A-Za-z$_][\w$]*I18nModule)\b/gm;
 const i18nManifestSearchRoots = ["apps/desktop/src/shared/i18n", "packages"];
 const localeResourceModules = discoverI18nModules();
 const sourceRoots = [
@@ -53,7 +57,11 @@ const ignoredFileSuffixes = [
   ".test.tsx",
   ".spec.ts",
   ".spec.tsx",
-  ".d.ts"
+  ".d.ts",
+  // Shared fixture builders live beside the suites they serve rather than under
+  // __tests__/, so the suffix carries the exemption the same way .test.ts does.
+  "TestHarness.ts",
+  "TestHarness.tsx"
 ];
 const textExtensions = [".ts", ".tsx", ".js", ".jsx"];
 const uiAttributeNames = ["aria-label", "title", "alt", "placeholder"];
@@ -192,6 +200,15 @@ function discoverI18nModules() {
   );
 }
 
+function findI18nModuleExportNames(source) {
+  const names = new Set();
+  for (const match of source.matchAll(i18nModuleManifestExportPattern)) {
+    names.add(match[1]);
+  }
+
+  return names;
+}
+
 function collectI18nModuleManifests(root, manifests) {
   const absoluteRoot = join(workspaceRoot, root);
   if (!existsSync(absoluteRoot)) {
@@ -214,11 +231,7 @@ function collectI18nModuleManifests(root, manifests) {
     }
 
     const source = readFileSync(absolutePath, "utf8");
-    for (const exportName of i18nModuleManifestExportNames) {
-      if (!source.includes(`export const ${exportName}`)) {
-        continue;
-      }
-
+    for (const exportName of findI18nModuleExportNames(source)) {
       const manifest = parseExportedObjectLiteral(relativePath, exportName);
       if (!manifest) {
         continue;
@@ -335,7 +348,7 @@ function parseExportedObjectLiteral(
   if (helperMatch) {
     return vm.runInNewContext(
       `${helperMatch[1]}(${helperMatch[2]})`,
-      createI18nManifestVmContext()
+      createI18nManifestVmContext(source)
     );
   }
 
@@ -407,8 +420,32 @@ function toImportSourcePath(relativePath, importSpecifier) {
   return rawPath.endsWith(".ts") ? rawPath : `${rawPath}.ts`;
 }
 
-function createI18nManifestVmContext() {
+// A manifest may name its namespace through a sibling constant
+// (`namespace: richTextI18nNamespace`) instead of repeating the literal. The
+// manifest expression is evaluated in isolation, so those constants have to be
+// carried into the context or the evaluation throws ReferenceError. Only
+// top-level double-quoted string constants are carried: enough for the
+// namespace/name fields a manifest can reference, without evaluating the
+// module.
+function collectManifestStringConstants(source) {
+  const constants = {};
+  const pattern =
+    /^[ \t]*(?:export\s+)?const\s+([A-Za-z$_][\w$]*)\s*=\s*("(?:[^"\\]|\\.)*")\s*;/gm;
+  for (const match of source.matchAll(pattern)) {
+    try {
+      constants[match[1]] = JSON.parse(match[2]);
+    } catch {
+      // Leave it undefined rather than guessing; an unresolved reference is
+      // reported as an unparseable manifest by the caller.
+    }
+  }
+
+  return constants;
+}
+
+function createI18nManifestVmContext(source = "") {
   return {
+    ...collectManifestStringConstants(source),
     createLocaleObjectI18nModuleManifest(input) {
       return {
         exportMode: "locale-object",
@@ -614,6 +651,13 @@ function inspectI18nKeyUsages(relativePath, lines) {
           continue;
         }
 
+        // `t(`status.${status}`)` names a key that only exists at runtime, so
+        // there is nothing static to resolve it against; the locale objects
+        // still cover it through their own key-parity check.
+        if (key.includes("${")) {
+          continue;
+        }
+
         if (legacyKeyPattern.test(key)) {
           keyIssues.push({
             file: relativePath,
@@ -741,9 +785,23 @@ function inspectPatternMatches(relativePath, line, lineNumber, pattern, rule) {
   }
 }
 
+function stripInterpolations(value) {
+  return value.replaceAll(/\$\{[^}]*\}/gu, "");
+}
+
 function isReportableCopy(value) {
   const normalized = normalizeWhitespace(value);
   if (!normalized || allowedHardcodedCopy.has(normalized)) {
+    return false;
+  }
+  // A template literal that is only placeholders plus punctuation composes a
+  // value at runtime (`@${label}`); its translatable text, if any, lives at
+  // whatever feeds the placeholder. Copy that still reads as prose once the
+  // placeholders are removed (`Hello ${name}, welcome`) stays reportable.
+  if (
+    normalized.includes("${") &&
+    !/\p{L}/u.test(stripInterpolations(normalized))
+  ) {
     return false;
   }
   if (isLikelyCodeLikeSnippet(normalized)) {

--- a/tools/scripts/check-i18n.test.mjs
+++ b/tools/scripts/check-i18n.test.mjs
@@ -164,6 +164,61 @@ test("accepts product-neutral package i18n manifest names", async () => {
   assert.match(result.stdout, /i18n check passed/);
 });
 
+test("checks packages whose manifest name is not one of the built-in names", async () => {
+  const workspaceRoot = await createFixtureWorkspace({
+    packageFiles: {
+      "packages/workspace/terminal/src/i18n/terminalNodeI18n.ts": `
+        import { createScopedLocaleObjectsI18nModuleManifest } from "@tutti-os/ui-i18n-runtime";
+
+        export const terminalNodeI18nNamespace = "terminalNode";
+        export const terminalNodeI18nModule = createScopedLocaleObjectsI18nModuleManifest({
+          localeObjectByLocale: {
+            en: "terminalNodeEn",
+            "zh-CN": "terminalNodeZhCN"
+          },
+          name: "workspace-terminal",
+          namespace: terminalNodeI18nNamespace,
+          sourceRoot: "packages/workspace/terminal/src"
+        });
+
+        const terminalNodeEn = {
+          status: {
+            running: "Running"
+          }
+        } as const;
+
+        const terminalNodeZhCN = {
+          status: {}
+        } as const;
+      `
+    }
+  });
+
+  const result = runI18nCheck(workspaceRoot);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /locale-key-missing/);
+  assert.match(result.stderr, /terminalNode\.status\.running/);
+});
+
+test("skips runtime-composed keys and placeholder-only copy", async () => {
+  const workspaceRoot = await createFixtureWorkspace({
+    rendererFiles: {
+      "app/Status.tsx": `
+        export function Status({ status, label, t }) {
+          const mention = { label: \\\`@\\\${label}\\\` };
+          return <span aria-label={mention.label}>{t(\\\`status.\\\${status}\\\`)}</span>;
+        }
+      `
+    }
+  });
+
+  const result = runI18nCheck(workspaceRoot);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /i18n check passed/);
+});
+
 test("accepts package locale-object manifests with source roots", async () => {
   const workspaceRoot = await createFixtureWorkspace({
     packageFiles: {


### PR DESCRIPTION
## Summary

`check-i18n` discovered locale-module manifests through a hardcoded three-name allowlist (`tuttiI18nModule`, `agentGuiI18nModule`, `browserNodeI18nModule`), while `docs/conventions/static-analysis.md` documents those same three as non-exhaustive examples of a package-specific name ("such as"). Four shipped manifests chose names outside the list and were silently excluded from every i18n check (locale-key parity, placeholder parity, hardcoded-copy scan):

- `richTextI18nModule` (`packages/ui/rich-text`)
- `issueManagerI18nModule` (`packages/workspace/issue-manager`)
- `terminalNodeI18nModule` (`packages/workspace/terminal`)
- `workspaceUserProjectI18nModule` (`packages/workspace/user-project`)

Discovery now matches any `export const <name>I18nModule`; non-manifest matches are still discarded by `parseExportedObjectLiteral` returning `null`.

The remaining changes are what that coverage requires, not separate concerns:

- All four previously-skipped manifests name their namespace through a sibling constant (`namespace: richTextI18nNamespace`) rather than a literal, which threw `ReferenceError` once they were discovered. The manifest VM context now carries the module's top-level double-quoted string constants.
- Interpolated strings were read as static text, so `` label: `@${label}` `` was reported as hardcoded copy and `` t(`status.${status}`) `` as a missing key. Copy that is only placeholders plus punctuation is no longer reported, and a key composed at runtime is skipped; prose that survives placeholder removal (`Hello ${name}, welcome`) still reports.
- `controllerActionTestHarness.ts` (imported only by `*.test.ts` files) gets the same exemption `.test.ts` carries, via a `TestHarness.ts(x)` suffix entry.

Coverage grows from 4,317 keys / 2,082 source files to 4,604 / 2,275. No user-visible behavior changes; this is a check-script fix.

## Verification

- `node --test tools/scripts/check-i18n.test.mjs` — 15/15 pass (13 existing + 2 new)
- `node tools/scripts/check-i18n.mjs` — passes on the real tree at the new coverage
- `oxfmt --check` clean on both files
- Behavioral proof: deleting `status.running` from the terminal module's zh-CN locale passes silently on `main` and is caught by this branch as `locale-key-missing terminalNode.status.running`. The new regression test asserts exactly that and fails against the unmodified script.

## Checklist

- [x] This PR does not change agent lifecycle semantics (tooling-script only).
- [x] I kept the change focused on one concern.
- [x] Documentation: `docs/conventions/static-analysis.md` already describes the intended (example-based) behavior; the script now matches it, so no doc change is needed.
- [x] No README/CONTRIBUTING language-variant changes involved.
- [x] I ran the lowest meaningful local checks for the changed surface (unit suite + real-tree run + formatter).
- [x] Commit is signed off with DCO (`git commit -s`).