### PR TITLE
fix(release): pin macOS packaging to stable runner

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -275,7 +275,7 @@ jobs:
   build-macos:
     name: Build macOS (${{ matrix.arch }})
     needs: resolve
-    runs-on: macos-latest
+    runs-on: macos-15
     strategy:
       fail-fast: false
       matrix:

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -1103,6 +1103,15 @@ test("desktop release workflow materializes macOS signing certificate before pac
   );
 });
 
+test("desktop release pins macOS builds to the stable runner image", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+
+  assert.match(
+    workflow,
+    /build-macos:[\s\S]*?runs-on:\s+macos-15[\s\S]*?strategy:/
+  );
+});
+
 test("desktop release macOS builds reserve enough Node heap for the renderer bundle", async () => {
   const workflow = await readFile(workflowPath, "utf8");
 


### PR DESCRIPTION
## Summary
- pin desktop macOS release jobs to `macos-15`
- avoid the macOS 26 runner image keychain regression blocking universal signing
- add a workflow contract test for the runner pin

## Validation
- `node --test tools/scripts/desktop-release-config.test.mjs` (52 passed)

## Release failure
- https://github.com/tutti-os/tutti/actions/runs/33949312757

Signed-off-by: jomeswang <1551403343@qq.com>