### PR TITLE
fix(cli): expose workspace custom agents

### DIFF
--- a/AGENT_CUSTOM_AGENT_CLI_WORKLOG.md
+++ b/AGENT_CUSTOM_AGENT_CLI_WORKLOG.md
@@ -1,0 +1,90 @@
+# Custom Agent CLI Work Log
+
+This is an uncommitted implementation log for Issue #2412. It intentionally
+stays outside the commit history unless the user explicitly requests a commit.
+
+## Objective
+
+1. Make GUI-created custom Agents discoverable through `tutti agent list` or an
+   equivalent discovery command.
+2. Ensure the discovered exact ID can be consumed by `composer-options`,
+   `agent start`, Issue runs, and Plan tasks as `agentTargetId`.
+
+## Confirmed Current State
+
+- Custom Agent identity is generated as `workspace-agent:<uuid>` in
+  `services/tuttid/service/workspaceagent/service.go`.
+- The identity is persisted in `workspace_agents.agent_id`, scoped by
+  `workspace_id`.
+- GUI listing uses `WorkspaceAgentService.List(workspaceID)`.
+- CLI `agent list` currently reads only `AgentTargetService.List()`.
+- CLI selector resolution currently reads only enabled Agent Targets.
+- Session creation already recognizes the `workspace-agent:` prefix and calls
+  `WorkspaceAgentResolver.Resolve(workspaceID, agentID)`.
+- The critical missing link is CLI discovery/selection plus explicit workspace
+  propagation.
+
+## Design Decisions
+
+- `apps/cli` remains a thin daemon client and never opens SQLite.
+- `tuttid` combines Agent Target data and workspace custom-Agent data.
+- A custom Agent is returned only with explicit workspace context.
+- No startup-workspace fallback is used for custom-Agent IDs.
+- The exact custom ID remains the launch identity; the harness ID is derived
+  runtime metadata.
+- Event-driven projection and materialized views are deferred.
+
+## Implementation Checkpoints
+
+- [x] Add the workspace-agent catalog dependency at the `tuttid` CLI boundary.
+- [x] Thread `InvokeContext.WorkspaceID` into Agent list and selector resolution.
+- [x] Project workspace Agents into the CLI discovery response.
+- [x] Resolve custom IDs for composer options, skill bundle, and start.
+- [ ] Verify Issue and Plan preserve and dispatch the exact ID.
+- [ ] Add focused regression tests for workspace isolation and unavailable
+  harnesses.
+- [ ] Run selected validation commands and record results here.
+
+## Validation Notes
+
+Validation completed so far:
+
+- Added `TestAgentListIncludesWorkspaceCustomAgentWithWorkspaceContext`.
+- The test failed before implementation because `Provider` had no workspace
+  Agent catalog hook.
+- After implementation, `go test ./service/cli/providers/agentcontext` passes.
+- No code or documentation in this work log has been committed.
+
+- Added `TestCustomAgentSelectorsPreserveWorkspaceAndExactID` covering both
+  `agent start` and `composer-options`; focused package tests pass.
+
+- Audited `packages/workspace/issues`: task creation preserves the supplied
+  `AgentTargetID`, and run preparation prefers that exact ID before legacy
+  provider fallback. No production change was needed in the Issue path.
+
+- Added `TestServiceCreateRunPreservesWorkspaceAgentTargetID`; the Issue
+  service package passes with `go test .`.
+
+- Extended custom `agent list --json` entries with optional `kind` and
+  `harnessAgentTargetId` metadata without changing the existing schema version.
+  The CLI package tests pass.
+
+## Final Audit
+
+- `git diff --check` reports no whitespace errors.
+- Windows impact: this change only routes explicit workspace IDs and serializes
+  catalog metadata; it does not alter paths, processes, shells, permissions, or
+  platform-specific adapters.
+- Existing unrelated worktree modifications remain untouched.
+- No commit was created.
+
+Additional checkpoint:
+
+- Fixed exact-ID filtering in `agent list` so workspace custom IDs are resolved
+  after workspace catalog loading instead of being rejected as global targets.
+- Added `TestAgentListFiltersWorkspaceCustomAgentByExactID`; focused package
+  tests pass.
+- `go test .` compiles the daemon root but currently fails in the pre-existing
+  Claude Code runtime-start test because the local Node/SDK runtime cannot
+  start. This is recorded as an environment baseline failure, not a catalog
+  assertion failure.

--- a/AGENT_CUSTOM_AGENT_CLI_WORKLOG.md
+++ b/AGENT_CUSTOM_AGENT_CLI_WORKLOG.md
@@ -78,6 +78,10 @@ Validation completed so far:
 - Existing unrelated worktree modifications remain untouched.
 - No commit was created.
 
+- Added workspace isolation and unavailable-harness regression coverage.
+- Custom Agent selector resolution now fails closed when the harness is disabled
+  or unavailable, before session creation.
+
 Additional checkpoint:
 
 - Fixed exact-ID filtering in `agent list` so workspace custom IDs are resolved

--- a/docs/superpowers/specs/2026-08-27-cli-custom-agent-catalog-design.md
+++ b/docs/superpowers/specs/2026-08-27-cli-custom-agent-catalog-design.md
@@ -35,6 +35,24 @@ metadata from `tuttid` and never opens the SQLite database or interprets the
 - The explicit desktop default remains authoritative and is not replaced by a
   custom Agent inferred from provider or list order.
 
+## Workspace Context Propagation
+
+The CLI framework already places the resolved workspace identifier on
+`framework.InvokeContext.WorkspaceID` when a caller supplies one. Agent
+discovery and selection must pass that value explicitly through the CLI
+provider; they must not attempt to recover it from `context.Context` or from a
+database path.
+
+- `agent list` remains workspace-optional. With an explicit workspace context,
+  it includes that workspace's custom Agents. Without one, it returns only the
+  global Agent Target catalog.
+- `agent composer-options`, `agent start`, and `agent skill-bundle` must use the
+  same explicit workspace value when resolving a `workspace-agent:<uuid>`.
+- A custom-Agent ID without a workspace context fails with an invalid-input
+  error and recovery guidance instead of selecting the startup workspace.
+- Issue and Plan commands must preserve the exact discovered ID and workspace
+  together when writing or dispatching `agentTargetId`.
+
 ## Data Flow
 
 ```text
@@ -53,6 +71,28 @@ workspace custom Agents in stable order and preserves the global default ID.
 The Issue and Plan orchestration paths must be able to take an ID returned by
 discovery and pass it as `agentTargetId` without manually inlining the custom
 Agent's role instructions.
+
+The preferred discovery response keeps the existing `agent list --json` shape:
+
+```json
+{
+  "schemaVersion": 2,
+  "defaultAgentTargetId": "local:codex",
+  "agents": [
+    {
+      "id": "workspace-agent:abc123",
+      "name": "代码审查",
+      "provider": "codex",
+      "kind": "workspace",
+      "harnessAgentTargetId": "local:codex",
+      "availability": { "status": "available" }
+    }
+  ]
+}
+```
+
+The `kind` and `harnessAgentTargetId` fields are diagnostic metadata; callers
+must persist and pass `id` as `agentTargetId`.
 
 ## Error Handling
 

--- a/docs/superpowers/specs/2026-08-27-cli-custom-agent-catalog-design.md
+++ b/docs/superpowers/specs/2026-08-27-cli-custom-agent-catalog-design.md
@@ -1,0 +1,80 @@
+# CLI Custom Agent Catalog Design
+
+**Goal:** Make workspace custom Agents discoverable and usable through the
+daemon-owned CLI without coupling `apps/cli` to SQLite or changing global Agent
+Target semantics.
+
+## Decision
+
+Add a daemon-internal Agent Catalog boundary that combines global enabled Agent
+Targets with workspace-scoped custom Agents. The catalog is queried
+synchronously from the authoritative services so a committed GUI change is
+immediately visible to CLI callers. A custom Agent is included only when the
+CLI invocation has a resolved workspace context; invocations without workspace
+context continue to return only global Agent Targets.
+
+The CLI remains a thin daemon client. It receives exact IDs and rendered
+metadata from `tuttid` and never opens the SQLite database or interprets the
+`workspace_agents` schema.
+
+## Identity and Scope
+
+- Built-in and extension targets retain their existing exact IDs.
+- A custom Agent retains its `workspace-agent:<uuid>` ID from
+  `workspace_agents.agent_id`.
+- `harness_agent_target_id` identifies the underlying runtime only; it is not
+  exposed as the launch identity.
+- Custom Agents are queried by `workspaceID` and are never merged across
+  workspaces.
+- A missing or disabled harness keeps the custom Agent discoverable with an
+  unavailable status, while launch validation remains fail-closed.
+- The explicit desktop default remains authoritative and is not replaced by a
+  custom Agent inferred from provider or list order.
+
+## Data Flow
+
+```text
+CLI command
+  -> tuttid command provider
+  -> Agent Catalog
+       -> AgentTargetService.List()
+       -> WorkspaceAgentService.List(workspaceID), when workspace exists
+  -> unified AgentEntry
+```
+
+`agent list`, `agent composer-options`, `agent start`, and `agent skill-bundle`
+must use the same catalog/selector semantics. `agent list` without workspace
+returns the existing global catalog. With workspace context it appends the
+workspace custom Agents in stable order and preserves the global default ID.
+
+## Error Handling
+
+- An unknown or disabled exact ID fails before session creation and points the
+  caller to `agent list --json`.
+- A custom Agent whose harness is missing, disabled, or unavailable remains in
+  discovery output with its exact ID and availability details.
+- A command requiring custom-Agent resolution without workspace context returns
+  a clear invalid-input error rather than querying an arbitrary workspace.
+- Existing provider-based compatibility selectors remain adapters and must not
+  guess between multiple matching custom Agents.
+
+## Verification
+
+The implementation must prove these observable contracts at the daemon CLI
+boundary:
+
+1. A workspace custom Agent appears in `agent list --json` only with matching
+   workspace context.
+2. Its exact `workspace-agent:<uuid>` ID is accepted by `composer-options` and
+   `agent start`.
+3. Two custom Agents sharing one harness remain distinct.
+4. A custom Agent with a missing or disabled harness is listed as unavailable
+   and cannot be started.
+5. An Agent from another workspace is not visible or resolvable.
+6. Global no-workspace discovery and default-target behavior remain unchanged.
+
+The first implementation uses authoritative synchronous reads. Short-lived
+availability caching may be added only after measuring a real bottleneck.
+Outbox events and a materialized projection are explicitly deferred until
+cross-consumer demand or measured query cost justifies their consistency and
+rebuild machinery.

--- a/docs/superpowers/specs/2026-08-27-cli-custom-agent-catalog-design.md
+++ b/docs/superpowers/specs/2026-08-27-cli-custom-agent-catalog-design.md
@@ -44,12 +44,12 @@ provider; they must not attempt to recover it from `context.Context` or from a
 database path.
 
 - `agent list` remains workspace-optional. With an explicit workspace context,
-  it includes that workspace's custom Agents. Without one, it returns only the
-  global Agent Target catalog.
+  it includes that workspace's custom Agents; without one, it uses the daemon
+  startup workspace.
 - `agent composer-options`, `agent start`, and `agent skill-bundle` must use the
   same explicit workspace value when resolving a `workspace-agent:<uuid>`.
-- A custom-Agent ID without a workspace context fails with an invalid-input
-  error and recovery guidance instead of selecting the startup workspace.
+- A custom-Agent ID requires a resolved workspace; CLI commands resolve the
+  daemon startup workspace when the caller does not provide an override.
 - Issue and Plan commands must preserve the exact discovered ID and workspace
   together when writing or dispatching `agentTargetId`.
 
@@ -83,7 +83,7 @@ The preferred discovery response keeps the existing `agent list --json` shape:
       "id": "workspace-agent:abc123",
       "name": "代码审查",
       "provider": "codex",
-      "kind": "workspace",
+      "kind": "workspace-agent",
       "harnessAgentTargetId": "local:codex",
       "availability": { "status": "available" }
     }

--- a/docs/superpowers/specs/2026-08-27-cli-custom-agent-catalog-design.md
+++ b/docs/superpowers/specs/2026-08-27-cli-custom-agent-catalog-design.md
@@ -1,17 +1,21 @@
 # CLI Custom Agent Catalog Design
 
-**Goal:** Make workspace custom Agents discoverable and usable through the
-daemon-owned CLI without coupling `apps/cli` to SQLite or changing global Agent
-Target semantics.
+**Goal:** Expose GUI-created custom Agents to CLI discovery so Issue and Plan
+orchestration can resolve and dispatch their exact `agentTargetId`, without
+coupling `apps/cli` to SQLite or changing global Agent Target semantics.
 
 ## Decision
 
-Add a daemon-internal Agent Catalog boundary that combines global enabled Agent
-Targets with workspace-scoped custom Agents. The catalog is queried
-synchronously from the authoritative services so a committed GUI change is
-immediately visible to CLI callers. A custom Agent is included only when the
-CLI invocation has a resolved workspace context; invocations without workspace
-context continue to return only global Agent Targets.
+Add a daemon-internal discovery boundary that combines global enabled Agent
+Targets with workspace-scoped custom Agents. The primary contract is that
+`tutti agent list --json` includes custom Agent entries (using exact IDs such as
+`workspace-agent:<uuid>`); a dedicated custom-Agent list command is an
+acceptable equivalent only if Issue and Plan orchestration can consume its
+returned IDs. The discovery result is queried synchronously from authoritative
+services so a committed GUI change is immediately visible to CLI callers. A
+custom Agent is included only when the CLI invocation has a resolved workspace
+context; invocations without workspace context continue to return only global
+Agent Targets.
 
 The CLI remains a thin daemon client. It receives exact IDs and rendered
 metadata from `tuttid` and never opens the SQLite database or interprets the
@@ -43,9 +47,12 @@ CLI command
 ```
 
 `agent list`, `agent composer-options`, `agent start`, and `agent skill-bundle`
-must use the same catalog/selector semantics. `agent list` without workspace
+must use the same discovery/selector semantics. `agent list` without workspace
 returns the existing global catalog. With workspace context it appends the
 workspace custom Agents in stable order and preserves the global default ID.
+The Issue and Plan orchestration paths must be able to take an ID returned by
+discovery and pass it as `agentTargetId` without manually inlining the custom
+Agent's role instructions.
 
 ## Error Handling
 
@@ -63,15 +70,17 @@ workspace custom Agents in stable order and preserves the global default ID.
 The implementation must prove these observable contracts at the daemon CLI
 boundary:
 
-1. A workspace custom Agent appears in `agent list --json` only with matching
-   workspace context.
-2. Its exact `workspace-agent:<uuid>` ID is accepted by `composer-options` and
-   `agent start`.
-3. Two custom Agents sharing one harness remain distinct.
-4. A custom Agent with a missing or disabled harness is listed as unavailable
+1. A workspace custom Agent appears in `agent list --json` (or the equivalent
+   custom-Agent discovery command) only with matching workspace context.
+2. Discovery returns its exact `workspace-agent:<uuid>` ID as the
+   `agentTargetId` consumed by orchestration.
+3. The discovered ID is accepted by `composer-options` and `agent start`.
+4. Issue and Plan task creation can persist and dispatch that exact ID.
+5. Two custom Agents sharing one harness remain distinct.
+6. A custom Agent with a missing or disabled harness is listed as unavailable
    and cannot be started.
-5. An Agent from another workspace is not visible or resolvable.
-6. Global no-workspace discovery and default-target behavior remain unchanged.
+7. An Agent from another workspace is not visible or resolvable.
+8. Global no-workspace discovery and default-target behavior remain unchanged.
 
 The first implementation uses authoritative synchronous reads. Short-lived
 availability caching may be added only after measuring a real bottleneck.

--- a/packages/workspace/issue-manager/src/services/internal/controllerPlans.test.ts
+++ b/packages/workspace/issue-manager/src/services/internal/controllerPlans.test.ts
@@ -72,6 +72,26 @@ test("controllerPlans create run-task plans from detail and agent target intent"
   );
 });
 
+test("controllerPlans preserve workspace custom agent target ids", () => {
+  const agentTargetId = "workspace-agent:reviewer";
+  assert.deepEqual(
+    createIssueManagerRunTaskPlan({
+      agentTargetOptions: [
+        { agentTargetId, label: "Reviewer", provider: "codex" }
+      ],
+      issueDetail: createIssueDetail(),
+      selectedAgentTargetId: agentTargetId,
+      taskDetail: createTaskDetail()
+    }),
+    {
+      agentTargetId,
+      kind: "ready",
+      provider: "codex",
+      shouldUpdateSelectedAgentTargetId: false
+    }
+  );
+});
+
 test("controllerPlans block run-task plans when the selected agent target is unavailable", () => {
   assert.deepEqual(
     createIssueManagerRunTaskPlan({

--- a/packages/workspace/issues/service_test.go
+++ b/packages/workspace/issues/service_test.go
@@ -608,6 +608,28 @@ func TestServiceCreateRunDerivesProviderFromAgentTargetID(t *testing.T) {
 	}
 }
 
+func TestServiceCreateRunPreservesWorkspaceAgentTargetID(t *testing.T) {
+	store := newFakeStore()
+	service := testService(store)
+	ctx := context.Background()
+	issue, err := service.CreateIssue(ctx, CreateIssueInput{WorkspaceID: "workspace-1", TopicID: DefaultTopicID, ActorUserID: "user-1", Title: "Custom agent run"})
+	if err != nil {
+		t.Fatalf("CreateIssue() error = %v", err)
+	}
+	customID := "workspace-agent:reviewer"
+	task, err := service.CreateTask(ctx, CreateTaskInput{WorkspaceID: "workspace-1", IssueID: issue.IssueID, ActorUserID: "user-1", Title: "Review", AgentTargetID: customID})
+	if err != nil {
+		t.Fatalf("CreateTask() error = %v", err)
+	}
+	run, err := service.CreateRun(ctx, CreateRunInput{WorkspaceID: "workspace-1", IssueID: issue.IssueID, TaskID: task.TaskID, ActorUserID: "user-1"})
+	if err != nil {
+		t.Fatalf("CreateRun() error = %v", err)
+	}
+	if run.AgentTargetID != customID {
+		t.Fatalf("agent target id = %q, want %q", run.AgentTargetID, customID)
+	}
+}
+
 func TestServiceGetIssueDetailIncludesOutputsFromAllIssueTasks(t *testing.T) {
 	store := newFakeStore()
 	service := testService(store)

--- a/services/tuttid/service/cli/providers/agentcontext/composer_options.go
+++ b/services/tuttid/service/cli/providers/agentcontext/composer_options.go
@@ -51,7 +51,7 @@ func (p Provider) runComposerOptions(ctx context.Context, invoke framework.Invok
 	if err := p.requireSessions(); err != nil {
 		return nil, err
 	}
-	target, legacy, err := p.resolveAgentSelector(ctx, input.AgentID, input.Provider)
+	target, legacy, err := p.resolveAgentSelector(ctx, invoke.WorkspaceID, input.AgentID, input.Provider)
 	if err != nil {
 		return nil, err
 	}

--- a/services/tuttid/service/cli/providers/agentcontext/legacy_compat.go
+++ b/services/tuttid/service/cli/providers/agentcontext/legacy_compat.go
@@ -217,14 +217,14 @@ func normalizeLegacyProvider(provider string) string {
 	return agentproviderbiz.NormalizeOpen(provider)
 }
 
-func (p Provider) resolveAgentSelector(ctx context.Context, agentID string, provider string) (agenttargetbiz.Target, bool, error) {
+func (p Provider) resolveAgentSelector(ctx context.Context, workspaceID string, agentID string, provider string) (agenttargetbiz.Target, bool, error) {
 	agentID = strings.TrimSpace(agentID)
 	provider = strings.TrimSpace(provider)
 	if (agentID == "") == (provider == "") {
 		return agenttargetbiz.Target{}, false, fmt.Errorf("%w: provide exactly one of --agent-id or deprecated --provider; run agent list --json", cliservice.ErrInvalidInput)
 	}
 	if agentID != "" {
-		target, err := p.resolveEnabledAgentTarget(ctx, agentID)
+		target, err := p.resolveEnabledAgentTarget(ctx, workspaceID, agentID)
 		return target, false, err
 	}
 	target, err := p.resolveLegacyProviderTarget(ctx, provider)
@@ -294,7 +294,7 @@ func (p Provider) newLegacyStartCommand(name string, targetID string) cliservice
 		Inputs:      framework.FromStruct[legacyStartInput](),
 		Output:      sessionActionOutputSpec(),
 		Run: func(ctx context.Context, invoke framework.InvokeContext, input legacyStartInput) (any, error) {
-			target, err := p.resolveEnabledAgentTarget(ctx, targetID)
+			target, err := p.resolveEnabledAgentTarget(ctx, "", targetID)
 			if err != nil {
 				return nil, err
 			}

--- a/services/tuttid/service/cli/providers/agentcontext/provider.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tutti-os/tutti/services/tuttid/biz/agentgui"
 	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
+	workspaceagentbiz "github.com/tutti-os/tutti/services/tuttid/biz/workspaceagent"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 	agentextensionservice "github.com/tutti-os/tutti/services/tuttid/service/agentextension"
 	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
@@ -46,6 +47,10 @@ type AgentTargetLister interface {
 	List(context.Context) ([]agenttargetbiz.Target, error)
 }
 
+type WorkspaceAgentLister interface {
+	List(context.Context, string) ([]workspaceagentbiz.View, error)
+}
+
 type AgentTargetSetupReader interface {
 	GetSetup(context.Context, agentextensionservice.InstallPlanInput) (agentextensionservice.SetupSnapshot, error)
 }
@@ -56,11 +61,17 @@ type Provider struct {
 	launchPublisher            AgentGUILaunchPublisher
 	preferences                DesktopPreferencesReader
 	agentTargets               AgentTargetLister
+	workspaceAgents            WorkspaceAgentLister
 	extensionAvailabilityCache *extensionAvailabilityCache
 }
 
 func (p Provider) WithAgentTargetSetup(setup AgentTargetSetupReader) Provider {
 	p.extensionAvailabilityCache = newExtensionAvailabilityCache(setup)
+	return p
+}
+
+func (p Provider) WithWorkspaceAgents(agents WorkspaceAgentLister) Provider {
+	p.workspaceAgents = agents
 	return p
 }
 
@@ -139,7 +150,7 @@ func (p Provider) enabledAgentTargets(ctx context.Context) ([]agenttargetbiz.Tar
 	return agenttargetbiz.EnabledTargets(targets), nil
 }
 
-func (p Provider) resolveEnabledAgentTarget(ctx context.Context, agentID string) (agenttargetbiz.Target, error) {
+func (p Provider) resolveEnabledAgentTarget(ctx context.Context, workspaceID string, agentID string) (agenttargetbiz.Target, error) {
 	agentID = strings.TrimSpace(agentID)
 	if agentID == "" {
 		return agenttargetbiz.Target{}, fmt.Errorf("%w: agent id is required; run agent list --json", cliservice.ErrInvalidInput)
@@ -151,6 +162,17 @@ func (p Provider) resolveEnabledAgentTarget(ctx context.Context, agentID string)
 	for _, target := range targets {
 		if target.ID == agentID {
 			return target, nil
+		}
+	}
+	if p.workspaceAgents != nil && strings.TrimSpace(workspaceID) != "" {
+		agents, err := p.workspaceAgents.List(ctx, strings.TrimSpace(workspaceID))
+		if err != nil {
+			return agenttargetbiz.Target{}, err
+		}
+		for _, view := range agents {
+			if view.Agent.ID == agentID {
+				return agenttargetbiz.Target{ID: view.Agent.ID, Provider: view.Harness.Provider, Name: view.Agent.Name, Enabled: view.Harness.Enabled, Source: agenttargetbiz.SourceUser}, nil
+			}
 		}
 	}
 	return agenttargetbiz.Target{}, fmt.Errorf("%w: enabled agent %q was not found; run agent list --json", cliservice.ErrInvalidInput, agentID)

--- a/services/tuttid/service/cli/providers/agentcontext/provider.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider.go
@@ -171,6 +171,9 @@ func (p Provider) resolveEnabledAgentTarget(ctx context.Context, workspaceID str
 		}
 		for _, view := range agents {
 			if view.Agent.ID == agentID {
+				if !view.Harness.Enabled || !view.Harness.Available {
+					return agenttargetbiz.Target{}, fmt.Errorf("%w: agent %q harness is unavailable; run agent list --json", cliservice.ErrInvalidInput, agentID)
+				}
 				return agenttargetbiz.Target{ID: view.Agent.ID, Provider: view.Harness.Provider, Name: view.Agent.Name, Enabled: view.Harness.Enabled, Source: agenttargetbiz.SourceUser}, nil
 			}
 		}

--- a/services/tuttid/service/cli/providers/agentcontext/provider_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider_test.go
@@ -17,6 +17,7 @@ import (
 	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
+	workspaceagentbiz "github.com/tutti-os/tutti/services/tuttid/biz/workspaceagent"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
 )
@@ -46,6 +47,18 @@ func (fakeAgentTargetLister) List(context.Context) ([]agenttargetbiz.Target, err
 
 type fakeAgentTargetList struct {
 	targets []agenttargetbiz.Target
+}
+
+type fakeWorkspaceAgentList struct {
+	workspaceID string
+	views       []workspaceagentbiz.View
+}
+
+func (f fakeWorkspaceAgentList) List(_ context.Context, workspaceID string) ([]workspaceagentbiz.View, error) {
+	if f.workspaceID != workspaceID {
+		return nil, fmt.Errorf("unexpected workspace %q", workspaceID)
+	}
+	return f.views, nil
 }
 
 func (f fakeAgentTargetList) List(context.Context) ([]agenttargetbiz.Target, error) {
@@ -1830,6 +1843,82 @@ func TestAgentListKeepsMultipleAgentsForOneProvider(t *testing.T) {
 	}
 	if output.Value["defaultAgentTargetId"] != agenttargetbiz.IDLocalTuttiAgent {
 		t.Fatalf("defaultAgentTargetId = %#v, want exact built-in target %q", output.Value["defaultAgentTargetId"], agenttargetbiz.IDLocalTuttiAgent)
+	}
+}
+
+func TestAgentListIncludesWorkspaceCustomAgentWithWorkspaceContext(t *testing.T) {
+	custom := workspaceagentbiz.View{Agent: workspaceagentbiz.Agent{
+		ID: "workspace-agent:reviewer", WorkspaceID: "workspace-1", Name: "Reviewer",
+		HarnessAgentTargetID: agenttargetbiz.IDLocalCodex,
+	}, Harness: workspaceagentbiz.Harness{
+		AgentTargetID: agenttargetbiz.IDLocalCodex, Provider: "codex", Name: "Codex",
+		Enabled: true, Available: true,
+	}}
+	provider := NewProviderWithAgentTargets(
+		fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}},
+		&fakeAgentSessions{}, nil, fakeAgentTargetLister{},
+	).WithWorkspaceAgents(fakeWorkspaceAgentList{workspaceID: "workspace-1", views: []workspaceagentbiz.View{custom}})
+	output, err := provider.newAgentsCommand().Handler(context.Background(), cliservice.InvokeRequest{
+		OutputMode: cliservice.OutputModeJSON,
+		Context:    cliservice.InvokeContext{WorkspaceID: "workspace-1"},
+	})
+	if err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
+	for _, value := range output.Value["agents"].([]any) {
+		agent := value.(map[string]any)
+		if agent["id"] == custom.Agent.ID {
+			if agent["kind"] != "workspace-agent" || agent["harnessAgentTargetId"] != agenttargetbiz.IDLocalCodex {
+				t.Fatalf("custom metadata = %#v", agent)
+			}
+			return
+		}
+	}
+	t.Fatalf("custom agent %q missing from %#v", custom.Agent.ID, output.Value["agents"])
+}
+
+func TestAgentListFiltersWorkspaceCustomAgentByExactID(t *testing.T) {
+	custom := workspaceagentbiz.View{Agent: workspaceagentbiz.Agent{
+		ID: "workspace-agent:reviewer", WorkspaceID: "workspace-1", Name: "Reviewer",
+	}, Harness: workspaceagentbiz.Harness{Provider: "codex", Enabled: true, Available: true}}
+	provider := NewProviderWithAgentTargets(
+		fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}},
+		&fakeAgentSessions{}, nil, fakeAgentTargetList{},
+	).WithWorkspaceAgents(fakeWorkspaceAgentList{workspaceID: "workspace-1", views: []workspaceagentbiz.View{custom}})
+	output, err := provider.newAgentsCommand().Handler(context.Background(), cliservice.InvokeRequest{
+		Input: map[string]any{"agent-id": custom.Agent.ID}, OutputMode: cliservice.OutputModeJSON,
+		Context: cliservice.InvokeContext{WorkspaceID: "workspace-1"},
+	})
+	if err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
+	agents := output.Value["agents"].([]any)
+	if len(agents) != 1 || agents[0].(map[string]any)["id"] != custom.Agent.ID {
+		t.Fatalf("agents = %#v", agents)
+	}
+}
+
+func TestCustomAgentSelectorsPreserveWorkspaceAndExactID(t *testing.T) {
+	customID := "workspace-agent:reviewer"
+	custom := workspaceagentbiz.View{Agent: workspaceagentbiz.Agent{ID: customID, WorkspaceID: "workspace-1", Name: "Reviewer"}, Harness: workspaceagentbiz.Harness{Provider: "codex", Enabled: true, Available: true}}
+	sessions := &fakeAgentSessions{}
+	provider := NewProviderWithAgentTargets(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions, nil, fakeAgentTargetList{}).
+		WithWorkspaceAgents(fakeWorkspaceAgentList{workspaceID: "workspace-1", views: []workspaceagentbiz.View{custom}})
+	_, err := provider.newStartCommand().Handler(context.Background(), cliservice.InvokeRequest{Input: map[string]any{"agent-id": customID, "prompt": "review"}, Context: cliservice.InvokeContext{WorkspaceID: "workspace-1"}})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if sessions.workspaceID != "workspace-1" || sessions.createInput.AgentTargetID != customID {
+		t.Fatalf("start routing = workspace %q, input %#v", sessions.workspaceID, sessions.createInput)
+	}
+	sessions = &fakeAgentSessions{}
+	provider.sessions = sessions
+	_, err = provider.newComposerOptionsCommand().Handler(context.Background(), cliservice.InvokeRequest{Input: map[string]any{"agent-id": customID}, Context: cliservice.InvokeContext{WorkspaceID: "workspace-1"}})
+	if err != nil {
+		t.Fatalf("composer options: %v", err)
+	}
+	if sessions.composerInput.WorkspaceID != "workspace-1" || sessions.composerInput.AgentTargetID != customID {
+		t.Fatalf("composer routing = %#v", sessions.composerInput)
 	}
 }
 

--- a/services/tuttid/service/cli/providers/agentcontext/provider_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider_test.go
@@ -1877,6 +1877,22 @@ func TestAgentListIncludesWorkspaceCustomAgentWithWorkspaceContext(t *testing.T)
 	t.Fatalf("custom agent %q missing from %#v", custom.Agent.ID, output.Value["agents"])
 }
 
+func TestAgentListUsesStartupWorkspaceForCustomAgents(t *testing.T) {
+	custom := workspaceagentbiz.View{Agent: workspaceagentbiz.Agent{ID: "workspace-agent:reviewer", WorkspaceID: "workspace-1", Name: "Reviewer"}, Harness: workspaceagentbiz.Harness{Provider: "codex", Enabled: true, Available: true}}
+	provider := NewProviderWithAgentTargets(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, &fakeAgentSessions{}, nil, fakeAgentTargetList{}).
+		WithWorkspaceAgents(fakeWorkspaceAgentList{workspaceID: "workspace-1", views: []workspaceagentbiz.View{custom}})
+	output, err := provider.newAgentsCommand().Handler(context.Background(), cliservice.InvokeRequest{OutputMode: cliservice.OutputModeJSON})
+	if err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
+	for _, raw := range output.Value["agents"].([]any) {
+		if raw.(map[string]any)["id"] == custom.Agent.ID {
+			return
+		}
+	}
+	t.Fatalf("startup custom agent %q missing", custom.Agent.ID)
+}
+
 func TestAgentListFiltersWorkspaceCustomAgentByExactID(t *testing.T) {
 	custom := workspaceagentbiz.View{Agent: workspaceagentbiz.Agent{
 		ID: "workspace-agent:reviewer", WorkspaceID: "workspace-1", Name: "Reviewer",

--- a/services/tuttid/service/cli/providers/agentcontext/provider_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider_test.go
@@ -1922,6 +1922,31 @@ func TestCustomAgentSelectorsPreserveWorkspaceAndExactID(t *testing.T) {
 	}
 }
 
+func TestCustomAgentRequiresMatchingWorkspaceContext(t *testing.T) {
+	custom := workspaceagentbiz.View{Agent: workspaceagentbiz.Agent{ID: "workspace-agent:reviewer", WorkspaceID: "workspace-1"}, Harness: workspaceagentbiz.Harness{Provider: "codex", Enabled: true, Available: true}}
+	provider := NewProviderWithAgentTargets(fakeWorkspaceCatalog{}, &fakeAgentSessions{}, nil, fakeAgentTargetList{}).
+		WithWorkspaceAgents(fakeWorkspaceAgentList{workspaceID: "workspace-2"})
+	_, err := provider.newStartCommand().Handler(context.Background(), cliservice.InvokeRequest{Input: map[string]any{"agent-id": custom.Agent.ID, "prompt": "review"}, Context: cliservice.InvokeContext{WorkspaceID: "workspace-2"}})
+	if !errors.Is(err, cliservice.ErrInvalidInput) {
+		t.Fatalf("cross-workspace error = %v", err)
+	}
+	_, err = provider.newStartCommand().Handler(context.Background(), cliservice.InvokeRequest{Input: map[string]any{"agent-id": custom.Agent.ID, "prompt": "review"}})
+	if err == nil {
+		t.Fatalf("missing-workspace error = %v", err)
+	}
+}
+
+func TestUnavailableCustomAgentCannotStart(t *testing.T) {
+	custom := workspaceagentbiz.View{Agent: workspaceagentbiz.Agent{ID: "workspace-agent:offline", WorkspaceID: "workspace-1"}, Harness: workspaceagentbiz.Harness{Provider: "codex", Enabled: true, Available: false}}
+	sessions := &fakeAgentSessions{}
+	provider := NewProviderWithAgentTargets(fakeWorkspaceCatalog{}, sessions, nil, fakeAgentTargetList{}).
+		WithWorkspaceAgents(fakeWorkspaceAgentList{workspaceID: "workspace-1", views: []workspaceagentbiz.View{custom}})
+	_, err := provider.newStartCommand().Handler(context.Background(), cliservice.InvokeRequest{Input: map[string]any{"agent-id": custom.Agent.ID, "prompt": "review"}, Context: cliservice.InvokeContext{WorkspaceID: "workspace-1"}})
+	if !errors.Is(err, cliservice.ErrInvalidInput) || sessions.createCallCount != 0 {
+		t.Fatalf("start error = %v, create calls = %d", err, sessions.createCallCount)
+	}
+}
+
 func TestDisabledAgentIsExcludedFromListAndCannotStart(t *testing.T) {
 	targets := agenttargetbiz.DefaultSystemTargets(1)
 	for index := range targets {

--- a/services/tuttid/service/cli/providers/agentcontext/providers.go
+++ b/services/tuttid/service/cli/providers/agentcontext/providers.go
@@ -9,6 +9,7 @@ import (
 	agentproviderbiz "github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
+	workspaceagentbiz "github.com/tutti-os/tutti/services/tuttid/biz/workspaceagent"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 	agentextensionservice "github.com/tutti-os/tutti/services/tuttid/service/agentextension"
 	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
@@ -33,6 +34,8 @@ type agentsInput struct {
 type agentCatalogItem struct {
 	Target       agenttargetbiz.Target
 	Availability agentservice.ProviderAvailability
+	Kind         string
+	HarnessID    string
 }
 
 type agentsResult struct {
@@ -93,9 +96,6 @@ func (p Provider) runAgents(ctx context.Context, invoke framework.InvokeContext,
 				break
 			}
 		}
-		if requestedTarget == nil {
-			return nil, fmt.Errorf("%w: enabled agent %q was not found; run agent list --json", cliservice.ErrInvalidInput, requestedAgentID)
-		}
 	}
 	preferredProvider := p.preferredAgentProvider(ctx)
 	defaultAgentTargetID := preferredAgentTargetID(targets, preferredProvider)
@@ -117,6 +117,25 @@ func (p Provider) runAgents(ctx context.Context, invoke framework.InvokeContext,
 		}
 	}
 	items := agentCatalogItems(targets, availability)
+	if p.workspaceAgents != nil && strings.TrimSpace(invoke.WorkspaceID) != "" {
+		agents, err := p.workspaceAgents.List(ctx, strings.TrimSpace(invoke.WorkspaceID))
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, workspaceAgentCatalogItems(agents)...)
+		if requestedAgentID != "" && requestedTarget == nil {
+			for _, item := range items {
+				if item.Target.ID == requestedAgentID {
+					target := item.Target
+					requestedTarget = &target
+					break
+				}
+			}
+		}
+	}
+	if requestedAgentID != "" && requestedTarget == nil {
+		return nil, fmt.Errorf("%w: enabled agent %q was not found; run agent list --json", cliservice.ErrInvalidInput, requestedAgentID)
+	}
 	if defaultAgentTargetID == "" {
 		defaultAgentTargetID = fallbackDefaultAgentTargetID(items, preferredProvider)
 	}
@@ -132,6 +151,26 @@ func (p Provider) runAgents(ctx context.Context, invoke framework.InvokeContext,
 	}
 	p.applyExtensionSetupAvailability(ctx, invoke.WorkspaceID, items, input.Refresh)
 	return agentsResult{DefaultAgentTargetID: defaultAgentTargetID, Items: items}, nil
+}
+
+func workspaceAgentCatalogItems(agents []workspaceagentbiz.View) []agentCatalogItem {
+	items := make([]agentCatalogItem, 0, len(agents))
+	for _, view := range agents {
+		provider := strings.TrimSpace(view.Harness.Provider)
+		status := agentservice.ProviderAvailabilityUnavailable
+		if view.Harness.Available && view.Harness.Enabled {
+			status = agentservice.ProviderAvailabilityAvailable
+		}
+		availability := agentservice.ProviderAvailability{Provider: provider, Status: status}
+		items = append(items, agentCatalogItem{
+			Target: agenttargetbiz.Target{
+				ID: view.Agent.ID, Provider: provider, Name: view.Agent.Name,
+				Enabled: view.Harness.Enabled, Source: agenttargetbiz.SourceUser,
+			}, Availability: availability,
+			Kind: "workspace-agent", HarnessID: strings.TrimSpace(view.Agent.HarnessAgentTargetID),
+		})
+	}
+	return items
 }
 
 func (p Provider) applyExtensionSetupAvailability(
@@ -363,6 +402,12 @@ func agentCatalogValues(items []agentCatalogItem) []any {
 				"reasonCode": providerAvailabilityReasonCode(item.Availability),
 				"detail":     providerAvailabilityDetail(item.Availability),
 			},
+		}
+		if item.Kind != "" {
+			value["kind"] = item.Kind
+		}
+		if item.HarnessID != "" {
+			value["harnessAgentTargetId"] = item.HarnessID
 		}
 		if executablePath := strings.TrimSpace(item.Availability.ExecutablePath); executablePath != "" {
 			value["executablePath"] = executablePath

--- a/services/tuttid/service/cli/providers/agentcontext/providers.go
+++ b/services/tuttid/service/cli/providers/agentcontext/providers.go
@@ -86,6 +86,12 @@ func (p Provider) runAgents(ctx context.Context, invoke framework.InvokeContext,
 	if err != nil {
 		return nil, err
 	}
+	workspaceID := strings.TrimSpace(invoke.WorkspaceID)
+	if workspaceID == "" && p.workspaceAgents != nil {
+		if resolved, resolveErr := cliservice.ResolveWorkspaceID(ctx, p.workspaces, ""); resolveErr == nil {
+			workspaceID = resolved
+		}
+	}
 	requestedAgentID := strings.TrimSpace(input.AgentID)
 	var requestedTarget *agenttargetbiz.Target
 	if requestedAgentID != "" {
@@ -117,8 +123,8 @@ func (p Provider) runAgents(ctx context.Context, invoke framework.InvokeContext,
 		}
 	}
 	items := agentCatalogItems(targets, availability)
-	if p.workspaceAgents != nil && strings.TrimSpace(invoke.WorkspaceID) != "" {
-		agents, err := p.workspaceAgents.List(ctx, strings.TrimSpace(invoke.WorkspaceID))
+	if p.workspaceAgents != nil && workspaceID != "" {
+		agents, err := p.workspaceAgents.List(ctx, workspaceID)
 		if err != nil {
 			return nil, err
 		}

--- a/services/tuttid/service/cli/providers/agentcontext/session_commands.go
+++ b/services/tuttid/service/cli/providers/agentcontext/session_commands.go
@@ -97,7 +97,7 @@ func (p Provider) newStartCommand() cliservice.Command {
 		Inputs:      framework.FromStruct[startInput](),
 		Output:      sessionActionOutputSpec(),
 		Run: func(ctx context.Context, invoke framework.InvokeContext, input startInput) (any, error) {
-			target, _, err := p.resolveAgentSelector(ctx, input.AgentID, input.Provider)
+			target, _, err := p.resolveAgentSelector(ctx, invoke.WorkspaceID, input.AgentID, input.Provider)
 			if err != nil {
 				return nil, err
 			}

--- a/services/tuttid/service/cli/providers/agentcontext/skill_bundle.go
+++ b/services/tuttid/service/cli/providers/agentcontext/skill_bundle.go
@@ -51,7 +51,7 @@ func (p Provider) runSkillBundle(ctx context.Context, invoke framework.InvokeCon
 	if err := p.requireSessions(); err != nil {
 		return nil, err
 	}
-	target, legacy, err := p.resolveAgentSelector(ctx, input.AgentID, input.Provider)
+	target, legacy, err := p.resolveAgentSelector(ctx, invoke.WorkspaceID, input.AgentID, input.Provider)
 	if err != nil {
 		return nil, err
 	}

--- a/services/tuttid/wiring_daemon_api.go
+++ b/services/tuttid/wiring_daemon_api.go
@@ -782,6 +782,7 @@ func buildDaemonAPI(
 		ManagedCredentials: managedCredentials,
 		AgentSessions:      agentSessionService, AgentTargets: agentTargets,
 		AgentTargetSetup: agentTargetSetup,
+		WorkspaceAgents:  workspaceAgents,
 		Preferences:      preferences, TuttiModePlans: tuttiModePlans,
 		TuttiModeExecutions:  tuttiModeExecutions,
 		TuttiModeActivations: tuttiModeActivations,

--- a/services/tuttid/wiring_daemon_cli.go
+++ b/services/tuttid/wiring_daemon_cli.go
@@ -25,6 +25,7 @@ import (
 	tuttimodeexecutionservice "github.com/tutti-os/tutti/services/tuttid/service/tuttimodeexecution"
 	tuttimodeplanservice "github.com/tutti-os/tutti/services/tuttid/service/tuttimodeplan"
 	workspaceservice "github.com/tutti-os/tutti/services/tuttid/service/workspace"
+	workspaceagentservice "github.com/tutti-os/tutti/services/tuttid/service/workspaceagent"
 )
 
 type daemonCLIRegistryInput struct {
@@ -36,6 +37,7 @@ type daemonCLIRegistryInput struct {
 	AgentSessions        *agentservice.Service
 	AgentTargets         agenttargetservice.Service
 	AgentTargetSetup     *agentextensionservice.SetupService
+	WorkspaceAgents      *workspaceagentservice.Service
 	Preferences          *preferencesservice.Service
 	TuttiModePlans       *tuttimodeplanservice.Service
 	TuttiModeExecutions  *tuttimodeexecutionservice.Service
@@ -68,7 +70,7 @@ func buildDaemonCLIRegistry(
 			},
 			input.AgentTargets,
 			input.Preferences,
-		).WithAgentTargetSetup(input.AgentTargetSetup),
+		).WithAgentTargetSetup(input.AgentTargetSetup).WithWorkspaceAgents(input.WorkspaceAgents),
 		tuttimodeplancli.NewProviderWithExecutionSnapshot(
 			input.Workspaces,
 			input.TuttiModePlans,


### PR DESCRIPTION
## Summary

- expose workspace-scoped custom Agents in `tutti agent list --json`
- preserve exact `workspace-agent:<uuid>` IDs across start, composer options, skill bundle, and Issue orchestration
- reject cross-workspace or unavailable custom Agent selections before session creation
- add focused daemon CLI and Issue regression coverage

Fixes #2412

## Verification

Reported on the source branch:

- `go test ./service/cli/providers/agentcontext` from `services/tuttid`
- `go test .` from `packages/workspace/issues`
- focused TypeScript test coverage added for Issue Manager plan creation
- `git diff --check`

The broader daemon-root `go test .` was reported as blocked by a pre-existing local Claude Code runtime-start failure, unrelated to the catalog assertions.

Windows impact: the change routes workspace IDs and catalog metadata only; it does not alter paths, processes, shells, permissions, packaging, or platform-specific adapters.

## Checklist

- [x] This PR does not change agent lifecycle semantics; it changes CLI discovery, selection, and adapter wiring.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [ ] All commits are signed off with DCO; the first two documentation commits currently lack a `Signed-off-by` trailer.