### PR TITLE
fix(agent): backport external Claude command protection to release/0818

### DIFF
--- a/docs/architecture/agent-runtime-preparation.md
+++ b/docs/architecture/agent-runtime-preparation.md
@@ -43,6 +43,18 @@ their parent task explicitly authorizes nested delegation and sets a total
 nested-worker and tool-call budget. The policy does not create an unbounded
 automatic retry loop.
 
+Claude Code follows a separate SDK compatibility contract. The daemon keeps the
+SDK-paired executable under the private Agent runtime root, and runtime
+preparation passes its absolute path to the Claude SDK. A user-level `claude`
+command is published only when the complete effective command search contains no
+independently installed Claude executable. If a later reconciliation finds an
+external command, the daemon removes only a user entry that is still provably
+Tutti-owned: it atomically quarantines the current entry, inspects the moved
+object, and restores it without replacement if ownership changed concurrently.
+The private stable hop stays active. This prevents the managed runtime from
+shadowing or deleting a user's CLI while preserving Tutti's existing managed
+runtime selection inside Claude Sessions.
+
 Deployment differences are expressed with `DeploymentProfile` and
 `CapabilityPack`. A pack resolves policy, skills, and environment together.
 Dynamic host skills use `SkillSource`; per-session skills use `ExtraSkills`.

--- a/docs/architecture/windows-platform-support.md
+++ b/docs/architecture/windows-platform-support.md
@@ -201,15 +201,20 @@ existing verified package is reused and updated in place instead of creating a
 second copy. After verification the daemon publishes the directory that owns
 the selected launcher. It does not migrate or delete the legacy package.
 
-Managed Agent Extensions and the provisioned Claude Code runtime publish into
-the same `%USERPROFILE%\.local\bin` contract. Their versioned executables stay
-under `%USERPROFILE%\.local\share\tutti\agent-runtimes`; a stable per-Agent
-`.cmd` launcher and a user-level `.cmd` launcher form two verified hops to the
-active executable. This avoids file-symlink privilege and keeps versioned
-runtime directories out of `PATH`. The daemon refuses to replace an existing
-entry unless it carries the Tutti launcher marker and points inside the
-expected managed runtime root. Successful install actions surface user-PATH
-write failures, while status-time adoption repairs PATH on a best-effort basis.
+Managed Agent Extensions and the provisioned Claude Code runtime use the same
+`%USERPROFILE%\.local\bin` publication contract. Their versioned executables
+stay under `%USERPROFILE%\.local\share\tutti\agent-runtimes`; a stable per-Agent
+`.cmd` launcher and an optional user-level `.cmd` launcher form two verified
+hops to the active executable. This avoids file-symlink privilege and keeps
+versioned runtime directories out of `PATH`. Before publishing Claude, the
+daemon scans the complete effective command search and preserves any
+independently installed launcher. A later reconciliation removes an older
+public launcher only when it still carries the Tutti marker and targets the
+expected stable runtime hop. Removal first atomically quarantines the launcher,
+then inspects the moved file; a concurrently replaced external launcher is
+restored without overwriting a newer entry. The private hop remains active.
+Successful publication surfaces user-PATH write failures, while skipped
+publication never adds the directory to the current-user registry PATH.
 Registry changes affect new processes only, so an already-open terminal must be
 restarted before it can resolve a newly published command.
 

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -25,7 +25,8 @@ Use the focused runtime index or open one area directly:
   Also covers focus-driven provider CLI scans, repeated Extension Target version
   probes, optional Provider absence misclassified as an environment failure,
   extension release refresh delaying daemon startup, Tutti Agent browser login
-  that loses the managed Node environment, and CPU spikes.
+  that loses the managed Node environment, a Tutti-published Claude command
+  shadowing an external CLI, and CPU spikes.
 - [Agent Sessions And Lifecycle](./agent-session-lifecycle.md): Turn state, activation, planning-mode classification, capability snapshots, Tutti workflow response contracts, loading, cancel, goal controls, restore, file-change undo, rail projection, realtime completion provenance, event updates, imports, and performance.
   Includes shared-device recovery that looks terminal while the host is still retrying.
   Also covers new or derived conversations that silently fail or lose

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -1373,6 +1373,39 @@ file or directory`. A failed `codex app-server` probe is diagnostic evidence,
   [acp_live_state.go](../../../packages/agent/daemon/runtime/acp_live_state.go)
   [service_helpers.go](../../../services/tuttid/service/agentstatus/service_helpers.go)
 
+### Installing Tutti changes the terminal's Claude version
+
+- Symptom:
+  `claude --version` reports a newer independently installed release before
+  Tutti starts, then resolves to the SDK-paired Tutti release afterward.
+- Quick checks:
+  Enumerate every `claude` candidate in effective PATH order and resolve links
+  or Windows launchers. Compare `~/.local/bin/claude` (or
+  `%USERPROFILE%\.local\bin\claude.cmd`) with the private
+  `agent-runtimes/claude-code/bin` hop. Do not infer ownership from the public
+  pathname alone.
+- Root cause:
+  Older releases checked only whether the intended public pathname was occupied.
+  When an external Claude command existed later in PATH, Tutti could fill the
+  earlier user-bin slot and shadow it even though no file was overwritten.
+- Fix:
+  Keep the SDK-paired Claude executable private and pass it to the SDK by
+  absolute path. Publish a user command only when the complete effective search
+  has no external Claude candidate. During reconciliation, atomically quarantine
+  the current public entry and inspect the moved Tutti symlink or Windows
+  launcher before deletion. If ownership changed concurrently, restore it with
+  no-replace semantics; never delete or overwrite a foreign file or launcher.
+- Validation:
+  Cover an external command later in PATH, migration from an older managed
+  public entry, preservation of a foreign occupant at the publication path, and
+  private stable-hop activation after publication is skipped. Run the native
+  Windows launcher tests as well as the POSIX symlink tests.
+- References:
+  [claude_binary.go](../../../services/tuttid/service/agentstatus/claude_binary.go)
+  [entry.go](../../../services/tuttid/service/usercommand/entry.go)
+  [entry_unix.go](../../../services/tuttid/service/usercommand/entry_unix.go)
+  [entry_windows.go](../../../services/tuttid/service/usercommand/entry_windows.go)
+
 ### Claude SDK model aliases resolve to configured Anthropic defaults
 
 - Symptom:

--- a/packages/agent/claude-sdk-sidecar/package.json
+++ b/packages/agent/claude-sdk-sidecar/package.json
@@ -62,7 +62,7 @@
     "typecheck": "node ../../../tools/scripts/run-tsgo-typecheck.mjs"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.220",
+    "@anthropic-ai/claude-agent-sdk": "0.3.258",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,8 +449,8 @@ importers:
   packages/agent/claude-sdk-sidecar:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.220
-        version: 0.3.220(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+        specifier: 0.3.258
+        version: 0.3.258(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
       zod:
         specifier: ^4.0.0
         version: 4.4.3
@@ -1708,48 +1708,48 @@ packages:
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.220':
-    resolution: {integrity: sha512-7VxlbEosK7DODiOnsjoVd0DSJzbnaPrM2jelMHI0y8zx1UnLS3WC6EFUXbvy74F2sXqEznh2tzn7EKWInaRN6Q==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.258':
+    resolution: {integrity: sha512-Hrhzc9WVGSid+DghdTcpVr/8fyXnTD6KeSlDpKx6Wru47J/Nq7RTYiZJt+cex+O2ehaHMEcuYEgoqJ3K/X9NlA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.220':
-    resolution: {integrity: sha512-X9RwDsSmbF6ultKZroaip+DL8WRgC64gHbrAwrRlAFSPNZV7zmJyP2ur8rW7KrxqmtuehdMMkw8+SAC/6hD2PA==}
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.258':
+    resolution: {integrity: sha512-AVqxGX4988J5cS+TMqIzH85+sbsLhJu5Ou9TIALcO/v2Z9ze8GK4vX2ydAYvU/SRnjTvEaiITX+Xcm5afP1IbQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.220':
-    resolution: {integrity: sha512-OHoZOZ8Cf2TBr6oXIXPwyvUxj9jrq2w8E4poA8dMpacXszcPSPiCQCMuuOh4aWJzfeJE1+TtWxhKMVb2csXyZQ==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.258':
+    resolution: {integrity: sha512-I/BLt2vdvqK2B2px526U1lw7Rv+SI+Ld22+wLwu8gLRQk5SYhSW9dmMYEO+GCeF7vQzfzJvMQ4IzbbY+aSGACg==}
     cpu: [arm64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.220':
-    resolution: {integrity: sha512-WkROPwWskqhKR9XgnmseHQ6rLi9zM9qt57IWoToIjL/eXOqDWipp7JXZ1L5ud+LrA42dunHPZfBwD/vXZ+A7LA==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.258':
+    resolution: {integrity: sha512-Jj3K1Ip7WpyMouZCjd7kgV3KswUBF62WAnyG0iaYvKZJvXgYKbIAkjcQ2F2Rx5ZuRUNWAVncE9LeHmdIdx78VQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.220':
-    resolution: {integrity: sha512-K+FWj+LcGhC1Z7wqeWoLxm1iemcba5xKpLLFVwYm4V6HyMx3ruYd/2r2TiQtjT+JWeNFWIys0ScHiItR6vWAiA==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.258':
+    resolution: {integrity: sha512-sM7GzRyrOpFhwMn2Ng8nLiWK6cc04uCEu3Zh9mrJS2r3iQu1TryHKoPTjc2Ip0N75sHmwhNodgoRs8NtG1Gkkw==}
     cpu: [x64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.220':
-    resolution: {integrity: sha512-tkTJFnpR9VifvWX2fmkCAPkT6+8Wk/gVu8B5jsVekKZPiZoWRHmMXO30BnZn+f0TZhgYP+82PSX3S8crH1kn+w==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.258':
+    resolution: {integrity: sha512-2MJeFVJM/3xwZASP3yn2OuQ9RHIoS30DC/B7oG1XPYcbToPLH4QIfCPLWbSQfqCdp+NEBupLMM9BWpDz4s8Q0g==}
     cpu: [x64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.220':
-    resolution: {integrity: sha512-rIwgq0UwQExWl6KrHUyC4w5KwpL9l6nd95aUTx6RitexaAuEw//xtfTVLnuE4hDDQZFkzEwpdKc3nxDWoGcUbA==}
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.258':
+    resolution: {integrity: sha512-n/Vf6oXAo9EZVSSM5+9d+8dFrUrX9cbgSHK/1njkvykWAN5xsfBbikJYqwhbW84GCYkpXYM+gGNZe23h0fHldw==}
     cpu: [arm64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.220':
-    resolution: {integrity: sha512-MuOuXhbr66HlGaWXD2f3w0k2PsvmnbkwcUZ0dAe2poFLdl72GC2dapwwOBefxm9QmoNqk9+jmv/dSKGOVWyvLw==}
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.258':
+    resolution: {integrity: sha512-UDbXE6n37ZMUogVVYEWX901NNmbyXUv1VvGYN/vfOiIWKUJXCAypam71dBlYFhlAhVX28qCd64w+pTZDYQfYQA==}
     cpu: [x64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk@0.3.220':
-    resolution: {integrity: sha512-glc7SdwPkOkLw8oxwLo9PKTdLJGqW/PIR4urWXFoRtX9YllwozsEVc5Tc1+EvLSkfrsxPJqQWqOgpjUOQXf1oA==}
+  '@anthropic-ai/claude-agent-sdk@0.3.258':
+    resolution: {integrity: sha512-RxJ5fSPCGCxX5qO/b4IPXhldvtLHeYBAzTUJ4eOzO+gTrepZQSDmwSlQD6nnoEquKGJzOMHCjhdEtBfDjbDWUg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@anthropic-ai/sdk': '>=0.93.0'
@@ -10885,44 +10885,44 @@ snapshots:
       package-manager-detector: 1.8.0
       tinyexec: 1.1.2
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.220':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.258':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.220':
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.258':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.220':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.258':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.220':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.258':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.220':
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.258':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.220':
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.258':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.220':
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.258':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.220':
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.258':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.3.220(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
+  '@anthropic-ai/claude-agent-sdk@0.3.258(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.109.0(zod@4.4.3)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.220
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.220
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.220
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.220
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.220
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.220
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.220
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.220
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.258
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.258
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.258
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.258
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.258
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.258
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.258
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.258
 
   '@anthropic-ai/sdk@0.109.0(zod@4.4.3)':
     dependencies:

--- a/services/tuttid/service/agentextension/managed_runtime_entry.go
+++ b/services/tuttid/service/agentextension/managed_runtime_entry.go
@@ -34,9 +34,11 @@ func (m *Manager) isManagedRuntimeExecutable(executable string) bool {
 
 func validateManagedRuntimeEntry(entry managedRuntimeEntry) error { return entry.Validate() }
 
-func verifyManagedRuntimeEntry(entry managedRuntimeEntry) error { return entry.Verify() }
+func verifyManagedRuntimeEntry(entry managedRuntimeEntry) error { return entry.VerifyPublished() }
 
-func publishManagedRuntimeEntry(entry managedRuntimeEntry) error { return entry.Publish() }
+func publishManagedRuntimeEntry(entry managedRuntimeEntry) error {
+	return entry.PublishRequired()
+}
 
 func (m *Manager) ensureUserCommandPath(ctx context.Context) error {
 	if m.UserPathAdapter == nil {

--- a/services/tuttid/service/agentstatus/claude_binary.go
+++ b/services/tuttid/service/agentstatus/claude_binary.go
@@ -214,15 +214,50 @@ func (s Service) activateClaudeCodeBinary(
 	if err := entry.Validate(); err != nil {
 		return fmt.Errorf("validate claude user command: %w", err)
 	}
+	if external := s.externalClaudeCodeCommand(); external != "" {
+		if err := entry.ActivateRuntime(); err != nil {
+			return fmt.Errorf("activate private claude command: %w", err)
+		}
+		removed, err := entry.Unpublish()
+		if err != nil {
+			return fmt.Errorf("unpublish managed claude user command: %w", err)
+		}
+		slog.Info("claude user command publication skipped; an external command already owns the effective PATH namespace",
+			"externalPath", external,
+			"userPath", entry.UserPath,
+			"removedManagedUserCommand", removed)
+		return nil
+	}
 	if s.UserPathAdapter != nil {
 		if err := s.UserPathAdapter.Ensure(ctx, userBinDir); err != nil {
 			return fmt.Errorf("publish claude user command directory: %w", err)
 		}
 	}
-	if err := entry.Publish(); err != nil {
+	published, err := entry.Publish()
+	if err != nil {
 		return fmt.Errorf("publish claude user command: %w", err)
 	}
+	if !published {
+		slog.Warn("claude user command publication skipped; a user-owned command with the same name is preserved",
+			"userPath", entry.UserPath)
+	}
 	return nil
+}
+
+// externalClaudeCodeCommand scans the complete effective command-search plan,
+// not only the intended publication directory. This prevents a Tutti launcher
+// in an earlier fallback directory from shadowing an independently installed
+// Claude command elsewhere on PATH.
+func (s Service) externalClaudeCodeCommand() string {
+	runtimeRoot := strings.TrimSpace(s.ClaudeCodeRuntimeDir)
+	resolver := s.commandResolver()
+	for _, candidate := range resolver.ResolveAll("claude", resolver.Env(nil)) {
+		if runtimeRoot != "" && usercommand.IsManagedExecutable(candidate, runtimeRoot) {
+			continue
+		}
+		return candidate
+	}
+	return ""
 }
 
 // Per-source download budgets: a stalled primary source must not consume the

--- a/services/tuttid/service/agentstatus/claude_binary_test.go
+++ b/services/tuttid/service/agentstatus/claude_binary_test.go
@@ -38,6 +38,8 @@ func TestActivateClaudeCodeBinaryPublishesStableUserCommand(t *testing.T) {
 	}
 	adapter := &recordingUserPathAdapter{}
 	service := Service{
+		Environ:              func() []string { return []string{"PATH="} },
+		HomeDir:              func() (string, error) { return t.TempDir(), nil },
 		ClaudeCodeRuntimeDir: runtimeRoot,
 		UserCommandBinDir:    userBinDir,
 		UserPathAdapter:      adapter,
@@ -55,6 +57,118 @@ func TestActivateClaudeCodeBinaryPublishesStableUserCommand(t *testing.T) {
 	}
 	if err := entry.Verify(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestActivateClaudeCodeBinaryPreservesExternalCommandElsewhereOnPath(t *testing.T) {
+	runtimeRoot := filepath.Join(t.TempDir(), "agent-runtimes", "claude-code")
+	userBinDir := filepath.Join(t.TempDir(), ".local", "bin")
+	externalBinDir := t.TempDir()
+	external := writeTestClaudeCommand(t, externalBinDir, "external claude")
+	executable := filepath.Join(runtimeRoot, "versions", testClaudeVersion, testClaudeBinaryName())
+	if err := os.MkdirAll(filepath.Dir(executable), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(executable, []byte("managed claude"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	adapter := &recordingUserPathAdapter{}
+	service := Service{
+		Environ:              func() []string { return testClaudePathEnv(externalBinDir) },
+		HomeDir:              func() (string, error) { return t.TempDir(), nil },
+		ClaudeCodeRuntimeDir: runtimeRoot,
+		UserCommandBinDir:    userBinDir,
+		UserPathAdapter:      adapter,
+	}
+	entry, err := usercommand.NewEntry(runtimeRoot, userBinDir, "claude", executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := service.activateClaudeCodeBinary(context.Background(), t.TempDir(), claudeSDKRuntimeDescriptor{ClaudeVersion: testClaudeVersion}, executable); err != nil {
+		t.Fatal(err)
+	}
+	if adapter.directory != "" {
+		t.Fatalf("external Claude caused user PATH publication: %q", adapter.directory)
+	}
+	if _, err := os.Lstat(entry.UserPath); !os.IsNotExist(err) {
+		t.Fatalf("managed user command was published over external PATH ownership: %v", err)
+	}
+	if _, err := os.Lstat(entry.StablePath); err != nil {
+		t.Fatalf("private stable command was not activated: %v", err)
+	}
+	if content, err := os.ReadFile(external); err != nil || string(content) != "external claude" {
+		t.Fatalf("external Claude changed: content=%q err=%v", content, err)
+	}
+}
+
+func TestActivateClaudeCodeBinaryRemovesOlderManagedUserCommandWhenExternalExists(t *testing.T) {
+	runtimeRoot := filepath.Join(t.TempDir(), "agent-runtimes", "claude-code")
+	userBinDir := filepath.Join(t.TempDir(), ".local", "bin")
+	externalBinDir := t.TempDir()
+	writeTestClaudeCommand(t, externalBinDir, "external claude")
+	oldExecutable := filepath.Join(runtimeRoot, "versions", "2.1.220", testClaudeBinaryName())
+	newExecutable := filepath.Join(runtimeRoot, "versions", testClaudeVersion, testClaudeBinaryName())
+	for path, content := range map[string]string{oldExecutable: "old managed", newExecutable: "new managed"} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	entry, err := usercommand.NewEntry(runtimeRoot, userBinDir, "claude", oldExecutable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := entry.Publish(); err != nil {
+		t.Fatal(err)
+	}
+	adapter := &recordingUserPathAdapter{}
+	service := Service{
+		Environ:              func() []string { return testClaudePathEnv(userBinDir, externalBinDir) },
+		HomeDir:              func() (string, error) { return t.TempDir(), nil },
+		ClaudeCodeRuntimeDir: runtimeRoot,
+		UserCommandBinDir:    userBinDir,
+		UserPathAdapter:      adapter,
+	}
+	if err := service.activateClaudeCodeBinary(context.Background(), t.TempDir(), claudeSDKRuntimeDescriptor{ClaudeVersion: testClaudeVersion}, newExecutable); err != nil {
+		t.Fatal(err)
+	}
+	if adapter.directory != "" {
+		t.Fatalf("external Claude caused user PATH publication: %q", adapter.directory)
+	}
+	if _, err := os.Lstat(entry.UserPath); !os.IsNotExist(err) {
+		t.Fatalf("older managed user command was not removed: %v", err)
+	}
+	content, err := os.ReadFile(entry.StablePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS == "windows" && !strings.Contains(strings.ToLower(string(content)), strings.ToLower(newExecutable)) {
+		t.Fatalf("stable launcher does not target refreshed managed runtime: %q", content)
+	}
+	if runtime.GOOS != "windows" && string(content) != "new managed" {
+		t.Fatalf("stable command content = %q, want refreshed managed runtime", content)
+	}
+}
+
+func writeTestClaudeCommand(t *testing.T, dir string, content string) string {
+	t.Helper()
+	name := "claude"
+	if runtime.GOOS == "windows" {
+		name = "claude.cmd"
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func testClaudePathEnv(dirs ...string) []string {
+	return []string{
+		"PATH=" + strings.Join(dirs, string(os.PathListSeparator)),
+		"PATHEXT=.COM;.EXE;.BAT;.CMD;.PS1",
 	}
 }
 
@@ -163,6 +277,16 @@ func TestManagedClaudeCodeInstallerUsesProvisionedRuntime(t *testing.T) {
 
 func TestResolveProviderRuntimeUsesManagedClaudeCodePointer(t *testing.T) {
 	fixture := newClaudeBinaryFixture(t)
+	externalPath := filepath.Join(t.TempDir(), testClaudeBinaryName())
+	if err := os.WriteFile(externalPath, []byte("external claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fixture.service.LookPath = func(name string) (string, error) {
+		if name == "claude" || name == "claude.exe" {
+			return externalPath, nil
+		}
+		return "", os.ErrNotExist
+	}
 	installedPath := fixture.installedBinaryPath()
 	if err := os.MkdirAll(filepath.Dir(installedPath), 0o755); err != nil {
 		t.Fatal(err)
@@ -182,7 +306,7 @@ func TestResolveProviderRuntimeUsesManagedClaudeCodePointer(t *testing.T) {
 	}
 	runtimeResolution := fixture.service.resolveProviderRuntime(context.Background(), specs[0])
 	if runtimeResolution.CLIPath != installedPath {
-		t.Fatalf("CLIPath = %q, want managed Claude binary %q", runtimeResolution.CLIPath, installedPath)
+		t.Fatalf("CLIPath = %q, want managed Claude binary %q instead of external %q", runtimeResolution.CLIPath, installedPath, externalPath)
 	}
 }
 

--- a/services/tuttid/service/agentstatus/installer_runtime.go
+++ b/services/tuttid/service/agentstatus/installer_runtime.go
@@ -53,9 +53,12 @@ func (s Service) resolveProviderRuntime(ctx context.Context, spec ProviderSpec) 
 		}
 		return result
 	}
-	cliPath := resolveBinaryWithResolver(resolver, spec.BinaryNames, nil)
-	if isClaudeStatusSpec(spec) && strings.TrimSpace(cliPath) == "" {
+	cliPath := ""
+	if isClaudeStatusSpec(spec) {
 		cliPath = s.managedClaudeCodeExecutable()
+	}
+	if strings.TrimSpace(cliPath) == "" {
+		cliPath = resolveBinaryWithResolver(resolver, spec.BinaryNames, nil)
 	}
 	adapterPath := resolveBinaryWithResolver(resolver, adapterBinaryNames(spec), spec.AdapterEnv)
 	if isStandardACPStatusSpec(spec) && len(spec.AdapterCommand) > 0 && s.executableFile(spec.AdapterCommand[0]) {

--- a/services/tuttid/service/usercommand/entry.go
+++ b/services/tuttid/service/usercommand/entry.go
@@ -43,16 +43,59 @@ func NewEntry(runtimeRoot, userBinDir, commandName, finalExecutable string) (Ent
 	}, nil
 }
 
+// userEntryKind classifies the state of the user-command hop.
+type userEntryKind uint8
+
+const (
+	// userEntryAbsent: no command with this name exists in the user bin dir.
+	userEntryAbsent userEntryKind = iota
+	// userEntryManaged: the entry is Tutti's and points at the stable path.
+	userEntryManaged
+	// userEntryForeign: the user owns a command with the same name (e.g. a
+	// locally installed CLI). It is preserved untouched, and user-command
+	// publication is skipped instead of failing the managed runtime.
+	userEntryForeign
+)
+
+func (e Entry) validateStablePath() error {
+	return validatePlatformEntry(e.StablePath, e.RuntimeRoot, "managed runtime entry")
+}
+
 func (e Entry) Validate() error {
-	if err := validatePlatformEntry(e.StablePath, e.RuntimeRoot, "managed runtime entry"); err != nil {
+	if err := e.validateStablePath(); err != nil {
 		return err
 	}
-	return validateExactPlatformEntry(e.UserPath, e.StablePath, "user executable entry")
+	_, err := e.classifyUserEntry()
+	return err
 }
 
 func (e Entry) Verify() error {
+	return e.verify(false)
+}
+
+// VerifyPublished requires the user-level command to be owned by Tutti. It is
+// used by release-era Agent Extension callers whose readiness contract still
+// requires a published command, while Verify allows Claude's private runtime
+// to remain valid when an external command owns the PATH namespace.
+func (e Entry) VerifyPublished() error {
+	return e.verify(true)
+}
+
+func (e Entry) verify(requirePublished bool) error {
 	if err := e.Validate(); err != nil {
 		return err
+	}
+	kind, err := e.classifyUserEntry()
+	if err != nil {
+		return err
+	}
+	if kind != userEntryManaged {
+		if requirePublished {
+			return fmt.Errorf("user executable entry is not published by Tutti: %s", e.UserPath)
+		}
+		// No Tutti user command is installed (absent or foreign). The managed
+		// runtime is still usable; there is nothing to verify on the user hop.
+		return nil
 	}
 	for label, path := range map[string]string{
 		"managed runtime entry": e.StablePath,
@@ -76,21 +119,76 @@ func (e Entry) Verify() error {
 	return nil
 }
 
-func (e Entry) Publish() error {
-	if err := e.Validate(); err != nil {
+// ActivateRuntime refreshes the private stable command hop without publishing
+// or changing the user-level command. Callers use this when an independently
+// installed command already owns the effective PATH namespace.
+func (e Entry) ActivateRuntime() error {
+	if err := e.validateStablePath(); err != nil {
 		return err
 	}
-	createdUserEntry, err := ensurePlatformEntry(e.UserPath, e.StablePath)
+	return replacePlatformEntry(e.StablePath, e.FinalExecutable)
+}
+
+// Unpublish removes the user-level command only when it is still provably
+// owned by this entry. Foreign or already-absent commands are preserved.
+func (e Entry) Unpublish() (bool, error) {
+	kind, err := e.classifyUserEntry()
 	if err != nil {
-		return err
+		return false, err
 	}
-	if err := replacePlatformEntry(e.StablePath, e.FinalExecutable); err != nil {
+	if kind != userEntryManaged {
+		return false, nil
+	}
+	return removePlatformEntry(e.UserPath, e.StablePath)
+}
+
+// Publish installs the managed command hops. It returns whether the
+// user-command entry is owned by Tutti. A foreign occupant is preserved
+// untouched: publication is then skipped (the internal stable hop is still
+// refreshed) and the caller should treat the runtime as activated.
+func (e Entry) Publish() (bool, error) {
+	return e.publish(false)
+}
+
+// PublishRequired preserves the strict release-era Agent Extension contract:
+// a foreign user command fails before the private stable hop is changed.
+func (e Entry) PublishRequired() error {
+	_, err := e.publish(true)
+	return err
+}
+
+func (e Entry) publish(requirePublished bool) (bool, error) {
+	if err := e.validateStablePath(); err != nil {
+		return false, err
+	}
+	kind, err := e.classifyUserEntry()
+	if err != nil {
+		return false, err
+	}
+	if kind == userEntryForeign {
+		if requirePublished {
+			return false, fmt.Errorf("user executable entry is already occupied: %s", e.UserPath)
+		}
+		if err := e.ActivateRuntime(); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+	createdUserEntry := false
+	if kind == userEntryAbsent {
+		created, err := ensurePlatformEntry(e.UserPath, e.StablePath)
+		if err != nil {
+			return false, err
+		}
+		createdUserEntry = created
+	}
+	if err := e.ActivateRuntime(); err != nil {
 		if createdUserEntry {
 			_ = os.Remove(e.UserPath)
 		}
-		return err
+		return false, err
 	}
-	return nil
+	return true, nil
 }
 
 func IsManagedExecutable(executable, runtimeRoot string) bool {
@@ -109,4 +207,50 @@ func pathWithin(path, root string) bool {
 
 func samePath(left, right string) bool {
 	return platformSamePath(filepath.Clean(left), filepath.Clean(right))
+}
+
+func newEntryQuarantinePath(path string) (string, error) {
+	temporary, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tutti-unpublish-*")
+	if err != nil {
+		return "", err
+	}
+	temporaryPath := temporary.Name()
+	if err := errors.Join(temporary.Close(), os.Remove(temporaryPath)); err != nil {
+		return "", err
+	}
+	return temporaryPath, nil
+}
+
+func restoreQuarantinedEntry(path, quarantinePath string) error {
+	// Creating the restored name is atomic and no-replace. A concurrent
+	// installer that has already recreated path therefore wins; its entry is
+	// never overwritten, and the quarantined command remains recoverable.
+	info, err := os.Lstat(quarantinePath)
+	if err != nil {
+		return err
+	}
+	var restoreErr error
+	if info.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(quarantinePath)
+		if err != nil {
+			return err
+		}
+		restoreErr = os.Symlink(target, path)
+	} else {
+		restoreErr = os.Link(quarantinePath, path)
+	}
+	if restoreErr != nil {
+		return fmt.Errorf("restore changed user command; preserved at %s: %w", quarantinePath, restoreErr)
+	}
+	if err := os.Remove(quarantinePath); err != nil {
+		return fmt.Errorf("remove restored command quarantine %s: %w", quarantinePath, err)
+	}
+	return nil
+}
+
+func removeQuarantinedManagedEntry(path, quarantinePath string) (bool, error) {
+	if err := os.Remove(quarantinePath); err != nil {
+		return false, errors.Join(err, restoreQuarantinedEntry(path, quarantinePath))
+	}
+	return true, nil
 }

--- a/services/tuttid/service/usercommand/entry_unix.go
+++ b/services/tuttid/service/usercommand/entry_unix.go
@@ -34,25 +34,25 @@ func validatePlatformEntry(path, runtimeRoot, label string) error {
 	return nil
 }
 
-func validateExactPlatformEntry(path, expectedTarget, label string) error {
-	info, err := os.Lstat(path)
+func (e Entry) classifyUserEntry() (userEntryKind, error) {
+	info, err := os.Lstat(e.UserPath)
 	if errors.Is(err, os.ErrNotExist) {
-		return nil
+		return userEntryAbsent, nil
 	}
 	if err != nil {
-		return err
+		return 0, err
 	}
 	if info.Mode()&os.ModeSymlink == 0 {
-		return fmt.Errorf("%s is already occupied: %s", label, path)
+		return userEntryForeign, nil
 	}
-	target, err := resolvedSymlinkTarget(path)
+	target, err := resolvedSymlinkTarget(e.UserPath)
 	if err != nil {
-		return err
+		return 0, err
 	}
-	if !samePath(target, expectedTarget) {
-		return fmt.Errorf("%s is not owned by Tutti: %s", label, path)
+	if samePath(target, e.StablePath) {
+		return userEntryManaged, nil
 	}
-	return nil
+	return userEntryForeign, nil
 }
 
 func ensurePlatformEntry(path, target string) (bool, error) {
@@ -96,6 +96,33 @@ func replacePlatformEntry(path, target string) error {
 		return err
 	}
 	return replaceFile(path, temporaryPath)
+}
+
+func removePlatformEntry(path, target string) (bool, error) {
+	quarantinePath, err := newEntryQuarantinePath(path)
+	if err != nil {
+		return false, err
+	}
+	if err := os.Rename(path, quarantinePath); errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+	info, err := os.Lstat(quarantinePath)
+	if err != nil {
+		return false, errors.Join(err, restoreQuarantinedEntry(path, quarantinePath))
+	}
+	currentTarget, err := resolvedSymlinkTarget(quarantinePath)
+	if err != nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return false, errors.Join(err, restoreQuarantinedEntry(path, quarantinePath))
+		}
+		return false, restoreQuarantinedEntry(path, quarantinePath)
+	}
+	if info.Mode()&os.ModeSymlink == 0 || !samePath(currentTarget, target) {
+		return false, restoreQuarantinedEntry(path, quarantinePath)
+	}
+	return removeQuarantinedManagedEntry(path, quarantinePath)
 }
 
 func resolvePlatformEntry(path string) (string, error) {

--- a/services/tuttid/service/usercommand/entry_unix_test.go
+++ b/services/tuttid/service/usercommand/entry_unix_test.go
@@ -8,6 +8,18 @@ import (
 	"testing"
 )
 
+func writeTestExecutable(t *testing.T, runtimeRoot, relative string) string {
+	t.Helper()
+	executable := filepath.Join(runtimeRoot, relative)
+	if err := os.MkdirAll(filepath.Dir(executable), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(executable, []byte("#!/bin/sh\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return executable
+}
+
 func TestUnixEntryVerifiesSymlinkFinalExecutable(t *testing.T) {
 	runtimeRoot := t.TempDir()
 	userBinDir := t.TempDir()
@@ -29,10 +41,187 @@ func TestUnixEntryVerifiesSymlinkFinalExecutable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := entry.Publish(); err != nil {
+	published, err := entry.Publish()
+	if err != nil {
 		t.Fatal(err)
+	}
+	if !published {
+		t.Fatal("Publish() reported a skipped user entry on an empty user bin dir")
 	}
 	if err := entry.Verify(); err != nil {
 		t.Fatal(err)
+	}
+}
+func TestUnixEntrySkipsForeignSymlinkUserCommand(t *testing.T) {
+	runtimeRoot := t.TempDir()
+	userBinDir := t.TempDir()
+	foreignTarget := writeTestExecutable(t, t.TempDir(), "tools/hermes/bin/hermes")
+	finalExecutable := writeTestExecutable(t, runtimeRoot, "runtime-id/bin/hermes")
+	entry, err := NewEntry(runtimeRoot, userBinDir, "hermes", finalExecutable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foreign := filepath.Join(userBinDir, "hermes")
+	if err := os.Symlink(foreignTarget, foreign); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := entry.Validate(); err != nil {
+		t.Fatalf("Validate() rejected a foreign user command: %v", err)
+	}
+	published, err := entry.Publish()
+	if err != nil {
+		t.Fatalf("Publish() failed on a foreign user command: %v", err)
+	}
+	if published {
+		t.Fatal("Publish() reported it published over a foreign user command")
+	}
+	target, err := os.Readlink(foreign)
+	if err != nil {
+		t.Fatalf("foreign user command was replaced: %v", err)
+	}
+	if target != foreignTarget {
+		t.Fatalf("foreign user command target changed: %q", target)
+	}
+	if err := entry.Verify(); err != nil {
+		t.Fatalf("Verify() rejected a runtime with a skipped user command: %v", err)
+	}
+	// The internal stable hop must still be refreshed. The platform entry
+	// stores a directory-relative symlink target, so resolve it first.
+	stableTarget, err := os.Readlink(entry.StablePath)
+	if err != nil {
+		t.Fatalf("stable entry missing after Publish: %v", err)
+	}
+	resolvedStableTarget, err := resolvedSymlinkTarget(entry.StablePath)
+	if err != nil {
+		t.Fatalf("resolve stable entry target: %v", err)
+	}
+	if resolvedStableTarget != finalExecutable {
+		t.Fatalf("stable entry target = %q, want %q", stableTarget, finalExecutable)
+	}
+}
+
+func TestUnixEntrySkipsForeignFileUserCommand(t *testing.T) {
+	runtimeRoot := t.TempDir()
+	userBinDir := t.TempDir()
+	finalExecutable := writeTestExecutable(t, runtimeRoot, "runtime-id/bin/hermes")
+	entry, err := NewEntry(runtimeRoot, userBinDir, "hermes", finalExecutable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foreign := filepath.Join(userBinDir, "hermes")
+	if err := os.WriteFile(foreign, []byte("#!/bin/sh\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	published, err := entry.Publish()
+	if err != nil {
+		t.Fatalf("Publish() failed on a foreign regular file: %v", err)
+	}
+	if published {
+		t.Fatal("Publish() reported it published over a foreign regular file")
+	}
+	if err := entry.Verify(); err != nil {
+		t.Fatalf("Verify() rejected a runtime with a skipped user command: %v", err)
+	}
+	content, err := os.ReadFile(foreign)
+	if err != nil || string(content) != "#!/bin/sh\n" {
+		t.Fatalf("foreign regular file was modified: %q err=%v", content, err)
+	}
+}
+
+func TestUnixEntryPublishRequiredRejectsForeignBeforeActivatingRuntime(t *testing.T) {
+	runtimeRoot := t.TempDir()
+	userBinDir := t.TempDir()
+	finalExecutable := writeTestExecutable(t, runtimeRoot, "runtime-id/bin/codex")
+	entry, err := NewEntry(runtimeRoot, userBinDir, "codex", finalExecutable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foreign := filepath.Join(userBinDir, "codex")
+	if err := os.WriteFile(foreign, []byte("#!/bin/sh\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := entry.PublishRequired(); err == nil {
+		t.Fatal("PublishRequired() accepted a foreign user command")
+	}
+	if _, err := os.Lstat(entry.StablePath); !os.IsNotExist(err) {
+		t.Fatalf("strict publication changed the private stable entry: %v", err)
+	}
+	content, err := os.ReadFile(foreign)
+	if err != nil || string(content) != "#!/bin/sh\n" {
+		t.Fatalf("strict publication modified the foreign command: %q err=%v", content, err)
+	}
+}
+
+func TestUnixEntryUnpublishesOnlyManagedUserCommand(t *testing.T) {
+	runtimeRoot := t.TempDir()
+	userBinDir := t.TempDir()
+	finalExecutable := writeTestExecutable(t, runtimeRoot, "runtime-id/bin/claude")
+	entry, err := NewEntry(runtimeRoot, userBinDir, "claude", finalExecutable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := entry.Publish(); err != nil {
+		t.Fatal(err)
+	}
+	removed, err := entry.Unpublish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !removed {
+		t.Fatal("Unpublish() did not remove the managed user command")
+	}
+	if _, err := os.Lstat(entry.UserPath); !os.IsNotExist(err) {
+		t.Fatalf("managed user command still exists: %v", err)
+	}
+	if _, err := os.Lstat(entry.StablePath); err != nil {
+		t.Fatalf("private stable command was removed: %v", err)
+	}
+
+	foreignTarget := writeTestExecutable(t, t.TempDir(), "external/bin/claude")
+	if err := os.Symlink(foreignTarget, entry.UserPath); err != nil {
+		t.Fatal(err)
+	}
+	removed, err = entry.Unpublish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed {
+		t.Fatal("Unpublish() removed a foreign user command")
+	}
+	if target, err := os.Readlink(entry.UserPath); err != nil || target != foreignTarget {
+		t.Fatalf("foreign user command changed: target=%q err=%v", target, err)
+	}
+}
+
+func TestUnixRemovePlatformEntryRestoresConcurrentForeignReplacement(t *testing.T) {
+	runtimeRoot := t.TempDir()
+	userBinDir := t.TempDir()
+	finalExecutable := writeTestExecutable(t, runtimeRoot, "runtime-id/bin/claude")
+	entry, err := NewEntry(runtimeRoot, userBinDir, "claude", finalExecutable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := entry.Publish(); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate an external installer replacing the command after Unpublish has
+	// classified the old entry but before the platform removal step runs.
+	if err := os.Remove(entry.UserPath); err != nil {
+		t.Fatal(err)
+	}
+	foreignTarget := writeTestExecutable(t, t.TempDir(), "external/bin/claude")
+	if err := os.Symlink(foreignTarget, entry.UserPath); err != nil {
+		t.Fatal(err)
+	}
+	removed, err := removePlatformEntry(entry.UserPath, entry.StablePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed {
+		t.Fatal("concurrent foreign replacement was reported as removed")
+	}
+	if target, err := os.Readlink(entry.UserPath); err != nil || target != foreignTarget {
+		t.Fatalf("concurrent foreign replacement was not restored: target=%q err=%v", target, err)
 	}
 }

--- a/services/tuttid/service/usercommand/entry_windows.go
+++ b/services/tuttid/service/usercommand/entry_windows.go
@@ -36,21 +36,21 @@ func validatePlatformEntry(path, runtimeRoot, label string) error {
 	return nil
 }
 
-func validateExactPlatformEntry(path, expectedTarget, label string) error {
-	if err := validateWindowsCommandNamespace(path); err != nil {
-		return fmt.Errorf("%s is shadowed: %w", label, err)
-	}
-	target, exists, err := readWindowsLauncher(path)
+func (e Entry) classifyUserEntry() (userEntryKind, error) {
+	target, exists, err := readWindowsLauncher(e.UserPath)
 	if err != nil {
-		return fmt.Errorf("%s is already occupied: %s", label, path)
+		return userEntryForeign, nil
 	}
-	if !exists {
-		return nil
+	if exists {
+		if samePath(target, e.StablePath) {
+			return userEntryManaged, nil
+		}
+		return userEntryForeign, nil
 	}
-	if !samePath(target, expectedTarget) {
-		return fmt.Errorf("%s is not owned by Tutti: %s", label, path)
+	if err := validateWindowsCommandNamespace(e.UserPath); err != nil {
+		return userEntryForeign, nil
 	}
-	return nil
+	return userEntryAbsent, nil
 }
 
 func ensurePlatformEntry(path, target string) (bool, error) {
@@ -72,6 +72,24 @@ func ensurePlatformEntry(path, target string) (bool, error) {
 
 func replacePlatformEntry(path, target string) error {
 	return writeWindowsLauncherAtomic(path, target)
+}
+
+func removePlatformEntry(path, target string) (bool, error) {
+	quarantinePath, err := newEntryQuarantinePath(path)
+	if err != nil {
+		return false, err
+	}
+	if err := os.Rename(path, quarantinePath); errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+	currentTarget, exists, err := readWindowsLauncher(quarantinePath)
+	if err != nil || !exists || !samePath(currentTarget, target) {
+		// A malformed or different launcher is user-owned and must be restored.
+		return false, restoreQuarantinedEntry(path, quarantinePath)
+	}
+	return removeQuarantinedManagedEntry(path, quarantinePath)
 }
 
 func resolvePlatformEntry(path string) (string, error) {

--- a/services/tuttid/service/usercommand/entry_windows_test.go
+++ b/services/tuttid/service/usercommand/entry_windows_test.go
@@ -31,8 +31,12 @@ func TestWindowsEntryPublishesAndRepointsCommandLauncher(t *testing.T) {
 	if err := first.Validate(); err != nil {
 		t.Fatal(err)
 	}
-	if err := first.Publish(); err != nil {
+	published, err := first.Publish()
+	if err != nil {
 		t.Fatal(err)
+	}
+	if !published {
+		t.Fatal("Publish() reported a skipped user entry on an empty user bin dir")
 	}
 	if err := first.Verify(); err != nil {
 		t.Fatal(err)
@@ -46,8 +50,12 @@ func TestWindowsEntryPublishesAndRepointsCommandLauncher(t *testing.T) {
 	if err := second.Validate(); err != nil {
 		t.Fatal(err)
 	}
-	if err := second.Publish(); err != nil {
+	published, err = second.Publish()
+	if err != nil {
 		t.Fatal(err)
+	}
+	if !published {
+		t.Fatal("Publish() reported a skipped user entry on a managed upgrade")
 	}
 	if err := second.Verify(); err != nil {
 		t.Fatal(err)
@@ -99,8 +107,12 @@ func TestWindowsEntryRefusesHigherPriorityCommandSibling(t *testing.T) {
 			if err := os.WriteFile(foreignPath, []byte("foreign"), 0o600); err != nil {
 				t.Fatal(err)
 			}
-			if err := entry.Publish(); err == nil {
-				t.Fatal("Publish() unexpectedly accepted a higher-priority foreign command")
+			published, err := entry.Publish()
+			if err != nil {
+				t.Fatalf("Publish() failed on a higher-priority foreign command: %v", err)
+			}
+			if published {
+				t.Fatal("Publish() reported it published next to a higher-priority foreign command")
 			}
 			if _, err := os.Stat(entry.UserPath); !errors.Is(err, os.ErrNotExist) {
 				t.Fatalf("managed launcher exists after collision: %v", err)
@@ -116,7 +128,7 @@ func TestWindowsEntryVerifyRejectsMissingFinalExecutable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := entry.Publish(); err != nil {
+	if _, err := entry.Publish(); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.Remove(target); err != nil {
@@ -124,6 +136,76 @@ func TestWindowsEntryVerifyRejectsMissingFinalExecutable(t *testing.T) {
 	}
 	if err := entry.Verify(); err == nil {
 		t.Fatal("Verify() unexpectedly accepted a missing final executable")
+	}
+}
+
+func TestWindowsEntryUnpublishesOnlyManagedUserCommand(t *testing.T) {
+	root := t.TempDir()
+	userBinDir := t.TempDir()
+	target := writeWindowsTestCommand(t, root, "runtime", 0)
+	entry, err := NewEntry(root, userBinDir, "sample", target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := entry.Publish(); err != nil {
+		t.Fatal(err)
+	}
+	removed, err := entry.Unpublish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !removed {
+		t.Fatal("Unpublish() did not remove the managed user launcher")
+	}
+	if _, err := os.Stat(entry.UserPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("managed user launcher still exists: %v", err)
+	}
+	if _, err := os.Stat(entry.StablePath); err != nil {
+		t.Fatalf("private stable launcher was removed: %v", err)
+	}
+
+	foreignContent := []byte("@echo foreign\r\n")
+	if err := os.WriteFile(entry.UserPath, foreignContent, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	removed, err = entry.Unpublish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed {
+		t.Fatal("Unpublish() removed a foreign user launcher")
+	}
+	content, err := os.ReadFile(entry.UserPath)
+	if err != nil || string(content) != string(foreignContent) {
+		t.Fatalf("foreign user launcher changed: content=%q err=%v", content, err)
+	}
+}
+
+func TestWindowsRemovePlatformEntryRestoresConcurrentForeignReplacement(t *testing.T) {
+	root := t.TempDir()
+	entry, err := NewEntry(root, t.TempDir(), "sample", writeWindowsTestCommand(t, root, "runtime", 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := entry.Publish(); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate an external installer replacing the launcher after Unpublish has
+	// classified the old entry but before the platform removal step runs.
+	foreignContent := []byte("@echo foreign replacement\r\n")
+	if err := os.WriteFile(entry.UserPath, foreignContent, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	removed, err := removePlatformEntry(entry.UserPath, entry.StablePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed {
+		t.Fatal("concurrent foreign replacement was reported as removed")
+	}
+	content, err := os.ReadFile(entry.UserPath)
+	if err != nil || string(content) != string(foreignContent) {
+		t.Fatalf("concurrent foreign replacement was not restored: content=%q err=%v", content, err)
 	}
 }
 

--- a/tools/scripts/claude-code-lockfile.mjs
+++ b/tools/scripts/claude-code-lockfile.mjs
@@ -1,0 +1,53 @@
+export function pnpmPackageIntegrity(lockfile, packageName, version) {
+  const packageKey = `${packageName}@${version}`;
+  const lines = lockfile.split(/\r?\n/);
+  let packageIndent = -1;
+  let resolutionIndent = -1;
+
+  for (const line of lines) {
+    const indent = line.length - line.trimStart().length;
+    const mapping = line.match(/^(\s*)(?:(['"])(.*?)\2|([^'"].*?)):\s*$/);
+    if (packageIndent < 0) {
+      const key = mapping?.[3] ?? mapping?.[4];
+      if (key === packageKey) {
+        packageIndent = indent;
+      }
+      continue;
+    }
+
+    if (line.trim() === "") {
+      continue;
+    }
+    if (indent <= packageIndent) {
+      return null;
+    }
+
+    const trimmed = line.trim();
+    if (resolutionIndent >= 0) {
+      if (indent <= resolutionIndent) {
+        resolutionIndent = -1;
+      } else {
+        const integrity = integrityFromText(trimmed);
+        if (integrity) {
+          return integrity;
+        }
+        continue;
+      }
+    }
+    if (trimmed === "resolution:") {
+      resolutionIndent = indent;
+      continue;
+    }
+    if (trimmed.startsWith("resolution:")) {
+      return integrityFromText(trimmed);
+    }
+  }
+  return null;
+}
+
+function integrityFromText(value) {
+  return (
+    value.match(/(?:^|[{,]\s*)integrity:\s*(sha512-[A-Za-z0-9+/=]+)/)?.[1] ??
+    null
+  );
+}

--- a/tools/scripts/claude-code-lockfile.test.mjs
+++ b/tools/scripts/claude-code-lockfile.test.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { pnpmPackageIntegrity } from "./claude-code-lockfile.mjs";
+
+const integrity = "sha512-RxJ5fSPCGCxX5qO/b4IPXhldvtLHeYBAzTUJ4eOzO+g=";
+
+test("reads pnpm single-quoted package keys", () => {
+  const lockfile = `
+packages:
+  '@anthropic-ai/claude-agent-sdk@0.3.258':
+    resolution: {integrity: ${integrity}}
+`;
+  assert.equal(
+    pnpmPackageIntegrity(lockfile, "@anthropic-ai/claude-agent-sdk", "0.3.258"),
+    integrity
+  );
+});
+
+test("keeps compatibility with double-quoted package keys", () => {
+  const lockfile = `
+packages:
+  "@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.258":
+    resolution: {integrity: ${integrity}}
+`;
+  assert.equal(
+    pnpmPackageIntegrity(
+      lockfile,
+      "@anthropic-ai/claude-agent-sdk-darwin-arm64",
+      "0.3.258"
+    ),
+    integrity
+  );
+});
+
+test("does not borrow integrity from another package version", () => {
+  const lockfile = `
+packages:
+  '@anthropic-ai/claude-agent-sdk@0.3.220':
+    resolution: {integrity: ${integrity}}
+`;
+  assert.equal(
+    pnpmPackageIntegrity(lockfile, "@anthropic-ai/claude-agent-sdk", "0.3.258"),
+    null
+  );
+});
+
+test("does not borrow integrity from the next package mapping", () => {
+  const lockfile = `
+packages:
+  '@anthropic-ai/claude-agent-sdk@0.3.258':
+    resolution: {tarball: https://example.invalid/sdk.tgz}
+  '@anthropic-ai/another-package@1.0.0':
+    resolution: {integrity: ${integrity}}
+`;
+  assert.equal(
+    pnpmPackageIntegrity(lockfile, "@anthropic-ai/claude-agent-sdk", "0.3.258"),
+    null
+  );
+});

--- a/tools/scripts/dev-gui.sh
+++ b/tools/scripts/dev-gui.sh
@@ -5,6 +5,10 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DESKTOP_APP_DIR="${ROOT_DIR}/apps/desktop"
 TUTTID_DIR="${ROOT_DIR}/services/tuttid"
 TUTTID_BIN_DIR="${DESKTOP_APP_DIR}/build/tuttid"
+CLAUDE_SDK_SIDECAR_DIR="${DESKTOP_APP_DIR}/build/claude-sdk-sidecar"
+CLAUDE_SDK_SIDECAR_ENTRY_PATH="${CLAUDE_SDK_SIDECAR_DIR}/src/main.ts"
+CLAUDE_SDK_SIDECAR_PACKAGE_JSON="${ROOT_DIR}/packages/agent/claude-sdk-sidecar/package.json"
+CLAUDE_SDK_SIDECAR_SOURCE_DIR="${ROOT_DIR}/packages/agent/claude-sdk-sidecar/src"
 NODE_VERSION_FILE="${ROOT_DIR}/.node-version"
 GO_MOD_FILE="${TUTTID_DIR}/go.mod"
 PACKAGE_JSON_FILE="${ROOT_DIR}/package.json"
@@ -321,10 +325,128 @@ NODE
 prepare_dev_gui_runtime() {
   DEV_GUI_PID_PATH="$(resolve_tuttid_pid_path)"
   DEV_GUI_INITIAL_TUTTID_PID="$(read_tuttid_pid_file "${DEV_GUI_PID_PATH}")"
+  prepare_claude_sdk_sidecar
   prepare_managed_posix_shell
   if [[ "$(uname -s)" == "Darwin" ]]; then
     node "${ROOT_DIR}/tools/scripts/prepare-dev-login-protocol.mjs"
   fi
+}
+
+claude_sdk_sidecar_is_current() {
+  [[ -f "${CLAUDE_SDK_SIDECAR_ENTRY_PATH}" ]] || return 1
+  diff -qr \
+    "${CLAUDE_SDK_SIDECAR_SOURCE_DIR}" \
+    "${CLAUDE_SDK_SIDECAR_DIR}/src" >/dev/null 2>&1 || return 1
+
+  node - \
+    "${CLAUDE_SDK_SIDECAR_PACKAGE_JSON}" \
+    "${CLAUDE_SDK_SIDECAR_DIR}" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+
+const [, , sourcePackagePath, bundleDir] = process.argv;
+const sdkDir = path.join(
+  bundleDir,
+  "node_modules",
+  "@anthropic-ai",
+  "claude-agent-sdk"
+);
+
+try {
+  const sourcePackage = JSON.parse(fs.readFileSync(sourcePackagePath, "utf8"));
+  const bundlePackage = JSON.parse(
+    fs.readFileSync(path.join(bundleDir, "package.json"), "utf8")
+  );
+  const expectedVersion =
+    sourcePackage.dependencies?.["@anthropic-ai/claude-agent-sdk"];
+  const installedPackage = JSON.parse(
+    fs.readFileSync(path.join(sdkDir, "package.json"), "utf8")
+  );
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(sdkDir, "manifest.json"), "utf8")
+  );
+  let hasNativeOptionalPackage = false;
+  const pendingDirectories = [path.join(bundleDir, "node_modules")];
+  while (pendingDirectories.length > 0 && !hasNativeOptionalPackage) {
+    const directory = pendingDirectories.pop();
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const child = path.join(directory, entry.name);
+      const packagePath = path.join(child, "package.json");
+      if (fs.existsSync(packagePath)) {
+        const packageMetadata = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+        if (
+          typeof packageMetadata.name === "string" &&
+          packageMetadata.name.startsWith("@anthropic-ai/claude-agent-sdk-")
+        ) {
+          hasNativeOptionalPackage = true;
+          break;
+        }
+      }
+      pendingDirectories.push(child);
+    }
+  }
+
+  if (
+    typeof expectedVersion !== "string" ||
+    expectedVersion.length === 0 ||
+    JSON.stringify(bundlePackage.dependencies ?? {}) !==
+      JSON.stringify(sourcePackage.dependencies ?? {}) ||
+    installedPackage.version !== expectedVersion ||
+    typeof manifest.version !== "string" ||
+    manifest.version.length === 0 ||
+    hasNativeOptionalPackage
+  ) {
+    process.exit(1);
+  }
+} catch {
+  process.exit(1);
+}
+NODE
+
+  npm --prefix "${CLAUDE_SDK_SIDECAR_DIR}" \
+    ls --omit=optional --all --json >/dev/null 2>&1
+  node "${DESKTOP_APP_DIR}/scripts/smoke-claude-sdk-sidecar.mjs" \
+    "${CLAUDE_SDK_SIDECAR_DIR}" >/dev/null 2>&1
+}
+
+prepare_claude_sdk_sidecar() {
+  local entry_override="${DEV_GUI_CLAUDE_SDK_SIDECAR_ENTRY_PATH:-}"
+  local command_override="${DEV_GUI_CLAUDE_SDK_SIDECAR_COMMAND:-}"
+  local test_driver_override="${DEV_GUI_CLAUDE_SDK_SIDECAR_TEST_DRIVER:-}"
+
+  # make dev-gui may itself be launched from a Tutti Agent Session. Do not let
+  # that host application's packaged sidecar path leak into this worktree's
+  # daemon: provisioning must read the SDK manifest being developed here.
+  unset TUTTI_CLAUDE_SDK_SIDECAR_COMMAND
+  unset TUTTI_CLAUDE_SDK_SIDECAR_ENTRY_PATH
+  unset TUTTI_CLAUDE_SDK_SIDECAR_TEST_DRIVER
+
+  if [[ -n "${entry_override}" ]]; then
+    [[ -f "${entry_override}" ]] || fail \
+      "DEV_GUI_CLAUDE_SDK_SIDECAR_ENTRY_PATH does not point to a file: ${entry_override}"
+    export TUTTI_CLAUDE_SDK_SIDECAR_ENTRY_PATH="${entry_override}"
+  else
+    if claude_sdk_sidecar_is_current; then
+      log "reusing current vendored Claude SDK sidecar"
+    else
+      log "preparing vendored Claude SDK sidecar"
+      node "${DESKTOP_APP_DIR}/scripts/vendor-claude-sdk-sidecar.mjs"
+    fi
+    [[ -f "${CLAUDE_SDK_SIDECAR_ENTRY_PATH}" ]] || fail \
+      "vendored Claude SDK sidecar entry is missing: ${CLAUDE_SDK_SIDECAR_ENTRY_PATH}"
+    export TUTTI_CLAUDE_SDK_SIDECAR_ENTRY_PATH="${CLAUDE_SDK_SIDECAR_ENTRY_PATH}"
+  fi
+
+  if [[ -n "${command_override}" ]]; then
+    export TUTTI_CLAUDE_SDK_SIDECAR_COMMAND="${command_override}"
+  fi
+  if [[ -n "${test_driver_override}" ]]; then
+    export TUTTI_CLAUDE_SDK_SIDECAR_TEST_DRIVER="${test_driver_override}"
+  fi
+  log "using Claude SDK sidecar at ${TUTTI_CLAUDE_SDK_SIDECAR_ENTRY_PATH}"
 }
 
 prepare_managed_posix_shell() {

--- a/tools/scripts/stage-claude-code-binaries.mjs
+++ b/tools/scripts/stage-claude-code-binaries.mjs
@@ -35,6 +35,8 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { pnpmPackageIntegrity } from "./claude-code-lockfile.mjs";
+
 const DEFAULT_PLATFORMS = [
   "darwin-arm64",
   "darwin-x64",
@@ -72,22 +74,13 @@ function sha256File(path) {
 // would otherwise both come from the same unpinned registry source.
 function verifyTarballAgainstLockfile(tarballPath, packageName, version) {
   const lockfile = readFileSync(join(repoRoot, "pnpm-lock.yaml"), "utf8");
-  const escaped = `${packageName}@${version}`.replace(
-    /[.*+?^${}()|[\]\\]/g,
-    "\\$&"
-  );
-  const match = lockfile.match(
-    new RegExp(
-      `"${escaped}":\\s*\\n\\s*resolution:[\\s\\S]{0,200}?integrity: (sha512-[A-Za-z0-9+/=]+)`
-    )
-  );
-  if (!match) {
+  const expected = pnpmPackageIntegrity(lockfile, packageName, version);
+  if (!expected) {
     throw new Error(
       `pnpm-lock.yaml has no integrity entry for ${packageName}@${version}; ` +
         `refusing to publish unpinned bytes`
     );
   }
-  const expected = match[1];
   const actual =
     "sha512-" +
     createHash("sha512").update(readFileSync(tarballPath)).digest("base64");


### PR DESCRIPTION
## Summary

- backport #2636 to the latest stable release branch
- preserve user-owned Claude commands while keeping Tutti's private Claude runtime active
- upgrade the managed Claude SDK from 0.3.220 to 0.3.258 (Claude Code 2.1.258)
- keep release-era Agent Extensions on their strict published-command contract

## Validation

- `go test ./service/usercommand ./service/agentstatus ./service/agentextension` (527 tests)
- release Agent Extension contract regressions (2 tests)
- strict publication transaction test (1 test)
- Windows amd64 compile for usercommand, agentstatus, and agentextension
- lockfile parser tests (4 tests)
- `pnpm install --frozen-lockfile`
- `bash -n tools/scripts/dev-gui.sh`
- independent subagent review: APPROVED

Cherry-picked from `404a084f7780c475212f80d6563964c4bd7d8324`.