### PR TITLE
fix(agent): support workspace agent cli selection

### DIFF
--- a/docs/conventions/tutti-cli-contract.md
+++ b/docs/conventions/tutti-cli-contract.md
@@ -606,9 +606,19 @@ grouped under their source message. Do not flatten images across turns in this
 command; the calling agent decides which turns to inspect and which returned
 `localPath` values to pass to provider launchers as `--image`.
 
-Agent discovery and launch are target-first. `agent list --json` returns every
-enabled Agent Target in stable target order, including its exact agent id,
-display name, provider metadata, current runtime availability, and an explicit
+Agent discovery and launch are target-first with an explicit workspace policy.
+When the invocation supplies an explicit workspace, `agent list --json`
+validates that workspace and returns every enabled global Agent Target in stable
+target order followed by that workspace's configured WorkspaceAgents. Without a
+workspace context, an unfiltered `agent list --json` returns the global Agent
+Targets only; it does not enumerate WorkspaceAgents or infer a workspace for
+WorkspaceAgent discovery. An exact `--agent-id workspace-agent:<uuid>` selector
+also requires an explicit workspace and resolves the opaque id only within that
+scope. This does not remove the existing runtime setup probe for global Agent
+Extension targets: when no workspace is supplied, that probe may use the
+startup workspace only to report global target availability; it never enumerates
+or selects a WorkspaceAgent. Each entry includes its exact agent id, display
+name, provider metadata, current runtime availability, and an explicit
 `defaultAgentTargetId` resolved from the current desktop preference. The
 JSON entry may also include `executablePath`, the host-resolved executable for
 that exact Agent Target. App-owned runtimes must treat it as opaque launch
@@ -628,6 +638,21 @@ probe rather than their sum. Tutti coalesces broad and exact-target probes
 across app callers and keeps a short-lived daemon result; `--refresh` bypasses
 that result. New callers may still use `agent list --agent-id <agent-id>` when
 they only need one target.
+WorkspaceAgent ids are opaque `workspace-agent:<uuid>` launch identities. The
+daemon lists them through the repair-friendly WorkspaceAgent View and derives
+provider and Harness runtime metadata without validating the optional model
+Plan for every list entry. CLI callers pass the WorkspaceAgent id unchanged to
+`composer-options`, `start`, and `skill-bundle`; they do not reconstruct a
+Harness id or infer provider from the opaque id. Composer options use the same
+policy: a legacy provider or global Agent Target does not require a workspace,
+while an exact WorkspaceAgent selector requires an explicit workspace. `start`
+and `skill-bundle` retain their workspace-required operation contract. A broken
+WorkspaceAgent remains listable with unavailable or unknown configuration
+status so it can be diagnosed. The Agent service performs the final strict
+Harness, model-plan, and runtime validation for exact composer, skill-bundle,
+and start operations before creating a session. WorkspaceAgents do not replace
+the global desktop default and do not participate in deprecated provider
+selection.
 The command must not collapse several agents that share one provider or make
 callers guess a default from list order. Callers select an exact id and start it with
 `agent start --agent-id <agent-id> ...`; provider-specific command

--- a/services/tuttid/service/cli/providers/agentcontext/composer_options.go
+++ b/services/tuttid/service/cli/providers/agentcontext/composer_options.go
@@ -2,6 +2,7 @@ package agentcontext
 
 import (
 	"context"
+	"strings"
 
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
@@ -32,6 +33,7 @@ func (p Provider) newComposerOptionsCommand() cliservice.Command {
 		Description: "Get model, reasoning, and permission options for one agent without starting a session. Some runtimes may spin up a hidden discovery session.",
 		Kind:        framework.KindGet,
 		Workspace:   framework.WorkspaceOptional,
+		Workspaces:  p.workspaces,
 		Inputs:      framework.FromStruct[composerOptionsInput](),
 		Output: framework.OutputSpec{
 			DefaultMode: cliservice.OutputModeJSON,
@@ -51,9 +53,13 @@ func (p Provider) runComposerOptions(ctx context.Context, invoke framework.Invok
 	if err := p.requireSessions(); err != nil {
 		return nil, err
 	}
-	target, legacy, err := p.resolveAgentSelector(ctx, input.AgentID, input.Provider)
+	target, legacy, err := p.resolveAgentSelector(ctx, invoke.WorkspaceID, input.AgentID, input.Provider)
 	if err != nil {
 		return nil, err
+	}
+	workspaceID := strings.TrimSpace(invoke.WorkspaceID)
+	if target.WorkspaceAgent {
+		workspaceID = target.WorkspaceID
 	}
 	canonicalProvider := target.Provider
 	locale := input.Locale
@@ -68,7 +74,7 @@ func (p Provider) runComposerOptions(ctx context.Context, invoke framework.Invok
 		Cwd:                      input.Cwd,
 		Locale:                   locale,
 		Provider:                 canonicalProvider,
-		WorkspaceID:              invoke.WorkspaceID,
+		WorkspaceID:              workspaceID,
 		IncludeCapabilityCatalog: &includeCapabilityCatalog,
 		Settings: agentservice.ComposerSettings{
 			Model:            input.Model,

--- a/services/tuttid/service/cli/providers/agentcontext/legacy_compat.go
+++ b/services/tuttid/service/cli/providers/agentcontext/legacy_compat.go
@@ -217,18 +217,18 @@ func normalizeLegacyProvider(provider string) string {
 	return agentproviderbiz.NormalizeOpen(provider)
 }
 
-func (p Provider) resolveAgentSelector(ctx context.Context, agentID string, provider string) (agenttargetbiz.Target, bool, error) {
+func (p Provider) resolveAgentSelector(ctx context.Context, workspaceID string, agentID string, provider string) (selectedAgent, bool, error) {
 	agentID = strings.TrimSpace(agentID)
 	provider = strings.TrimSpace(provider)
 	if (agentID == "") == (provider == "") {
-		return agenttargetbiz.Target{}, false, fmt.Errorf("%w: provide exactly one of --agent-id or deprecated --provider; run agent list --json", cliservice.ErrInvalidInput)
+		return selectedAgent{}, false, fmt.Errorf("%w: provide exactly one of --agent-id or deprecated --provider; run agent list --json", cliservice.ErrInvalidInput)
 	}
 	if agentID != "" {
-		target, err := p.resolveEnabledAgentTarget(ctx, agentID)
+		target, err := p.resolveSelectedAgent(ctx, workspaceID, agentID)
 		return target, false, err
 	}
 	target, err := p.resolveLegacyProviderTarget(ctx, provider)
-	return target, true, err
+	return selectedAgent{ID: target.ID, Provider: target.Provider}, true, err
 }
 
 func (p Provider) resolveLegacyProviderTarget(ctx context.Context, provider string) (agenttargetbiz.Target, error) {
@@ -298,7 +298,7 @@ func (p Provider) newLegacyStartCommand(name string, targetID string) cliservice
 			if err != nil {
 				return nil, err
 			}
-			return p.runStart(ctx, invoke, target, startFields{
+			return p.runStart(ctx, invoke, selectedAgent{ID: target.ID, Provider: target.Provider}, startFields{
 				Cwd: input.Cwd, DisplayPrompt: input.DisplayPrompt, Hidden: input.Hidden, Images: input.Images,
 				Model: input.Model, PermissionMode: input.PermissionMode, Prompt: input.Prompt,
 				ReasoningEffort: input.ReasoningEffort, Show: input.Show, Speed: input.Speed, Title: input.Title,

--- a/services/tuttid/service/cli/providers/agentcontext/provider.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider.go
@@ -2,6 +2,7 @@ package agentcontext
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -9,6 +10,8 @@ import (
 	"github.com/tutti-os/tutti/services/tuttid/biz/agentgui"
 	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
+	workspaceagentbiz "github.com/tutti-os/tutti/services/tuttid/biz/workspaceagent"
+	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 	agentextensionservice "github.com/tutti-os/tutti/services/tuttid/service/agentextension"
 	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
@@ -50,13 +53,31 @@ type AgentTargetSetupReader interface {
 	GetSetup(context.Context, agentextensionservice.InstallPlanInput) (agentextensionservice.SetupSnapshot, error)
 }
 
+type WorkspaceAgentDirectory interface {
+	Get(context.Context, string, string) (workspaceagentbiz.View, error)
+	List(context.Context, string) ([]workspaceagentbiz.View, error)
+}
+
+type selectedAgent struct {
+	ID             string
+	Provider       string
+	WorkspaceID    string
+	WorkspaceAgent bool
+}
+
 type Provider struct {
 	workspaces                 cliservice.WorkspaceCatalog
 	sessions                   AgentSessions
 	launchPublisher            AgentGUILaunchPublisher
 	preferences                DesktopPreferencesReader
 	agentTargets               AgentTargetLister
+	workspaceAgents            WorkspaceAgentDirectory
 	extensionAvailabilityCache *extensionAvailabilityCache
+}
+
+func (p Provider) WithWorkspaceAgents(workspaceAgents WorkspaceAgentDirectory) Provider {
+	p.workspaceAgents = workspaceAgents
+	return p
 }
 
 func (p Provider) WithAgentTargetSetup(setup AgentTargetSetupReader) Provider {
@@ -154,4 +175,35 @@ func (p Provider) resolveEnabledAgentTarget(ctx context.Context, agentID string)
 		}
 	}
 	return agenttargetbiz.Target{}, fmt.Errorf("%w: enabled agent %q was not found; run agent list --json", cliservice.ErrInvalidInput, agentID)
+}
+
+func (p Provider) resolveSelectedAgent(ctx context.Context, workspaceID string, agentID string) (selectedAgent, error) {
+	agentID = strings.TrimSpace(agentID)
+	if strings.HasPrefix(agentID, workspaceagentbiz.IDPrefix) {
+		workspaceID = strings.TrimSpace(workspaceID)
+		if workspaceID == "" {
+			return selectedAgent{}, fmt.Errorf("%w: workspace id is required for WorkspaceAgent selection", cliservice.ErrInvalidInput)
+		}
+		if p.workspaceAgents == nil {
+			return selectedAgent{}, errors.New("workspace agent directory is not configured")
+		}
+		view, err := p.workspaceAgents.Get(ctx, workspaceID, agentID)
+		if err != nil {
+			if errors.Is(err, workspacedata.ErrWorkspaceAgentNotFound) {
+				return selectedAgent{}, fmt.Errorf("%w: enabled agent %q was not found; run agent list --json", cliservice.ErrInvalidInput, agentID)
+			}
+			return selectedAgent{}, err
+		}
+		return selectedAgent{
+			ID:             agentID,
+			Provider:       strings.TrimSpace(view.Harness.Provider),
+			WorkspaceID:    workspaceID,
+			WorkspaceAgent: true,
+		}, nil
+	}
+	target, err := p.resolveEnabledAgentTarget(ctx, agentID)
+	if err != nil {
+		return selectedAgent{}, err
+	}
+	return selectedAgent{ID: target.ID, Provider: target.Provider}, nil
 }

--- a/services/tuttid/service/cli/providers/agentcontext/provider_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider_test.go
@@ -17,19 +17,29 @@ import (
 	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
+	workspaceagentbiz "github.com/tutti-os/tutti/services/tuttid/biz/workspaceagent"
+	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
 )
 
 type fakeWorkspaceCatalog struct {
-	startup workspacebiz.Summary
+	startup    workspacebiz.Summary
+	startupErr error
+	getErr     error
 }
 
 func (f fakeWorkspaceCatalog) Startup(context.Context) (*workspacebiz.Summary, error) {
+	if f.startupErr != nil {
+		return nil, f.startupErr
+	}
 	return &f.startup, nil
 }
 
-func (fakeWorkspaceCatalog) Get(_ context.Context, workspaceID string) (workspacebiz.Summary, error) {
+func (f fakeWorkspaceCatalog) Get(_ context.Context, workspaceID string) (workspacebiz.Summary, error) {
+	if f.getErr != nil {
+		return workspacebiz.Summary{}, f.getErr
+	}
 	return workspacebiz.Summary{ID: workspaceID}, nil
 }
 
@@ -46,6 +56,36 @@ func (fakeAgentTargetLister) List(context.Context) ([]agenttargetbiz.Target, err
 
 type fakeAgentTargetList struct {
 	targets []agenttargetbiz.Target
+}
+
+type fakeWorkspaceAgentDirectory struct {
+	views              map[string][]workspaceagentbiz.View
+	listErr            map[string]error
+	listedWorkspaceIDs []string
+	getKeys            []string
+}
+
+func (f *fakeWorkspaceAgentDirectory) Get(_ context.Context, workspaceID string, agentID string) (workspaceagentbiz.View, error) {
+	key := workspaceID + "\x00" + agentID
+	f.getKeys = append(f.getKeys, key)
+	for _, view := range f.views[workspaceID] {
+		if view.Agent.ID == agentID {
+			return view, nil
+		}
+	}
+	return workspaceagentbiz.View{}, workspacedata.ErrWorkspaceAgentNotFound
+}
+
+func (f *fakeWorkspaceAgentDirectory) List(_ context.Context, workspaceID string) ([]workspaceagentbiz.View, error) {
+	f.listedWorkspaceIDs = append(f.listedWorkspaceIDs, workspaceID)
+	if err, ok := f.listErr[workspaceID]; ok {
+		return nil, err
+	}
+	views, ok := f.views[workspaceID]
+	if !ok {
+		panic(fmt.Sprintf("unexpected workspace agent list for workspace %q", workspaceID))
+	}
+	return views, nil
 }
 
 func (f fakeAgentTargetList) List(context.Context) ([]agenttargetbiz.Target, error) {
@@ -1830,6 +1870,339 @@ func TestAgentListKeepsMultipleAgentsForOneProvider(t *testing.T) {
 	}
 	if output.Value["defaultAgentTargetId"] != agenttargetbiz.IDLocalTuttiAgent {
 		t.Fatalf("defaultAgentTargetId = %#v, want exact built-in target %q", output.Value["defaultAgentTargetId"], agenttargetbiz.IDLocalTuttiAgent)
+	}
+}
+
+func TestAgentListIncludesWorkspaceAgentsWithoutCollapsingSharedHarness(t *testing.T) {
+	targets := agenttargetbiz.DefaultSystemTargets(1)
+	var codexTarget agenttargetbiz.Target
+	for _, target := range targets {
+		if target.ID == agenttargetbiz.IDLocalCodex {
+			codexTarget = target
+			break
+		}
+	}
+	directory := &fakeWorkspaceAgentDirectory{
+		views: map[string][]workspaceagentbiz.View{"workspace-1": {
+			{Agent: workspaceagentbiz.Agent{ID: "workspace-agent:reviewer", Name: "Reviewer"}, Harness: workspaceagentbiz.Harness{AgentTargetID: codexTarget.ID, Available: true, Enabled: true, Provider: "codex"}},
+			{Agent: workspaceagentbiz.Agent{ID: "workspace-agent:writer", Name: "Writer"}, Harness: workspaceagentbiz.Harness{AgentTargetID: codexTarget.ID, Available: true, Enabled: true, Provider: "codex"}},
+		}, "workspace-2": {{Agent: workspaceagentbiz.Agent{ID: "workspace-agent:other", Name: "Other"}}}},
+	}
+	sessions := &fakeAgentSessions{availability: []agentservice.ProviderAvailability{{Provider: "codex", Status: agentservice.ProviderAvailabilityAvailable}}}
+	provider := NewProviderWithAgentTargets(
+		fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions, nil,
+		fakeAgentTargetList{targets: targets},
+	).WithWorkspaceAgents(directory)
+
+	output, err := provider.newAgentsCommand().Handler(context.Background(), cliservice.InvokeRequest{
+		Context: cliservice.InvokeContext{WorkspaceID: "workspace-1"}, OutputMode: cliservice.OutputModeJSON,
+	})
+	if err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
+	agents := output.Value["agents"].([]any)
+	gotIDs := make([]string, 0, len(agents))
+	for _, value := range agents {
+		gotIDs = append(gotIDs, value.(map[string]any)["id"].(string))
+	}
+	expectedIDs := make([]string, 0, len(agenttargetbiz.EnabledTargets(targets))+2)
+	for _, target := range agenttargetbiz.EnabledTargets(targets) {
+		expectedIDs = append(expectedIDs, target.ID)
+	}
+	expectedIDs = append(expectedIDs, "workspace-agent:reviewer", "workspace-agent:writer")
+	if !equalStrings(gotIDs, expectedIDs) {
+		t.Fatalf("agent ids = %#v, want %v", gotIDs, expectedIDs)
+	}
+	for index, id := range []string{"workspace-agent:reviewer", "workspace-agent:writer"} {
+		agent := agents[len(agents)-2+index].(map[string]any)
+		availability := agent["availability"].(map[string]any)
+		if agent["id"] != id || agent["name"] != []string{"Reviewer", "Writer"}[index] ||
+			agent["provider"] != "codex" || availability["status"] != agentservice.ProviderAvailabilityAvailable {
+			t.Fatalf("workspace agent %q = %#v", id, agent)
+		}
+	}
+	if output.Value["defaultAgentTargetId"] != agenttargetbiz.IDLocalTuttiAgent {
+		t.Fatalf("defaultAgentTargetId = %#v, want global default", output.Value["defaultAgentTargetId"])
+	}
+	if !equalStrings(directory.listedWorkspaceIDs, []string{"workspace-1"}) {
+		t.Fatalf("listed workspaces = %#v", directory.listedWorkspaceIDs)
+	}
+}
+
+func TestAgentListExactWorkspaceAgentDoesNotResolveUnrelatedAgents(t *testing.T) {
+	targets := agenttargetbiz.DefaultSystemTargets(1)
+	var codexTarget agenttargetbiz.Target
+	for _, target := range targets {
+		if target.ID == agenttargetbiz.IDLocalCodex {
+			codexTarget = target
+			break
+		}
+	}
+	const selectedID = "workspace-agent:selected"
+	directory := &fakeWorkspaceAgentDirectory{
+		views: map[string][]workspaceagentbiz.View{"workspace-1": {
+			{Agent: workspaceagentbiz.Agent{ID: selectedID, Name: "Selected"}, Harness: workspaceagentbiz.Harness{AgentTargetID: codexTarget.ID, Available: true, Enabled: true, Provider: "codex"}},
+			{Agent: workspaceagentbiz.Agent{ID: "workspace-agent:unrelated", Name: "Unrelated"}},
+		}},
+	}
+	provider := NewProviderWithAgentTargets(
+		fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}},
+		&fakeAgentSessions{availability: []agentservice.ProviderAvailability{{
+			Provider: "codex", Status: agentservice.ProviderAvailabilityAvailable,
+		}}}, nil, fakeAgentTargetList{targets: targets},
+	).WithWorkspaceAgents(directory)
+
+	output, err := provider.newAgentsCommand().Handler(context.Background(), cliservice.InvokeRequest{
+		Context:    cliservice.InvokeContext{WorkspaceID: "workspace-1"},
+		Input:      map[string]any{"agent-id": selectedID},
+		OutputMode: cliservice.OutputModeJSON,
+	})
+	if err != nil {
+		t.Fatalf("agent list: %v", err)
+	}
+	agents := output.Value["agents"].([]any)
+	if len(agents) != 1 {
+		t.Fatalf("agents = %#v", agents)
+	}
+	selected := agents[0].(map[string]any)
+	availability := selected["availability"].(map[string]any)
+	if selected["id"] != selectedID || selected["name"] != "Selected" || selected["provider"] != "codex" ||
+		availability["status"] != agentservice.ProviderAvailabilityAvailable {
+		t.Fatalf("selected agent = %#v", selected)
+	}
+	if !equalStrings(directory.getKeys, []string{"workspace-1\x00" + selectedID}) || len(directory.listedWorkspaceIDs) != 0 {
+		t.Fatalf("workspace agent calls = get=%#v list=%#v", directory.getKeys, directory.listedWorkspaceIDs)
+	}
+}
+
+func TestDeprecatedProviderSelectorIgnoresWorkspaceAgents(t *testing.T) {
+	targets := agenttargetbiz.DefaultSystemTargets(1)
+	directory := &fakeWorkspaceAgentDirectory{
+		views: map[string][]workspaceagentbiz.View{"workspace-1": {{Agent: workspaceagentbiz.Agent{ID: "workspace-agent:reviewer", Name: "Reviewer"}}}},
+	}
+	sessions := &fakeAgentSessions{}
+	provider := NewProviderWithAgentTargets(
+		fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions, nil,
+		fakeAgentTargetList{targets: targets},
+	).WithWorkspaceAgents(directory)
+
+	if _, err := provider.newStartCommand().Handler(context.Background(), cliservice.InvokeRequest{
+		Input: map[string]any{"provider": "codex", "prompt": "review"},
+	}); err != nil {
+		t.Fatalf("legacy provider start: %v", err)
+	}
+	if sessions.createInput.AgentTargetID != agenttargetbiz.IDLocalCodex {
+		t.Fatalf("agent target id = %q, want global legacy target", sessions.createInput.AgentTargetID)
+	}
+	if len(directory.listedWorkspaceIDs) != 0 || len(directory.getKeys) != 0 {
+		t.Fatalf("legacy selector touched workspace-agent directory: listed=%#v get=%#v", directory.listedWorkspaceIDs, directory.getKeys)
+	}
+}
+
+func TestWorkspaceAgentExactIDFlowsThroughAgentCommands(t *testing.T) {
+	targets := agenttargetbiz.DefaultSystemTargets(1)
+	var codexTarget agenttargetbiz.Target
+	for _, target := range targets {
+		if target.ID == agenttargetbiz.IDLocalCodex {
+			codexTarget = target
+		}
+	}
+	const customID = "workspace-agent:reviewer"
+	directory := &fakeWorkspaceAgentDirectory{
+		views: map[string][]workspaceagentbiz.View{"workspace-1": {{
+			Agent:   workspaceagentbiz.Agent{ID: customID, Name: "Reviewer"},
+			Harness: workspaceagentbiz.Harness{AgentTargetID: codexTarget.ID, Available: true, Enabled: true, Provider: "codex"},
+		}}},
+	}
+	sessions := &fakeAgentSessions{}
+	provider := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).WithWorkspaceAgents(directory)
+
+	if _, err := provider.newComposerOptionsCommand().Handler(context.Background(), cliservice.InvokeRequest{
+		Context: cliservice.InvokeContext{WorkspaceID: "workspace-1"},
+		Input:   map[string]any{"agent-id": customID},
+	}); err != nil {
+		t.Fatalf("composer-options: %v", err)
+	}
+	if sessions.composerInput.AgentTargetID != customID || sessions.composerInput.Provider != "codex" || sessions.composerInput.WorkspaceID != "workspace-1" {
+		t.Fatalf("composer input = %#v", sessions.composerInput)
+	}
+	if _, err := provider.newStartCommand().Handler(context.Background(), cliservice.InvokeRequest{
+		Context: cliservice.InvokeContext{WorkspaceID: "workspace-1"},
+		Input:   map[string]any{"agent-id": customID, "prompt": "review"},
+	}); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if sessions.createInput.AgentTargetID != customID || sessions.createInput.Provider != "codex" || sessions.workspaceID != "workspace-1" {
+		t.Fatalf("create input = %#v workspace=%q", sessions.createInput, sessions.workspaceID)
+	}
+	if _, err := provider.newSkillBundleCommand().Handler(context.Background(), cliservice.InvokeRequest{
+		Context: cliservice.InvokeContext{WorkspaceID: "workspace-1"},
+		Input:   map[string]any{"agent-id": customID},
+	}); err != nil {
+		t.Fatalf("skill-bundle: %v", err)
+	}
+	if sessions.skillBundleIn.AgentTargetID != customID || sessions.workspaceID != "workspace-1" {
+		t.Fatalf("skill bundle input = %#v workspace=%q", sessions.skillBundleIn, sessions.workspaceID)
+	}
+}
+
+func TestLegacyComposerOptionsDoesNotRequireStartupWorkspaceOrWorkspaceAgents(t *testing.T) {
+	directory := &fakeWorkspaceAgentDirectory{}
+	sessions := &fakeAgentSessions{}
+	provider := newTestProvider(fakeWorkspaceCatalog{
+		startupErr: errors.New("startup workspace unavailable"),
+	}, sessions).WithWorkspaceAgents(directory)
+
+	output, err := provider.newComposerOptionsCommand().Handler(context.Background(), cliservice.InvokeRequest{
+		Input: map[string]any{"provider": "codex"}, OutputMode: cliservice.OutputModeJSON,
+	})
+	if err != nil {
+		t.Fatalf("legacy composer-options: %v", err)
+	}
+	if output.Value["schemaVersion"] != 1 || output.Value["provider"] != "codex" {
+		t.Fatalf("output = %#v", output.Value)
+	}
+	if len(directory.listedWorkspaceIDs) != 0 || len(directory.getKeys) != 0 {
+		t.Fatalf("legacy selector touched workspace-agent directory: listed=%#v get=%#v", directory.listedWorkspaceIDs, directory.getKeys)
+	}
+}
+
+func TestGlobalAgentListDoesNotRequireStartupWorkspace(t *testing.T) {
+	directory := &fakeWorkspaceAgentDirectory{}
+	sessions := &fakeAgentSessions{}
+	provider := newTestProvider(fakeWorkspaceCatalog{
+		startupErr: errors.New("startup workspace unavailable"),
+	}, sessions).WithWorkspaceAgents(directory)
+
+	output, err := provider.newAgentsCommand().Handler(context.Background(), cliservice.InvokeRequest{
+		Input: map[string]any{"agent-id": agenttargetbiz.IDLocalCodex}, OutputMode: cliservice.OutputModeJSON,
+	})
+	if err != nil {
+		t.Fatalf("global agent list: %v", err)
+	}
+	agents := output.Value["agents"].([]any)
+	if len(agents) != 1 || agents[0].(map[string]any)["id"] != agenttargetbiz.IDLocalCodex {
+		t.Fatalf("agents = %#v", agents)
+	}
+	if len(directory.listedWorkspaceIDs) != 0 || len(directory.getKeys) != 0 {
+		t.Fatalf("global selector touched workspace-agent directory: listed=%#v get=%#v", directory.listedWorkspaceIDs, directory.getKeys)
+	}
+}
+
+func TestAgentListWithoutWorkspaceReturnsGlobalAgentsOnly(t *testing.T) {
+	directory := &fakeWorkspaceAgentDirectory{}
+	targets := agenttargetbiz.DefaultSystemTargets(1)
+	provider := NewProviderWithAgentTargets(
+		fakeWorkspaceCatalog{startupErr: errors.New("startup workspace must not be consulted")},
+		&fakeAgentSessions{}, nil, fakeAgentTargetList{targets: targets},
+	).WithWorkspaceAgents(directory)
+
+	output, err := provider.newAgentsCommand().Handler(context.Background(), cliservice.InvokeRequest{
+		OutputMode: cliservice.OutputModeJSON,
+	})
+	if err != nil {
+		t.Fatalf("agent list: %v", err)
+	}
+	agents := output.Value["agents"].([]any)
+	expectedTargets := agenttargetbiz.EnabledTargets(targets)
+	if len(agents) != len(expectedTargets) {
+		t.Fatalf("agent count = %d, want %d", len(agents), len(expectedTargets))
+	}
+	gotIDs := make([]string, 0, len(agents))
+	for _, value := range agents {
+		gotIDs = append(gotIDs, value.(map[string]any)["id"].(string))
+	}
+	expectedIDs := make([]string, 0, len(expectedTargets))
+	for _, target := range expectedTargets {
+		expectedIDs = append(expectedIDs, target.ID)
+	}
+	if !equalStrings(gotIDs, expectedIDs) {
+		t.Fatalf("agent ids without workspace = %#v, want %v", gotIDs, expectedIDs)
+	}
+	if len(directory.listedWorkspaceIDs) != 0 || len(directory.getKeys) != 0 {
+		t.Fatalf("workspace agent directory calls = listed=%#v get=%#v", directory.listedWorkspaceIDs, directory.getKeys)
+	}
+}
+
+func TestAgentListWorkspaceAgentRequiresExplicitWorkspace(t *testing.T) {
+	const customID = "workspace-agent:startup-only"
+	directory := &fakeWorkspaceAgentDirectory{
+		views: map[string][]workspaceagentbiz.View{
+			"workspace-startup": {{Agent: workspaceagentbiz.Agent{ID: customID, Name: "Startup only"}}},
+		},
+	}
+	provider := newTestProvider(
+		fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-startup"}},
+		&fakeAgentSessions{},
+	).WithWorkspaceAgents(directory)
+
+	_, err := provider.newAgentsCommand().Handler(context.Background(), cliservice.InvokeRequest{
+		Input: map[string]any{"agent-id": customID},
+	})
+	if !errors.Is(err, cliservice.ErrInvalidInput) || !strings.Contains(err.Error(), "workspace id is required") {
+		t.Fatalf("workspace agent list error = %v, want explicit workspace validation", err)
+	}
+	if len(directory.listedWorkspaceIDs) != 0 || len(directory.getKeys) != 0 {
+		t.Fatalf("agent list consulted workspace-agent directory without workspace: listed=%#v get=%#v", directory.listedWorkspaceIDs, directory.getKeys)
+	}
+}
+
+func TestWorkspaceAgentSelectorUsesExplicitWorkspaceOverStartupWorkspace(t *testing.T) {
+	targets := agenttargetbiz.DefaultSystemTargets(1)
+	var codexTarget agenttargetbiz.Target
+	for _, target := range targets {
+		if target.ID == agenttargetbiz.IDLocalCodex {
+			codexTarget = target
+			break
+		}
+	}
+	const customID = "workspace-agent:explicit"
+	directory := &fakeWorkspaceAgentDirectory{
+		views: map[string][]workspaceagentbiz.View{
+			"workspace-explicit": {{
+				Agent:   workspaceagentbiz.Agent{ID: customID, Name: "Explicit"},
+				Harness: workspaceagentbiz.Harness{AgentTargetID: codexTarget.ID, Available: true, Enabled: true, Provider: "codex"},
+			}},
+		},
+	}
+	sessions := &fakeAgentSessions{}
+	provider := NewProviderWithAgentTargets(
+		fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-startup"}},
+		sessions, nil, fakeAgentTargetList{targets: targets},
+	).WithWorkspaceAgents(directory)
+
+	if _, err := provider.newComposerOptionsCommand().Handler(context.Background(), cliservice.InvokeRequest{
+		Context: cliservice.InvokeContext{WorkspaceID: "workspace-explicit"},
+		Input:   map[string]any{"agent-id": customID},
+	}); err != nil {
+		t.Fatalf("composer-options: %v", err)
+	}
+	if sessions.composerInput.WorkspaceID != "workspace-explicit" {
+		t.Fatalf("composer workspace = %q, want explicit workspace", sessions.composerInput.WorkspaceID)
+	}
+	if !equalStrings(directory.listedWorkspaceIDs, []string{}) || !equalStrings(directory.getKeys, []string{"workspace-explicit\x00" + customID}) {
+		t.Fatalf("directory calls = listed=%#v get=%#v", directory.listedWorkspaceIDs, directory.getKeys)
+	}
+}
+
+func TestWorkspaceAgentSelectorRequiresExplicitWorkspace(t *testing.T) {
+	const customID = "workspace-agent:startup-only"
+	directory := &fakeWorkspaceAgentDirectory{
+		views: map[string][]workspaceagentbiz.View{
+			"workspace-startup": {{Agent: workspaceagentbiz.Agent{ID: customID, Name: "Startup only"}}},
+		},
+	}
+	sessions := &fakeAgentSessions{}
+	provider := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-startup"}}, sessions).WithWorkspaceAgents(directory)
+
+	_, err := provider.newComposerOptionsCommand().Handler(context.Background(), cliservice.InvokeRequest{
+		Input: map[string]any{"agent-id": customID},
+	})
+	if !errors.Is(err, cliservice.ErrInvalidInput) || !strings.Contains(err.Error(), "workspace id is required") {
+		t.Fatalf("workspace agent selection error = %v, want explicit workspace validation", err)
+	}
+	if len(directory.listedWorkspaceIDs) != 0 || len(directory.getKeys) != 0 {
+		t.Fatalf("selector consulted workspace-agent directory without workspace: listed=%#v get=%#v", directory.listedWorkspaceIDs, directory.getKeys)
 	}
 }
 

--- a/services/tuttid/service/cli/providers/agentcontext/providers.go
+++ b/services/tuttid/service/cli/providers/agentcontext/providers.go
@@ -2,6 +2,7 @@ package agentcontext
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -9,6 +10,8 @@ import (
 	agentproviderbiz "github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
+	workspaceagentbiz "github.com/tutti-os/tutti/services/tuttid/biz/workspaceagent"
+	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 	agentextensionservice "github.com/tutti-os/tutti/services/tuttid/service/agentextension"
 	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
@@ -31,8 +34,11 @@ type agentsInput struct {
 }
 
 type agentCatalogItem struct {
-	Target       agenttargetbiz.Target
-	Availability agentservice.ProviderAvailability
+	Target           agenttargetbiz.Target
+	IdentityID       string
+	IdentityName     string
+	IdentityProvider string
+	Availability     agentservice.ProviderAvailability
 }
 
 type agentsResult struct {
@@ -48,6 +54,7 @@ func (p Provider) newAgentsCommand() cliservice.Command {
 		Description: "List every enabled agent and whether tuttid can start its runtime. Multiple agents may share one provider.",
 		Kind:        framework.KindList,
 		Workspace:   framework.WorkspaceOptional,
+		Workspaces:  p.workspaces,
 		Inputs:      framework.FromStruct[agentsInput](),
 		Output: framework.OutputSpec{
 			DefaultMode: cliservice.OutputModeTable,
@@ -84,30 +91,59 @@ func (p Provider) runAgents(ctx context.Context, invoke framework.InvokeContext,
 		return nil, err
 	}
 	requestedAgentID := strings.TrimSpace(input.AgentID)
-	var requestedTarget *agenttargetbiz.Target
-	if requestedAgentID != "" {
-		for index := range targets {
-			target := &targets[index]
-			if target.ID == requestedAgentID {
-				requestedTarget = target
-				break
-			}
-		}
-		if requestedTarget == nil {
-			return nil, fmt.Errorf("%w: enabled agent %q was not found; run agent list --json", cliservice.ErrInvalidInput, requestedAgentID)
-		}
-	}
+	workspaceID := strings.TrimSpace(invoke.WorkspaceID)
 	preferredProvider := p.preferredAgentProvider(ctx)
 	defaultAgentTargetID := preferredAgentTargetID(targets, preferredProvider)
 
-	extensionTargets := extensionAgentTargets(targets)
-	if requestedTarget != nil {
-		if isExtensionAgentTarget(*requestedTarget) {
-			extensionTargets = []agenttargetbiz.Target{*requestedTarget}
-		} else {
-			extensionTargets = nil
+	if requestedAgentID != "" {
+		if strings.HasPrefix(requestedAgentID, workspaceagentbiz.IDPrefix) {
+			if workspaceID == "" {
+				return nil, fmt.Errorf("%w: workspace id is required for WorkspaceAgent selection", cliservice.ErrInvalidInput)
+			}
+			view, err := p.getWorkspaceAgentView(ctx, workspaceID, requestedAgentID)
+			if err != nil {
+				return nil, err
+			}
+			item, err := p.workspaceAgentCatalogItemForSelection(ctx, workspaceID, view, targets, input.Refresh)
+			if err != nil {
+				return nil, err
+			}
+			if defaultAgentTargetID == "" {
+				defaultAgentTargetID = fallbackDefaultAgentTargetID(agentCatalogItems(targets, nil), preferredProvider)
+			}
+			return agentsResult{DefaultAgentTargetID: defaultAgentTargetID, Items: []agentCatalogItem{item}}, nil
 		}
+
+		var selectedTarget *agenttargetbiz.Target
+		for index := range targets {
+			if targets[index].ID == requestedAgentID {
+				selectedTarget = &targets[index]
+				break
+			}
+		}
+		if selectedTarget == nil {
+			return nil, fmt.Errorf("%w: enabled agent %q was not found; run agent list --json", cliservice.ErrInvalidInput, requestedAgentID)
+		}
+		availability := []agentservice.ProviderAvailability{}
+		if !isExtensionAgentTarget(*selectedTarget) {
+			availability, err = p.sessions.ListProviderAvailability(ctx, agentservice.ProviderAvailabilityInput{
+				Provider: selectedTarget.Provider,
+			})
+			if err != nil {
+				return nil, err
+			}
+		}
+		item := agentCatalogItems([]agenttargetbiz.Target{*selectedTarget}, availability)
+		if isExtensionAgentTarget(*selectedTarget) {
+			p.applyExtensionSetupAvailability(ctx, workspaceID, item, input.Refresh)
+		}
+		if defaultAgentTargetID == "" {
+			defaultAgentTargetID = fallbackDefaultAgentTargetID(agentCatalogItems(targets, availability), preferredProvider)
+		}
+		return agentsResult{DefaultAgentTargetID: defaultAgentTargetID, Items: item}, nil
 	}
+
+	extensionTargets := extensionAgentTargets(targets)
 	extensionItems := agentCatalogItems(extensionTargets, nil)
 	probeCtx, cancelProbes := context.WithCancel(ctx)
 	defer cancelProbes()
@@ -117,22 +153,15 @@ func (p Provider) runAgents(ctx context.Context, invoke framework.InvokeContext,
 	} else {
 		go func() {
 			defer close(extensionAvailabilityDone)
-			p.applyExtensionSetupAvailability(probeCtx, invoke.WorkspaceID, extensionItems, input.Refresh)
+			p.applyExtensionSetupAvailability(probeCtx, workspaceID, extensionItems, input.Refresh)
 		}()
 	}
 
 	availability := []agentservice.ProviderAvailability{}
 	builtinTargets := builtinAgentTargets(targets)
 	needsAvailability := len(builtinTargets) > 0
-	if requestedTarget != nil {
-		needsAvailability = !isExtensionAgentTarget(*requestedTarget)
-	}
 	if needsAvailability {
-		availabilityInput := agentservice.ProviderAvailabilityInput{}
-		if requestedTarget != nil && !isExtensionAgentTarget(*requestedTarget) {
-			availabilityInput.Provider = requestedTarget.Provider
-		}
-		availability, err = p.sessions.ListProviderAvailability(ctx, availabilityInput)
+		availability, err = p.sessions.ListProviderAvailability(ctx, agentservice.ProviderAvailabilityInput{})
 		if err != nil {
 			cancelProbes()
 			<-extensionAvailabilityDone
@@ -153,17 +182,135 @@ func (p Provider) runAgents(ctx context.Context, invoke framework.InvokeContext,
 	if defaultAgentTargetID == "" {
 		defaultAgentTargetID = fallbackDefaultAgentTargetID(items, preferredProvider)
 	}
-	if requestedAgentID != "" {
-		filtered := make([]agentCatalogItem, 0, 1)
-		for _, item := range items {
-			if item.Target.ID == requestedAgentID {
-				filtered = append(filtered, item)
-				break
-			}
+	if workspaceID != "" && p.workspaceAgents != nil {
+		workspaceAgents, listErr := p.workspaceAgents.List(ctx, workspaceID)
+		if listErr != nil {
+			return nil, listErr
 		}
-		items = filtered
+		items = append(items, workspaceAgentCatalogItems(workspaceAgents, items)...)
 	}
 	return agentsResult{DefaultAgentTargetID: defaultAgentTargetID, Items: items}, nil
+}
+
+func (p Provider) getWorkspaceAgentView(ctx context.Context, workspaceID string, agentID string) (workspaceagentbiz.View, error) {
+	if p.workspaceAgents == nil {
+		return workspaceagentbiz.View{}, errors.New("workspace agent directory is not configured")
+	}
+	view, err := p.workspaceAgents.Get(ctx, workspaceID, agentID)
+	if errors.Is(err, workspacedata.ErrWorkspaceAgentNotFound) {
+		return workspaceagentbiz.View{}, fmt.Errorf("%w: enabled agent %q was not found; run agent list --json", cliservice.ErrInvalidInput, agentID)
+	}
+	return view, err
+}
+
+func (p Provider) workspaceAgentCatalogItemForSelection(
+	ctx context.Context,
+	workspaceID string,
+	view workspaceagentbiz.View,
+	targets []agenttargetbiz.Target,
+	refresh bool,
+) (agentCatalogItem, error) {
+	if !view.Harness.Available || !view.Harness.Enabled {
+		return workspaceAgentCatalogItem(view, nil, nil), nil
+	}
+	for _, target := range targets {
+		if target.ID != view.Harness.AgentTargetID {
+			continue
+		}
+		if isExtensionAgentTarget(target) {
+			items := agentCatalogItems([]agenttargetbiz.Target{target}, nil)
+			p.applyExtensionSetupAvailability(ctx, workspaceID, items, refresh)
+			return workspaceAgentCatalogItem(view, &target, items), nil
+		}
+		availability, err := p.sessions.ListProviderAvailability(ctx, agentservice.ProviderAvailabilityInput{
+			Provider: target.Provider,
+		})
+		if err != nil {
+			return agentCatalogItem{}, err
+		}
+		return workspaceAgentCatalogItem(view, &target, agentCatalogItems([]agenttargetbiz.Target{target}, availability)), nil
+	}
+	return workspaceAgentCatalogItem(view, nil, nil), nil
+}
+
+func workspaceAgentCatalogItems(
+	views []workspaceagentbiz.View,
+	harnessItems []agentCatalogItem,
+) []agentCatalogItem {
+	availabilityByHarnessID := make(map[string]agentservice.ProviderAvailability, len(harnessItems))
+	for _, item := range harnessItems {
+		availabilityByHarnessID[item.Target.ID] = item.Availability
+	}
+	items := make([]agentCatalogItem, 0, len(views))
+	for _, view := range views {
+		items = append(items, agentCatalogItemForWorkspaceAgent(view, nil, availabilityByHarnessID))
+	}
+	return items
+}
+
+func workspaceAgentCatalogItem(
+	view workspaceagentbiz.View,
+	harnessTarget *agenttargetbiz.Target,
+	harnessItems []agentCatalogItem,
+) agentCatalogItem {
+	availabilityByHarnessID := make(map[string]agentservice.ProviderAvailability, len(harnessItems))
+	for _, item := range harnessItems {
+		availabilityByHarnessID[item.Target.ID] = item.Availability
+	}
+	return agentCatalogItemForWorkspaceAgent(view, harnessTarget, availabilityByHarnessID)
+}
+
+func agentCatalogItemForWorkspaceAgent(
+	view workspaceagentbiz.View,
+	harnessTarget *agenttargetbiz.Target,
+	availabilityByHarnessID map[string]agentservice.ProviderAvailability,
+) agentCatalogItem {
+	provider := strings.TrimSpace(view.Harness.Provider)
+	item := agentCatalogItem{
+		IdentityID:       view.Agent.ID,
+		IdentityName:     view.Agent.Name,
+		IdentityProvider: provider,
+		Availability:     unavailableWorkspaceAgentAvailability(provider),
+	}
+	if !view.Harness.Available || !view.Harness.Enabled {
+		return item
+	}
+	if harnessTarget != nil {
+		item.Target = *harnessTarget
+		item.IdentityProvider = harnessTarget.Provider
+		if availability, ok := availabilityByHarnessID[harnessTarget.ID]; ok {
+			item.Availability = availability
+		} else {
+			item.Availability = unknownWorkspaceAgentAvailability(harnessTarget.Provider)
+		}
+		return item
+	}
+	if availability, ok := availabilityByHarnessID[view.Harness.AgentTargetID]; ok {
+		item.Availability = availability
+	} else {
+		item.Availability = unknownWorkspaceAgentAvailability(provider)
+	}
+	return item
+}
+
+func unavailableWorkspaceAgentAvailability(provider string) agentservice.ProviderAvailability {
+	return agentservice.ProviderAvailability{
+		Provider: provider,
+		Status:   agentservice.ProviderAvailabilityUnavailable,
+		LastError: &agentservice.ProviderAvailabilityError{
+			Code: "workspace_agent_configuration_unavailable", Message: "workspace agent configuration is unavailable",
+		},
+	}
+}
+
+func unknownWorkspaceAgentAvailability(provider string) agentservice.ProviderAvailability {
+	return agentservice.ProviderAvailability{
+		Provider: provider,
+		Status:   agentservice.ProviderAvailabilityUnknown,
+		LastError: &agentservice.ProviderAvailabilityError{
+			Code: "agent_provider_status_unknown", Message: "provider runtime status is unavailable",
+		},
+	}
 }
 
 func (p Provider) applyExtensionSetupAvailability(
@@ -316,7 +463,7 @@ func agentCatalogItems(targets []agenttargetbiz.Target, availability []agentserv
 	items := make([]agentCatalogItem, 0, len(targets))
 	for _, target := range targets {
 		if isExtensionAgentTarget(target) {
-			items = append(items, agentCatalogItem{Target: target, Availability: extensionTargetAvailability(target)})
+			items = append(items, agentCatalogItem{Target: target, IdentityID: target.ID, IdentityName: target.Name, IdentityProvider: target.Provider, Availability: extensionTargetAvailability(target)})
 			continue
 		}
 		item, ok := byProvider[target.Provider]
@@ -330,9 +477,30 @@ func agentCatalogItems(targets []agenttargetbiz.Target, availability []agentserv
 				},
 			}
 		}
-		items = append(items, agentCatalogItem{Target: target, Availability: item})
+		items = append(items, agentCatalogItem{Target: target, IdentityID: target.ID, IdentityName: target.Name, IdentityProvider: target.Provider, Availability: item})
 	}
 	return items
+}
+
+func catalogItemID(item agentCatalogItem) string {
+	if item.IdentityID != "" {
+		return item.IdentityID
+	}
+	return item.Target.ID
+}
+
+func catalogItemName(item agentCatalogItem) string {
+	if item.IdentityName != "" {
+		return item.IdentityName
+	}
+	return item.Target.Name
+}
+
+func catalogItemProvider(item agentCatalogItem) string {
+	if item.IdentityProvider != "" {
+		return item.IdentityProvider
+	}
+	return item.Target.Provider
 }
 
 func builtinAgentTargets(targets []agenttargetbiz.Target) []agenttargetbiz.Target {
@@ -383,9 +551,9 @@ func agentCatalogRows(items []agentCatalogItem) []map[string]any {
 	rows := make([]map[string]any, 0, len(items))
 	for _, item := range items {
 		rows = append(rows, map[string]any{
-			"id":       item.Target.ID,
-			"name":     item.Target.Name,
-			"provider": item.Target.Provider,
+			"id":       catalogItemID(item),
+			"name":     catalogItemName(item),
+			"provider": catalogItemProvider(item),
 			"status":   item.Availability.Status,
 			"detail":   providerAvailabilityDetail(item.Availability),
 		})
@@ -397,9 +565,9 @@ func agentCatalogValues(items []agentCatalogItem) []any {
 	values := make([]any, 0, len(items))
 	for _, item := range items {
 		value := map[string]any{
-			"id":       item.Target.ID,
-			"name":     item.Target.Name,
-			"provider": item.Target.Provider,
+			"id":       catalogItemID(item),
+			"name":     catalogItemName(item),
+			"provider": catalogItemProvider(item),
 			"availability": map[string]any{
 				"status":     item.Availability.Status,
 				"reasonCode": providerAvailabilityReasonCode(item.Availability),

--- a/services/tuttid/service/cli/providers/agentcontext/session_commands.go
+++ b/services/tuttid/service/cli/providers/agentcontext/session_commands.go
@@ -14,7 +14,6 @@ import (
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	agentactivitybiz "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 	"github.com/tutti-os/tutti/services/tuttid/biz/agentgui"
-	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
 	"github.com/tutti-os/tutti/services/tuttid/service/cli/framework"
@@ -97,7 +96,7 @@ func (p Provider) newStartCommand() cliservice.Command {
 		Inputs:      framework.FromStruct[startInput](),
 		Output:      sessionActionOutputSpec(),
 		Run: func(ctx context.Context, invoke framework.InvokeContext, input startInput) (any, error) {
-			target, _, err := p.resolveAgentSelector(ctx, input.AgentID, input.Provider)
+			target, _, err := p.resolveAgentSelector(ctx, invoke.WorkspaceID, input.AgentID, input.Provider)
 			if err != nil {
 				return nil, err
 			}
@@ -134,7 +133,7 @@ type startFields struct {
 	Title           string
 }
 
-func (p Provider) runStart(ctx context.Context, invoke framework.InvokeContext, target agenttargetbiz.Target, input startFields) (any, error) {
+func (p Provider) runStart(ctx context.Context, invoke framework.InvokeContext, target selectedAgent, input startFields) (any, error) {
 	if err := p.requireSessions(); err != nil {
 		return nil, err
 	}

--- a/services/tuttid/service/cli/providers/agentcontext/skill_bundle.go
+++ b/services/tuttid/service/cli/providers/agentcontext/skill_bundle.go
@@ -51,7 +51,7 @@ func (p Provider) runSkillBundle(ctx context.Context, invoke framework.InvokeCon
 	if err := p.requireSessions(); err != nil {
 		return nil, err
 	}
-	target, legacy, err := p.resolveAgentSelector(ctx, input.AgentID, input.Provider)
+	target, legacy, err := p.resolveAgentSelector(ctx, invoke.WorkspaceID, input.AgentID, input.Provider)
 	if err != nil {
 		return nil, err
 	}

--- a/services/tuttid/wiring_daemon_api.go
+++ b/services/tuttid/wiring_daemon_api.go
@@ -801,6 +801,7 @@ func buildDaemonAPI(
 		Apps: appCenterService, Events: events,
 		ManagedCredentials: managedCredentials,
 		AgentSessions:      agentSessionService, AgentTargets: agentTargets,
+		WorkspaceAgents:  workspaceAgents,
 		AgentTargetSetup: agentTargetSetup,
 		Preferences:      preferences, TuttiModePlans: tuttiModePlans,
 		TuttiModeExecutions:  tuttiModeExecutions,

--- a/services/tuttid/wiring_daemon_cli.go
+++ b/services/tuttid/wiring_daemon_cli.go
@@ -25,6 +25,7 @@ import (
 	tuttimodeexecutionservice "github.com/tutti-os/tutti/services/tuttid/service/tuttimodeexecution"
 	tuttimodeplanservice "github.com/tutti-os/tutti/services/tuttid/service/tuttimodeplan"
 	workspaceservice "github.com/tutti-os/tutti/services/tuttid/service/workspace"
+	workspaceagentservice "github.com/tutti-os/tutti/services/tuttid/service/workspaceagent"
 )
 
 type daemonCLIRegistryInput struct {
@@ -35,6 +36,7 @@ type daemonCLIRegistryInput struct {
 	ManagedCredentials   *managedcredentialsservice.Service
 	AgentSessions        *agentservice.Service
 	AgentTargets         agenttargetservice.Service
+	WorkspaceAgents      *workspaceagentservice.Service
 	AgentTargetSetup     *agentextensionservice.SetupService
 	Preferences          *preferencesservice.Service
 	TuttiModePlans       *tuttimodeplanservice.Service
@@ -48,6 +50,16 @@ type daemonCLIRegistryInput struct {
 func buildDaemonCLIRegistry(
 	input daemonCLIRegistryInput,
 ) (*cliservice.Registry, error) {
+	agentContextProvider := agentcontextcli.NewProviderWithAgentTargets(
+		input.Workspaces,
+		input.AgentSessions,
+		eventstreamservice.AgentGUILaunchPublisher{Service: input.Events},
+		input.AgentTargets,
+		input.Preferences,
+	).WithAgentTargetSetup(input.AgentTargetSetup)
+	if input.WorkspaceAgents != nil {
+		agentContextProvider = agentContextProvider.WithWorkspaceAgents(input.WorkspaceAgents)
+	}
 	providers := []cliservice.Provider{
 		diagnosticscli.NewProvider(),
 		managedmodelscli.NewProvider(input.ManagedCredentials),
@@ -60,15 +72,7 @@ func buildDaemonCLIRegistry(
 				Service: input.Events,
 			},
 		),
-		agentcontextcli.NewProviderWithAgentTargets(
-			input.Workspaces,
-			input.AgentSessions,
-			eventstreamservice.AgentGUILaunchPublisher{
-				Service: input.Events,
-			},
-			input.AgentTargets,
-			input.Preferences,
-		).WithAgentTargetSetup(input.AgentTargetSetup),
+		agentContextProvider,
 		tuttimodeplancli.NewProviderWithExecutionSnapshot(
 			input.Workspaces,
 			input.TuttiModePlans,


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Verification

<!-- Commands run, manual checks, or why verification is not applicable. -->

## Fallback Three Questions

<!--
Required when this change adds a timer, retry, cache, or defensive branch;
delete otherwise.

- Source: which event or state does this fallback compensate for?
- Why can it not be fixed at that source?
- Removal condition: when can this fallback be deleted?
-->

## Checklist

- [ ] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.
- [ ] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [ ] I ran the lowest meaningful local checks for the changed surface.
- [ ] My commits are signed off with DCO when required: `git commit -s`.
