### PR TITLE
fix(connector): preserve authorization terminal state

### DIFF
--- a/docs/architecture/connector.md
+++ b/docs/architecture/connector.md
@@ -454,6 +454,15 @@ fabricates a permanently pending observation. Disconnect is completed only
 after the disconnected projection and exact disabled Runtime Observed state are
 durable.
 
+A credential-broker failure is terminal for its exact `start_authorization`
+operation. Continuation polling with the same operation identity returns that
+cached failure and never starts another broker; only a new user-owned operation
+may replace it. A resolved private receipt also wins over a stale `pending`
+account projection in the Start response so the renderer can leave its waiting
+state while durable projection repair converges. Connector-provided failure
+codes cross the runtime boundary only when they match the bounded lowercase
+failure-code grammar; malformed codes collapse to `credential_broker_failed`.
+
 Managed credential brokers read process output through the context-aware
 transport when available. Cancellation closes the owned process connection as
 the termination fallback and waits for the broker consumer to finish before the

--- a/docs/conventions/troubleshooting/connector-market.md
+++ b/docs/conventions/troubleshooting/connector-market.md
@@ -84,6 +84,36 @@ renders its code; the user-owned `activate` action opens the verification URL.
 Continue to auto-open ordinary `external_link` Views, whose URL is itself the
 next authorization step.
 
+### Browser authorization finishes but the dialog remains Authorizing
+
+**Symptoms**
+
+- the provider page reports success, but the Connector dialog remains on its
+  waiting view
+- the matching `start_authorization` receipt is resolved as `provider_failed`
+  while the account projection still reads `pending`
+- repeated continuation requests may launch another credential broker for the
+  same operation and publish another pending observation
+
+**Check**
+
+Match the renderer continuation, private authorization receipt, projection,
+and credential-broker process by `clientRequestId`, operation ID, account, and
+Connector key. If one broker emitted an authorization URL and then failed,
+verify that a later Begin with the same operation returns that cached failure
+instead of creating another process. Treat browser completion and local
+credential persistence as separate steps; a provider page can succeed before
+the CLI stores and verifies its local credential.
+
+**Rule**
+
+A broker failure is terminal for one operation. Automatic continuation polling
+must never clear it or restart the broker; an explicit retry uses a new
+operation ID. A resolved receipt overrides stale pending presentation so the
+renderer exits loading while projection repair converges. Preserve only a
+bounded connector failure code and a redacted diagnostic reason—never persist
+device codes, tokens, or raw provider output.
+
 ### A second authorize click starts another OAuth session
 
 **Symptoms**

--- a/packages/connector/daemon/core/application.go
+++ b/packages/connector/daemon/core/application.go
@@ -723,6 +723,14 @@ func (application *Application) BeginAuthorization(
 		if !session.IsResolved() && session.State == AuthorizationStatePending && connector.Authorization.State != AuthorizationStateConnected {
 			connector.Authorization = Authorization{State: AuthorizationStatePending}
 		}
+		// A resolved private receipt is newer than a stale account projection.
+		// Return its terminal state immediately so a continuation caller cannot
+		// remain authorizing while projection convergence repairs durable state.
+		// Preserve an already-matching projection so its provider failure code is
+		// not replaced by the receipt's intentionally minimal terminal metadata.
+		if session.IsResolved() && connector.Authorization.State != session.State {
+			connector.Authorization = Authorization{State: session.State}
+		}
 	}
 	return AuthorizationResult{
 		Connector:                 connector,

--- a/packages/connector/daemon/core/application_test.go
+++ b/packages/connector/daemon/core/application_test.go
@@ -1576,6 +1576,45 @@ func TestApplicationResolvedAuthorizationReplayDoesNotRestartProvider(t *testing
 	}
 }
 
+func TestApplicationResolvedFailedAuthorizationReplayOverridesStalePendingProjection(t *testing.T) {
+	connector := testManagedAuthorizedConnector("lark-cli")
+	connector.Authorization = Authorization{State: AuthorizationStateDisconnected}
+	repository := newMemoryRepository(connector)
+	projections := &recordingAuthorizationProjectionStore{}
+	provider := &continuingAuthorizationProviderStub{}
+	application := newTestApplication(t, repository, &memoryScheduler{}, &memoryInstallRuntime{}, CatalogSnapshot{})
+	application.config.Authorization = provider
+	application.config.AuthorizationProjections = projections
+	mutation := ConnectorMutation{
+		Mutation:     Mutation{ClientRequestID: "failed-authorization-request", ExpectedRevision: 0},
+		ConnectorKey: connector.Key,
+		AccountID:    "account-1",
+	}
+
+	first, err := application.BeginAuthorization(context.Background(), mutation, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	operation := repository.operations[first.Operation.OperationID]
+	operation.Execution.AuthorizationSession.Resolution = AuthorizationSessionResolutionProviderFailed
+	repository.operations[operation.OperationID] = operation
+	projections.projection = AuthorizationProjection{
+		AccountID: "account-1", ConnectorKey: connector.Key,
+		ConnectionID: "account-1", State: AuthorizationStatePending,
+	}
+
+	replayed, err := application.BeginAuthorization(context.Background(), mutation, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if provider.begins != 1 {
+		t.Fatalf("provider begins = %d, want 1", provider.begins)
+	}
+	if replayed.AuthorizationURL != "" || replayed.Connector.Authorization.State != AuthorizationStateFailed {
+		t.Fatalf("replayed result = %#v", replayed)
+	}
+}
+
 func TestApplicationConnectedProjectionConvergesReceiptWithoutProviderPolling(t *testing.T) {
 	connector := testConnector("tencent-docs")
 	connector.Release.Manifest.AuthorizationKind = "oauth2"

--- a/packages/connector/runtime/implementationhost/credential_authorization.go
+++ b/packages/connector/runtime/implementationhost/credential_authorization.go
@@ -279,13 +279,12 @@ func (provider *managedCredentialAuthorizationProvider) authorizationSessionOrSt
 			provider.mu.Unlock()
 			return session, nil
 		}
-		// A broker can fail after emitting its first authorization URL. Do not
-		// make the next user action consume that terminal error merely to clear
-		// the cache; replace it with a fresh broker in this same request.
-		delete(provider.sessions, operationID)
-		if provider.activeByRoute[route.id] == operationID {
-			delete(provider.activeByRoute, route.id)
-		}
+		// Continuation polls reuse the same durable operation. Preserve its
+		// terminal error so an automatic poll cannot silently start a new broker
+		// and regress the account projection from failed back to pending. An
+		// explicit retry has a new operation ID and is admitted below.
+		provider.mu.Unlock()
+		return nil, sessionErr
 	}
 	if activeOperationID := provider.activeByRoute[route.id]; activeOperationID != "" {
 		active := provider.sessions[activeOperationID]
@@ -704,17 +703,6 @@ func safeCredentialBrokerURL(value string, allowedHosts map[string]struct{}) boo
 	}
 	_, allowed := allowedHosts[strings.ToLower(parsed.Hostname())]
 	return allowed
-}
-
-func credentialBrokerEventError(event credentialBrokerEvent, operation string) error {
-	message := boundedBrokerMessage(event.Message)
-	if message == "" {
-		message = "connector credential broker reported an error"
-	}
-	if code := strings.TrimSpace(event.Code); code != "" {
-		return fmt.Errorf("%s connector authorization (%s): %s", operation, code, message)
-	}
-	return fmt.Errorf("%s connector authorization: %s", operation, message)
 }
 
 func boundedBrokerMessage(message string) string {

--- a/packages/connector/runtime/implementationhost/credential_authorization_observer.go
+++ b/packages/connector/runtime/implementationhost/credential_authorization_observer.go
@@ -40,7 +40,7 @@ func (provider *managedCredentialAuthorizationProvider) Observe(
 		}
 		if sessionErr != nil {
 			observationState = market.AuthorizationObservationFailed
-			failureCode = "credential_broker_failed"
+			failureCode = credentialBrokerFailureCode(sessionErr)
 			reason = boundedBrokerMessage(sessionErr.Error())
 		}
 		return market.AuthorizationObservation{

--- a/packages/connector/runtime/implementationhost/credential_authorization_test.go
+++ b/packages/connector/runtime/implementationhost/credential_authorization_test.go
@@ -516,6 +516,83 @@ func TestManagedCredentialAuthorizationRestartsFailedBrokerOnFirstRetry(t *testi
 	}
 }
 
+func TestManagedCredentialAuthorizationPreservesFailedBrokerForSameOperation(t *testing.T) {
+	connection := newCredentialBrokerConnection()
+	route := &connectorRoute{
+		id: "account-1\x00lark-cli", connectorKey: "lark-cli", connectionID: "account-1",
+		releaseDigest: strings.Repeat("a", 64), credentialBrokerLaunch: &managedCredentialBrokerLaunch{
+			timeout: 5 * time.Minute, allowedHosts: map[string]struct{}{"accounts.feishu.cn": {}},
+		},
+	}
+	host := &credentialAuthorizationHostStub{
+		route: route, connections: []agentruntime.ProcessConnection{connection},
+	}
+	provider := newManagedCredentialAuthorizationProvider(host)
+	connector := market.Connector{Key: "lark-cli", Release: market.Release{ReleaseDigest: route.releaseDigest}}
+	request := market.AuthorizationStartRequest{
+		OperationID: "authorize-lark", Scope: market.OperationScope{AccountID: "user-1"}, Connector: connector,
+	}
+
+	beginResult := make(chan market.AuthorizationSession, 1)
+	beginError := make(chan error, 1)
+	go func() {
+		session, err := provider.Begin(context.Background(), request)
+		beginResult <- session
+		beginError <- err
+	}()
+	connection.frames <- agentruntime.ProcessFrame{Stdout: []byte(`{"type":"authorization_url","url":"https://accounts.feishu.cn/device"}` + "\n")}
+	if err := <-beginError; err != nil {
+		t.Fatal(err)
+	}
+	session := <-beginResult
+
+	exitCode := 1
+	connection.frames <- agentruntime.ProcessFrame{Stdout: []byte(`{"type":"error","code":"lark_cli_device_authorization_denied","message":"Lark CLI user authorization was denied"}` + "\n"), ExitCode: &exitCode}
+	awaitCachedAuthorizationFailure(t, provider, request.OperationID)
+
+	observation, err := provider.Observe(context.Background(), market.AuthorizationObserveRequest{
+		Scope: request.Scope, Connector: connector, Release: connector.Release, Session: session,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observation.State != market.AuthorizationObservationFailed ||
+		observation.FailureCode != "lark_cli_device_authorization_denied" {
+		t.Fatalf("failed authorization observation = %#v", observation)
+	}
+
+	_, err = provider.Begin(context.Background(), request)
+	if err == nil || !strings.Contains(err.Error(), "Lark CLI user authorization was denied") {
+		t.Fatalf("same-operation continuation error = %v", err)
+	}
+	if len(host.requests) != 1 {
+		t.Fatalf("same operation restarted credential broker %d times", len(host.requests))
+	}
+}
+
+func TestCredentialBrokerFailureCodeRejectsUnboundedConnectorValues(t *testing.T) {
+	tests := []struct {
+		name string
+		code string
+		want string
+	}{
+		{name: "valid", code: "lark_cli_device_authorization_denied", want: "lark_cli_device_authorization_denied"},
+		{name: "starts with digit", code: "1_invalid", want: "credential_broker_failed"},
+		{name: "contains whitespace", code: "invalid code", want: "credential_broker_failed"},
+		{name: "oversized", code: "a" + strings.Repeat("b", 128), want: "credential_broker_failed"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := credentialBrokerEventError(credentialBrokerEvent{
+				Type: "error", Code: test.code, Message: "safe failure",
+			}, "authorize")
+			if got := credentialBrokerFailureCode(err); got != test.want {
+				t.Fatalf("credentialBrokerFailureCode() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func TestManagedCredentialAuthorizationCancelTerminatesAndWaitsForBrokerExit(t *testing.T) {
 	connection := newCredentialBrokerConnection()
 	route := &connectorRoute{id: "default\x00dingtalk-cli", credentialBrokerLaunch: &managedCredentialBrokerLaunch{

--- a/packages/connector/runtime/implementationhost/credential_broker_error.go
+++ b/packages/connector/runtime/implementationhost/credential_broker_error.go
@@ -1,0 +1,57 @@
+package implementationhost
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type credentialBrokerReportedError struct {
+	operation string
+	code      string
+	message   string
+}
+
+func (failure *credentialBrokerReportedError) Error() string {
+	if failure.code != "" {
+		return fmt.Sprintf("%s connector authorization (%s): %s", failure.operation, failure.code, failure.message)
+	}
+	return fmt.Sprintf("%s connector authorization: %s", failure.operation, failure.message)
+}
+
+func credentialBrokerEventError(event credentialBrokerEvent, operation string) error {
+	message := boundedBrokerMessage(event.Message)
+	if message == "" {
+		message = "connector credential broker reported an error"
+	}
+	return &credentialBrokerReportedError{
+		operation: operation,
+		code:      normalizeCredentialBrokerFailureCode(event.Code),
+		message:   message,
+	}
+}
+
+func credentialBrokerFailureCode(err error) string {
+	var reported *credentialBrokerReportedError
+	if errors.As(err, &reported) && reported.code != "" {
+		return reported.code
+	}
+	return "credential_broker_failed"
+}
+
+func normalizeCredentialBrokerFailureCode(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" || len(value) > 128 {
+		return ""
+	}
+	for index := 0; index < len(value); index++ {
+		character := value[index]
+		if character >= 'a' && character <= 'z' ||
+			index > 0 && character >= '0' && character <= '9' ||
+			index > 0 && (character == '_' || character == '-' || character == '.') {
+			continue
+		}
+		return ""
+	}
+	return value
+}


### PR DESCRIPTION
## Summary

Lark CLI authorization can finish in the provider browser while the Connector dialog remains authorizing. A failed credential broker was discarded when the renderer continued polling the same `start_authorization` operation, which started a replacement broker and regressed the account projection to `pending`. The Core response could also prefer that stale projection over an already resolved private authorization receipt.

This change makes a broker failure terminal for its exact operation, lets a resolved receipt override a stale non-matching projection, and preserves bounded connector-provided failure codes across observation. Explicit user retries still use a new operation ID. It also documents the convergence rule and adds regression coverage for replaying failed authorization operations.

## Verification

- `pnpm check:changed -- --base tutti-os/main` — passed all 8 selected lanes
- `go test ./...` in `packages/connector/runtime` — passed
- `go test ./...` in `packages/connector/daemon/core` — passed

## Fallback Three Questions

- Source: continuation polling can observe a terminal private authorization receipt before the asynchronous account projection leaves `pending`.
- Why can it not be fixed at that source? Browser completion, CLI credential persistence, private operation resolution, and durable account projection are intentionally separate asynchronous boundaries. The shared Connector Core must arbitrate their ordering for every host.
- Removal condition: this handling could be removed only if authorization completion and account projection become one atomic authoritative state and continuation polling can no longer race projection convergence.

## Checklist

- [x] This does not change agent session/turn/goal/runtime-operation lifecycle semantics; the change belongs to the shared Connector Core and Runtime owners.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] No README or CONTRIBUTING source changed, so multilingual updates are not applicable.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
