### PR TITLE
fix(agent): backport current Codex CLI requirement to release/0818

### DIFF
--- a/.changeset/agent-codex-version-floor.md
+++ b/.changeset/agent-codex-version-floor.md
@@ -2,4 +2,4 @@
 "@tutti-os/desktop": patch
 ---
 
-Lower the minimum supported Codex version to 0.126.0. The floor is now capability-derived — 0.126.0 is the release that introduced the newest app-server method our codex runtime integrates — instead of an arbitrary "latest at the time" value.
+Raise the minimum supported Codex version to 0.153.4 so outdated clients rejected by the upstream service are routed through Tutti's upgrade flow before starting a model request.

--- a/.github/workflows/windows-agent-adapters.yml
+++ b/.github/workflows/windows-agent-adapters.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           $contractRoot = Join-Path $env:RUNNER_TEMP 'tutti-codex-contract'
-          npm install --prefix $contractRoot --no-save --no-audit --no-fund --include=optional @openai/codex@0.147.0
+          npm install --prefix $contractRoot --no-save --no-audit --no-fund --include=optional @openai/codex@0.153.4
           $binaries = @(Get-ChildItem -Path $contractRoot -Recurse -Filter codex.exe)
           if ($binaries.Count -ne 1) {
             throw "Expected one native codex.exe, found $($binaries.Count)"

--- a/packages/agent/daemon/providerregistry/codex.go
+++ b/packages/agent/daemon/providerregistry/codex.go
@@ -5,7 +5,7 @@ import canonical "github.com/tutti-os/tutti/packages/agent/store-sqlite/canonica
 const (
 	CodexProviderID                = canonical.CodexProviderID
 	CodexTargetID                  = "local:codex"
-	CodexMinVersion                = "0.126.0"
+	CodexMinVersion                = "0.153.4"
 	CodexThroughTurnForkMinVersion = "0.144.0"
 )
 

--- a/services/tuttid/service/agentstatus/codex_bun_discovery_test.go
+++ b/services/tuttid/service/agentstatus/codex_bun_discovery_test.go
@@ -32,7 +32,7 @@ func TestCodexDiscoveryUsesBunConfiguredGlobalBinForStatusAndLaunch(t *testing.T
 		"exit 1\n")
 	codexPath := filepath.Join(customGlobalBin, "codex")
 	writeExecutable(t, codexPath, "#!/bin/sh\n"+
-		"if [ \"$1\" = \"--version\" ]; then echo 'codex 0.142.0'; exit 0; fi\n"+
+		"if [ \"$1\" = \"--version\" ]; then echo 'codex "+MinSupportedCodexVersion+"'; exit 0; fi\n"+
 		"exit 1\n")
 
 	service := probeTestService(home)

--- a/services/tuttid/service/agentstatus/codex_runtime_catalog_test.go
+++ b/services/tuttid/service/agentstatus/codex_runtime_catalog_test.go
@@ -43,8 +43,8 @@ func TestCodexRuntimeSelectionUsesOnlyReadyCandidateForStatusAndLaunch(t *testin
 	home := t.TempDir()
 	broken := filepath.Join(home, "broken", "codex")
 	healthy := filepath.Join(home, "healthy", "codex")
-	broken = writeCodexVersionFixture(t, broken, "0.142.0")
-	healthy = writeCodexVersionFixture(t, healthy, "0.142.0")
+	broken = writeCodexVersionFixture(t, broken, MinSupportedCodexVersion)
+	healthy = writeCodexVersionFixture(t, healthy, MinSupportedCodexVersion)
 	service := probeTestService(home)
 	service.Environ = func() []string {
 		return []string{"PATH=" + filepath.Dir(broken) + string(filepath.ListSeparator) + filepath.Dir(healthy)}
@@ -75,8 +75,8 @@ func TestCodexRuntimeSelectionRequiresAUserChoiceBeforeStatusOrLaunch(t *testing
 	home := t.TempDir()
 	first := filepath.Join(home, "first", "codex")
 	second := filepath.Join(home, "second", "codex")
-	first = writeCodexVersionFixture(t, first, "0.142.0")
-	second = writeCodexVersionFixture(t, second, "0.142.0")
+	first = writeCodexVersionFixture(t, first, MinSupportedCodexVersion)
+	second = writeCodexVersionFixture(t, second, MinSupportedCodexVersion)
 	service := probeTestService(home)
 	service.Environ = func() []string {
 		return []string{"PATH=" + filepath.Dir(first) + string(filepath.ListSeparator) + filepath.Dir(second)}
@@ -118,8 +118,8 @@ func TestCodexRuntimeSelectionPersistsOnlyAReadyCandidateFromTheCurrentCatalog(t
 	home := t.TempDir()
 	first := filepath.Join(home, "first", "codex")
 	second := filepath.Join(home, "second", "codex")
-	first = writeCodexVersionFixture(t, first, "0.142.0")
-	second = writeCodexVersionFixture(t, second, "0.142.0")
+	first = writeCodexVersionFixture(t, first, MinSupportedCodexVersion)
+	second = writeCodexVersionFixture(t, second, MinSupportedCodexVersion)
 	store := &memoryCodexRuntimeSelectionStore{}
 	service := probeTestService(home)
 	service.Environ = func() []string {
@@ -169,8 +169,8 @@ func TestCodexRuntimeSelectionDoesNotFallbackFromBrokenExplicitCandidate(t *test
 	home := t.TempDir()
 	broken := filepath.Join(home, "broken", "codex")
 	healthy := filepath.Join(home, "healthy", "codex")
-	broken = writeCodexVersionFixture(t, broken, "0.142.0")
-	healthy = writeCodexVersionFixture(t, healthy, "0.142.0")
+	broken = writeCodexVersionFixture(t, broken, MinSupportedCodexVersion)
+	healthy = writeCodexVersionFixture(t, healthy, MinSupportedCodexVersion)
 	service := probeTestService(home)
 	service.Environ = func() []string {
 		return []string{"PATH=" + filepath.Dir(broken) + string(filepath.ListSeparator) + filepath.Dir(healthy)}
@@ -199,7 +199,7 @@ func TestCodexRuntimeSelectionDoesNotFallbackFromBrokenExplicitCandidate(t *test
 func TestSetCodexRuntimeSelectionInvalidatesDerivedAvailability(t *testing.T) {
 	home := t.TempDir()
 	launcher := filepath.Join(home, "codex")
-	launcher = writeCodexVersionFixture(t, launcher, "0.146.0")
+	launcher = writeCodexVersionFixture(t, launcher, MinSupportedCodexVersion)
 	service := probeTestService(home)
 	service.CodexRuntimeSelectionStore = &memoryCodexRuntimeSelectionStore{}
 	service.Environ = func() []string {

--- a/services/tuttid/service/agentstatus/codex_runtime_validation_test.go
+++ b/services/tuttid/service/agentstatus/codex_runtime_validation_test.go
@@ -11,8 +11,8 @@ func TestValidateCodexRuntimeCandidatesImplicitlyUsesOnlyReadyCandidate(t *testi
 	home := t.TempDir()
 	broken := filepath.Join(home, "broken", "codex")
 	healthy := filepath.Join(home, "healthy", "codex")
-	broken = writeCodexVersionFixture(t, broken, "0.142.0")
-	healthy = writeCodexVersionFixture(t, healthy, "0.142.0")
+	broken = writeCodexVersionFixture(t, broken, MinSupportedCodexVersion)
+	healthy = writeCodexVersionFixture(t, healthy, MinSupportedCodexVersion)
 
 	service := probeTestService(home)
 	service.CodexProtocolProbe = func(_ context.Context, command, _ []string) CodexProbeEvidence {
@@ -43,7 +43,7 @@ func TestValidateCodexRuntimeCandidatesSkipsUnsupportedCandidate(t *testing.T) {
 	old := filepath.Join(home, "old", "codex")
 	current := filepath.Join(home, "current", "codex")
 	old = writeCodexVersionFixture(t, old, "0.125.0")
-	current = writeCodexVersionFixture(t, current, "0.142.0")
+	current = writeCodexVersionFixture(t, current, MinSupportedCodexVersion)
 
 	service := probeTestService(home)
 	service.CodexProtocolProbe = codexProtocolReadyFixture

--- a/services/tuttid/service/agentstatus/codex_version.go
+++ b/services/tuttid/service/agentstatus/codex_version.go
@@ -10,12 +10,10 @@ import (
 
 // MinSupportedCodexVersion is the lowest Codex CLI version Tutti supports.
 //
-// Capability-derived: 0.126.0 is the release that introduced the newest
-// app-server method our codex runtime integrates (the thread/goal API); every
-// other app-server capability we call landed earlier, and the enrichment ones
-// (account/models/rateLimits/collaborationMode/goal) degrade gracefully below
-// their version. So 0.126.0 is the floor at which the full app-server feature
-// set we wire up is present.
+// Service-compatibility-derived: older Codex releases can still expose the
+// app-server methods Tutti calls while being rejected by the upstream service
+// before current model requests complete. The floor therefore tracks the
+// current stable Codex release verified by Tutti's app-server contract tests.
 //
 // Single tunable hard gate: a detected codex below this floor is flagged as
 // too old (surfaced as CODEX_VERSION_TOO_OLD) and the server-side 400 is the

--- a/services/tuttid/service/agentstatus/service_codex_runtime_verification_test.go
+++ b/services/tuttid/service/agentstatus/service_codex_runtime_verification_test.go
@@ -65,7 +65,7 @@ func codexBunInstallStatus(t *testing.T, launcherScript string, probe CodexProbe
 }
 
 const codexBunReadyLauncher = "#!/bin/sh\n" +
-	"if [ \"$1\" = \"--version\" ]; then echo 'codex 0.142.0'; exit 0; fi\nexit 1\n"
+	"if [ \"$1\" = \"--version\" ]; then echo 'codex " + MinSupportedCodexVersion + "'; exit 0; fi\nexit 1\n"
 
 func TestCodexAvailabilityUnsupportedAppServerRequiresUpgrade(t *testing.T) {
 	status := codexBunInstallStatus(t, codexBunReadyLauncher, CodexProbeEvidence{
@@ -89,7 +89,7 @@ func TestCodexAvailabilityBunInstallVerifiedByProductionProbe(t *testing.T) {
 	}
 	home := t.TempDir()
 	launcher := "#!/bin/sh\n" +
-		"if [ \"$1\" = \"--version\" ]; then echo 'codex 0.142.0'; exit 0; fi\n" +
+		"if [ \"$1\" = \"--version\" ]; then echo 'codex " + MinSupportedCodexVersion + "'; exit 0; fi\n" +
 		"if [ \"$1\" = \"app-server\" ]; then TUTTI_CODEX_APP_SERVER_TEST_HELPER=1 exec \"$TUTTI_CODEX_TEST_BINARY\" -test.run=^TestCodexAppServerBlackBoxHelper$; fi\n" +
 		"exit 1\n"
 	writeCodexBunInstall(t, home, launcher)
@@ -283,7 +283,7 @@ func TestCodexInstallDoesNotNPMRepairBrokenBunInstall(t *testing.T) {
 // nested binary.
 func TestCodexAvailabilityMissingPlatformPackageReportsIncomplete(t *testing.T) {
 	launcher := "#!/bin/sh\n" +
-		"if [ \"$1\" = \"--version\" ]; then echo 'codex 0.142.0'; exit 0; fi\n" +
+		"if [ \"$1\" = \"--version\" ]; then echo 'codex " + MinSupportedCodexVersion + "'; exit 0; fi\n" +
 		"if [ \"$1\" = \"app-server\" ]; then echo 'Cannot find module @openai/codex-darwin-arm64 (enoent)' >&2; exit 127; fi\n" +
 		"exit 0\n"
 	status := codexBunInstallStatus(t, launcher, codexPlatformENOENTFixture())
@@ -304,7 +304,7 @@ func TestCodexAvailabilityMissingPlatformPackageReportsIncomplete(t *testing.T) 
 // unavailable".
 func TestCodexAvailabilityUnclassifiedLaunchFailureReportsGeneric(t *testing.T) {
 	launcher := "#!/bin/sh\n" +
-		"if [ \"$1\" = \"--version\" ]; then echo 'codex 0.142.0'; exit 0; fi\n" +
+		"if [ \"$1\" = \"--version\" ]; then echo 'codex " + MinSupportedCodexVersion + "'; exit 0; fi\n" +
 		"if [ \"$1\" = \"app-server\" ]; then echo 'app-server failed' >&2; exit 127; fi\n" +
 		"exit 0\n"
 	status := codexBunInstallStatus(t, launcher, CodexProbeEvidence{CommandStarted: true, Category: "process_exited_early", Message: "app-server failed"})

--- a/tools/scripts/pr-checks-workflow.test.mjs
+++ b/tools/scripts/pr-checks-workflow.test.mjs
@@ -10,6 +10,10 @@ const workspaceRoot = join(dirname(fileURLToPath(import.meta.url)), "../..");
 const workflow = YAML.parse(
   readFileSync(join(workspaceRoot, ".github/workflows/pr-checks.yml"), "utf8")
 );
+const codexProviderSource = readFileSync(
+  join(workspaceRoot, "packages/agent/daemon/providerregistry/codex.go"),
+  "utf8"
+);
 
 const windowsWorkflows = [
   {
@@ -196,6 +200,28 @@ test("Windows adapter workflows keep setup and tests scoped", () => {
     assert.equal(checkout.with?.["fetch-depth"], undefined, path);
     assert.equal(goTestCommands.length, 1, path);
   }
+});
+
+test("Windows Codex contract test uses the minimum supported version", () => {
+  const codexMinimum = codexProviderSource.match(
+    /CodexMinVersion\s*=\s*"([^"]+)"/u
+  )?.[1];
+  const windowsAgentWorkflow = windowsWorkflows.find(
+    ({ path }) => path === ".github/workflows/windows-agent-adapters.yml"
+  )?.workflow;
+
+  assert.ok(windowsAgentWorkflow);
+  const [job] = Object.values(windowsAgentWorkflow.jobs);
+  const installCodex = job.steps.find(
+    (step) => step.name === "Install pinned Codex app-server contract binary"
+  );
+
+  assert.ok(codexMinimum);
+  assert.ok(installCodex);
+  assert.match(
+    installCodex.run,
+    new RegExp(`@openai/codex@${codexMinimum.replaceAll(".", "\\.")}`, "u")
+  );
 });
 
 function stepScripts(job) {


### PR DESCRIPTION
## Summary
- cherry-pick #2643 into the active `release/0818` line
- require Codex CLI `0.153.4` and keep Windows contract fixtures aligned

## Validation
- `node --test tools/scripts/pr-checks-workflow.test.mjs`
- `go test ./packages/agent/daemon/providerregistry -count=1`
- `go test ./services/tuttid/service/agentstatus -count=1`

## Source
- Cherry-picked from `8821cf4788f6a8fe5886942b2ab2890900c14997`

Signed-off-by: jomeswang <1551403343@qq.com>