### PR TITLE
chore(release): disable daily desktop builds

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -9,8 +9,6 @@ on:
   push:
     tags:
       - "v*"
-  schedule:
-    - cron: "16 20 * * *"
   workflow_dispatch:
     inputs:
       release_mode:
@@ -163,15 +161,11 @@ jobs:
         id: mode
         shell: bash
         env:
-          RELEASE_EVENT_NAME: ${{ github.event_name }}
           RELEASE_MODE: ${{ inputs.release_mode }}
         run: |
           dry_run=false
           strategy=patch
 
-          if [[ "${RELEASE_EVENT_NAME}" == "schedule" ]]; then
-            strategy=patch_rc
-          else
           case "${RELEASE_MODE:-}" in
             "")
               strategy=explicit_tag
@@ -209,7 +203,6 @@ jobs:
               exit 1
               ;;
           esac
-          fi
 
           echo "dry_run=${dry_run}" >> "$GITHUB_OUTPUT"
           echo "strategy=${strategy}" >> "$GITHUB_OUTPUT"

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -483,19 +483,11 @@ test("desktop release checks the managed app runtime before reserving a tag or b
   );
 });
 
-test("desktop release workflow schedules a daily Beijing 4:16am rc release", async () => {
+test("desktop release workflow does not schedule daily rc releases", async () => {
   const workflow = await readFile(workflowPath, "utf8");
 
-  assert.match(workflow, /schedule:\s*\n\s*-\s*cron:\s*"16 20 \* \* \*"/);
-  assert.doesNotMatch(workflow, /timezone:\s*"Asia\/Shanghai"/);
-  assert.match(
-    workflow,
-    /RELEASE_EVENT_NAME:\s+\${{\s*github\.event_name\s*}}/
-  );
-  assert.match(
-    workflow,
-    /if \[\[ "\$\{RELEASE_EVENT_NAME\}" == "schedule" \]\]; then\s*\n\s*strategy=patch_rc/
-  );
+  assert.doesNotMatch(workflow, /schedule:\s*\n\s*-\s*cron:/);
+  assert.doesNotMatch(workflow, /RELEASE_EVENT_NAME.*schedule/);
 });
 
 test("desktop release workflow keeps less common rc bumps behind explicit version input", async () => {


### PR DESCRIPTION
## Summary

- remove the daily cron trigger from the desktop release workflow
- remove the now-unreachable scheduled release-mode branch
- update the repository workflow contract test
- preserve tag and manual release triggers

## Why

Desktop packages should no longer be built automatically every day.

## Risk

Low. This changes only workflow trigger and mode resolution. Manual and tag-based releases remain available.

## Verification

- `git diff --check`
- `node --test tools/scripts/desktop-release-config.test.mjs` (56 passed)

## Documentation

No documentation impact.