### PR TITLE
feat(managedcredentials): add orcarouter as a named model provider

### DIFF
--- a/packages/workspace/external-core/src/contracts/index.ts
+++ b/packages/workspace/external-core/src/contracts/index.ts
@@ -160,7 +160,8 @@ export interface TuttiExternalFileUploadProgress {
 export const tuttiExternalManagedAiModelProviderIds = [
   "agnes",
   "openai",
-  "anthropic"
+  "anthropic",
+  "orcarouter"
 ] as const;
 
 export type TuttiExternalManagedAiModelProviderId =

--- a/packages/workspace/external-core/src/core/index.test.ts
+++ b/packages/workspace/external-core/src/core/index.test.ts
@@ -25,6 +25,7 @@ import {
   normalizeTuttiExternalUserProjectRememberDefaultSelectionInput,
   normalizeTuttiExternalUserProjectSelectionPreparationInput,
   normalizeTuttiExternalWorkspaceOpenFeatureInput,
+  isTuttiExternalManagedAiModelProviderId,
   tuttiExternalAtDefaultMaxResults,
   tuttiExternalAtMaxResultsLimit
 } from "./index.ts";
@@ -456,6 +457,31 @@ test("normalizes managed AI model permission requests", () => {
       scopes: ["model:invoke"],
       state: "state-1"
     }
+  );
+  assert.deepEqual(
+    normalizeTuttiExternalPermissionRequestInput({
+      nonce: "nonce-2",
+      permission: "managed-ai-models",
+      providers: ["orcarouter", "agnes"],
+      scopes: ["model:invoke"],
+      state: "state-2"
+    }),
+    {
+      nonce: "nonce-2",
+      permission: "managed-ai-models",
+      providers: ["orcarouter", "agnes"],
+      scopes: ["model:invoke"],
+      state: "state-2"
+    }
+  );
+});
+
+test("recognizes orcarouter as a managed AI model provider", () => {
+  assert.equal(isTuttiExternalManagedAiModelProviderId("orcarouter"), true);
+  assert.equal(isTuttiExternalManagedAiModelProviderId("agnes"), true);
+  assert.equal(
+    isTuttiExternalManagedAiModelProviderId("not-a-provider"),
+    false
   );
 });
 

--- a/services/tuttid/biz/managedcredentials/model.go
+++ b/services/tuttid/biz/managedcredentials/model.go
@@ -5,14 +5,15 @@ import "time"
 type ProviderID string
 
 const (
-	ProviderAgnes     ProviderID = "agnes"
-	ProviderOpenAI    ProviderID = "openai"
-	ProviderAnthropic ProviderID = "anthropic"
+	ProviderAgnes      ProviderID = "agnes"
+	ProviderOpenAI     ProviderID = "openai"
+	ProviderAnthropic  ProviderID = "anthropic"
+	ProviderOrcaRouter ProviderID = "orcarouter"
 )
 
 func IsProviderID(value string) bool {
 	switch ProviderID(value) {
-	case ProviderAgnes, ProviderOpenAI, ProviderAnthropic:
+	case ProviderAgnes, ProviderOpenAI, ProviderAnthropic, ProviderOrcaRouter:
 		return true
 	default:
 		return false

--- a/services/tuttid/service/managedcredentials/service.go
+++ b/services/tuttid/service/managedcredentials/service.go
@@ -510,6 +510,8 @@ func defaultProviderBaseURL(provider managedcredentialsbiz.ProviderID) string {
 		return "https://apihub.agnes-ai.com/v1"
 	case managedcredentialsbiz.ProviderAnthropic:
 		return "https://api.anthropic.com/v1"
+	case managedcredentialsbiz.ProviderOrcaRouter:
+		return "https://api.orcarouter.ai/v1"
 	default:
 		return "https://api.openai.com/v1"
 	}

--- a/services/tuttid/service/managedcredentials/service_test.go
+++ b/services/tuttid/service/managedcredentials/service_test.go
@@ -541,3 +541,70 @@ func (s *managedCredentialsMemoryStore) RevokeManagedModelGrant(_ context.Contex
 	s.grants[workspaceID+":"+appID+":"+grantRef] = grant
 	return nil
 }
+
+func TestDefaultProviderBaseURLIncludesOrcaRouter(t *testing.T) {
+	if got := defaultProviderBaseURL(managedcredentialsbiz.ProviderOrcaRouter); got != "https://api.orcarouter.ai/v1" {
+		t.Fatalf("defaultProviderBaseURL(orcarouter) = %q, want https://api.orcarouter.ai/v1", got)
+	}
+}
+
+func TestServiceAcceptsOrcaRouterProvider(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+	store := newManagedCredentialsMemoryStore()
+	service := &Service{
+		Store: store,
+		Now: func() time.Time {
+			return now
+		},
+	}
+	apiKey := "orca-secret"
+	if _, err := service.PutProvider(ctx, PutProviderInput{
+		WorkspaceID: "workspace-1",
+		Provider:    "orcarouter",
+		Enabled:     true,
+		APIKey:      &apiKey,
+		BaseURL:     "https://api.orcarouter.ai/v1",
+		Models: []managedcredentialsbiz.Model{{
+			ID:       "anthropic/claude-opus-4.8",
+			Name:     "Claude Opus 4.8",
+			Provider: managedcredentialsbiz.ProviderOrcaRouter,
+		}},
+	}); err != nil {
+		t.Fatalf("PutProvider: %v", err)
+	}
+	config, err := store.GetManagedModelProviderConfig(ctx, "workspace-1", managedcredentialsbiz.ProviderOrcaRouter)
+	if err != nil {
+		t.Fatalf("GetManagedModelProviderConfig: %v", err)
+	}
+	if config.BaseURL != "https://api.orcarouter.ai/v1" {
+		t.Fatalf("saved base URL = %q, want https://api.orcarouter.ai/v1", config.BaseURL)
+	}
+
+	grant, err := service.CreateGrant(ctx, CreateGrantInput{
+		ContextToken: "context-token",
+		WorkspaceID:  "workspace-1",
+		AppID:        "app-1",
+		Nonce:        "nonce-1",
+		ProviderIDs:  []string{"orcarouter"},
+		Scopes:       []string{"models:use"},
+		State:        "state-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateGrant: %v", err)
+	}
+	credential, err := service.Credential(ctx, CredentialInput{
+		WorkspaceID: "workspace-1",
+		AppID:       "app-1",
+		GrantRef:    grant.Grant.GrantRef,
+		Provider:    "orcarouter",
+		Model:       "anthropic/claude-opus-4.8",
+		Capability:  "agent",
+	})
+	if err != nil {
+		t.Fatalf("Credential: %v", err)
+	}
+	if got := credential.Credential.APIKey; got != "orca-secret" {
+		t.Fatalf("Credential API key = %q, want orca-secret", got)
+	}
+}


### PR DESCRIPTION
Users of Tutti's workspace apps can now request OrcaRouter as a first-class managed AI model provider — the same way `agnes`, `openai`, and `anthropic` already work — instead of pointing an anonymous custom base URL at it. OrcaRouter is an [OpenAI-compatible](https://www.orcarouter.ai) gateway that exposes a provider/model namespace across many models; adding it to the managed credential registry gives it a dedicated default endpoint (`https://api.orcarouter.ai/v1`) and lets workspace apps obtain OrcaRouter models through the existing managed-model grant flow.

OrcaRouter goes beyond a plain provider namespace: it combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind a single OpenAI-compatible endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes. Registering it as a named provider means Tutti users get that whole stack without configuring a generic relay.

Changes: `ProviderOrcaRouter` joins the `managedcredentials` provider registry (mirroring the existing `ProviderAgnes`/`ProviderOpenAI`/`ProviderAnthropic` entries) with its default base URL, and `orcarouter` is added to the `tuttiExternalManagedAiModelProviderIds` contract used by workspace-app model permissions. Verified with `go test ./service/managedcredentials`, the `workspace-external-core` test suite (51 passing), and a live call to `https://api.orcarouter.ai/v1/models` (HTTP 200, bearer auth).

## Checklist

- [x] I kept the change focused on one concern.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
I'm an engineer on the OrcaRouter team.
